### PR TITLE
feat: Add announce button to Discovered Nodes screen top bar

### DIFF
--- a/app/src/test/java/com/lxmf/messenger/ui/screens/AnnounceStreamScreenTest.kt
+++ b/app/src/test/java/com/lxmf/messenger/ui/screens/AnnounceStreamScreenTest.kt
@@ -1,0 +1,286 @@
+package com.lxmf.messenger.ui.screens
+
+import android.app.Application
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.assertIsEnabled
+import androidx.compose.ui.test.assertIsNotEnabled
+import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.onNodeWithContentDescription
+import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.performClick
+import androidx.paging.PagingData
+import com.lxmf.messenger.data.repository.Announce
+import com.lxmf.messenger.reticulum.model.NodeType
+import com.lxmf.messenger.test.RegisterComponentActivityRule
+import com.lxmf.messenger.viewmodel.AnnounceStreamViewModel
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.flowOf
+import org.junit.Rule
+import org.junit.Test
+import org.junit.rules.RuleChain
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+
+/**
+ * UI tests for AnnounceStreamScreen.kt.
+ * Tests the announce button functionality added to the top bar.
+ * Uses Robolectric + Compose for local testing.
+ */
+@RunWith(RobolectricTestRunner::class)
+@Config(sdk = [34], application = Application::class)
+class AnnounceStreamScreenTest {
+    private val registerActivityRule = RegisterComponentActivityRule()
+    private val composeRule = createComposeRule()
+
+    @get:Rule
+    val ruleChain: RuleChain = RuleChain.outerRule(registerActivityRule).around(composeRule)
+
+    val composeTestRule get() = composeRule
+
+    // ========== Top App Bar Tests ==========
+
+    @Test
+    fun announceStreamScreen_displaysTitle() {
+        val mockViewModel = createMockAnnounceStreamViewModel()
+
+        composeTestRule.setContent {
+            AnnounceStreamScreen(viewModel = mockViewModel)
+        }
+
+        composeTestRule.onNodeWithText("Discovered Nodes").assertIsDisplayed()
+    }
+
+    @Test
+    fun announceStreamScreen_displaysReachableCount() {
+        val mockViewModel = createMockAnnounceStreamViewModel(reachableCount = 5)
+
+        composeTestRule.setContent {
+            AnnounceStreamScreen(viewModel = mockViewModel)
+        }
+
+        composeTestRule.onNodeWithText("5 nodes in range (active paths)").assertIsDisplayed()
+    }
+
+    @Test
+    fun announceStreamScreen_displaysAnnounceButton() {
+        val mockViewModel = createMockAnnounceStreamViewModel()
+
+        composeTestRule.setContent {
+            AnnounceStreamScreen(viewModel = mockViewModel)
+        }
+
+        composeTestRule.onNodeWithContentDescription("Announce now").assertIsDisplayed()
+    }
+
+    @Test
+    fun announceStreamScreen_displaysFilterButton() {
+        val mockViewModel = createMockAnnounceStreamViewModel()
+
+        composeTestRule.setContent {
+            AnnounceStreamScreen(viewModel = mockViewModel)
+        }
+
+        composeTestRule.onNodeWithContentDescription("Filter node types").assertIsDisplayed()
+    }
+
+    // ========== Announce Button Tests ==========
+
+    @Test
+    fun announceButton_whenNotAnnouncing_isEnabled() {
+        val mockViewModel = createMockAnnounceStreamViewModel(isAnnouncing = false)
+
+        composeTestRule.setContent {
+            AnnounceStreamScreen(viewModel = mockViewModel)
+        }
+
+        composeTestRule.onNodeWithContentDescription("Announce now").assertIsEnabled()
+    }
+
+    @Test
+    fun announceButton_whenAnnouncing_showsProgressIndicator() {
+        val mockViewModel = createMockAnnounceStreamViewModel(isAnnouncing = true)
+
+        composeTestRule.setContent {
+            AnnounceStreamScreen(viewModel = mockViewModel)
+        }
+
+        // When announcing, the Campaign icon is replaced with a progress indicator
+        // so "Announce now" content description should not exist
+        composeTestRule.onNodeWithContentDescription("Announce now").assertDoesNotExist()
+    }
+
+    @Test
+    fun announceButton_click_triggersTriggerAnnounce() {
+        val mockViewModel = createMockAnnounceStreamViewModel()
+
+        composeTestRule.setContent {
+            AnnounceStreamScreen(viewModel = mockViewModel)
+        }
+
+        composeTestRule.onNodeWithContentDescription("Announce now").performClick()
+
+        verify { mockViewModel.triggerAnnounce() }
+    }
+
+    // ========== Search Tests ==========
+
+    @Test
+    fun announceStreamScreen_displaysSearchButton() {
+        val mockViewModel = createMockAnnounceStreamViewModel()
+
+        composeTestRule.setContent {
+            AnnounceStreamScreen(viewModel = mockViewModel)
+        }
+
+        composeTestRule.onNodeWithContentDescription("Search").assertIsDisplayed()
+    }
+
+    @Test
+    fun announceStreamScreen_searchButtonClick_togglesSearchBar() {
+        val mockViewModel = createMockAnnounceStreamViewModel()
+
+        composeTestRule.setContent {
+            AnnounceStreamScreen(viewModel = mockViewModel)
+        }
+
+        // Initially search bar is hidden
+        composeTestRule.onNodeWithText("Search by name or hash...").assertDoesNotExist()
+
+        // Click search button
+        composeTestRule.onNodeWithContentDescription("Search").performClick()
+
+        // Search bar appears
+        composeTestRule.onNodeWithText("Search by name or hash...").assertIsDisplayed()
+    }
+
+    // ========== Empty State Tests ==========
+
+    @Test
+    fun announceStreamScreen_emptyList_displaysEmptyState() {
+        val mockViewModel = createMockAnnounceStreamViewModel()
+
+        composeTestRule.setContent {
+            AnnounceStreamScreen(viewModel = mockViewModel)
+        }
+
+        composeTestRule.onNodeWithText("No nodes discovered yet").assertIsDisplayed()
+    }
+
+    @Test
+    fun announceStreamScreen_emptyList_displaysEmptyStateDescription() {
+        val mockViewModel = createMockAnnounceStreamViewModel()
+
+        composeTestRule.setContent {
+            AnnounceStreamScreen(viewModel = mockViewModel)
+        }
+
+        composeTestRule.onNodeWithText("Listening for announces...").assertIsDisplayed()
+    }
+
+    @Test
+    fun emptyAnnounceState_displaysCorrectText() {
+        composeTestRule.setContent {
+            EmptyAnnounceState()
+        }
+
+        composeTestRule.onNodeWithText("No nodes discovered yet").assertIsDisplayed()
+        composeTestRule.onNodeWithText("Listening for announces...").assertIsDisplayed()
+    }
+
+    // ========== Filter Dialog Tests ==========
+
+    @Test
+    fun filterButton_click_opensFilterDialog() {
+        val mockViewModel = createMockAnnounceStreamViewModel()
+
+        composeTestRule.setContent {
+            AnnounceStreamScreen(viewModel = mockViewModel)
+        }
+
+        // Click filter button
+        composeTestRule.onNodeWithContentDescription("Filter node types").performClick()
+
+        // Filter dialog should appear
+        composeTestRule.onNodeWithText("Filter Node Types").assertIsDisplayed()
+    }
+
+    @Test
+    fun filterDialog_displaysNodeTypeOptions() {
+        val mockViewModel = createMockAnnounceStreamViewModel()
+
+        composeTestRule.setContent {
+            AnnounceStreamScreen(viewModel = mockViewModel)
+        }
+
+        // Open filter dialog
+        composeTestRule.onNodeWithContentDescription("Filter node types").performClick()
+
+        // Verify node type options are displayed
+        composeTestRule.onNodeWithText("Node").assertIsDisplayed()
+        composeTestRule.onNodeWithText("Peer").assertIsDisplayed()
+        composeTestRule.onNodeWithText("Relay").assertIsDisplayed()
+    }
+
+    @Test
+    fun nodeTypeFilterDialog_standalone_displaysCorrectly() {
+        composeTestRule.setContent {
+            NodeTypeFilterDialog(
+                selectedTypes = setOf(NodeType.PEER),
+                showAudio = true,
+                onDismiss = {},
+                onConfirm = { _, _ -> },
+            )
+        }
+
+        composeTestRule.onNodeWithText("Filter Node Types").assertIsDisplayed()
+        composeTestRule.onNodeWithText("Select which node types to display:").assertIsDisplayed()
+        composeTestRule.onNodeWithText("Node").assertIsDisplayed()
+        composeTestRule.onNodeWithText("Peer").assertIsDisplayed()
+        composeTestRule.onNodeWithText("Relay").assertIsDisplayed()
+    }
+
+    @Test
+    fun nodeTypeFilterDialog_displaysAudioOption() {
+        composeTestRule.setContent {
+            NodeTypeFilterDialog(
+                selectedTypes = setOf(NodeType.PEER),
+                showAudio = true,
+                onDismiss = {},
+                onConfirm = { _, _ -> },
+            )
+        }
+
+        // Audio option may require scrolling, so check existence rather than displayed
+        composeTestRule.onNodeWithText("Audio").assertExists()
+        composeTestRule.onNodeWithText("Show audio call announces").assertExists()
+    }
+
+    // ========== Test Helpers ==========
+
+    private fun createMockAnnounceStreamViewModel(
+        reachableCount: Int = 0,
+        isAnnouncing: Boolean = false,
+        announceSuccess: Boolean = false,
+        announceError: String? = null,
+        selectedNodeTypes: Set<NodeType> = setOf(NodeType.PEER),
+        showAudioAnnounces: Boolean = true,
+        searchQuery: String = "",
+    ): AnnounceStreamViewModel {
+        val mockViewModel = mockk<AnnounceStreamViewModel>(relaxed = true)
+
+        every { mockViewModel.announces } returns flowOf(PagingData.empty<Announce>())
+        every { mockViewModel.reachableAnnounceCount } returns MutableStateFlow(reachableCount)
+        every { mockViewModel.searchQuery } returns MutableStateFlow(searchQuery)
+        every { mockViewModel.selectedNodeTypes } returns MutableStateFlow(selectedNodeTypes)
+        every { mockViewModel.showAudioAnnounces } returns MutableStateFlow(showAudioAnnounces)
+        every { mockViewModel.isAnnouncing } returns MutableStateFlow(isAnnouncing)
+        every { mockViewModel.announceSuccess } returns MutableStateFlow(announceSuccess)
+        every { mockViewModel.announceError } returns MutableStateFlow(announceError)
+
+        return mockViewModel
+    }
+}

