### PR TITLE
fix: show actual instance state in SharedInstanceBannerCard toggle

### DIFF
--- a/app/src/main/java/com/lxmf/messenger/ui/screens/SettingsScreen.kt
+++ b/app/src/main/java/com/lxmf/messenger/ui/screens/SettingsScreen.kt
@@ -127,7 +127,6 @@ fun SettingsScreen(
                 if (showSharedInstanceBanner) {
                     SharedInstanceBannerCard(
                         isExpanded = state.isSharedInstanceBannerExpanded,
-                        preferOwnInstance = state.preferOwnInstance,
                         isUsingSharedInstance = state.isSharedInstance,
                         rpcKey = state.rpcKey,
                         wasUsingSharedInstance = state.wasUsingSharedInstance,


### PR DESCRIPTION
## Summary
- Fixed toggle showing user preference (`preferOwnInstance`) instead of actual state (`!isUsingSharedInstance`)
- When Columba started first without Sideband, then Sideband started later, the toggle incorrectly showed OFF even though Columba was using its own instance
- Removed now-unused `preferOwnInstance` parameter from `SharedInstanceBannerCard`

## Test plan
- [x] Added unit tests for toggle checked state scenarios
- [x] All existing tests pass
- [x] Manual verification on device: toggle now correctly shows ON when using own instance

🤖 Generated with [Claude Code](https://claude.com/claude-code)