### PR TITLE
feat: make location permission card dismissable on map screen

### DIFF
--- a/app/src/main/java/com/lxmf/messenger/util/LocationPermissionManager.kt
+++ b/app/src/main/java/com/lxmf/messenger/util/LocationPermissionManager.kt
@@ -130,6 +130,11 @@ object LocationPermissionManager {
                     "Location data, like all data on Columba, is encrypted end to end, " +
                     "never stored on a central server, and is only readable by the contacts you send it to.",
             )
+            appendLine()
+            appendLine(
+                "Columba will not and can not share your location with anyone until you actively " +
+                    "send it to someone. Your location is always encrypted safely over Reticulum.",
+            )
         }
     }
 

--- a/app/src/main/java/com/lxmf/messenger/viewmodel/MapViewModel.kt
+++ b/app/src/main/java/com/lxmf/messenger/viewmodel/MapViewModel.kt
@@ -64,6 +64,7 @@ data class ContactMarker(
 data class MapState(
     val userLocation: Location? = null,
     val hasLocationPermission: Boolean = false,
+    val isPermissionCardDismissed: Boolean = false,
     val contactMarkers: List<ContactMarker> = emptyList(),
     val isLoading: Boolean = true,
     val errorMessage: String? = null,
@@ -239,6 +240,16 @@ class MapViewModel
         fun clearError() {
             _state.update { currentState ->
                 currentState.copy(errorMessage = null)
+            }
+        }
+
+        /**
+         * Dismiss the location permission card for this session.
+         * User can still trigger permission request via My Location button.
+         */
+        fun dismissPermissionCard() {
+            _state.update { currentState ->
+                currentState.copy(isPermissionCardDismissed = true)
             }
         }
 

--- a/app/src/test/java/com/lxmf/messenger/ui/screens/EmptyMapStateCardTest.kt
+++ b/app/src/test/java/com/lxmf/messenger/ui/screens/EmptyMapStateCardTest.kt
@@ -1,0 +1,110 @@
+package com.lxmf.messenger.ui.screens
+
+import android.app.Application
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.onNodeWithContentDescription
+import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.performClick
+import com.lxmf.messenger.test.RegisterComponentActivityRule
+import org.junit.Assert.assertTrue
+import org.junit.Rule
+import org.junit.Test
+import org.junit.rules.RuleChain
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+
+/**
+ * UI tests for EmptyMapStateCard.
+ *
+ * Tests:
+ * - Displays location permission required message
+ * - Displays dismiss button
+ * - Dismiss button invokes callback
+ */
+@RunWith(RobolectricTestRunner::class)
+@Config(sdk = [34], application = Application::class)
+class EmptyMapStateCardTest {
+    private val registerActivityRule = RegisterComponentActivityRule()
+    private val composeRule = createComposeRule()
+
+    @get:Rule
+    val ruleChain: RuleChain = RuleChain.outerRule(registerActivityRule).around(composeRule)
+
+    val composeTestRule get() = composeRule
+
+    // ========== Display Tests ==========
+
+    @Test
+    fun `emptyMapStateCard displays title text`() {
+        composeTestRule.setContent {
+            EmptyMapStateCard(
+                contactCount = 0,
+                onDismiss = {},
+            )
+        }
+
+        composeTestRule.onNodeWithText("Location permission required").assertIsDisplayed()
+    }
+
+    @Test
+    fun `emptyMapStateCard displays description text`() {
+        composeTestRule.setContent {
+            EmptyMapStateCard(
+                contactCount = 0,
+                onDismiss = {},
+            )
+        }
+
+        composeTestRule.onNodeWithText("Enable location access to see your position on the map.")
+            .assertIsDisplayed()
+    }
+
+    @Test
+    fun `emptyMapStateCard displays dismiss button`() {
+        composeTestRule.setContent {
+            EmptyMapStateCard(
+                contactCount = 0,
+                onDismiss = {},
+            )
+        }
+
+        composeTestRule.onNodeWithContentDescription("Dismiss").assertIsDisplayed()
+    }
+
+    // ========== Callback Tests ==========
+
+    @Test
+    fun `emptyMapStateCard dismiss button invokes callback`() {
+        var dismissed = false
+
+        composeTestRule.setContent {
+            EmptyMapStateCard(
+                contactCount = 0,
+                onDismiss = { dismissed = true },
+            )
+        }
+
+        composeTestRule.onNodeWithContentDescription("Dismiss").performClick()
+
+        assertTrue(dismissed)
+    }
+
+    @Test
+    fun `emptyMapStateCard dismiss button can be clicked multiple times`() {
+        var dismissCount = 0
+
+        composeTestRule.setContent {
+            EmptyMapStateCard(
+                contactCount = 0,
+                onDismiss = { dismissCount++ },
+            )
+        }
+
+        composeTestRule.onNodeWithContentDescription("Dismiss").performClick()
+        composeTestRule.onNodeWithContentDescription("Dismiss").performClick()
+
+        assertTrue(dismissCount >= 2)
+    }
+}

--- a/app/src/test/java/com/lxmf/messenger/viewmodel/MapViewModelTest.kt
+++ b/app/src/test/java/com/lxmf/messenger/viewmodel/MapViewModelTest.kt
@@ -175,6 +175,55 @@ class MapViewModelTest {
         assertNull(viewModel.state.value.errorMessage)
     }
 
+    // ===== dismissPermissionCard Tests =====
+
+    @Test
+    fun `initial state has permission card not dismissed`() = runTest {
+        viewModel = MapViewModel(contactRepository, receivedLocationDao, locationSharingManager, announceDao)
+
+        viewModel.state.test {
+            val state = awaitItem()
+            assertFalse(state.isPermissionCardDismissed)
+        }
+    }
+
+    @Test
+    fun `dismissPermissionCard updates state to dismissed`() = runTest {
+        viewModel = MapViewModel(contactRepository, receivedLocationDao, locationSharingManager, announceDao)
+
+        viewModel.state.test {
+            // Consume initial state
+            awaitItem()
+
+            viewModel.dismissPermissionCard()
+
+            val updatedState = awaitItem()
+            assertTrue(updatedState.isPermissionCardDismissed)
+        }
+    }
+
+    @Test
+    fun `dismissed state persists after permission granted`() = runTest {
+        viewModel = MapViewModel(contactRepository, receivedLocationDao, locationSharingManager, announceDao)
+
+        viewModel.state.test {
+            awaitItem() // initial state
+
+            // Dismiss the card
+            viewModel.dismissPermissionCard()
+            val dismissedState = awaitItem()
+            assertTrue(dismissedState.isPermissionCardDismissed)
+
+            // Grant permission
+            viewModel.onPermissionResult(true)
+            val afterPermission = awaitItem()
+
+            // Dismissed state should persist even when permission is granted
+            assertTrue(afterPermission.isPermissionCardDismissed)
+            assertTrue(afterPermission.hasLocationPermission)
+        }
+    }
+
     @Test
     fun `contact markers come from received locations`() = runTest {
         val contacts = listOf(


### PR DESCRIPTION
## Summary
- Add dismiss button (X) to the location permission card on the map screen
- Track dismissed state in MapViewModel (persists within session)
- My Location FAB now shows permission sheet when tapped without permission granted
- Append privacy text to LocationPermissionManager rationale

Closes #152

## Test plan
- [ ] Open map screen without location permission
- [ ] Verify the permission card shows with an X button in the top-right corner
- [ ] Tap X to dismiss the card - verify it disappears
- [ ] Switch to another tab and back to map - verify card stays dismissed
- [ ] Tap the My Location button - verify permission sheet appears
- [ ] Grant permission and verify the blue dot appears on the map

🤖 Generated with [Claude Code](https://claude.com/claude-code)