### PR TITLE
fix: increase bottom padding in ContactsScreen for FAB clearance

### DIFF
--- a/app/src/main/java/com/lxmf/messenger/ui/screens/ContactsScreen.kt
+++ b/app/src/main/java/com/lxmf/messenger/ui/screens/ContactsScreen.kt
@@ -271,7 +271,7 @@ fun ContactsScreen(
                         .fillMaxSize()
                         .padding(paddingValues)
                         .consumeWindowInsets(paddingValues),
-                contentPadding = PaddingValues(16.dp),
+                contentPadding = PaddingValues(start = 16.dp, end = 16.dp, top = 16.dp, bottom = 88.dp),
                 verticalArrangement = Arrangement.spacedBy(12.dp),
             ) {
                 // Pinned contacts section


### PR DESCRIPTION
The LazyColumn content was being obscured by the FloatingActionButton, preventing users from scrolling to see all contacts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)