--- a/app/src/test/java/com/lxmf/messenger/viewmodel/AnnounceStreamViewModelTest.kt
+++ b/app/src/test/java/com/lxmf/messenger/viewmodel/AnnounceStreamViewModelTest.kt
@@ -4,13 +4,16 @@ import androidx.arch.core.executor.testing.InstantTaskExecutorRule
 import androidx.lifecycle.viewModelScope
 import androidx.paging.PagingData
 import app.cash.turbine.test
+import com.lxmf.messenger.data.db.entity.LocalIdentityEntity
 import com.lxmf.messenger.data.repository.AnnounceRepository
 import com.lxmf.messenger.data.repository.ContactRepository
+import com.lxmf.messenger.data.repository.IdentityRepository
 import com.lxmf.messenger.reticulum.model.AnnounceEvent
 import com.lxmf.messenger.reticulum.model.Identity
 import com.lxmf.messenger.reticulum.model.NetworkStatus
 import com.lxmf.messenger.reticulum.model.NodeType
 import com.lxmf.messenger.reticulum.protocol.ReticulumProtocol
+import com.lxmf.messenger.reticulum.protocol.ServiceReticulumProtocol
 import com.lxmf.messenger.service.PropagationNodeManager
 import io.mockk.*
 import kotlinx.coroutines.Dispatchers
