### PR TITLE
fix: add IFAC network_name and passphrase support for TCP interfaces

### DIFF
--- a/app/src/main/java/com/lxmf/messenger/repository/InterfaceRepository.kt
+++ b/app/src/main/java/com/lxmf/messenger/repository/InterfaceRepository.kt
@@ -139,6 +139,8 @@ class InterfaceRepository
                             put("target_port", config.targetPort)
                             put("kiss_framing", config.kissFraming)
                             put("mode", config.mode)
+                            config.networkName?.let { put("network_name", it) }
+                            config.passphrase?.let { put("passphrase", it) }
                         }.toString()
 
                     is InterfaceConfig.RNode ->
@@ -242,6 +244,8 @@ class InterfaceRepository
                             targetPort = targetPort,
                             kissFraming = json.optBoolean("kiss_framing", false),
                             mode = json.optString("mode", "full"),
+                            networkName = json.optString("network_name", "").ifEmpty { null },
+                            passphrase = json.optString("passphrase", "").ifEmpty { null },
                         )
                     }
 

--- a/app/src/main/java/com/lxmf/messenger/reticulum/protocol/ServiceReticulumProtocol.kt
+++ b/app/src/main/java/com/lxmf/messenger/reticulum/protocol/ServiceReticulumProtocol.kt
@@ -617,6 +617,8 @@ class ServiceReticulumProtocol(
                     ifaceJson.put("target_port", iface.targetPort)
                     ifaceJson.put("kiss_framing", iface.kissFraming)
                     ifaceJson.put("mode", iface.mode)
+                    iface.networkName?.let { ifaceJson.put("network_name", it) }
+                    iface.passphrase?.let { ifaceJson.put("passphrase", it) }
                 }
                 is InterfaceConfig.RNode -> {
                     ifaceJson.put("type", "RNode")

--- a/app/src/main/java/com/lxmf/messenger/ui/components/InterfaceConfigDialog.kt
+++ b/app/src/main/java/com/lxmf/messenger/ui/components/InterfaceConfigDialog.kt
@@ -12,6 +12,8 @@ import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.KeyboardArrowDown
 import androidx.compose.material.icons.filled.KeyboardArrowUp
+import androidx.compose.material.icons.filled.Visibility
+import androidx.compose.material.icons.filled.VisibilityOff
 import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.Button
 import androidx.compose.material3.Divider
@@ -20,12 +22,15 @@ import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.ExposedDropdownMenuBox
 import androidx.compose.material3.ExposedDropdownMenuDefaults
 import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.OutlinedButton
 import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.Switch
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
+import androidx.compose.ui.text.input.PasswordVisualTransformation
+import androidx.compose.ui.text.input.VisualTransformation
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
@@ -290,6 +295,71 @@ fun TCPClientFields(
         singleLine = true,
         isError = configState.targetPortError != null,
         supportingText = configState.targetPortError?.let { { Text(it) } },
+    )
+
+    // Network Name (IFAC)
+    OutlinedTextField(
+        value = configState.networkName,
+        onValueChange = { onConfigUpdate(configState.copy(networkName = it)) },
+        label = { Text("Network Name") },
+        placeholder = { Text("Optional") },
+        modifier = Modifier.fillMaxWidth(),
+        singleLine = true,
+        supportingText = {
+            Text(
+                "Optional: Sets the virtual network name for this segment. " + 
+                    "This allows multiple separate networks to exist on the same " +
+                    "physical channel or medium.",
+                style = MaterialTheme.typography.bodySmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
+        },
+    )
+
+    // Passphrase (IFAC)
+    OutlinedTextField(
+        value = configState.passphrase,
+        onValueChange = { onConfigUpdate(configState.copy(passphrase = it)) },
+        label = { Text("Passphrase") },
+        placeholder = { Text("Optional") },
+        modifier = Modifier.fillMaxWidth(),
+        singleLine = true,
+        visualTransformation =
+            if (configState.passphraseVisible) {
+                VisualTransformation.None
+            } else {
+                PasswordVisualTransformation()
+            },
+        trailingIcon = {
+            IconButton(
+                onClick = {
+                    onConfigUpdate(configState.copy(passphraseVisible = !configState.passphraseVisible))
+                },
+            ) {
+                Icon(
+                    imageVector =
+                        if (configState.passphraseVisible) {
+                            Icons.Default.VisibilityOff
+                        } else {
+                            Icons.Default.Visibility
+                        },
+                    contentDescription =
+                        if (configState.passphraseVisible) {
+                            "Hide passphrase"
+                        } else {
+                            "Show passphrase"
+                        },
+                )
+            }
+        },
+        supportingText = {
+            Text(
+                "Optional: Sets an authentication passphrase on the interface. " +
+                    "This can be used in conjunction with Network Name, or alone.",
+                style = MaterialTheme.typography.bodySmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
+        },
     )
 }
 

--- a/app/src/main/java/com/lxmf/messenger/viewmodel/InterfaceManagementViewModel.kt
+++ b/app/src/main/java/com/lxmf/messenger/viewmodel/InterfaceManagementViewModel.kt
@@ -63,6 +63,9 @@ data class InterfaceConfigState(
     // TCPClient fields
     val targetHost: String = "",
     val targetPort: String = "4242",
+    val networkName: String = "",
+    val passphrase: String = "",
+    val passphraseVisible: Boolean = false,
     // AndroidBLE fields
     val deviceName: String = "",
     val maxConnections: String = "7",
@@ -375,6 +378,27 @@ class InterfaceManagementViewModel
         }
 
         /**
+         * Update network name for TCP interface.
+         */
+        fun updateNetworkName(value: String) {
+            _configState.update { it.copy(networkName = value) }
+        }
+
+        /**
+         * Update passphrase for TCP interface.
+         */
+        fun updatePassphrase(value: String) {
+            _configState.update { it.copy(passphrase = value) }
+        }
+
+        /**
+         * Toggle passphrase visibility.
+         */
+        fun togglePassphraseVisibility() {
+            _configState.update { it.copy(passphraseVisible = !it.passphraseVisible) }
+        }
+
+        /**
          * Show error message.
          */
         private fun showError(message: String) {
@@ -518,6 +542,8 @@ class InterfaceManagementViewModel
                         enabled = config.enabled,
                         targetHost = config.targetHost,
                         targetPort = config.targetPort.toString(),
+                        networkName = config.networkName ?: "",
+                        passphrase = config.passphrase ?: "",
                         mode = config.mode,
                     )
 
@@ -559,6 +585,8 @@ class InterfaceManagementViewModel
                         targetPort = state.targetPort.toIntOrNull() ?: 4242,
                         kissFraming = false, // Always false, removed from UI
                         mode = state.mode,
+                        networkName = state.networkName.trim().ifEmpty { null },
+                        passphrase = state.passphrase.ifEmpty { null },
                     )
 
                 "AndroidBLE" ->

--- a/python/reticulum_wrapper.py
+++ b/python/reticulum_wrapper.py
@@ -337,6 +337,15 @@ class ReticulumWrapper:
                 if kiss_framing:
                     config_lines.append("    kiss_framing = True")
 
+                # IFAC parameters
+                network_name = iface.get("network_name")
+                if network_name:
+                    config_lines.append(f"    network_name = {network_name}")
+
+                passphrase = iface.get("passphrase")
+                if passphrase:
+                    config_lines.append(f"    passphrase = {passphrase}")
+
                 mode = iface.get("mode", "full")
                 if mode != "full":
                     config_lines.append(f"    mode = {mode}")

--- a/reticulum/src/main/java/com/lxmf/messenger/reticulum/model/ReticulumConfig.kt
+++ b/reticulum/src/main/java/com/lxmf/messenger/reticulum/model/ReticulumConfig.kt
@@ -49,6 +49,8 @@ sealed class InterfaceConfig {
      * @param targetPort TCP port number of the remote server
      * @param kissFraming Whether to use KISS framing (for connecting to TNCs/modems)
      * @param mode Interface mode: "full", "gateway", "access_point", "roaming", "boundary"
+     * @param networkName Optional IFAC network name for cryptographic authentication
+     * @param passphrase Optional IFAC passphrase for cryptographic authentication
      */
     data class TCPClient(
         override val name: String = "TCP Connection",
@@ -57,6 +59,8 @@ sealed class InterfaceConfig {
         val targetPort: Int,
         val kissFraming: Boolean = false,
         val mode: String = "full",
+        val networkName: String? = null,
+        val passphrase: String? = null,
     ) : InterfaceConfig()
 
     /**


### PR DESCRIPTION
Add optional network_name and passphrase fields to TCP interface configuration, enabling Reticulum's Interface Access Code (IFAC) cryptographic authentication.

Changes:
- Add networkName and passphrase fields to TCPClient data class
- Update InterfaceRepository JSON serialization/deserialization
- Add UI fields in Advanced Options with info text explaining IFAC
- Passphrase field hidden by default with visibility toggle
- Pass IFAC params from Kotlin to Python via JSON bridge
- Generate network_name and passphrase in config file

IFAC allows interfaces with matching network_name and passphrase to communicate securely by signing and verifying packets using keys derived from these shared credentials.

🤖 Generated with [Claude Code](https://claude.com/claude-code)