### PR TITLE
feat: add configurable file attachment size limits

### DIFF
--- a/app/src/main/java/com/lxmf/messenger/ColumbaApplication.kt
+++ b/app/src/main/java/com/lxmf/messenger/ColumbaApplication.kt
@@ -255,9 +255,11 @@ class ColumbaApplication : Application() {
                     val preferOwnInstance = startupConfig.preferOwn
                     val rpcKey = startupConfig.rpcKey
                     val transportNodeEnabled = startupConfig.transport
+                    val maxInboundAttachmentSizeBytes = startupConfig.maxInboundAttachmentSizeBytes
                     android.util.Log.d("ColumbaApplication", "Loaded ${enabledInterfaces.size} enabled interface(s)")
                     android.util.Log.d("ColumbaApplication", "Prefer own instance: $preferOwnInstance")
                     android.util.Log.d("ColumbaApplication", "Transport node enabled: $transportNodeEnabled")
+                    android.util.Log.d("ColumbaApplication", "Max inbound attachment size: $maxInboundAttachmentSizeBytes bytes")
 
                     // Ensure identity file exists (recover from keyData if missing)
                     var identityPath: String? = null
@@ -297,6 +299,7 @@ class ColumbaApplication : Application() {
                             preferOwnInstance = preferOwnInstance,
                             rpcKey = rpcKey,
                             enableTransport = transportNodeEnabled,
+                            maxInboundAttachmentSizeBytes = maxInboundAttachmentSizeBytes,
                         )
 
                     reticulumProtocol.initialize(config)

--- a/app/src/main/java/com/lxmf/messenger/reticulum/protocol/ServiceReticulumProtocol.kt
+++ b/app/src/main/java/com/lxmf/messenger/reticulum/protocol/ServiceReticulumProtocol.kt
@@ -824,6 +824,9 @@ class ServiceReticulumProtocol(
         // Transport node setting
         json.put("enable_transport", config.enableTransport)
 
+        // Maximum inbound file attachment size (for security)
+        json.put("max_inbound_attachment_size", config.maxInboundAttachmentSizeBytes)
+
         return json.toString()
     }
 

--- a/app/src/main/java/com/lxmf/messenger/service/InterfaceConfigManager.kt
+++ b/app/src/main/java/com/lxmf/messenger/service/InterfaceConfigManager.kt
@@ -220,6 +220,11 @@ class InterfaceConfigManager
                 val transportNodeEnabled = settingsRepository.getTransportNodeEnabled()
                 Log.d(TAG, "Transport node enabled: $transportNodeEnabled")
 
+                // Load max inbound attachment size (security protection for incoming files)
+                val maxInboundAttachmentSizeKb = settingsRepository.maxInboundAttachmentSizeKbFlow.first()
+                val maxInboundAttachmentSizeBytes = maxInboundAttachmentSizeKb * 1024
+                Log.d(TAG, "Max inbound attachment size: $maxInboundAttachmentSizeKb KB ($maxInboundAttachmentSizeBytes bytes)")
+
                 val config =
                     ReticulumConfig(
                         storagePath = context.filesDir.absolutePath + "/reticulum",
@@ -231,6 +236,7 @@ class InterfaceConfigManager
                         preferOwnInstance = preferOwnInstance,
                         rpcKey = rpcKey,
                         enableTransport = transportNodeEnabled,
+                        maxInboundAttachmentSizeBytes = maxInboundAttachmentSizeBytes,
                     )
 
                 reticulumProtocol.initialize(config)

--- a/app/src/main/java/com/lxmf/messenger/service/manager/PythonWrapperManager.kt
+++ b/app/src/main/java/com/lxmf/messenger/service/manager/PythonWrapperManager.kt
@@ -308,6 +308,24 @@ class PythonWrapperManager(
     }
 
     /**
+     * Set maximum allowed size for inbound file attachments.
+     * Messages with file attachments exceeding this limit will have their attachments
+     * silently stripped (the message text will still be delivered).
+     *
+     * @param sizeBytes Maximum size in bytes (0 = unlimited)
+     */
+    fun setMaxInboundAttachmentSize(sizeBytes: Int) {
+        withWrapper { wrapper ->
+            try {
+                wrapper.callAttr("set_max_inbound_attachment_size", sizeBytes)
+                Log.d(TAG, "Max inbound attachment size set to $sizeBytes bytes")
+            } catch (e: Exception) {
+                Log.w(TAG, "Failed to set max inbound attachment size: ${e.message}", e)
+            }
+        }
+    }
+
+    /**
      * Set native Kotlin stamp generator callback.
      *
      * This bypasses Python multiprocessing-based stamp generation which fails on Android

--- a/app/src/main/java/com/lxmf/messenger/startup/StartupConfigLoader.kt
+++ b/app/src/main/java/com/lxmf/messenger/startup/StartupConfigLoader.kt
@@ -30,6 +30,7 @@ class StartupConfigLoader @Inject constructor(
         val preferOwn: Boolean,
         val rpcKey: String?,
         val transport: Boolean,
+        val maxInboundAttachmentSizeBytes: Int,
     )
 
     /**
@@ -44,6 +45,10 @@ class StartupConfigLoader @Inject constructor(
         val preferOwnDeferred = async { settingsRepository.preferOwnInstanceFlow.first() }
         val rpcKeyDeferred = async { settingsRepository.rpcKeyFlow.first() }
         val transportDeferred = async { settingsRepository.getTransportNodeEnabled() }
+        val maxInboundSizeDeferred = async {
+            // Convert KB to bytes
+            settingsRepository.maxInboundAttachmentSizeKbFlow.first() * 1024
+        }
 
         StartupConfig(
             interfaces = interfacesDeferred.await(),
@@ -51,6 +56,7 @@ class StartupConfigLoader @Inject constructor(
             preferOwn = preferOwnDeferred.await(),
             rpcKey = rpcKeyDeferred.await(),
             transport = transportDeferred.await(),
+            maxInboundAttachmentSizeBytes = maxInboundSizeDeferred.await(),
         )
     }
 }

--- a/app/src/main/java/com/lxmf/messenger/ui/screens/MessagingScreen.kt
+++ b/app/src/main/java/com/lxmf/messenger/ui/screens/MessagingScreen.kt
@@ -136,6 +136,7 @@ fun MessagingScreen(
     // File attachment state
     val selectedFileAttachments by viewModel.selectedFileAttachments.collectAsStateWithLifecycle()
     val totalAttachmentSize by viewModel.totalAttachmentSize.collectAsStateWithLifecycle()
+    val maxOutboundAttachmentSizeBytes by viewModel.maxOutboundAttachmentSizeBytes.collectAsStateWithLifecycle()
     val isProcessingFile by viewModel.isProcessingFile.collectAsStateWithLifecycle()
 
     // Observe loaded image IDs to trigger recomposition when images become available
@@ -521,6 +522,7 @@ fun MessagingScreen(
                     onClearImage = { viewModel.clearSelectedImage() },
                     selectedFileAttachments = selectedFileAttachments,
                     totalAttachmentSize = totalAttachmentSize,
+                    maxAttachmentSizeBytes = maxOutboundAttachmentSizeBytes,
                     isProcessingFile = isProcessingFile,
                     onFileAttachmentClick = { filePickerLauncher.launch(arrayOf("*/*")) },
                     onRemoveFileAttachment = { index -> viewModel.removeFileAttachment(index) },
@@ -819,6 +821,7 @@ fun MessageInputBar(
     onClearImage: () -> Unit = {},
     selectedFileAttachments: List<FileAttachment> = emptyList(),
     totalAttachmentSize: Int = 0,
+    maxAttachmentSizeBytes: Int = FileUtils.DEFAULT_MAX_TOTAL_ATTACHMENT_SIZE,
     isProcessingFile: Boolean = false,
     onFileAttachmentClick: () -> Unit = {},
     onRemoveFileAttachment: (Int) -> Unit = {},
@@ -836,6 +839,7 @@ fun MessageInputBar(
                     attachments = selectedFileAttachments,
                     totalSizeBytes = totalAttachmentSize,
                     onRemove = onRemoveFileAttachment,
+                    maxSizeBytes = maxAttachmentSizeBytes,
                 )
             }
 

--- a/app/src/test/java/com/lxmf/messenger/startup/StartupConfigLoaderTest.kt
+++ b/app/src/test/java/com/lxmf/messenger/startup/StartupConfigLoaderTest.kt
@@ -83,6 +83,7 @@ class StartupConfigLoaderTest {
         coEvery { settingsRepository.preferOwnInstanceFlow } returns flowOf(true)
         coEvery { settingsRepository.rpcKeyFlow } returns flowOf("test-rpc-key")
         coEvery { settingsRepository.getTransportNodeEnabled() } returns false
+        coEvery { settingsRepository.maxInboundAttachmentSizeKbFlow } returns flowOf(8192)
 
         // Act
         val config = loader.loadConfig()
@@ -94,6 +95,7 @@ class StartupConfigLoaderTest {
         assertTrue(config.preferOwn)
         assertEquals("test-rpc-key", config.rpcKey)
         assertFalse(config.transport)
+        assertEquals(8 * 1024 * 1024, config.maxInboundAttachmentSizeBytes)
     }
 
     @Test
@@ -104,6 +106,7 @@ class StartupConfigLoaderTest {
         coEvery { settingsRepository.preferOwnInstanceFlow } returns flowOf(false)
         coEvery { settingsRepository.rpcKeyFlow } returns flowOf(null)
         coEvery { settingsRepository.getTransportNodeEnabled() } returns true
+        coEvery { settingsRepository.maxInboundAttachmentSizeKbFlow } returns flowOf(8192)
 
         // Act
         val config = loader.loadConfig()
@@ -134,6 +137,7 @@ class StartupConfigLoaderTest {
         coEvery { settingsRepository.preferOwnInstanceFlow } returns flowOf(false)
         coEvery { settingsRepository.rpcKeyFlow } returns flowOf(null)
         coEvery { settingsRepository.getTransportNodeEnabled() } returns false
+        coEvery { settingsRepository.maxInboundAttachmentSizeKbFlow } returns flowOf(8192)
 
         // Act
         val config = loader.loadConfig()
@@ -154,6 +158,7 @@ class StartupConfigLoaderTest {
         coEvery { settingsRepository.preferOwnInstanceFlow } returns flowOf(false)
         coEvery { settingsRepository.rpcKeyFlow } returns flowOf(null)
         coEvery { settingsRepository.getTransportNodeEnabled() } returns false
+        coEvery { settingsRepository.maxInboundAttachmentSizeKbFlow } returns flowOf(8192)
 
         // Act
         loader.loadConfig()
@@ -165,6 +170,7 @@ class StartupConfigLoaderTest {
         coVerify(exactly = 1) { settingsRepository.preferOwnInstanceFlow }
         coVerify(exactly = 1) { settingsRepository.rpcKeyFlow }
         coVerify(exactly = 1) { settingsRepository.getTransportNodeEnabled() }
+        coVerify(exactly = 1) { settingsRepository.maxInboundAttachmentSizeKbFlow }
     }
 
     @Test
@@ -175,6 +181,7 @@ class StartupConfigLoaderTest {
         coEvery { settingsRepository.preferOwnInstanceFlow } returns flowOf(false)
         coEvery { settingsRepository.rpcKeyFlow } returns flowOf(null)
         coEvery { settingsRepository.getTransportNodeEnabled() } returns false
+        coEvery { settingsRepository.maxInboundAttachmentSizeKbFlow } returns flowOf(8192)
 
         // Act
         val config = loader.loadConfig()
@@ -198,6 +205,7 @@ class StartupConfigLoaderTest {
         coEvery { settingsRepository.preferOwnInstanceFlow } returns flowOf(true)
         coEvery { settingsRepository.rpcKeyFlow } returns flowOf("key")
         coEvery { settingsRepository.getTransportNodeEnabled() } returns true
+        coEvery { settingsRepository.maxInboundAttachmentSizeKbFlow } returns flowOf(8192)
 
         // Act
         val config = loader.loadConfig()
@@ -208,6 +216,7 @@ class StartupConfigLoaderTest {
         assertTrue(config.preferOwn)
         assertEquals("key", config.rpcKey)
         assertTrue(config.transport)
+        assertEquals(8 * 1024 * 1024, config.maxInboundAttachmentSizeBytes)
     }
 
     @Test
@@ -218,6 +227,7 @@ class StartupConfigLoaderTest {
             preferOwn = true,
             rpcKey = "key",
             transport = false,
+            maxInboundAttachmentSizeBytes = 8 * 1024 * 1024,
         )
         val config2 = StartupConfigLoader.StartupConfig(
             interfaces = listOf(testInterface),
@@ -225,6 +235,7 @@ class StartupConfigLoaderTest {
             preferOwn = true,
             rpcKey = "key",
             transport = false,
+            maxInboundAttachmentSizeBytes = 8 * 1024 * 1024,
         )
         val config3 = StartupConfigLoader.StartupConfig(
             interfaces = emptyList(),
@@ -232,6 +243,7 @@ class StartupConfigLoaderTest {
             preferOwn = false,
             rpcKey = null,
             transport = true,
+            maxInboundAttachmentSizeBytes = 0,
         )
 
         assertEquals(config1, config2)

--- a/app/src/test/java/com/lxmf/messenger/util/FileUtilsTest.kt
+++ b/app/src/test/java/com/lxmf/messenger/util/FileUtilsTest.kt
@@ -177,36 +177,48 @@ class FileUtilsTest {
 
     @Test
     fun `wouldExceedSizeLimit returns false when within limit`() {
-        assertFalse(FileUtils.wouldExceedSizeLimit(0, 100))
-        assertFalse(FileUtils.wouldExceedSizeLimit(256 * 1024, 256 * 1024))
-        assertFalse(FileUtils.wouldExceedSizeLimit(400 * 1024, 112 * 1024))
+        val maxSize = FileUtils.DEFAULT_MAX_TOTAL_ATTACHMENT_SIZE
+        assertFalse(FileUtils.wouldExceedSizeLimit(0, 100, maxSize))
+        assertFalse(FileUtils.wouldExceedSizeLimit(256 * 1024, 256 * 1024, maxSize))
+        assertFalse(FileUtils.wouldExceedSizeLimit(400 * 1024, 112 * 1024, maxSize))
     }
 
     @Test
     fun `wouldExceedSizeLimit returns false at exactly the limit`() {
-        val maxSize = FileUtils.MAX_TOTAL_ATTACHMENT_SIZE
-        assertFalse(FileUtils.wouldExceedSizeLimit(maxSize - 100, 100))
-        assertFalse(FileUtils.wouldExceedSizeLimit(0, maxSize))
+        val maxSize = FileUtils.DEFAULT_MAX_TOTAL_ATTACHMENT_SIZE
+        assertFalse(FileUtils.wouldExceedSizeLimit(maxSize - 100, 100, maxSize))
+        assertFalse(FileUtils.wouldExceedSizeLimit(0, maxSize, maxSize))
     }
 
     @Test
     fun `wouldExceedSizeLimit returns true when exceeding limit`() {
-        val maxSize = FileUtils.MAX_TOTAL_ATTACHMENT_SIZE
-        assertTrue(FileUtils.wouldExceedSizeLimit(maxSize, 1))
-        assertTrue(FileUtils.wouldExceedSizeLimit(maxSize - 100, 101))
-        assertTrue(FileUtils.wouldExceedSizeLimit(400 * 1024, 200 * 1024))
+        val maxSize = FileUtils.DEFAULT_MAX_TOTAL_ATTACHMENT_SIZE
+        assertTrue(FileUtils.wouldExceedSizeLimit(maxSize, 1, maxSize))
+        assertTrue(FileUtils.wouldExceedSizeLimit(maxSize - 100, 101, maxSize))
+        assertTrue(FileUtils.wouldExceedSizeLimit(400 * 1024, 200 * 1024, 500 * 1024))
     }
 
     // ========== Constants Tests ==========
 
     @Test
-    fun `MAX_TOTAL_ATTACHMENT_SIZE is 512KB`() {
-        assertEquals(512 * 1024, FileUtils.MAX_TOTAL_ATTACHMENT_SIZE)
+    fun `DEFAULT_MAX_TOTAL_ATTACHMENT_SIZE is 8MB`() {
+        assertEquals(8 * 1024 * 1024, FileUtils.DEFAULT_MAX_TOTAL_ATTACHMENT_SIZE)
     }
 
     @Test
-    fun `MAX_SINGLE_FILE_SIZE is 512KB`() {
-        assertEquals(512 * 1024, FileUtils.MAX_SINGLE_FILE_SIZE)
+    fun `DEFAULT_MAX_SINGLE_FILE_SIZE is 8MB`() {
+        assertEquals(8 * 1024 * 1024, FileUtils.DEFAULT_MAX_SINGLE_FILE_SIZE)
+    }
+
+    @Test
+    fun `SLOW_TRANSFER_WARNING_THRESHOLD is 1MB`() {
+        assertEquals(1024 * 1024, FileUtils.SLOW_TRANSFER_WARNING_THRESHOLD)
+    }
+
+    @Test
+    fun `wouldExceedSizeLimit with zero limit allows any size`() {
+        // 0 means unlimited
+        assertFalse(FileUtils.wouldExceedSizeLimit(100 * 1024 * 1024, 100 * 1024 * 1024, 0))
     }
 
     // ========== Additional getMimeTypeFromFilename Tests ==========

--- a/reticulum/src/main/java/com/lxmf/messenger/reticulum/model/ReticulumConfig.kt
+++ b/reticulum/src/main/java/com/lxmf/messenger/reticulum/model/ReticulumConfig.kt
@@ -27,6 +27,14 @@ data class ReticulumConfig(
      * When false, only handles its own traffic without relaying for other peers.
      */
     val enableTransport: Boolean = true,
+    /**
+     * Maximum allowed size for inbound file attachments in bytes.
+     * Messages with file attachments exceeding this limit will have their attachments
+     * silently stripped (the message text will still be delivered).
+     * Set to 0 for unlimited.
+     * Default: 8 MB (8 * 1024 * 1024)
+     */
+    val maxInboundAttachmentSizeBytes: Int = 8 * 1024 * 1024,
 )
 
 /**


### PR DESCRIPTION
## Summary
- Replace hard-coded 512KB file attachment size limit with configurable outbound and inbound limits
- Add warning banner for files >1MB to warn about slow mesh network transfers
- Implement inbound file size protection to prevent storage attacks from malicious senders

## Changes
- **SettingsRepository**: Add `maxOutboundAttachmentSizeKbFlow` and `maxInboundAttachmentSizeKbFlow` settings (default 8MB each)
- **FileUtils**: Update limits to 8MB defaults, add `SLOW_TRANSFER_WARNING_THRESHOLD` (1MB), make `wouldExceedSizeLimit` accept dynamic limit
- **FileAttachmentPreviewRow**: Add `SlowTransferWarningBanner` composable showing warning when total attachment size exceeds 1MB
- **MessagingViewModel**: Use configurable outbound limit from settings
- **Python wrapper**: Validate inbound file attachments against configured limit, silently strip oversized attachments (message text still delivered)
- **Config flow**: Pass inbound limit from Kotlin to Python via ReticulumConfig JSON

## Test plan
- [x] Unit tests for FileUtils (dynamic limits, warning threshold)
- [x] Unit tests for MessagingViewModel (configurable limit enforcement)
- [x] Unit tests for StartupConfigLoader (inbound limit in config)
- [ ] Manual testing: attach file >1MB, verify warning banner appears
- [ ] Manual testing: verify files up to 8MB can be attached (previously limited to 512KB)

🤖 Generated with [Claude Code](https://claude.com/claude-code)