### PR TITLE
fix: default location sharing toggle to disabled

### DIFF
--- a/app/src/main/java/com/lxmf/messenger/repository/SettingsRepository.kt
+++ b/app/src/main/java/com/lxmf/messenger/repository/SettingsRepository.kt
@@ -823,12 +823,12 @@ class SettingsRepository
         /**
          * Flow of the location sharing enabled setting.
          * When disabled, no location sharing is allowed and all active sessions should be stopped.
-         * Defaults to true if not set.
+         * Defaults to false if not set.
          */
         val locationSharingEnabledFlow: Flow<Boolean> =
             context.dataStore.data
                 .map { preferences ->
-                    preferences[PreferencesKeys.LOCATION_SHARING_ENABLED] ?: true
+                    preferences[PreferencesKeys.LOCATION_SHARING_ENABLED] ?: false
                 }
                 .distinctUntilChanged()
 

--- a/app/src/test/java/com/lxmf/messenger/repository/SettingsRepositoryTest.kt
+++ b/app/src/test/java/com/lxmf/messenger/repository/SettingsRepositoryTest.kt
@@ -584,4 +584,41 @@ class SettingsRepositoryTest {
                 cancelAndIgnoreRemainingEvents()
             }
         }
+
+    // ========== Location Sharing Flow Tests ==========
+
+    @Test
+    fun locationSharingEnabledFlow_defaultsToFalse() =
+        runTest {
+            // Issue #151: Location sharing should default to disabled for privacy
+            repository.locationSharingEnabledFlow.test(timeout = 5.seconds) {
+                val initial = awaitItem()
+
+                // Default should be false (disabled) for privacy-conscious defaults
+                assertFalse(
+                    "Location sharing should default to disabled for privacy",
+                    initial,
+                )
+
+                cancelAndIgnoreRemainingEvents()
+            }
+        }
+
+    @Test
+    fun locationSharingEnabledFlow_emitsOnlyOnChange() =
+        runTest {
+            repository.locationSharingEnabledFlow.test(timeout = 5.seconds) {
+                val initial = awaitItem()
+
+                // Save same value - should NOT emit
+                repository.saveLocationSharingEnabled(initial)
+                expectNoEvents()
+
+                // Save opposite value - should emit
+                repository.saveLocationSharingEnabled(!initial)
+                assertEquals(!initial, awaitItem())
+
+                cancelAndIgnoreRemainingEvents()
+            }
+        }
 }


### PR DESCRIPTION
## Summary
- Changes location sharing enabled preference to default to `false` instead of `true`
- More privacy-conscious: users must explicitly opt-in to location sharing

Fixes #151

## Test plan
- [ ] Fresh install or clear app data
- [ ] Open Settings → Location Sharing
- [ ] Verify toggle shows as disabled by default

🤖 Generated with [Claude Code](https://claude.com/claude-code)