### PR TITLE
fix: message context menu keyboard dismissal and large message scaling

### DIFF
--- a/app/src/main/java/com/lxmf/messenger/ui/components/OverlayLayoutDimensions.kt
+++ b/app/src/main/java/com/lxmf/messenger/ui/components/OverlayLayoutDimensions.kt
@@ -1,0 +1,57 @@
+package com.lxmf.messenger.ui.components
+
+import kotlin.math.max
+
+/**
+ * Layout dimensions for the reaction mode overlay.
+ * Contains all the measurements needed to calculate proper scaling and positioning.
+ *
+ * @property screenHeight The total screen height in pixels
+ * @property emojiBarHeight Height of the emoji bar in pixels (typically ~56dp)
+ * @property emojiBarGap Gap between emoji bar and message in pixels (typically ~76dp)
+ * @property actionButtonsHeight Height of action buttons in pixels (typically ~56dp)
+ * @property actionButtonsGap Gap between message and action buttons in pixels (typically ~12dp)
+ * @property topPadding Padding for status bar etc. in pixels (typically ~48dp)
+ * @property bottomPadding Padding for navigation bar etc. in pixels (typically ~48dp)
+ */
+data class OverlayLayoutDimensions(
+    val screenHeight: Float,
+    val emojiBarHeight: Float,
+    val emojiBarGap: Float,
+    val actionButtonsHeight: Float,
+    val actionButtonsGap: Float,
+    val topPadding: Float,
+    val bottomPadding: Float,
+)
+
+/**
+ * Calculates the scale factor for a message in the reaction mode overlay.
+ *
+ * When a message is very large (e.g., a long text or large image), the context menu
+ * (emoji bar above and action buttons below) may be pushed off screen. This function
+ * calculates how much to scale down the message so that everything fits on screen.
+ *
+ * @param messageHeight The original height of the message in pixels
+ * @param dimensions Layout dimensions for the overlay
+ * @param minScale Minimum scale factor (default 0.3 to keep content readable)
+ * @return Scale factor between minScale and 1.0
+ */
+fun calculateMessageScaleForOverlay(
+    messageHeight: Int,
+    dimensions: OverlayLayoutDimensions,
+    minScale: Float = 0.3f,
+): Float {
+    if (messageHeight <= 0) return 1f
+
+    val availableHeight = dimensions.screenHeight - dimensions.topPadding - dimensions.bottomPadding
+    val uiElementsHeight = dimensions.emojiBarHeight + dimensions.emojiBarGap +
+        dimensions.actionButtonsGap + dimensions.actionButtonsHeight
+    val totalHeightNeeded = uiElementsHeight + messageHeight
+
+    return if (totalHeightNeeded > availableHeight) {
+        val maxMessageHeight = max(0f, availableHeight - uiElementsHeight)
+        (maxMessageHeight / messageHeight).coerceIn(minScale, 1f)
+    } else {
+        1f
+    }
+}

--- a/app/src/main/java/com/lxmf/messenger/ui/screens/MessagingScreen.kt
+++ b/app/src/main/java/com/lxmf/messenger/ui/screens/MessagingScreen.kt
@@ -100,6 +100,7 @@ import androidx.compose.ui.draw.clip
 import androidx.compose.ui.draw.drawWithCache
 import androidx.compose.ui.draw.scale
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.SolidColor
 import androidx.compose.ui.graphics.asImageBitmap
 import androidx.compose.ui.graphics.graphicsLayer
 import androidx.compose.ui.graphics.rememberGraphicsLayer
@@ -112,6 +113,7 @@ import androidx.compose.ui.platform.LocalClipboardManager
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.platform.LocalHapticFeedback
+import androidx.compose.ui.platform.LocalSoftwareKeyboardController
 import androidx.compose.ui.text.AnnotatedString
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.input.ImeAction
@@ -344,6 +346,9 @@ fun MessagingScreen(
 
     // Clipboard for copy functionality
     val clipboardManager = LocalClipboardManager.current
+
+    // Keyboard controller for dismissing keyboard when entering reaction mode
+    val keyboardController = LocalSoftwareKeyboardController.current
 
     // Track IME (keyboard) visibility
     val density = LocalDensity.current
@@ -675,6 +680,8 @@ fun MessagingScreen(
                                             },
                                             onReact = { emoji -> viewModel.sendReaction(message.id, emoji) },
                                             onLongPress = { msgId, fromMe, failed, bitmap, x, y, width, height ->
+                                                // Dismiss keyboard before entering reaction mode
+                                                keyboardController?.hide()
                                                 viewModel.enterReactionMode(msgId, index, fromMe, failed, bitmap, x, y, width, height)
                                             },
                                         )
