### PR TITLE
fix: allow saving edited LoRa interface with unchanged name

### DIFF
--- a/app/src/main/java/com/lxmf/messenger/viewmodel/RNodeWizardViewModel.kt
+++ b/app/src/main/java/com/lxmf/messenger/viewmodel/RNodeWizardViewModel.kt
@@ -1842,7 +1842,19 @@ class RNodeWizardViewModel
                     val state = _state.value
 
                     // Check for duplicate interface names before saving
-                    val existingNames = interfaceRepository.allInterfaces.first().map { it.name }
+                    var existingNames = interfaceRepository.allInterfaces.first().map { it.name }
+
+                    // When editing, exclude the original interface from duplicate check
+                    if (state.editingInterfaceId != null) {
+                        val originalInterface =
+                            interfaceRepository.getInterfaceById(state.editingInterfaceId).first()
+                        originalInterface?.name?.let { originalName ->
+                            existingNames = existingNames.filter {
+                                !it.equals(originalName, ignoreCase = true)
+                            }
+                        }
+                    }
+
                     when (
                         val uniqueResult =
                             InputValidator.validateInterfaceNameUniqueness(


### PR DESCRIPTION
## Summary
- Fixes bug where editing an existing LoRa interface couldn't be saved without changing the name
- The duplicate name validation now excludes the interface being edited when checking for conflicts
- Users can now save changes to an interface while keeping the original name

## Test plan
- [x] Added unit test: `saveConfiguration succeeds in edit mode with same name`
- [x] All RNodeWizardViewModel tests pass
- [x] ktlint and detekt pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)