### PR TITLE
feat: fix propagation sync completion timing with real-time progress UI

### DIFF
--- a/app/src/main/aidl/com/lxmf/messenger/IReticulumServiceCallback.aidl
+++ b/app/src/main/aidl/com/lxmf/messenger/IReticulumServiceCallback.aidl
@@ -83,4 +83,12 @@ interface IReticulumServiceCallback {
      *        {"reaction_to": "msg_id", "emoji": "👍", "sender": "sender_hash", "source_hash": "...", "timestamp": ...}
      */
     void onReactionReceived(String reactionJson);
+
+    /**
+     * Called when propagation sync state changes.
+     * Used for real-time sync progress display.
+     * @param stateJson JSON string with propagation state data:
+     *        {"state": 0-7 or 0xf0-0xf4, "state_name": "...", "progress": 0.0-1.0, "messages_received": N}
+     */
+    void onPropagationStateChanged(String stateJson);
 }

--- a/app/src/main/java/com/lxmf/messenger/reticulum/protocol/ServiceReticulumProtocol.kt
+++ b/app/src/main/java/com/lxmf/messenger/reticulum/protocol/ServiceReticulumProtocol.kt
@@ -187,6 +187,14 @@ class ServiceReticulumProtocol(
         )
     val reactionReceivedFlow: SharedFlow<String> = _reactionReceivedFlow.asSharedFlow()
 
+    // Propagation sync state changes (for real-time sync progress)
+    private val _propagationStateFlow =
+        MutableSharedFlow<PropagationState>(
+            replay = 1,
+            extraBufferCapacity = 1,
+        )
+    val propagationStateFlow: SharedFlow<PropagationState> = _propagationStateFlow.asSharedFlow()
+
     /**
      * Handler for alternative relay requests from the service.
      * Set by ColumbaApplication to provide PropagationNodeManager integration.
@@ -492,6 +500,22 @@ class ServiceReticulumProtocol(
                     _reactionReceivedFlow.tryEmit(reactionJson)
                 } catch (e: Exception) {
                     Log.e(TAG, "Error handling reaction received callback", e)
+                }
+            }
+
+            override fun onPropagationStateChanged(stateJson: String) {
+                try {
+                    Log.d(TAG, "Propagation state changed: $stateJson")
+                    val json = JSONObject(stateJson)
+                    val state = PropagationState(
+                        state = json.optInt("state", 0),
+                        stateName = json.optString("state_name", "unknown"),
+                        progress = json.optDouble("progress", 0.0).toFloat(),
+                        messagesReceived = json.optInt("messages_received", 0),
+                    )
+                    _propagationStateFlow.tryEmit(state)
+                } catch (e: Exception) {
+                    Log.e(TAG, "Error handling propagation state callback", e)
                 }
             }
         }

--- a/app/src/main/java/com/lxmf/messenger/service/binder/ReticulumServiceBinder.kt
+++ b/app/src/main/java/com/lxmf/messenger/service/binder/ReticulumServiceBinder.kt
@@ -903,6 +903,16 @@ class ReticulumServiceBinder(
             Log.w(TAG, "Failed to set reaction received callback: ${e.message}", e)
         }
 
+        // Setup propagation state callback for real-time sync progress
+        try {
+            wrapperManager.setPropagationStateCallback { stateJson ->
+                Log.d(TAG, "Propagation state changed: ${stateJson.take(100)}")
+                broadcaster.broadcastPropagationStateChange(stateJson)
+            }
+        } catch (e: Exception) {
+            Log.w(TAG, "Failed to set propagation state callback: ${e.message}", e)
+        }
+
         // Setup native stamp generator (bypasses Python multiprocessing issues)
         try {
             val stampGenerator = StampGenerator()

--- a/app/src/main/java/com/lxmf/messenger/service/manager/CallbackBroadcaster.kt
+++ b/app/src/main/java/com/lxmf/messenger/service/manager/CallbackBroadcaster.kt
@@ -187,6 +187,14 @@ class CallbackBroadcaster {
     }
 
     /**
+     * Broadcast propagation state change to all registered callbacks.
+     * Called when LXMF propagation sync state changes (idle, receiving, complete, etc.).
+     */
+    fun broadcastPropagationStateChange(stateJson: String) {
+        broadcast { it.onPropagationStateChanged(stateJson) }
+    }
+
+    /**
      * Thread-safe broadcast helper.
      * Ensures only one broadcast happens at a time (RemoteCallbackList is not re-entrant).
      */

