### PR TITLE
test: Fix flaky DebugViewModelEventDrivenTest

### DIFF
--- a/app/src/test/java/com/lxmf/messenger/viewmodel/DebugViewModelEventDrivenTest.kt
+++ b/app/src/test/java/com/lxmf/messenger/viewmodel/DebugViewModelEventDrivenTest.kt
@@ -18,7 +18,7 @@ import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.flowOf
-import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
 import kotlinx.coroutines.test.advanceUntilIdle
 import kotlinx.coroutines.test.resetMain
 import kotlinx.coroutines.test.runTest
@@ -41,7 +41,7 @@ import org.junit.Test
  */
 @OptIn(ExperimentalCoroutinesApi::class)
 class DebugViewModelEventDrivenTest {
-    private val testDispatcher = StandardTestDispatcher()
+    private val testDispatcher = UnconfinedTestDispatcher()
 
     private lateinit var mockProtocol: ServiceReticulumProtocol
     private lateinit var mockSettingsRepo: SettingsRepository


### PR DESCRIPTION
## Summary
- Fix flaky `DebugViewModelEventDrivenTest` that fails in CI with `UncaughtExceptionsBeforeTest`
- Change from `StandardTestDispatcher` to `UnconfinedTestDispatcher` to match pattern used in other ViewModel tests

## Root Cause
`StandardTestDispatcher` doesn't execute `viewModelScope` coroutines immediately, causing exceptions in coroutines to be detected as "uncaught" even though they're properly caught in try/catch blocks.

## Changes
- Replace `StandardTestDispatcher` with `UnconfinedTestDispatcher` in `DebugViewModelEventDrivenTest`
- Matches the pattern used in `SettingsViewModelTest` and other ViewModel tests

## Test plan
- [x] DebugViewModelEventDrivenTest passes locally
- [ ] CI tests pass without UncaughtExceptionsBeforeTest error

🤖 Generated with [Claude Code](https://claude.com/claude-code)