### PR TITLE
fix: Update default interface modes for better mesh behavior

### DIFF
--- a/app/src/main/java/com/lxmf/messenger/data/database/InterfaceDatabase.kt
+++ b/app/src/main/java/com/lxmf/messenger/data/database/InterfaceDatabase.kt
@@ -321,7 +321,7 @@ abstract class InterfaceDatabase : RoomDatabase() {
                         {
                             "device_name": "Reticulum-Android",
                             "max_connections": 7,
-                            "mode": "full"
+                            "mode": "roaming"
                         }
                         """.trimIndent(),
                     displayOrder = 1,
@@ -338,7 +338,7 @@ abstract class InterfaceDatabase : RoomDatabase() {
                             "target_host": "sideband.connect.reticulum.network",
                             "target_port": 4965,
                             "kiss_framing": false,
-                            "mode": "full"
+                            "mode": "boundary"
                         }
                         """.trimIndent(),
                     displayOrder = 2,

--- a/reticulum/src/main/java/com/lxmf/messenger/reticulum/model/ReticulumConfig.kt
+++ b/reticulum/src/main/java/com/lxmf/messenger/reticulum/model/ReticulumConfig.kt
@@ -118,7 +118,7 @@ sealed class InterfaceConfig {
         val codingRate: Int = 5,
         val stAlock: Double? = null, // Short-term airtime limit %
         val ltAlock: Double? = null, // Long-term airtime limit %
-        val mode: String = "full",
+        val mode: String = "access_point",
         val enableFramebuffer: Boolean = true, // Display logo on RNode OLED
     ) : InterfaceConfig()
 


### PR DESCRIPTION
## Summary
- BLE interface: `full` → `roaming` (mobile devices relative to peers)
- TCP interface: `full` → `boundary` (edge node connecting to infrastructure)
- RNode interface: `full` → `access_point` (stationary LoRa gateway)

These defaults better reflect typical mobile usage patterns where the phone is moving relative to other mesh nodes.

## Test plan
- [ ] Verify new users get roaming mode for BLE
- [ ] Verify new users get boundary mode for TCP
- [ ] Verify RNode wizard defaults to access_point mode
- [ ] Existing users' configurations are unaffected (no migration needed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)