### PR TITLE
Fixed SHA256 checksum value from release pipeline

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -74,6 +74,12 @@ jobs:
             columba-${{ steps.version.outputs.version }}.apk.sha256
           echo "✓ Generated SHA256 checksum"
 
+      - name: Read SHA256 checksum
+        id: sha256
+        run: |
+          SHA256=$(cat columba-${{ steps.version.outputs.version }}.apk.sha256)
+          echo "checksum=$SHA256" >> $GITHUB_OUTPUT
+
       - name: Create GitHub Release
         uses: softprops/action-gh-release@v2
         with:
@@ -91,7 +97,7 @@ jobs:
 
             **SHA256 Checksum:**
             ```
-            $(cat columba-${{ steps.version.outputs.version }}.apk.sha256)
+            ${{ steps.sha256.outputs.checksum }}
             ```
 
             ### What's Changed


### PR DESCRIPTION
As can be seen the release notes were displaying the literal command `$(cat columba-{version}.apk.sha256)` instead of the actual checksum value

<img width="1505" height="177" alt="image" src="https://github.com/user-attachments/assets/4fd4ae44-e990-4219-a222-031df9f9934f" />

This PR should fix that