### PR TITLE
feat: clarify interface type descriptions to prevent user confusion

### DIFF
--- a/app/src/main/java/com/lxmf/messenger/ui/screens/InterfaceManagementScreen.kt
+++ b/app/src/main/java/com/lxmf/messenger/ui/screens/InterfaceManagementScreen.kt
@@ -883,12 +883,12 @@ fun InterfaceTypeSelector(
                 )
                 InterfaceTypeOption(
                     title = "Bluetooth LE",
-                    description = "Connect to nearby devices via Bluetooth",
+                    description = "Direct connection to Columba users and Linux ble-reticulum devices",
                     onClick = { onTypeSelected("AndroidBLE") },
                 )
                 InterfaceTypeOption(
                     title = "RNode LoRa",
-                    description = "Long-range radio via RNode hardware",
+                    description = "Connects to separate RNode hardware via BLE or Bluetooth Classic",
                     onClick = { onTypeSelected("RNode") },
                 )
             }


### PR DESCRIPTION
Updated interface descriptions in InterfaceTypeSelector:
- Bluetooth LE: Now explicitly states it connects directly to other
  Columba users and Linux devices running ble-reticulum
- RNode LoRa: Now clarifies it connects to separate RNode hardware
  via BLE or Bluetooth Classic

This addresses user confusion where some thought they needed to select
Bluetooth LE to connect to an RNode device.

Fixes #143