### PR TITLE
Fix notification issue

### DIFF
--- a/app/src/main/java/com/lxmf/messenger/service/manager/ServiceNotificationManager.kt
+++ b/app/src/main/java/com/lxmf/messenger/service/manager/ServiceNotificationManager.kt
@@ -46,7 +46,7 @@ class ServiceNotificationManager(
                 NotificationChannel(
                     CHANNEL_ID,
                     CHANNEL_NAME,
-                    NotificationManager.IMPORTANCE_DEFAULT,
+                    NotificationManager.IMPORTANCE_LOW,
                 ).apply {
                     description = "Keeps Reticulum network running in background"
                     setShowBadge(false)


### PR DESCRIPTION
On Android 16 QPR2, notifications with IMPORTANCE_DEFAULT appear in the main notification area instead of the background services section. Changing to IMPORTANCE_LOW ensures the foreground service icon appears below the "Silent" indicator alongside other persistent services.

Fixes #141