### PR TITLE
fix: profile icon interoperability with Sideband and map display

### DIFF
--- a/app/src/main/java/com/lxmf/messenger/ui/components/ContactLocationBottomSheet.kt
+++ b/app/src/main/java/com/lxmf/messenger/ui/components/ContactLocationBottomSheet.kt
@@ -86,11 +86,14 @@ fun ContactLocationBottomSheet(
                 verticalAlignment = Alignment.CenterVertically,
                 modifier = Modifier.fillMaxWidth(),
             ) {
-                // Identicon avatar (dimmed for stale locations)
+                // Profile icon (dimmed for stale locations)
                 Box {
-                    Identicon(
-                        hash = hexStringToByteArray(marker.destinationHash),
+                    ProfileIcon(
+                        iconName = marker.iconName,
+                        foregroundColor = marker.iconForegroundColor,
+                        backgroundColor = marker.iconBackgroundColor,
                         size = 48.dp,
+                        fallbackHash = marker.publicKey ?: hexStringToByteArray(marker.destinationHash),
                         modifier = if (isStale) Modifier.alpha(0.6f) else Modifier,
                     )
                 }

--- a/app/src/main/java/com/lxmf/messenger/ui/screens/MapScreen.kt
+++ b/app/src/main/java/com/lxmf/messenger/ui/screens/MapScreen.kt
@@ -329,15 +329,33 @@ fun MapScreen(
             state.contactMarkers.forEach { marker ->
                 val imageId = "marker-${marker.destinationHash}"
                 if (style.getImage(imageId) == null) {
-                    val initial = marker.displayName.firstOrNull() ?: '?'
-                    val color = MarkerBitmapFactory.hashToColor(marker.destinationHash)
+                    // Try profile icon first, fall back to initials
                     val bitmap =
-                        MarkerBitmapFactory.createInitialMarker(
-                            initial = initial,
-                            displayName = marker.displayName,
-                            backgroundColor = color,
-                            density = screenDensity,
-                        )
+                        if (marker.iconName != null &&
+                            marker.iconForegroundColor != null &&
+                            marker.iconBackgroundColor != null
+                        ) {
+                            MarkerBitmapFactory.createProfileIconMarker(
+                                iconName = marker.iconName,
+                                foregroundColor = marker.iconForegroundColor,
+                                backgroundColor = marker.iconBackgroundColor,
+                                displayName = marker.displayName,
+                                density = screenDensity,
+                                context = context,
+                            )
+                        } else {
+                            null
+                        } ?: run {
+                            // Fallback to initials marker
+                            val initial = marker.displayName.firstOrNull() ?: '?'
+                            val color = MarkerBitmapFactory.hashToColor(marker.destinationHash)
+                            MarkerBitmapFactory.createInitialMarker(
+                                initial = initial,
+                                displayName = marker.displayName,
+                                backgroundColor = color,
+                                density = screenDensity,
+                            )
+                        }
                     style.addImage(imageId, bitmap)
                 }
             }

--- a/app/src/test/java/com/lxmf/messenger/ui/util/MarkerBitmapFactoryTest.kt
+++ b/app/src/test/java/com/lxmf/messenger/ui/util/MarkerBitmapFactoryTest.kt
@@ -7,6 +7,7 @@ import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertNotEquals
 import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertNull
 import org.junit.Assert.assertTrue
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -521,5 +522,169 @@ class MarkerBitmapFactoryTest {
         assertNotNull(bitmap)
         assertTrue(bitmap.width > 0)
         assertTrue(bitmap.height > 0)
+    }
+
+    // ========== createProfileIconMarker Tests ==========
+
+    @Test
+    fun `createProfileIconMarker returns null for invalid icon name`() {
+        val context = androidx.test.core.app.ApplicationProvider.getApplicationContext<android.content.Context>()
+
+        val bitmap =
+            MarkerBitmapFactory.createProfileIconMarker(
+                iconName = "invalid_icon_that_does_not_exist",
+                foregroundColor = "FFFFFF",
+                backgroundColor = "1E88E5",
+                displayName = "Test",
+                sizeDp = 40f,
+                density = TEST_DENSITY,
+                context = context,
+            )
+
+        assertNull(bitmap)
+    }
+
+    @Test
+    fun `createProfileIconMarker returns bitmap for valid icon name`() {
+        val context = androidx.test.core.app.ApplicationProvider.getApplicationContext<android.content.Context>()
+
+        val bitmap =
+            MarkerBitmapFactory.createProfileIconMarker(
+                iconName = "account",
+                foregroundColor = "FFFFFF",
+                backgroundColor = "1E88E5",
+                displayName = "Test User",
+                sizeDp = 40f,
+                density = TEST_DENSITY,
+                context = context,
+            )
+
+        assertNotNull(bitmap)
+        assertTrue(bitmap!!.width > 0)
+        assertTrue(bitmap.height > 0)
+    }
+
+    @Test
+    fun `createProfileIconMarker handles various MDI icons`() {
+        val context = androidx.test.core.app.ApplicationProvider.getApplicationContext<android.content.Context>()
+        val validIcons = listOf("account", "star", "heart", "home", "map-marker")
+
+        for (iconName in validIcons) {
+            val bitmap =
+                MarkerBitmapFactory.createProfileIconMarker(
+                    iconName = iconName,
+                    foregroundColor = "FFFFFF",
+                    backgroundColor = "FF5722",
+                    displayName = "Test",
+                    sizeDp = 40f,
+                    density = TEST_DENSITY,
+                    context = context,
+                )
+
+            assertNotNull("Icon '$iconName' should produce a valid bitmap", bitmap)
+        }
+    }
+
+    @Test
+    fun `createProfileIconMarker handles invalid color gracefully`() {
+        val context = androidx.test.core.app.ApplicationProvider.getApplicationContext<android.content.Context>()
+
+        val bitmap =
+            MarkerBitmapFactory.createProfileIconMarker(
+                iconName = "account",
+                foregroundColor = "invalid",
+                backgroundColor = "also_invalid",
+                displayName = "Test",
+                sizeDp = 40f,
+                density = TEST_DENSITY,
+                context = context,
+            )
+
+        // Should not crash, falls back to default colors
+        assertNotNull(bitmap)
+    }
+
+    @Test
+    fun `createProfileIconMarker scales with density`() {
+        val context = androidx.test.core.app.ApplicationProvider.getApplicationContext<android.content.Context>()
+        val sizeDp = 40f
+        val lowDensity = 1.0f
+        val highDensity = 3.0f
+
+        val lowDensityBitmap =
+            MarkerBitmapFactory.createProfileIconMarker(
+                iconName = "account",
+                foregroundColor = "FFFFFF",
+                backgroundColor = "1E88E5",
+                displayName = "Test",
+                sizeDp = sizeDp,
+                density = lowDensity,
+                context = context,
+            )
+
+        val highDensityBitmap =
+            MarkerBitmapFactory.createProfileIconMarker(
+                iconName = "account",
+                foregroundColor = "FFFFFF",
+                backgroundColor = "1E88E5",
+                displayName = "Test",
+                sizeDp = sizeDp,
+                density = highDensity,
+                context = context,
+            )
+
+        assertNotNull(lowDensityBitmap)
+        assertNotNull(highDensityBitmap)
+        assertTrue(highDensityBitmap!!.width > lowDensityBitmap!!.width)
+    }
+
+    @Test
+    fun `createProfileIconMarker expands width for long display names`() {
+        val context = androidx.test.core.app.ApplicationProvider.getApplicationContext<android.content.Context>()
+
+        val shortNameBitmap =
+            MarkerBitmapFactory.createProfileIconMarker(
+                iconName = "account",
+                foregroundColor = "FFFFFF",
+                backgroundColor = "1E88E5",
+                displayName = "Al",
+                sizeDp = 40f,
+                density = TEST_DENSITY,
+                context = context,
+            )
+
+        val longNameBitmap =
+            MarkerBitmapFactory.createProfileIconMarker(
+                iconName = "account",
+                foregroundColor = "FFFFFF",
+                backgroundColor = "1E88E5",
+                displayName = "Alexander the Great",
+                sizeDp = 40f,
+                density = TEST_DENSITY,
+                context = context,
+            )
+
+        assertNotNull(shortNameBitmap)
+        assertNotNull(longNameBitmap)
+        assertTrue(longNameBitmap!!.width >= shortNameBitmap!!.width)
+    }
+
+    @Test
+    fun `createProfileIconMarker has ARGB_8888 config`() {
+        val context = androidx.test.core.app.ApplicationProvider.getApplicationContext<android.content.Context>()
+
+        val bitmap =
+            MarkerBitmapFactory.createProfileIconMarker(
+                iconName = "account",
+                foregroundColor = "FFFFFF",
+                backgroundColor = "1E88E5",
+                displayName = "Test",
+                sizeDp = 40f,
+                density = TEST_DENSITY,
+                context = context,
+            )
+
+        assertNotNull(bitmap)
+        assertEquals(Bitmap.Config.ARGB_8888, bitmap!!.config)
     }
 }

--- a/app/src/test/java/com/lxmf/messenger/viewmodel/MessagingViewModelImageLoadingTest.kt
+++ b/app/src/test/java/com/lxmf/messenger/viewmodel/MessagingViewModelImageLoadingTest.kt
@@ -8,6 +8,7 @@ import androidx.paging.PagingData
 import com.lxmf.messenger.data.repository.AnnounceRepository
 import com.lxmf.messenger.data.repository.ContactRepository
 import com.lxmf.messenger.data.repository.ConversationRepository
+import com.lxmf.messenger.data.repository.IdentityRepository
 import com.lxmf.messenger.repository.SettingsRepository
 import com.lxmf.messenger.reticulum.model.Identity
 import com.lxmf.messenger.reticulum.protocol.ServiceReticulumProtocol
@@ -72,6 +73,7 @@ class MessagingViewModelImageLoadingTest {
     private lateinit var settingsRepository: SettingsRepository
     private lateinit var propagationNodeManager: PropagationNodeManager
     private lateinit var locationSharingManager: LocationSharingManager
+    private lateinit var identityRepository: IdentityRepository
     private lateinit var viewModel: MessagingViewModel
 
     @Before
@@ -89,6 +91,7 @@ class MessagingViewModelImageLoadingTest {
         settingsRepository = mockk(relaxed = true)
         propagationNodeManager = mockk(relaxed = true)
         locationSharingManager = mockk(relaxed = true)
+        identityRepository = mockk(relaxed = true)
 
         // Mock locationSharingManager flows
         every { locationSharingManager.activeSessions } returns MutableStateFlow(emptyList())
@@ -118,6 +121,7 @@ class MessagingViewModelImageLoadingTest {
                 settingsRepository = settingsRepository,
                 propagationNodeManager = propagationNodeManager,
                 locationSharingManager = locationSharingManager,
+                identityRepository = identityRepository,
             )
     }
 

--- a/app/src/test/java/com/lxmf/messenger/viewmodel/MessagingViewModelTest.kt
+++ b/app/src/test/java/com/lxmf/messenger/viewmodel/MessagingViewModelTest.kt
@@ -6,6 +6,7 @@ import com.lxmf.messenger.data.db.entity.MessageEntity
 import com.lxmf.messenger.data.repository.AnnounceRepository
 import com.lxmf.messenger.data.repository.ContactRepository
 import com.lxmf.messenger.data.repository.ConversationRepository
+import com.lxmf.messenger.data.repository.IdentityRepository
 import com.lxmf.messenger.data.repository.ReplyPreview
 import com.lxmf.messenger.repository.SettingsRepository
 import com.lxmf.messenger.reticulum.model.Identity
@@ -64,6 +65,7 @@ class MessagingViewModelTest {
     private lateinit var settingsRepository: SettingsRepository
     private lateinit var propagationNodeManager: PropagationNodeManager
     private lateinit var locationSharingManager: LocationSharingManager
+    private lateinit var identityRepository: IdentityRepository
 
     private val testPeerHash = "abcdef0123456789abcdef0123456789" // Valid 32-char hex hash
     private val testPeerName = "Test Peer"
@@ -86,6 +88,10 @@ class MessagingViewModelTest {
         settingsRepository = mockk(relaxed = true)
         propagationNodeManager = mockk(relaxed = true)
         locationSharingManager = mockk(relaxed = true)
+        identityRepository = mockk(relaxed = true)
+
+        // Mock identityRepository to return null by default (no icon set)
+        coEvery { identityRepository.getActiveIdentitySync() } returns null
 
         // Mock locationSharingManager flows
         every { locationSharingManager.activeSessions } returns MutableStateFlow(emptyList())
@@ -148,6 +154,7 @@ class MessagingViewModelTest {
             settingsRepository,
             propagationNodeManager,
             locationSharingManager,
+            identityRepository,
         )
 
     @Test
@@ -450,6 +457,7 @@ class MessagingViewModelTest {
                     failingSettingsRepository,
                     failingPropagationNodeManager,
                     failingLocationSharingManager,
+                    identityRepository,
                 )
 
             // Attempt to send message
@@ -891,6 +899,7 @@ class MessagingViewModelTest {
                 settingsRepository,
                 propagationNodeManager,
                 locationSharingManager,
+                identityRepository,
             )
             advanceUntilIdle()
 
@@ -951,6 +960,7 @@ class MessagingViewModelTest {
                 settingsRepository,
                 propagationNodeManager,
                 locationSharingManager,
+                identityRepository,
             )
             advanceUntilIdle()
 
@@ -1007,6 +1017,7 @@ class MessagingViewModelTest {
                 settingsRepository,
                 propagationNodeManager,
                 locationSharingManager,
+                identityRepository,
             )
             advanceUntilIdle()
 
@@ -1053,6 +1064,7 @@ class MessagingViewModelTest {
                 settingsRepository,
                 propagationNodeManager,
                 locationSharingManager,
+                identityRepository,
             )
             advanceUntilIdle()
 

--- a/python/reticulum_wrapper.py
+++ b/python/reticulum_wrapper.py
@@ -64,7 +64,7 @@ sys.excepthook = _global_exception_handler
 # ============================================================================
 FIELD_TELEMETRY = 0x02        # Standard telemetry field for Sideband interoperability
 FIELD_COLUMBA_META = 0x70     # Custom field for Columba-specific metadata (cease signals, etc.)
-FIELD_ICON_APPEARANCE = 0x04  # Icon appearance [name, fg_rgb, bg_rgb] for Sideband/MeshChat interoperability
+FIELD_ICON_APPEARANCE = 0x04  # Icon appearance [name, fg_bytes(3), bg_bytes(3)] for Sideband/MeshChat interoperability
 LEGACY_LOCATION_FIELD = 7     # Legacy field ID for backwards compatibility
 
 # Sensor IDs (from Sideband sense.py)
@@ -2543,15 +2543,19 @@ class ReticulumWrapper:
                     log_info("ReticulumWrapper", "send_lxmf_message", f"📎 Attaching {len(field_5_data)} file(s)")
 
             # Add icon appearance to outgoing messages if provided (Sideband/MeshChat interop)
+            # Format: [icon_name, fg_bytes(3), bg_bytes(3)] - same as Sideband
             if icon_name and icon_fg_color and icon_bg_color:
                 if fields is None:
                     fields = {}
+                fg_bytes = bytes.fromhex(icon_fg_color)
+                bg_bytes = bytes.fromhex(icon_bg_color)
                 fields[FIELD_ICON_APPEARANCE] = [
                     icon_name,
-                    bytes.fromhex(icon_fg_color),
-                    bytes.fromhex(icon_bg_color)
+                    fg_bytes,
+                    bg_bytes
                 ]
-                log_debug("ReticulumWrapper", "send_lxmf_message", f"📎 Adding icon appearance: {icon_name}")
+                log_info("ReticulumWrapper", "send_lxmf_message",
+                        f"📎 Adding icon appearance: {icon_name}, fg={icon_fg_color} ({fg_bytes.hex()}), bg={icon_bg_color} ({bg_bytes.hex()})")
 
             # Create LXMF message using destination OBJECTS
             log_debug("ReticulumWrapper", "send_lxmf_message", f"Creating LXMessage with destination objects...")
@@ -3175,15 +3179,19 @@ class ReticulumWrapper:
                         f"📎 Replying to message: {reply_to_message_id[:16]}...")
 
             # Add icon appearance to outgoing messages if provided (Sideband/MeshChat interop)
+            # Format: [icon_name, fg_bytes(3), bg_bytes(3)] - same as Sideband
             if icon_name and icon_fg_color and icon_bg_color:
                 if fields is None:
                     fields = {}
+                fg_bytes = bytes.fromhex(icon_fg_color)
+                bg_bytes = bytes.fromhex(icon_bg_color)
                 fields[FIELD_ICON_APPEARANCE] = [
                     icon_name,
-                    bytes.fromhex(icon_fg_color),
-                    bytes.fromhex(icon_bg_color)
+                    fg_bytes,
+                    bg_bytes
                 ]
-                log_debug("ReticulumWrapper", "send_lxmf_message_with_method", f"📎 Adding icon appearance: {icon_name}")
+                log_info("ReticulumWrapper", "send_lxmf_message_with_method",
+                        f"📎 Adding icon appearance: {icon_name}, fg={icon_fg_color} ({fg_bytes.hex()}), bg={icon_bg_color} ({bg_bytes.hex()})")
 
             # Create LXMF message with specified delivery method
             lxmf_message = LXMF.LXMessage(


### PR DESCRIPTION
## Summary
- Send icon appearance when sending messages to enable Sideband/MeshChat users to see Columba profile icons (was not being passed before)
- Add profile icon fields to ContactMarker for map rendering
- Create MarkerBitmapFactory.createProfileIconMarker() for MDI icon markers
- Use ProfileIcon in ContactLocationBottomSheet instead of Identicon
- Update MapScreen to show profile icons on map markers when available

## Test plan
- [x] Unit tests added for createProfileIconMarker() (7 tests)
- [x] Unit tests added for icon fields in ContactMarker (3 tests)
- [x] ktlintCheck passes
- [ ] Set profile icon in Columba, send message to Sideband user, verify they see the icon
- [ ] Receive announces with icons, share locations, verify map shows MDI icons
- [ ] Verify peers without icons still show initials/identicon fallback

🤖 Generated with [Claude Code](https://claude.com/claude-code)