### PR TITLE
fix: resolve JaCoCo coverage report generation for Codecov upload

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -175,6 +175,7 @@ jobs:
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v5
         with:
+          token: ${{ secrets.CODECOV_TOKEN }}
           files: ./build/reports/jacoco/jacocoTestReport/jacocoTestReport.xml
           flags: unittests
           name: codecov-umbrella


### PR DESCRIPTION
- Use lazy evaluation (provider blocks) for class directories and execution data so paths are resolved at execution time, not registration time when directories don't exist yet
- Fix execution data path from build/jacoco/ to the actual Android location: build/outputs/unit_test_code_coverage/debugUnitTest/
- Add CODECOV_TOKEN to codecov-action in CI workflow
- Exclude generated classes (R, BuildConfig, Hilt, etc.) from coverage

🤖 Generated with [Claude Code](https://claude.com/claude-code)