@@ -1558,6 +1565,10 @@ fun MessageInputBar(
                             },
                         textStyle = MaterialTheme.typography.bodyLarge.copy(
                             color = MaterialTheme.colorScheme.onSurface,
+                        ),
+                        cursorBrush = SolidColor(MaterialTheme.colorScheme.primary),
+                        keyboardOptions = KeyboardOptions(
+                            capitalization = KeyboardCapitalization.Sentences,
                         ),
                         lineLimits = TextFieldLineLimits.MultiLine(maxHeightInLines = 5),
                         decorator = { innerTextField ->

--- a/app/src/test/java/com/lxmf/messenger/ui/components/ReactionComponentsTest.kt
+++ b/app/src/test/java/com/lxmf/messenger/ui/components/ReactionComponentsTest.kt
@@ -561,4 +561,110 @@ class ReactionComponentsTest {
         val expectedEmojis = listOf("👍", "❤️", "😂", "😮", "😢", "😡")
         assertEquals(expectedEmojis, REACTION_EMOJIS)
     }
+
+    // ========== calculateMessageScaleForOverlay TESTS ==========
+
+    // Common UI dimensions for tests (in pixels, simulating a typical phone at 3x density)
+    private val testDimensions = OverlayLayoutDimensions(
+        screenHeight = 2400f, // ~800dp at 3x density
+        emojiBarHeight = 168f, // 56dp at 3x density
+        emojiBarGap = 228f, // 76dp at 3x density
+        actionButtonsHeight = 168f, // 56dp at 3x density
+        actionButtonsGap = 36f, // 12dp at 3x density
+        topPadding = 144f, // 48dp at 3x density
+        bottomPadding = 144f, // 48dp at 3x density
+    )
+
+    @Test
+    fun `calculateMessageScaleForOverlay returns 1f for small message that fits on screen`() {
+        val scale = calculateMessageScaleForOverlay(
+            messageHeight = 300, // Small message
+            dimensions = testDimensions,
+        )
+
+        assertEquals(1f, scale, 0.001f)
+    }
+
+    @Test
+    fun `calculateMessageScaleForOverlay returns scale less than 1 for large message`() {
+        // Available height = 2400 - 144 - 144 = 2112
+        // UI elements = 168 + 228 + 36 + 168 = 600
+        // Max message height = 2112 - 600 = 1512
+        // For a 2000px message, scale should be 1512/2000 = 0.756
+        val scale = calculateMessageScaleForOverlay(
+            messageHeight = 2000, // Large message
+            dimensions = testDimensions,
+        )
+
+        assertTrue("Scale should be less than 1 for large message", scale < 1f)
+        assertTrue("Scale should be greater than minScale", scale >= 0.3f)
+        assertEquals(0.756f, scale, 0.01f)
+    }
+
+    @Test
+    fun `calculateMessageScaleForOverlay respects minimum scale for very large message`() {
+        val scale = calculateMessageScaleForOverlay(
+            messageHeight = 10000, // Very large message
+            dimensions = testDimensions,
+        )
+
+        assertEquals("Scale should be clamped to minScale", 0.3f, scale, 0.001f)
+    }
+
+    @Test
+    fun `calculateMessageScaleForOverlay returns 1f for zero height message`() {
+        val scale = calculateMessageScaleForOverlay(
+            messageHeight = 0,
+            dimensions = testDimensions,
+        )
+
+        assertEquals(1f, scale, 0.001f)
+    }
+
+    @Test
+    fun `calculateMessageScaleForOverlay returns 1f for negative height message`() {
+        val scale = calculateMessageScaleForOverlay(
+            messageHeight = -100,
+            dimensions = testDimensions,
+        )
+
+        assertEquals(1f, scale, 0.001f)
+    }
+
+    @Test
+    fun `calculateMessageScaleForOverlay with custom minScale`() {
+        val customMinScale = 0.5f
+        val scale = calculateMessageScaleForOverlay(
+            messageHeight = 10000, // Very large message
+            dimensions = testDimensions,
+            minScale = customMinScale,
+        )
+
+        assertEquals("Scale should be clamped to custom minScale", customMinScale, scale, 0.001f)
+    }
+
+    @Test
+    fun `calculateMessageScaleForOverlay with message exactly at boundary`() {
+        // Available height = 2400 - 144 - 144 = 2112
+        // UI elements = 168 + 228 + 36 + 168 = 600
+        // Max message height = 2112 - 600 = 1512
+        val scale = calculateMessageScaleForOverlay(
+            messageHeight = 1512, // Exactly fits
+            dimensions = testDimensions,
+        )
+
+        assertEquals("Message that exactly fits should have scale 1", 1f, scale, 0.001f)
+    }
+
+    @Test
+    fun `calculateMessageScaleForOverlay with small screen`() {
+        val smallScreenDimensions = testDimensions.copy(screenHeight = 1200f)
+        val scale = calculateMessageScaleForOverlay(
+            messageHeight = 800,
+            dimensions = smallScreenDimensions,
+        )
+
+        assertTrue("Scale should be less than 1 on small screen", scale < 1f)
+        assertTrue("Scale should be greater than minScale", scale >= 0.3f)
+    }
 }


### PR DESCRIPTION
## Summary

- Dismiss keyboard when long-pressing a message to enter reaction mode
- Scale down large message bitmaps in ReactionModeOverlay so emoji bar and action buttons remain visible on screen (min 30% scale)
- Fix message input to use sentence capitalization (was lowercase)
- Fix cursor color to use theme primary color (was black)

## Test plan

- [ ] Open a conversation and show keyboard, long-press a message → keyboard should dismiss
- [ ] Long-press on a very tall message (long text or large image) → context menu should scale the message so emoji bar and action buttons are visible
- [ ] Tap message input field → cursor should be themed (primary color), first letter should auto-capitalize

🤖 Generated with [Claude Code](https://claude.com/claude-code)