### PR TITLE
Modified default Norwegian RNode parameters

### DIFF
--- a/app/src/main/java/com/lxmf/messenger/data/model/RNodeRegionalPreset.kt
+++ b/app/src/main/java/com/lxmf/messenger/data/model/RNodeRegionalPreset.kt
@@ -872,12 +872,12 @@ object RNodeRegionalPresets {
                 countryCode = "NO",
                 countryName = "Norway",
                 cityOrRegion = null,
-                frequency = 869525000,
-                bandwidth = 125000,
-                spreadingFactor = 8,
+                frequency = 869431250,
+                bandwidth = 62500,
+                spreadingFactor = 7,
                 codingRate = 5,
                 txPower = 14,
-                description = "868 MHz EU band",
+                description = "Norway narrowband",
             ),
             // ==================== SINGAPORE ====================
             RNodeRegionalPreset(


### PR DESCRIPTION
The current default is unusable in most towns and cities due to RF noise. 
This narrowband setup is used by most RNode operators in Norway. 
It is a similar narrowband setup as meshtastic users in Norway, however this on a different frequency. 