### PR TITLE
fix: display full destination hash on contacts and announces

### DIFF
--- a/app/src/main/java/com/lxmf/messenger/ui/components/PeerCard.kt
+++ b/app/src/main/java/com/lxmf/messenger/ui/components/PeerCard.kt
@@ -311,8 +311,8 @@ fun OtherBadge() {
 }
 
 /**
- * Format a destination hash string for display (first 16 characters).
+ * Format a destination hash string for display.
  */
 fun formatHashString(hashString: String): String {
-    return hashString.take(16)
+    return hashString
 }

--- a/app/src/main/java/com/lxmf/messenger/ui/screens/ContactsScreen.kt
+++ b/app/src/main/java/com/lxmf/messenger/ui/screens/ContactsScreen.kt
@@ -969,7 +969,7 @@ fun ContactListItem(
 
                 // Destination hash
                 Text(
-                    text = "${contact.destinationHash.take(12)}...",
+                    text = contact.destinationHash,
                     style = MaterialTheme.typography.bodySmall,
                     fontFamily = FontFamily.Monospace,
                     color = MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = textAlpha),
@@ -1443,7 +1443,7 @@ fun PendingContactBottomSheet(
                         fontWeight = FontWeight.Bold,
                     )
                     Text(
-                        text = "${contact.destinationHash.take(12)}...",
+                        text = contact.destinationHash,
                         style = MaterialTheme.typography.bodySmall,
                         fontFamily = FontFamily.Monospace,
                         color = MaterialTheme.colorScheme.onSurfaceVariant,
@@ -1560,7 +1560,7 @@ fun EditNicknameDialog(
 
                 // Show destination hash for context
                 Text(
-                    text = "Contact: ${destinationHash.take(12)}...",
+                    text = "Contact: $destinationHash",
                     style = MaterialTheme.typography.bodySmall,
                     fontFamily = FontFamily.Monospace,
                     color = MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.7f),

--- a/app/src/test/java/com/lxmf/messenger/ui/components/PeerCardTest.kt
+++ b/app/src/test/java/com/lxmf/messenger/ui/components/PeerCardTest.kt
@@ -66,8 +66,8 @@ class PeerCardTest {
             )
         }
 
-        // Then - destination hash is abbreviated to first 16 chars
-        composeTestRule.onNodeWithText(announce.destinationHash.take(16)).assertIsDisplayed()
+        // Then - full destination hash is displayed
+        composeTestRule.onNodeWithText(announce.destinationHash).assertIsDisplayed()
     }
 
     // ========== Star Button Tests ==========

--- a/app/src/test/java/com/lxmf/messenger/ui/screens/ContactsScreenTest.kt
+++ b/app/src/test/java/com/lxmf/messenger/ui/screens/ContactsScreenTest.kt
@@ -393,7 +393,7 @@ class ContactsScreenTest {
     }
 
     @Test
-    fun contactListItem_displaysTruncatedHash() {
+    fun contactListItem_displaysFullHash() {
         val contact =
             TestFactories.createEnrichedContact(
                 destinationHash = "0123456789abcdef0123456789abcdef",
@@ -407,8 +407,8 @@ class ContactsScreenTest {
             )
         }
 
-        // First 12 characters + "..."
-        composeTestRule.onNodeWithText("0123456789ab...").assertIsDisplayed()
+        // Full destination hash is displayed
+        composeTestRule.onNodeWithText("0123456789abcdef0123456789abcdef").assertIsDisplayed()
     }
 
     @Test
@@ -925,7 +925,7 @@ class ContactsScreenTest {
             )
         }
 
-        composeTestRule.onNodeWithText("Contact: abcdef123456...", substring = true).assertIsDisplayed()
+        composeTestRule.onNodeWithText("Contact: abcdef123456789", substring = true).assertIsDisplayed()
     }
 
     @Test


### PR DESCRIPTION
## Summary
- Display full destination hash on contact cards instead of truncating to 12 characters
- Display full destination hash on announce/peer cards instead of truncating to 16 characters
- Improves UI consistency across the app

Closes #31

## Test plan
- [ ] Check contacts tab - verify full hash displays on contact cards
- [ ] Tap a contact to open detail sheet - verify full hash displays
- [ ] Edit a contact nickname - verify full hash displays in dialog
- [ ] Check announces tab - verify full hash displays on peer cards

🤖 Generated with [Claude Code](https://claude.com/claude-code)