### PR TITLE
fix(ble): remove device from scanner cache on disconnect for reconnection

### DIFF
--- a/reticulum/src/main/java/com/lxmf/messenger/reticulum/ble/bridge/KotlinBLEBridge.kt
+++ b/reticulum/src/main/java/com/lxmf/messenger/reticulum/ble/bridge/KotlinBLEBridge.kt
@@ -1501,6 +1501,10 @@ class KotlinBLEBridge(
 
                 Log.i(TAG, "Peer disconnected: $address")
                 onDisconnected?.callAttr("__call__", address)
+
+                // Remove from scanner cache so device can be rediscovered and reconnected
+                // This enables automatic reconnection on next scan cycle
+                scanner.removeDevice(address)
             } else {
                 Log.d(TAG, "Peer $address partially disconnected (central=${peer.isCentral}, peripheral=${peer.isPeripheral})")
             }


### PR DESCRIPTION
## Summary
- Fix automatic BLE reconnection after disconnect by removing device from scanner cache
- When a peer disconnects, `scanner.removeDevice(address)` is now called in `KotlinBLEBridge.handlePeerDisconnected()`
- This allows the device to be rediscovered as NEW on subsequent scans, triggering the Python discovery callback and reconnection flow

## Problem
After a BLE disconnect, the device remained in the scanner cache. Subsequent scans only updated the RSSI without calling `onDeviceDiscovered`, so the Python layer never got notified to reconnect.

## Solution
Added `scanner.removeDevice(address)` after peer disconnect cleanup in `KotlinBLEBridge.handlePeerDisconnected()`. This clears the cache entry so the next scan treats the device as new.

## Test plan
- [x] Tested out-of-range disconnect and return - device was rediscovered and reconnected automatically
- [x] Verified log shows: `Removed device from cache` → `Discovered new device` → `CONNECTION ESTABLISHED`

🤖 Generated with [Claude Code](https://claude.com/claude-code)