### PR TITLE
fix: Prevent duplicate interface names that cause service freeze

### DIFF
--- a/app/src/main/java/com/lxmf/messenger/util/validation/InputValidator.kt
+++ b/app/src/main/java/com/lxmf/messenger/util/validation/InputValidator.kt
@@ -372,6 +372,36 @@ object InputValidator {
     }
 
     /**
+     * Validates that an interface name is unique among existing interfaces.
+     *
+     * RNS config files use section names like [[Interface Name]], so duplicate names
+     * will cause config parsing errors that crash the service.
+     *
+     * @param name The interface name to validate
+     * @param existingNames List of names already in use by other interfaces
+     * @param excludeName Optional name to exclude from the check (for editing existing interfaces)
+     * @return ValidationResult.Success if unique, or ValidationResult.Error if duplicate
+     */
+    fun validateInterfaceNameUniqueness(
+        name: String,
+        existingNames: List<String>,
+        excludeName: String? = null,
+    ): ValidationResult<String> {
+        val trimmed = name.trim()
+        val namesToCheck = if (excludeName != null) {
+            existingNames.filter { it != excludeName }
+        } else {
+            existingNames
+        }
+
+        return if (namesToCheck.any { it.equals(trimmed, ignoreCase = true) }) {
+            ValidationResult.Error("An interface with this name already exists")
+        } else {
+            ValidationResult.Success(trimmed)
+        }
+    }
+
+    /**
      * Validates a BLE device name.
      *
      * Checks:

--- a/app/src/main/java/com/lxmf/messenger/viewmodel/InterfaceManagementViewModel.kt
+++ b/app/src/main/java/com/lxmf/messenger/viewmodel/InterfaceManagementViewModel.kt
@@ -548,6 +548,28 @@ class InterfaceManagementViewModel
                 }
             }
 
+            // VALIDATION: Check for duplicate interface names
+            // RNS config uses section names like [[Interface Name]], so duplicates cause parsing errors
+            if (isValid) { // Only check if name is otherwise valid
+                val existingNames = _state.value.interfaces.map { it.name }
+                val excludeName = _state.value.editingInterface?.name
+                when (
+                    val uniqueResult = InputValidator.validateInterfaceNameUniqueness(
+                        config.name,
+                        existingNames,
+                        excludeName,
+                    )
+                ) {
+                    is ValidationResult.Error -> {
+                        _configState.value = _configState.value.copy(nameError = uniqueResult.message)
+                        isValid = false
+                    }
+                    is ValidationResult.Success -> {
+                        // Name is unique, keep any previous success state
+                    }
+                }
+            }
+
             // Type-specific validation
             when (config.type) {
                 "TCPClient" -> {

--- a/app/src/test/java/com/lxmf/messenger/util/validation/InputValidatorTest.kt
+++ b/app/src/test/java/com/lxmf/messenger/util/validation/InputValidatorTest.kt
@@ -331,6 +331,68 @@ class InputValidatorTest {
         assertTrue(result is ValidationResult.Error)
     }
 
+    // ========== INTERFACE NAME UNIQUENESS TESTS ==========
+
+    @Test
+    fun `validateInterfaceNameUniqueness - unique name passes`() {
+        val existingNames = listOf("TCP Client 1", "RNode LoRa", "AutoInterface")
+        val result = InputValidator.validateInterfaceNameUniqueness("TCP Client 2", existingNames)
+        assertTrue(result is ValidationResult.Success)
+    }
+
+    @Test
+    fun `validateInterfaceNameUniqueness - duplicate name fails`() {
+        val existingNames = listOf("TCP Client 1", "RNode LoRa", "AutoInterface")
+        val result = InputValidator.validateInterfaceNameUniqueness("RNode LoRa", existingNames)
+        assertTrue(result is ValidationResult.Error)
+        assertTrue((result as ValidationResult.Error).message.contains("already exists"))
+    }
+
+    @Test
+    fun `validateInterfaceNameUniqueness - case insensitive duplicate fails`() {
+        val existingNames = listOf("TCP Client 1", "RNode LoRa", "AutoInterface")
+        val result = InputValidator.validateInterfaceNameUniqueness("rnode lora", existingNames)
+        assertTrue(result is ValidationResult.Error)
+    }
+
+    @Test
+    fun `validateInterfaceNameUniqueness - excludeName allows editing same interface`() {
+        val existingNames = listOf("TCP Client 1", "RNode LoRa", "AutoInterface")
+        // When editing "RNode LoRa", we should exclude it from the duplicate check
+        val result = InputValidator.validateInterfaceNameUniqueness(
+            "RNode LoRa",
+            existingNames,
+            excludeName = "RNode LoRa",
+        )
+        assertTrue(result is ValidationResult.Success)
+    }
+
+    @Test
+    fun `validateInterfaceNameUniqueness - excludeName still catches other duplicates`() {
+        val existingNames = listOf("TCP Client 1", "RNode LoRa", "AutoInterface")
+        // When editing "TCP Client 1" but trying to rename to "RNode LoRa"
+        val result = InputValidator.validateInterfaceNameUniqueness(
+            "RNode LoRa",
+            existingNames,
+            excludeName = "TCP Client 1",
+        )
+        assertTrue(result is ValidationResult.Error)
+    }
+
+    @Test
+    fun `validateInterfaceNameUniqueness - trims whitespace before comparison`() {
+        val existingNames = listOf("TCP Client 1", "RNode LoRa")
+        val result = InputValidator.validateInterfaceNameUniqueness("  RNode LoRa  ", existingNames)
+        assertTrue(result is ValidationResult.Error)
+    }
+
+    @Test
+    fun `validateInterfaceNameUniqueness - empty existing names passes`() {
+        val existingNames = emptyList<String>()
+        val result = InputValidator.validateInterfaceNameUniqueness("Any Name", existingNames)
+        assertTrue(result is ValidationResult.Success)
+    }
+
     // ========== DEVICE NAME VALIDATION TESTS ==========
 
     @Test


### PR DESCRIPTION
## Summary

Fixes a bug where creating an interface with a duplicate name would cause the Reticulum service to freeze/crash due to config parsing errors.

## Problem

RNS (Reticulum Network Stack) config files use INI-style section names like `[[Interface Name]]` to identify each interface. When a user creates two interfaces with the same name:

1. The config file ends up with duplicate section headers
2. RNS config parser fails to parse the malformed config
3. The service crashes or freezes, requiring the user to manually edit config files to recover

This was particularly problematic because:
- The UI gave no warning about duplicate names
- Users could accidentally use the same name (e.g., multiple "TCP Connection" interfaces)
- Case variations like "RNode" vs "rnode" would also cause issues since RNS may treat them as duplicates

## Solution

Add proactive validation to prevent duplicate interface names before they're saved:

- **New validation function**: `InputValidator.validateInterfaceNameUniqueness()` performs case-insensitive comparison against existing interface names
- **Validation in all entry points**: Added uniqueness checks in:
  - `InterfaceManagementViewModel` - for the general interface editor
  - `RNodeWizardViewModel` - for the RNode setup wizard
  - `TcpClientWizardViewModel` - for the TCP client wizard
- **Edit-aware validation**: When editing an existing interface, the current name is excluded from the duplicate check (so you can keep the same name)

## Changes

| File | Change |
|------|--------|
| `InputValidator.kt` | Added `validateInterfaceNameUniqueness()` with case-insensitive matching and optional exclusion for editing |
| `InterfaceManagementViewModel.kt` | Added uniqueness validation in `validateConfiguration()` |
| `RNodeWizardViewModel.kt` | Added uniqueness check before saving in `saveConfiguration()` |
| `TcpClientWizardViewModel.kt` | Added uniqueness check before saving in `saveConfiguration()` |
| `InputValidatorTest.kt` | 7 new tests covering uniqueness validation edge cases |
| `RNodeWizardViewModelTest.kt` | Added mock for `interfaceRepository.allInterfaces` |
| `TcpClientWizardViewModelTest.kt` | Added mock for `interfaceRepository.allInterfaces` |

## Test Plan

- [x] Unit tests for `validateInterfaceNameUniqueness()`:
  - Unique name passes validation
  - Exact duplicate fails with error message
  - Case-insensitive duplicate fails (e.g., "RNode" vs "rnode")
  - `excludeName` parameter allows editing existing interface
  - `excludeName` still catches duplicates of *other* interfaces
  - Whitespace is trimmed before comparison
  - Empty existing names list passes
- [x] Existing tests still pass with new mocks

## Manual Testing

1. Create a TCP interface named "Test Interface"
2. Try to create another TCP interface with the same name → Should show error
3. Try to create an RNode interface named "test interface" (lowercase) → Should show error
4. Edit "Test Interface" and save without changing name → Should succeed

🤖 Generated with [Claude Code](https://claude.com/claude-code)