@@ -29,7 +32,9 @@ import kotlinx.coroutines.test.runTest
 import kotlinx.coroutines.test.setMain
 import org.junit.After
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
 import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertNull
 import org.junit.Assert.assertTrue
 import org.junit.Before
 import org.junit.Rule
@@ -47,9 +52,11 @@ class AnnounceStreamViewModelTest {
     private val testDispatcher = StandardTestDispatcher()
 
     private lateinit var reticulumProtocol: ReticulumProtocol
+    private lateinit var serviceReticulumProtocol: ServiceReticulumProtocol
     private lateinit var announceRepository: AnnounceRepository
     private lateinit var contactRepository: ContactRepository
     private lateinit var propagationNodeManager: PropagationNodeManager
+    private lateinit var identityRepository: IdentityRepository
     private lateinit var networkStatusFlow: MutableStateFlow<NetworkStatus>
     private lateinit var announceFlow: MutableSharedFlow<AnnounceEvent>
     private lateinit var viewModel: AnnounceStreamViewModel
@@ -72,6 +79,17 @@ class AnnounceStreamViewModelTest {
             receivingInterface = "ble0",
         )
 
+    private val testLocalIdentity =
+        LocalIdentityEntity(
+            identityHash = "testhash123",
+            displayName = "TestUser",
+            destinationHash = "destHash123",
+            filePath = "/test/path",
+            createdTimestamp = System.currentTimeMillis(),
+            lastUsedTimestamp = System.currentTimeMillis(),
+            isActive = true,
+        )
+
     @Before
     fun setup() {
         Dispatchers.setMain(testDispatcher)
@@ -80,9 +98,11 @@ class AnnounceStreamViewModelTest {
         AnnounceStreamViewModel.updateIntervalMs = 0
 
         reticulumProtocol = mockk()
+        serviceReticulumProtocol = mockk()
         announceRepository = mockk()
         contactRepository = mockk()
         propagationNodeManager = mockk(relaxed = true)
+        identityRepository = mockk()
 
         // Setup network status flow
         networkStatusFlow = MutableStateFlow(NetworkStatus.SHUTDOWN)
@@ -106,6 +126,17 @@ class AnnounceStreamViewModelTest {
         coEvery { contactRepository.hasContact(any()) } returns false
         coEvery { contactRepository.deleteContact(any()) } just Runs
         coEvery { contactRepository.addContactFromAnnounce(any(), any()) } returns Result.success(Unit)
+
+        // Mock identity repository
+        coEvery { identityRepository.getActiveIdentitySync() } returns testLocalIdentity
+
+        // Setup serviceReticulumProtocol mock (inherits ReticulumProtocol behavior)
+        every { serviceReticulumProtocol.networkStatus } returns networkStatusFlow
+        every { serviceReticulumProtocol.observeAnnounces() } returns announceFlow
+        coEvery { serviceReticulumProtocol.shutdown() } returns Result.success(Unit)
+        coEvery { serviceReticulumProtocol.getPathTableHashes() } returns emptyList()
+        // Note: Result is an inline class, use runCatching to create it properly
+        coEvery { serviceReticulumProtocol.triggerAutoAnnounce(any()) } returns runCatching { }
     }
 
     @After
@@ -123,7 +154,7 @@ class AnnounceStreamViewModelTest {
     @Test
     fun `waits for READY status before collecting announces`() =
         runTest {
-            viewModel = AnnounceStreamViewModel(reticulumProtocol, announceRepository, contactRepository, propagationNodeManager)
+            viewModel = AnnounceStreamViewModel(reticulumProtocol, announceRepository, contactRepository, propagationNodeManager, identityRepository)
 
             // Status starts as SHUTDOWN - should wait
             viewModel.initializationStatus.test {
@@ -143,7 +174,7 @@ class AnnounceStreamViewModelTest {
     @Test
     fun `handles ERROR status and stops waiting`() =
         runTest {
-            viewModel = AnnounceStreamViewModel(reticulumProtocol, announceRepository, contactRepository, propagationNodeManager)
+            viewModel = AnnounceStreamViewModel(reticulumProtocol, announceRepository, contactRepository, propagationNodeManager, identityRepository)
 
             viewModel.initializationStatus.test {
                 assertEquals("Reticulum managed by app", awaitItem())
@@ -164,7 +195,7 @@ class AnnounceStreamViewModelTest {
     fun `handles timeout waiting for READY`() =
         runTest {
             // Don't change status - let it timeout
-            viewModel = AnnounceStreamViewModel(reticulumProtocol, announceRepository, contactRepository, propagationNodeManager)
+            viewModel = AnnounceStreamViewModel(reticulumProtocol, announceRepository, contactRepository, propagationNodeManager, identityRepository)
 
             // Fast-forward past the 10 second timeout
             testScheduler.apply { advanceTimeBy(11000) }
@@ -186,7 +217,7 @@ class AnnounceStreamViewModelTest {
             networkStatusFlow.value = NetworkStatus.READY
             coEvery { announceRepository.getAnnounceCount() } returns 1
 
-            viewModel = AnnounceStreamViewModel(reticulumProtocol, announceRepository, contactRepository, propagationNodeManager)
+            viewModel = AnnounceStreamViewModel(reticulumProtocol, announceRepository, contactRepository, propagationNodeManager, identityRepository)
             advanceUntilIdle()
 
             // Emit an announce
@@ -215,7 +246,7 @@ class AnnounceStreamViewModelTest {
             var count = 0
             coEvery { announceRepository.getAnnounceCount() } answers { ++count }
 
-            viewModel = AnnounceStreamViewModel(reticulumProtocol, announceRepository, contactRepository, propagationNodeManager)
+            viewModel = AnnounceStreamViewModel(reticulumProtocol, announceRepository, contactRepository, propagationNodeManager, identityRepository)
             advanceUntilIdle()
 
             // Emit multiple announces
@@ -251,7 +282,7 @@ class AnnounceStreamViewModelTest {
                 announceRepository.saveAnnounce(any(), any(), any(), any(), any(), any(), any(), any())
             } throws Exception("Database error")
 
-            viewModel = AnnounceStreamViewModel(reticulumProtocol, announceRepository, contactRepository, propagationNodeManager)
+            viewModel = AnnounceStreamViewModel(reticulumProtocol, announceRepository, contactRepository, propagationNodeManager, identityRepository)
             advanceUntilIdle()
 
             // Emit an announce - should not crash
@@ -272,7 +303,7 @@ class AnnounceStreamViewModelTest {
         runTest {
             networkStatusFlow.value = NetworkStatus.READY
 
-            viewModel = AnnounceStreamViewModel(reticulumProtocol, announceRepository, contactRepository, propagationNodeManager)
+            viewModel = AnnounceStreamViewModel(reticulumProtocol, announceRepository, contactRepository, propagationNodeManager, identityRepository)
             advanceUntilIdle()
 
             // Trigger the flow by collecting the first emission
@@ -289,7 +320,7 @@ class AnnounceStreamViewModelTest {
             // Start with INITIALIZING
             networkStatusFlow.value = NetworkStatus.INITIALIZING
 
-            viewModel = AnnounceStreamViewModel(reticulumProtocol, announceRepository, contactRepository, propagationNodeManager)
+            viewModel = AnnounceStreamViewModel(reticulumProtocol, announceRepository, contactRepository, propagationNodeManager, identityRepository)
 
             viewModel.initializationStatus.test {
                 assertEquals("Reticulum managed by app", awaitItem())
@@ -315,7 +346,7 @@ class AnnounceStreamViewModelTest {
                     appData = "MyCustomNode".toByteArray(),
                 )
 
-            viewModel = AnnounceStreamViewModel(reticulumProtocol, announceRepository, contactRepository, propagationNodeManager)
+            viewModel = AnnounceStreamViewModel(reticulumProtocol, announceRepository, contactRepository, propagationNodeManager, identityRepository)
             advanceUntilIdle()
 
             announceFlow.emit(announceWithName)
@@ -341,7 +372,7 @@ class AnnounceStreamViewModelTest {
         runTest {
             networkStatusFlow.value = NetworkStatus.READY
 
-            viewModel = AnnounceStreamViewModel(reticulumProtocol, announceRepository, contactRepository, propagationNodeManager)
+            viewModel = AnnounceStreamViewModel(reticulumProtocol, announceRepository, contactRepository, propagationNodeManager, identityRepository)
             advanceUntilIdle()
 
             // Check default filter
@@ -360,7 +391,7 @@ class AnnounceStreamViewModelTest {
             // Mock both PEER (default) and the types we'll filter by
             every { announceRepository.getAnnouncesPaged(any(), any()) } returns flowOf(PagingData.empty())
 
-            viewModel = AnnounceStreamViewModel(reticulumProtocol, announceRepository, contactRepository, propagationNodeManager)
+            viewModel = AnnounceStreamViewModel(reticulumProtocol, announceRepository, contactRepository, propagationNodeManager, identityRepository)
             advanceUntilIdle()
 
             // Update filter to NODE and PROPAGATION_NODE
@@ -388,7 +419,7 @@ class AnnounceStreamViewModelTest {
         runTest {
             networkStatusFlow.value = NetworkStatus.READY
 
-            viewModel = AnnounceStreamViewModel(reticulumProtocol, announceRepository, contactRepository, propagationNodeManager)
+            viewModel = AnnounceStreamViewModel(reticulumProtocol, announceRepository, contactRepository, propagationNodeManager, identityRepository)
             advanceUntilIdle()
 
             // Set empty filter
@@ -415,7 +446,7 @@ class AnnounceStreamViewModelTest {
         runTest {
             networkStatusFlow.value = NetworkStatus.READY
 
-            viewModel = AnnounceStreamViewModel(reticulumProtocol, announceRepository, contactRepository, propagationNodeManager)
+            viewModel = AnnounceStreamViewModel(reticulumProtocol, announceRepository, contactRepository, propagationNodeManager, identityRepository)
             advanceUntilIdle()
 
             // Set search query
@@ -428,5 +459,261 @@ class AnnounceStreamViewModelTest {
 
             // Verify repository was called with search query
             verify { announceRepository.getAnnouncesPaged(listOf("PEER"), "Alice") }
+        }
+
+    // ========== Manual Announce Tests ==========
+
+    @Test
+    fun `triggerAnnounce succeeds with ServiceReticulumProtocol`() =
+        runTest {
+            networkStatusFlow.value = NetworkStatus.READY
+
+            // Use ServiceReticulumProtocol instead of base ReticulumProtocol
+            viewModel = AnnounceStreamViewModel(serviceReticulumProtocol, announceRepository, contactRepository, propagationNodeManager, identityRepository)
+            advanceUntilIdle()
+
+            // Initial state
+            assertFalse(viewModel.isAnnouncing.value)
+            assertFalse(viewModel.announceSuccess.value)
+            assertNull(viewModel.announceError.value)
+
+            // Trigger announce and run only until the triggerAutoAnnounce completes
+            // (don't advance past the 3-second auto-dismiss delay)
+            viewModel.triggerAnnounce()
+            runCurrent() // Start the coroutine
+            advanceTimeBy(100) // Advance a small amount to let the coroutine complete
+            runCurrent()
+
+            // Verify methods were called
+            coVerify { identityRepository.getActiveIdentitySync() }
+            coVerify { serviceReticulumProtocol.triggerAutoAnnounce("TestUser") }
+
+            // Verify success state (before auto-dismiss kicks in)
+            assertFalse("Expected isAnnouncing=false", viewModel.isAnnouncing.value)
+            assertTrue("Expected announceSuccess=true", viewModel.announceSuccess.value)
+            assertNull("Expected no error", viewModel.announceError.value)
+        }
+
+    @Test
+    fun `triggerAnnounce fails when ServiceReticulumProtocol returns error`() =
+        runTest {
+            networkStatusFlow.value = NetworkStatus.READY
+            coEvery { serviceReticulumProtocol.triggerAutoAnnounce(any()) } returns Result.failure(Exception("Network error"))
+
+            viewModel = AnnounceStreamViewModel(serviceReticulumProtocol, announceRepository, contactRepository, propagationNodeManager, identityRepository)
+            advanceUntilIdle()
+
+            // Trigger announce (don't advance past auto-dismiss)
+            viewModel.triggerAnnounce()
+            runCurrent()
+            advanceTimeBy(100)
+            runCurrent()
+
+            // Verify error state
+            assertFalse(viewModel.isAnnouncing.value)
+            assertFalse(viewModel.announceSuccess.value)
+            assertEquals("Network error", viewModel.announceError.value)
+        }
+
+    @Test
+    fun `triggerAnnounce fails when not using ServiceReticulumProtocol`() =
+        runTest {
+            networkStatusFlow.value = NetworkStatus.READY
+
+            // Use base ReticulumProtocol (not ServiceReticulumProtocol)
+            viewModel = AnnounceStreamViewModel(reticulumProtocol, announceRepository, contactRepository, propagationNodeManager, identityRepository)
+            advanceUntilIdle()
+
+            // Trigger announce (don't advance past auto-dismiss)
+            viewModel.triggerAnnounce()
+            runCurrent()
+            advanceTimeBy(100)
+            runCurrent()
+
+            // Verify error state - service not available
+            assertFalse(viewModel.isAnnouncing.value)
+            assertFalse(viewModel.announceSuccess.value)
+            assertEquals("Service not available", viewModel.announceError.value)
+        }
+
+    @Test
+    fun `triggerAnnounce uses Unknown when no active identity`() =
+        runTest {
+            networkStatusFlow.value = NetworkStatus.READY
+            coEvery { identityRepository.getActiveIdentitySync() } returns null
+
+            viewModel = AnnounceStreamViewModel(serviceReticulumProtocol, announceRepository, contactRepository, propagationNodeManager, identityRepository)
+            advanceUntilIdle()
+
+            // Trigger announce (don't advance past auto-dismiss)
+            viewModel.triggerAnnounce()
+            runCurrent()
+            advanceTimeBy(100)
+            runCurrent()
+
+            // Verify triggerAutoAnnounce was called with "Unknown"
+            coVerify { serviceReticulumProtocol.triggerAutoAnnounce("Unknown") }
+        }
+
+    @Test
+    fun `triggerAnnounce sets isAnnouncing during execution`() =
+        runTest {
+            networkStatusFlow.value = NetworkStatus.READY
+
+            viewModel = AnnounceStreamViewModel(serviceReticulumProtocol, announceRepository, contactRepository, propagationNodeManager, identityRepository)
+            advanceUntilIdle()
+
+            // Capture isAnnouncing states during execution
+            viewModel.isAnnouncing.test {
+                // Initial state
+                assertFalse(awaitItem())
+
+                // Trigger announce and advance to capture intermediate state
+                viewModel.triggerAnnounce()
+                runCurrent()
+
+                // Should be announcing
+                assertTrue(awaitItem())
+
+                // Complete the coroutine
+                advanceUntilIdle()
+
+                // Should be done announcing
+                assertFalse(awaitItem())
+
+                cancelAndConsumeRemainingEvents()
+            }
+        }
+
+    @Test
+    fun `clearAnnounceStatus resets success and error`() =
+        runTest {
+            networkStatusFlow.value = NetworkStatus.READY
+
+            viewModel = AnnounceStreamViewModel(serviceReticulumProtocol, announceRepository, contactRepository, propagationNodeManager, identityRepository)
+            advanceUntilIdle()
+
+            // Trigger successful announce (don't advance past auto-dismiss)
+            viewModel.triggerAnnounce()
+            runCurrent()
+            advanceTimeBy(100)
+            runCurrent()
+
+            assertTrue(viewModel.announceSuccess.value)
+
+            // Clear status
+            viewModel.clearAnnounceStatus()
+
+            assertFalse(viewModel.announceSuccess.value)
+            assertNull(viewModel.announceError.value)
+        }
+
+    @Test
+    fun `clearAnnounceStatus resets error state`() =
+        runTest {
+            networkStatusFlow.value = NetworkStatus.READY
+            coEvery { serviceReticulumProtocol.triggerAutoAnnounce(any()) } returns Result.failure(Exception("Test error"))
+
+            viewModel = AnnounceStreamViewModel(serviceReticulumProtocol, announceRepository, contactRepository, propagationNodeManager, identityRepository)
+            advanceUntilIdle()
+
+            // Trigger failed announce (don't advance past auto-dismiss)
+            viewModel.triggerAnnounce()
+            runCurrent()
+            advanceTimeBy(100)
+            runCurrent()
+
+            assertEquals("Test error", viewModel.announceError.value)
+
+            // Clear status
+            viewModel.clearAnnounceStatus()
+
+            assertFalse(viewModel.announceSuccess.value)
+            assertNull(viewModel.announceError.value)
+        }
+
+    @Test
+    fun `triggerAnnounce handles exception gracefully`() =
+        runTest {
+            networkStatusFlow.value = NetworkStatus.READY
+            coEvery { identityRepository.getActiveIdentitySync() } throws RuntimeException("Database error")
+
+            viewModel = AnnounceStreamViewModel(serviceReticulumProtocol, announceRepository, contactRepository, propagationNodeManager, identityRepository)
+            advanceUntilIdle()
+
+            // Trigger announce - should not crash (don't advance past auto-dismiss)
+            viewModel.triggerAnnounce()
+            runCurrent()
+            advanceTimeBy(100)
+            runCurrent()
+
+            // Verify error state is set
+            assertFalse(viewModel.isAnnouncing.value)
+            assertEquals("Database error", viewModel.announceError.value)
+        }
+
+    @Test
+    fun `announce success auto-dismisses after delay`() =
+        runTest {
+            networkStatusFlow.value = NetworkStatus.READY
+
+            viewModel = AnnounceStreamViewModel(serviceReticulumProtocol, announceRepository, contactRepository, propagationNodeManager, identityRepository)
+            advanceUntilIdle()
+
+            // Trigger announce and let it complete but NOT auto-dismiss
+            viewModel.triggerAnnounce()
+            runCurrent()
+            advanceTimeBy(100)
+            runCurrent()
+
+            // Success should be set
+            assertTrue(viewModel.announceSuccess.value)
+
+            // Advance time past the 3 second auto-dismiss (remaining ~2900ms)
+            advanceTimeBy(3000)
+            runCurrent()
+
+            // Success should be auto-cleared
+            assertFalse(viewModel.announceSuccess.value)
+        }
+
+    @Test
+    fun `announce error auto-dismisses after delay`() =
+        runTest {
+            networkStatusFlow.value = NetworkStatus.READY
+            coEvery { serviceReticulumProtocol.triggerAutoAnnounce(any()) } returns Result.failure(Exception("Network error"))
+
+            viewModel = AnnounceStreamViewModel(serviceReticulumProtocol, announceRepository, contactRepository, propagationNodeManager, identityRepository)
+            advanceUntilIdle()
+
+            // Trigger announce and let it complete but NOT auto-dismiss
+            viewModel.triggerAnnounce()
+            runCurrent()
+            advanceTimeBy(100)
+            runCurrent()
+
+            // Error should be set
+            assertEquals("Network error", viewModel.announceError.value)
+
+            // Advance time past the 5 second auto-dismiss (remaining ~4900ms)
+            advanceTimeBy(5000)
+            runCurrent()
+
+            // Error should be auto-cleared
+            assertNull(viewModel.announceError.value)
+        }
+
+    @Test
+    fun `initial announce state is correct`() =
+        runTest {
+            networkStatusFlow.value = NetworkStatus.READY
+
+            viewModel = AnnounceStreamViewModel(serviceReticulumProtocol, announceRepository, contactRepository, propagationNodeManager, identityRepository)
+            advanceUntilIdle()
+
+            // Verify initial state
+            assertFalse(viewModel.isAnnouncing.value)
+            assertFalse(viewModel.announceSuccess.value)
+            assertNull(viewModel.announceError.value)
         }
 }


### PR DESCRIPTION
## Summary

Adds an announce button to the top bar of the Discovered Nodes (Announces) screen, allowing users to trigger an immediate announce directly from the screen without navigating to Settings.

- Adds a Campaign (megaphone) icon button to the top bar next to the filter button
- Shows a loading spinner while the announce is in progress
- Displays Toast feedback on success ("Announce sent!") or error
- Implements the same announce mechanism as the "Announce Now" button in Settings

## Changes

### AnnounceStreamViewModel
- Added `IdentityRepository` dependency to retrieve display name
- Added state flows: `isAnnouncing`, `announceSuccess`, `announceError`
- Added `triggerAnnounce()` function that calls `ServiceReticulumProtocol.triggerAutoAnnounce()`
- Added `clearAnnounceStatus()` function with auto-dismiss behavior (3s for success, 5s for error)
- Added `@Suppress("TooManyFunctions")` annotation as ViewModels naturally have many UI interaction functions

### AnnounceStreamScreen
- Added Campaign icon button to `SearchableTopAppBar` `additionalActions`
- Added `CircularProgressIndicator` during announce operation
- Added Toast notifications for success/error feedback
- Added `LaunchedEffect` hooks for Toast display

### Unit Tests
Added 11 comprehensive tests covering:
- ✅ Success path with ServiceReticulumProtocol
- ✅ Error handling when protocol returns failure
- ✅ Fallback when not using ServiceReticulumProtocol ("Service not available")
- ✅ Fallback display name ("Unknown") when no active identity
- ✅ Loading state transitions (isAnnouncing flag)
- ✅ Manual status clearing
- ✅ Exception handling
- ✅ Auto-dismiss after 3 seconds (success)
- ✅ Auto-dismiss after 5 seconds (error)
- ✅ Initial state verification

## Test plan

- [x] Open the Discovered Nodes screen
- [x] Verify the Campaign (megaphone) icon appears in the top bar (left of filter icon)
- [x] Tap the announce button
- [x] Verify the button shows a loading spinner while announcing
- [x] Verify "Announce sent!" Toast appears on success
- [x] Verify the Toast auto-dismisses after ~3 seconds
- [x] Test error case by disconnecting network and tapping announce
- [x] Verify error Toast appears and auto-dismisses after ~5 seconds

Closes #71

🤖 Generated with [Claude Code](https://claude.com/claude-code)