--- a/app/src/main/java/com/lxmf/messenger/service/manager/PythonWrapperManager.kt
+++ b/app/src/main/java/com/lxmf/messenger/service/manager/PythonWrapperManager.kt
@@ -338,6 +338,21 @@ class PythonWrapperManager(
     }
 
     /**
+     * Set propagation state callback.
+     * Called by Python when LXMF propagation sync state changes.
+     */
+    fun setPropagationStateCallback(callback: (String) -> Unit) {
+        withWrapper { wrapper ->
+            try {
+                wrapper.callAttr("set_propagation_state_callback", callback)
+                Log.d(TAG, "Propagation state callback registered")
+            } catch (e: Exception) {
+                Log.w(TAG, "Failed to set propagation state callback: ${e.message}", e)
+            }
+        }
+    }
+
+    /**
      * Set native Kotlin stamp generator callback.
      *
      * This bypasses Python multiprocessing-based stamp generation which fails on Android

--- a/app/src/main/java/com/lxmf/messenger/ui/components/SyncStatusBottomSheet.kt
+++ b/app/src/main/java/com/lxmf/messenger/ui/components/SyncStatusBottomSheet.kt
@@ -1,0 +1,176 @@
+package com.lxmf.messenger.ui.components
+
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.WindowInsets
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.systemBarsPadding
+import androidx.compose.foundation.layout.width
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Check
+import androidx.compose.material.icons.filled.CloudSync
+import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Icon
+import androidx.compose.material3.LinearProgressIndicator
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.ModalBottomSheet
+import androidx.compose.material3.SheetState
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import com.lxmf.messenger.service.SyncProgress
+
+/**
+ * Bottom sheet showing real-time sync progress with propagation node.
+ *
+ * Displays:
+ * - Current sync state (path discovery, connecting, downloading)
+ * - Progress percentage during download
+ * - Success indicator when complete
+ *
+ * @param syncProgress Current sync progress state
+ * @param onDismiss Callback when the bottom sheet is dismissed
+ * @param sheetState The state of the bottom sheet
+ */
+@OptIn(ExperimentalMaterial3Api::class)
+@Suppress("FunctionNaming")
+@Composable
+fun SyncStatusBottomSheet(
+    syncProgress: SyncProgress,
+    onDismiss: () -> Unit,
+    sheetState: SheetState,
+) {
+    ModalBottomSheet(
+        onDismissRequest = onDismiss,
+        sheetState = sheetState,
+        contentWindowInsets = { WindowInsets(0) },
+        modifier = Modifier.systemBarsPadding(),
+    ) {
+        Column(
+            modifier =
+                Modifier
+                    .fillMaxWidth()
+                    .padding(horizontal = 24.dp)
+                    .padding(bottom = 32.dp),
+        ) {
+            // Header with icon
+            Row(
+                verticalAlignment = Alignment.CenterVertically,
+            ) {
+                Icon(
+                    imageVector = Icons.Default.CloudSync,
+                    contentDescription = null,
+                    modifier = Modifier.size(28.dp),
+                    tint = MaterialTheme.colorScheme.primary,
+                )
+                Spacer(modifier = Modifier.width(12.dp))
+                Text(
+                    text = "Propagation Node Sync",
+                    style = MaterialTheme.typography.headlineSmall,
+                    fontWeight = FontWeight.Bold,
+                )
+            }
+
+            Spacer(modifier = Modifier.height(24.dp))
+
+            // Status content based on sync state
+            when (syncProgress) {
+                is SyncProgress.Idle -> {
+                    SyncStateRow(
+                        icon = { Icon(Icons.Default.Check, null, tint = MaterialTheme.colorScheme.primary) },
+                        title = "Ready",
+                        subtitle = "Not currently syncing",
+                    )
+                }
+                is SyncProgress.Starting -> {
+                    SyncStateRow(
+                        icon = {
+                            CircularProgressIndicator(
+                                modifier = Modifier.size(24.dp),
+                                strokeWidth = 2.dp,
+                            )
+                        },
+                        title = "Starting sync...",
+                        subtitle = "Initiating connection to relay",
+                    )
+                }
+                is SyncProgress.InProgress -> {
+                    val stateName = syncProgress.stateName.replaceFirstChar { it.uppercase() }
+                    val subtitle = getStateDescription(syncProgress.stateName)
+
+                    SyncStateRow(
+                        icon = {
+                            CircularProgressIndicator(
+                                modifier = Modifier.size(24.dp),
+                                strokeWidth = 2.dp,
+                            )
+                        },
+                        title = stateName,
+                        subtitle = subtitle,
+                    )
+
+                    // Show progress bar if we have progress info
+                    if (syncProgress.progress > 0f) {
+                        Spacer(modifier = Modifier.height(16.dp))
+                        LinearProgressIndicator(
+                            progress = { syncProgress.progress },
+                            modifier = Modifier.fillMaxWidth(),
+                        )
+                        Spacer(modifier = Modifier.height(8.dp))
+                        Text(
+                            text = "${(syncProgress.progress * 100).toInt()}%",
+                            style = MaterialTheme.typography.bodyMedium,
+                            color = MaterialTheme.colorScheme.onSurfaceVariant,
+                        )
+                    }
+                }
+            }
+        }
+    }
+}
+
+@Suppress("FunctionNaming")
+@Composable
+private fun SyncStateRow(
+    icon: @Composable () -> Unit,
+    title: String,
+    subtitle: String,
+) {
+    Row(
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
+        icon()
+        Spacer(modifier = Modifier.width(16.dp))
+        Column {
+            Text(
+                text = title,
+                style = MaterialTheme.typography.titleMedium,
+                fontWeight = FontWeight.Medium,
+            )
+            Text(
+                text = subtitle,
+                style = MaterialTheme.typography.bodyMedium,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
+        }
+    }
+}
+
+private fun getStateDescription(stateName: String): String =
+    when (stateName.lowercase()) {
+        "path_requested" -> "Discovering network path to relay..."
+        "link_establishing" -> "Establishing secure connection..."
+        "link_established" -> "Connected, preparing request..."
+        "request_sent" -> "Requested message list from relay..."
+        "receiving", "downloading" -> "Downloading messages..."
+        "complete" -> "Sync complete!"
+        else -> "Processing..."
+    }

--- a/app/src/main/java/com/lxmf/messenger/ui/screens/ChatsScreen.kt
+++ b/app/src/main/java/com/lxmf/messenger/ui/screens/ChatsScreen.kt
@@ -40,6 +40,7 @@ import androidx.compose.material3.DropdownMenu
 import androidx.compose.material3.DropdownMenuItem
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.HorizontalDivider
+import androidx.compose.material3.rememberModalBottomSheetState
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
@@ -65,7 +66,9 @@ import androidx.compose.ui.unit.DpOffset
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
 import com.lxmf.messenger.data.repository.Conversation
+import com.lxmf.messenger.service.SyncProgress
 import com.lxmf.messenger.service.SyncResult
+import com.lxmf.messenger.ui.components.SyncStatusBottomSheet
 import com.lxmf.messenger.ui.components.ProfileIcon
 import com.lxmf.messenger.ui.components.SearchableTopAppBar
 import com.lxmf.messenger.ui.components.StarToggleButton
@@ -84,11 +87,16 @@ fun ChatsScreen(
     val conversations by viewModel.conversations.collectAsState()
     val searchQuery by viewModel.searchQuery.collectAsState()
     val isSyncing by viewModel.isSyncing.collectAsState()
+    val syncProgress by viewModel.syncProgress.collectAsState()
     var isSearching by remember { mutableStateOf(false) }
 
     // Delete dialog state (context menu state is now per-card)
     var selectedConversation by remember { mutableStateOf<Conversation?>(null) }
     var showDeleteDialog by remember { mutableStateOf(false) }
+
+    // Sync status bottom sheet state
+    var showSyncStatusSheet by remember { mutableStateOf(false) }
+    val syncStatusSheetState = rememberModalBottomSheetState()
 
     // Context for Toast notifications
     val context = LocalContext.current
@@ -98,9 +106,14 @@ fun ChatsScreen(
         viewModel.manualSyncResult.collect { result ->
             val message =
                 when (result) {
-                    is SyncResult.Success -> "Sync complete"
+                    is SyncResult.Success -> if (result.messagesReceived > 0) {
+                        "Sync complete: ${result.messagesReceived} new messages"
+                    } else {
+                        "Sync complete"
+                    }
                     is SyncResult.Error -> "Sync failed: ${result.message}"
                     is SyncResult.NoRelay -> "No relay configured"
+                    is SyncResult.Timeout -> "Sync timed out"
                 }
             Toast.makeText(context, message, Toast.LENGTH_SHORT).show()
         }
@@ -117,9 +130,15 @@ fun ChatsScreen(
                 onSearchToggle = { isSearching = !isSearching },
                 searchPlaceholder = "Search conversations...",
                 additionalActions = {
+                    // Sync button - shows spinner during sync, tapping opens status sheet
                     IconButton(
-                        onClick = { viewModel.syncFromPropagationNode() },
-                        enabled = !isSyncing,
+                        onClick = {
+                            if (isSyncing) {
+                                showSyncStatusSheet = true
+                            } else {
+                                viewModel.syncFromPropagationNode()
+                            }
+                        },
                     ) {
                         if (isSyncing) {
                             CircularProgressIndicator(
@@ -244,6 +263,15 @@ fun ChatsScreen(
                 onDismiss = {
                     showDeleteDialog = false
                 },
+            )
+        }
+
+        // Sync status bottom sheet - shows real-time propagation sync progress
+        if (showSyncStatusSheet) {
+            SyncStatusBottomSheet(
+                syncProgress = syncProgress,
+                onDismiss = { showSyncStatusSheet = false },
+                sheetState = syncStatusSheetState,
             )
         }
     }

--- a/app/src/main/java/com/lxmf/messenger/ui/screens/MessagingScreen.kt
+++ b/app/src/main/java/com/lxmf/messenger/ui/screens/MessagingScreen.kt
@@ -122,6 +122,7 @@ import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.paging.compose.collectAsLazyPagingItems
 import androidx.paging.compose.itemKey
+import com.lxmf.messenger.service.SyncProgress
 import com.lxmf.messenger.service.SyncResult
 import com.lxmf.messenger.ui.components.FileAttachmentCard
 import com.lxmf.messenger.ui.components.FileAttachmentOptionsSheet
@@ -135,6 +136,7 @@ import com.lxmf.messenger.ui.components.ReplyInputBar
 import com.lxmf.messenger.ui.components.ReplyPreviewBubble
 import com.lxmf.messenger.ui.components.StarToggleButton
 import com.lxmf.messenger.ui.components.SwipeableMessageBubble
+import com.lxmf.messenger.ui.components.SyncStatusBottomSheet
 import com.lxmf.messenger.ui.model.LocationSharingState
 import com.lxmf.messenger.ui.theme.MeshConnected
 import com.lxmf.messenger.ui.theme.MeshOffline
@@ -178,7 +180,10 @@ fun MessagingScreen(
     val selectedImageIsAnimated by viewModel.selectedImageIsAnimated.collectAsStateWithLifecycle()
     val isProcessingImage by viewModel.isProcessingImage.collectAsStateWithLifecycle()
     val isSyncing by viewModel.isSyncing.collectAsStateWithLifecycle()
+    val syncProgress by viewModel.syncProgress.collectAsStateWithLifecycle()
     val isContactSaved by viewModel.isContactSaved.collectAsStateWithLifecycle()
+    var showSyncStatusSheet by remember { mutableStateOf(false) }
+    val syncStatusSheetState = rememberModalBottomSheetState()
 
     // File attachment state
     val selectedFileAttachments by viewModel.selectedFileAttachments.collectAsStateWithLifecycle()
@@ -233,9 +238,14 @@ fun MessagingScreen(
         viewModel.manualSyncResult.collect { result ->
             val message =
                 when (result) {
-                    is SyncResult.Success -> "Sync complete"
+                    is SyncResult.Success -> if (result.messagesReceived > 0) {
+                        "Sync complete: ${result.messagesReceived} new messages"
+                    } else {
+                        "Sync complete"
+                    }
                     is SyncResult.Error -> "Sync failed: ${result.message}"
                     is SyncResult.NoRelay -> "No relay configured"
+                    is SyncResult.Timeout -> "Sync timed out"
                 }
             Toast.makeText(context, message, Toast.LENGTH_SHORT).show()
         }
@@ -522,10 +532,15 @@ fun MessagingScreen(
                         onClick = { viewModel.toggleContact() },
                     )
 
-                    // Sync button
+                    // Sync button - shows spinner during sync, tapping opens status sheet
                     IconButton(
-                        onClick = { viewModel.syncFromPropagationNode() },
-                        enabled = !isSyncing,
+                        onClick = {
+                            if (isSyncing) {
+                                showSyncStatusSheet = true
+                            } else {
+                                viewModel.syncFromPropagationNode()
+                            }
+                        },
                     ) {
                         if (isSyncing) {
                             CircularProgressIndicator(
@@ -899,6 +914,15 @@ fun MessagingScreen(
                     Text("Cancel")
                 }
             },
+        )
+    }
+
+    // Sync status bottom sheet - shows real-time propagation sync progress
+    if (showSyncStatusSheet) {
+        SyncStatusBottomSheet(
+            syncProgress = syncProgress,
+            onDismiss = { showSyncStatusSheet = false },
+            sheetState = syncStatusSheetState,
         )
     }
 }

--- a/app/src/main/java/com/lxmf/messenger/viewmodel/ChatsViewModel.kt
+++ b/app/src/main/java/com/lxmf/messenger/viewmodel/ChatsViewModel.kt
@@ -7,6 +7,7 @@ import com.lxmf.messenger.data.repository.ContactRepository
 import com.lxmf.messenger.data.repository.Conversation
 import com.lxmf.messenger.data.repository.ConversationRepository
 import com.lxmf.messenger.service.PropagationNodeManager
+import com.lxmf.messenger.service.SyncProgress
 import com.lxmf.messenger.service.SyncResult
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -36,6 +37,9 @@ class ChatsViewModel
 
         // Manual sync result events for Snackbar notifications
         val manualSyncResult: SharedFlow<SyncResult> = propagationNodeManager.manualSyncResult
+
+        // Sync progress for UI display
+        val syncProgress: StateFlow<SyncProgress> = propagationNodeManager.syncProgress
 
         // Cache for contact saved state flows to prevent flickering on recomposition
         private val contactSavedCache = ConcurrentHashMap<String, StateFlow<Boolean>>()

--- a/app/src/main/java/com/lxmf/messenger/viewmodel/MessagingViewModel.kt
+++ b/app/src/main/java/com/lxmf/messenger/viewmodel/MessagingViewModel.kt
@@ -16,6 +16,7 @@ import com.lxmf.messenger.reticulum.protocol.DeliveryMethod
 import com.lxmf.messenger.reticulum.protocol.ReticulumProtocol
 import com.lxmf.messenger.service.LocationSharingManager
 import com.lxmf.messenger.service.PropagationNodeManager
+import com.lxmf.messenger.service.SyncProgress
 import com.lxmf.messenger.service.SyncResult
 import com.lxmf.messenger.ui.model.ImageCache
 import com.lxmf.messenger.ui.model.LocationSharingState
@@ -160,6 +161,9 @@ class MessagingViewModel
 
         // Manual sync result events for Snackbar notifications
         val manualSyncResult: SharedFlow<SyncResult> = propagationNodeManager.manualSyncResult
+
+        // Real-time sync progress for status UI
+        val syncProgress: StateFlow<SyncProgress> = propagationNodeManager.syncProgress
 
         // Track which images have been decoded - used to trigger recomposition
         // when images become available. The UI observes this to know when to re-check the cache.

--- a/app/src/test/java/com/lxmf/messenger/service/PropagationNodeManagerTest.kt
+++ b/app/src/test/java/com/lxmf/messenger/service/PropagationNodeManagerTest.kt
@@ -6,7 +6,8 @@ import com.lxmf.messenger.data.repository.AnnounceRepository
 import com.lxmf.messenger.data.repository.ContactRepository
 import com.lxmf.messenger.repository.SettingsRepository
 import com.lxmf.messenger.reticulum.model.NetworkStatus
-import com.lxmf.messenger.reticulum.protocol.ReticulumProtocol
+import com.lxmf.messenger.reticulum.protocol.PropagationState
+import com.lxmf.messenger.reticulum.protocol.ServiceReticulumProtocol
 import com.lxmf.messenger.test.TestFactories
 import io.mockk.Runs
 import io.mockk.clearAllMocks
@@ -18,6 +19,8 @@ import io.mockk.mockk
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.async
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.test.StandardTestDispatcher
@@ -48,16 +51,18 @@ import kotlin.time.Duration.Companion.seconds
 @OptIn(ExperimentalCoroutinesApi::class)
 class PropagationNodeManagerTest {
     private val testDispatcher = StandardTestDispatcher()
+    private val testScheduler get() = testDispatcher.scheduler
     private lateinit var testScope: TestScope
 
     private lateinit var settingsRepository: SettingsRepository
     private lateinit var contactRepository: ContactRepository
     private lateinit var announceRepository: AnnounceRepository
-    private lateinit var reticulumProtocol: ReticulumProtocol
+    private lateinit var reticulumProtocol: ServiceReticulumProtocol
     private lateinit var manager: PropagationNodeManager
     private lateinit var myRelayFlow: MutableStateFlow<ContactEntity?>
     private lateinit var autoSelectFlow: MutableStateFlow<Boolean>
     private lateinit var networkStatusFlow: MutableStateFlow<NetworkStatus>
+    private lateinit var propagationStateFlow: MutableSharedFlow<PropagationState>
 
     private val testDestHash = TestFactories.TEST_DEST_HASH
     private val testDestHash2 = TestFactories.TEST_DEST_HASH_2
@@ -78,9 +83,13 @@ class PropagationNodeManagerTest {
         myRelayFlow = MutableStateFlow<ContactEntity?>(null)
         autoSelectFlow = MutableStateFlow(true)
         networkStatusFlow = MutableStateFlow<NetworkStatus>(NetworkStatus.READY)
+        propagationStateFlow = MutableSharedFlow(replay = 1, extraBufferCapacity = 1)
 
         // Mock networkStatus flow
         every { reticulumProtocol.networkStatus } returns networkStatusFlow
+
+        // Mock propagationStateFlow for sync completion observation
+        every { reticulumProtocol.propagationStateFlow } returns propagationStateFlow
 
         // Default settings mocks
         coEvery { settingsRepository.getAutoSelectPropagationNode() } returns true
@@ -1325,6 +1334,9 @@ class PropagationNodeManagerTest {
                     isMyRelay = true,
                 )
 
+            // Start manager to observe propagation state changes
+            manager.start()
+
             // Wait for currentRelayState to become Loaded
             manager.currentRelayState.test(timeout = 5.seconds) {
                 var state = awaitItem()
@@ -1335,7 +1347,7 @@ class PropagationNodeManagerTest {
             }
 
             val mockSyncState =
-                com.lxmf.messenger.reticulum.protocol.PropagationState(
+                PropagationState(
                     state = 0,
                     stateName = "IDLE",
                     progress = 0.0f,
@@ -1345,11 +1357,24 @@ class PropagationNodeManagerTest {
                 Result.success(mockSyncState)
 
             // When
-            manager.syncWithPropagationNode()
-            advanceUntilIdle()
+            launch { manager.syncWithPropagationNode() }
+            testScheduler.runCurrent()
+
+            // Simulate propagation state callback with PR_COMPLETE (state 7)
+            val completeState = PropagationState(
+                state = 7,
+                stateName = "complete",
+                progress = 1.0f,
+                messagesReceived = 0,
+            )
+            propagationStateFlow.emit(completeState)
+            testScheduler.runCurrent()
 
             // Then: Should save timestamp to settings repository
             coVerify { settingsRepository.saveLastSyncTimestamp(any()) }
+
+            // Stop manager to cancel observer
+            manager.stop()
         }
 
     @Test
@@ -1476,6 +1501,9 @@ class PropagationNodeManagerTest {
                     isMyRelay = true,
                 )
 
+            // Start manager to observe propagation state changes
+            manager.start()
+
             // Wait for currentRelayState to become Loaded
             manager.currentRelayState.test(timeout = 5.seconds) {
                 var state = awaitItem()
@@ -1486,7 +1514,7 @@ class PropagationNodeManagerTest {
             }
 
             val mockSyncState =
-                com.lxmf.messenger.reticulum.protocol.PropagationState(
+                PropagationState(
                     state = 0,
                     stateName = "IDLE",
                     progress = 0.0f,
@@ -1497,16 +1525,30 @@ class PropagationNodeManagerTest {
 
             // When: Trigger sync and collect result
             manager.manualSyncResult.test(timeout = 5.seconds) {
-                manager.triggerSync()
-                advanceUntilIdle()
+                launch { manager.triggerSync() }
+                testScheduler.runCurrent()
 
-                // Then: Should emit Success
+                // Simulate propagation state callback with PR_COMPLETE (state 7)
+                val completeState = PropagationState(
+                    state = 7,
+                    stateName = "complete",
+                    progress = 1.0f,
+                    messagesReceived = 3,
+                )
+                propagationStateFlow.emit(completeState)
+                testScheduler.runCurrent()
+
+                // Then: Should emit Success with messages count
                 val result = awaitItem()
                 assert(result is SyncResult.Success) {
                     "Should emit Success on successful sync, got $result"
                 }
+                assertEquals(3, (result as SyncResult.Success).messagesReceived)
                 cancelAndConsumeRemainingEvents()
             }
+
+            // Stop manager to cancel observer
+            manager.stop()
         }
 
     @Test
@@ -1558,6 +1600,9 @@ class PropagationNodeManagerTest {
                     isMyRelay = true,
                 )
 
+            // Start manager to observe propagation state changes
+            manager.start()
+
             // Wait for currentRelayState to become Loaded
             manager.currentRelayState.test(timeout = 5.seconds) {
                 var state = awaitItem()
@@ -1568,7 +1613,7 @@ class PropagationNodeManagerTest {
             }
 
             val mockSyncState =
-                com.lxmf.messenger.reticulum.protocol.PropagationState(
+                PropagationState(
                     state = 0,
                     stateName = "IDLE",
                     progress = 0.0f,
@@ -1578,8 +1623,18 @@ class PropagationNodeManagerTest {
                 Result.success(mockSyncState)
 
             // When
-            manager.triggerSync()
-            advanceUntilIdle()
+            launch { manager.triggerSync() }
+            testScheduler.runCurrent()
+
+            // Simulate propagation state callback with PR_COMPLETE (state 7)
+            val completeState = PropagationState(
+                state = 7,
+                stateName = "complete",
+                progress = 1.0f,
+                messagesReceived = 0,
+            )
+            propagationStateFlow.emit(completeState)
+            testScheduler.runCurrent()
 
             // Then: Should save timestamp to settings repository
             coVerify { settingsRepository.saveLastSyncTimestamp(any()) }
@@ -1588,6 +1643,9 @@ class PropagationNodeManagerTest {
             assert(manager.lastSyncTimestamp.value != null) {
                 "lastSyncTimestamp should be set after successful sync"
             }
+
+            // Stop manager to cancel observer
+            manager.stop()
         }
 
     // ========== RelayInfo Fallback Logic Tests (via currentRelay) ==========

--- a/python/reticulum_wrapper.py
+++ b/python/reticulum_wrapper.py
@@ -299,6 +299,11 @@ class ReticulumWrapper:
         # Used to bypass Python multiprocessing issues on Android
         self.kotlin_stamp_generator_callback = None
 
+        # Propagation sync state callback (for real-time sync progress updates)
+        # Invoked when LXMF propagation state changes (idle, receiving, complete, etc.)
+        self.kotlin_propagation_state_callback = None
+        self._last_propagation_state = None  # For change detection
+
         # Service heartbeat tracking (Sideband-inspired process monitoring)
         # Python updates timestamp every second; Kotlin monitors for stale heartbeats
         # If heartbeat is stale > 10 seconds, Kotlin should restart the service
@@ -533,6 +538,24 @@ class ReticulumWrapper:
         except Exception as e:
             log_error("ReticulumWrapper", "set_stamp_generator_callback",
                      f"Failed to register stamp generator: {e}")
+
+    def set_propagation_state_callback(self, callback):
+        """
+        Set callback for propagation sync state changes.
+
+        This callback is invoked whenever the LXMF propagation state changes
+        (e.g., idle -> path_requested -> receiving -> complete).
+        Used by Kotlin to show real-time sync progress.
+
+        Callback signature: callback(state_json: str) -> None
+        state_json contains: {"state": int, "state_name": str, "progress": float, "messages_received": int}
+
+        Args:
+            callback: PyObject callable from Kotlin (passed via Chaquopy)
+        """
+        self.kotlin_propagation_state_callback = callback
+        log_info("ReticulumWrapper", "set_propagation_state_callback",
+                "Propagation state callback registered")
 
     def _clear_stale_ble_paths(self):
         """
@@ -3834,16 +3857,74 @@ class ReticulumWrapper:
             log_info("ReticulumWrapper", "_start_heartbeat_thread",
                     "Started service heartbeat thread (1s interval)")
 
+    def _get_propagation_state_name(self, state: int) -> str:
+        """Map LXMF propagation state integer to human-readable name."""
+        state_names = {
+            0: "idle",
+            1: "path_requested",
+            2: "link_establishing",
+            3: "link_established",
+            4: "request_sent",
+            5: "receiving",
+            7: "complete",
+            0xf0: "no_path",
+            0xf1: "link_failed",
+            0xf2: "transfer_failed",
+            0xf3: "no_identity_rcvd",
+            0xf4: "no_access",
+        }
+        return state_names.get(state, f"unknown_{state}")
+
+    def _check_propagation_state_change(self):
+        """
+        Check if LXMF propagation state changed and notify Kotlin if so.
+        Called from heartbeat loop at higher frequency during active sync.
+        """
+        if not self.router or not self.kotlin_propagation_state_callback:
+            return
+
+        try:
+            current_state = self.router.propagation_transfer_state
+            if current_state != self._last_propagation_state:
+                self._last_propagation_state = current_state
+
+                progress = getattr(self.router, 'propagation_transfer_progress', 0.0) or 0.0
+                messages_received = getattr(self.router, 'propagation_transfer_last_result', 0) or 0
+
+                state_info = {
+                    "state": current_state,
+                    "state_name": self._get_propagation_state_name(current_state),
+                    "progress": progress,
+                    "messages_received": messages_received
+                }
+                self.kotlin_propagation_state_callback(json.dumps(state_info))
+                log_debug("ReticulumWrapper", "_check_propagation_state_change",
+                         f"Propagation state changed: {state_info['state_name']} ({current_state})")
+        except Exception as e:
+            log_error("ReticulumWrapper", "_check_propagation_state_change", f"Error: {e}")
+
     def _heartbeat_loop(self):
         """
-        Background loop that updates the heartbeat timestamp every second.
-        Runs while self.initialized is True. Kotlin monitors this timestamp
-        and will restart the service if it becomes stale (> 10 seconds old).
+        Background loop that updates the heartbeat timestamp.
+        Also monitors propagation state changes for real-time sync progress.
+        Uses faster interval (100ms) during active sync, slower (1s) when idle.
         """
         log_debug("ReticulumWrapper", "_heartbeat_loop", "Heartbeat loop started")
         while self.initialized:
             self._heartbeat_timestamp = time.time()
-            time.sleep(1)
+
+            # Check propagation state changes (for real-time sync progress)
+            self._check_propagation_state_change()
+
+            # Use faster interval during active sync (100ms), slower when idle (1s)
+            if (self.router and
+                self._last_propagation_state is not None and
+                self._last_propagation_state not in (0, 7, 0xf0, 0xf1, 0xf2, 0xf3, 0xf4)):
+                # Active sync in progress - check more frequently
+                time.sleep(0.1)
+            else:
+                # Idle or complete - normal heartbeat interval
+                time.sleep(1)
         log_debug("ReticulumWrapper", "_heartbeat_loop", "Heartbeat loop exiting (not initialized)")
 
     def get_heartbeat(self) -> float:


### PR DESCRIPTION
## Summary

This PR fixes the UX issue where manual sync with propagation node shows "Sync complete" immediately while large file downloads still happen in background.

### Changes

- **Event-driven sync state tracking**: Python now monitors LXMF propagation state and invokes Kotlin callback on state changes
- **Real-time progress UI**: New `SyncStatusBottomSheet` component shows current sync state (path discovery, connecting, downloading, etc.)
- **Proper completion detection**: Sync only reports "Success" when `PR_COMPLETE` (state 7) is reached
- **Loading spinner**: Sync button shows spinner during active sync; tapping opens status bottom sheet
- **5-minute timeout**: Sync times out with `SyncResult.Timeout` if completion not reached

### LXMF Propagation States Tracked

```
0 (PR_IDLE) → 1 (PR_PATH_REQUESTED) → 2 (PR_LINK_ESTABLISHING) →
3 (PR_LINK_ESTABLISHED) → 4 (PR_REQUEST_SENT) → 5 (PR_RECEIVING) → 7 (PR_COMPLETE)

Error states: 0xf0 (NO_PATH), 0xf1 (LINK_FAILED), 0xf2 (TRANSFER_FAILED), etc.
```

### Files Modified

- `python/reticulum_wrapper.py` - Propagation state callback and heartbeat monitoring
- `IReticulumServiceCallback.aidl` - New `onPropagationStateChanged` callback
- `CallbackBroadcaster.kt` - Broadcast propagation state changes
- `PythonWrapperManager.kt` - Register state callback
- `ReticulumServiceBinder.kt` - Register callback on service bind
- `ServiceReticulumProtocol.kt` - `propagationStateFlow` for reactive state updates
- `PropagationNodeManager.kt` - Refactored to wait for completion, added `SyncProgress` sealed class
- `ChatsViewModel.kt` / `MessagingViewModel.kt` - Expose `syncProgress`
- `ChatsScreen.kt` / `MessagingScreen.kt` - Sync button with spinner and bottom sheet
- `SyncStatusBottomSheet.kt` - NEW component for real-time sync display

---

## Unfinished: Recipient Rejection Notification

### Problem

When a message is rejected due to the recipient's incoming size limit:
- Sender sees the message fall back to "propagated" status (existing `retrying_propagated` works)
- **Receiver gets NO notification** that they rejected an incoming message

### Investigation Results

LXMF rejects oversized resources silently in `delivery_resource_advertised()` by returning `False`. There is no callback mechanism or hook point for us to intercept this rejection.

```python
# In LXMF LXMRouter.delivery_resource_advertised():
if resource.data_size > self.delivery_per_transfer_limit:
    return False  # Silent rejection, no callback
```

### Potential Solution: LXMF Extended Fields

It may be possible to achieve recipient notification using LXMF's extended fields mechanism:

1. **Sender-side**: When sending a large message, include metadata in LXMF extended fields:
   - `x-columba-size`: Total message size in bytes
   - `x-columba-has-attachment`: Boolean flag

2. **Recipient-side**: When receiving a message via propagation node (instead of direct):
   - Check if `x-columba-has-attachment` is set
   - If the attachment data is missing/truncated but the flag indicates one was sent
   - Show system message: "[Sender] sent a file that exceeded your size limit"

3. **Alternative**: The sender could send a separate "notification" message when direct delivery fails:
   - Small metadata-only message saying "I tried to send you a large file"
   - Recipient sees this notification even though they rejected the actual file

### Considerations

- Extended fields approach requires coordination between sender and receiver Columba versions
- May need protocol versioning to handle older clients gracefully
- Could be combined with the existing `retrying_propagated` status on sender side

## Test Plan

- [x] Unit tests for `PropagationNodeManager` sync completion
- [x] All existing tests pass
- [ ] Manual testing: sync with large pending file, verify progress shown correctly
- [ ] Manual testing: verify completion only shown when download actually finishes

🤖 Generated with [Claude Code](https://claude.com/claude-code)