### PR TITLE
fix: enable Codecov PR comments during review

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -1,0 +1,11 @@
+comment:
+  layout: "reach,diff,flags,tree"
+  behavior: default
+  require_changes: false
+  require_base: false
+  require_head: true
+
+coverage:
+  precision: 2
+  round: down
+  range: "70..100"


### PR DESCRIPTION
Add .codecov.yml configuration to ensure Codecov posts coverage comments during PR review rather than after merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)