### PR TITLE
fix: default LoRa wizard interface mode to boundary

### DIFF
--- a/app/src/main/java/com/lxmf/messenger/viewmodel/RNodeWizardViewModel.kt
+++ b/app/src/main/java/com/lxmf/messenger/viewmodel/RNodeWizardViewModel.kt
@@ -153,7 +153,7 @@ data class RNodeWizardState(
     val txPower: String = "17",
     val stAlock: String = "",
     val ltAlock: String = "",
-    val interfaceMode: String = "accesspoint",
+    val interfaceMode: String = "boundary",
     val showAdvancedSettings: Boolean = false,
     // Display logo on RNode OLED
     val enableFramebuffer: Boolean = true,

--- a/app/src/test/java/com/lxmf/messenger/viewmodel/RNodeWizardViewModelTest.kt
+++ b/app/src/test/java/com/lxmf/messenger/viewmodel/RNodeWizardViewModelTest.kt
@@ -860,11 +860,11 @@ class RNodeWizardViewModelTest {
             viewModel.state.test {
                 awaitItem() // Initial
 
-                viewModel.updateInterfaceMode("boundary")
+                viewModel.updateInterfaceMode("gateway")
                 advanceUntilIdle()
 
                 val state = awaitItem()
-                assertEquals("boundary", state.interfaceMode)
+                assertEquals("gateway", state.interfaceMode)
             }
         }
 
@@ -2243,7 +2243,7 @@ class RNodeWizardViewModelTest {
         runTest {
             viewModel.state.test {
                 var state = awaitItem()
-                assertEquals("accesspoint", state.interfaceMode) // Default
+                assertEquals("boundary", state.interfaceMode) // Default
 
                 viewModel.updateInterfaceMode("gateway")
                 advanceUntilIdle()


### PR DESCRIPTION
## Summary
- Changes the default interface mode in the RNode/LoRa wizard from "accesspoint" to "boundary"
- **Boundary mode**: Node's announces go out, but doesn't rebroadcast others' announces - ideal for LoRa where airtime is limited
- **Access point mode** (previous): Blocks ALL announces including the node's own - makes the node invisible on LoRa

## Why this matters
Access point mode assumes the node has other interfaces (e.g., TCP) through which it announces. For a phone with only an RNode, AP mode makes the device undiscoverable on the LoRa network.

## Test plan
- [x] Updated unit tests to expect new default
- [x] All RNodeWizardViewModel tests pass
- [x] ktlint and detekt pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)