### PR TITLE
Add APK signing certificate verification to releases

### DIFF
--- a/.github/workflows/build-prerelease-apk.yml
+++ b/.github/workflows/build-prerelease-apk.yml
@@ -48,6 +48,24 @@ jobs:
           KEY_PASSWORD: ${{ secrets.KEY_PASSWORD }}
         run: ./gradlew assembleRelease --stacktrace
 
+      - name: Extract signing certificate fingerprints
+        id: cert
+        env:
+          KEYSTORE_PASSWORD: ${{ secrets.KEYSTORE_PASSWORD }}
+          KEY_ALIAS: ${{ secrets.KEY_ALIAS }}
+        run: |
+          CERT_INFO=$(keytool -list -v -keystore app/build/keystore/release.keystore \
+            -alias "$KEY_ALIAS" -storepass "$KEYSTORE_PASSWORD")
+          SHA256=$(echo "$CERT_INFO" | grep "SHA256:" | awk '{print $2}')
+          SHA1=$(echo "$CERT_INFO" | grep "SHA1:" | awk '{print $2}')
+          if [ -z "$SHA256" ] || [ -z "$SHA1" ]; then
+            echo "::error::Failed to extract certificate fingerprints"
+            exit 1
+          fi
+          echo "sha256=$SHA256" >> $GITHUB_OUTPUT
+          echo "sha1=$SHA1" >> $GITHUB_OUTPUT
+          echo "✓ Extracted certificate fingerprints"
+
       - name: Get branch name
         id: branch
         run: echo "branch=${GITHUB_REF#refs/heads/}" >> $GITHUB_OUTPUT
@@ -83,17 +101,34 @@ jobs:
           echo "name=$(basename $APK_PATH)" >> $GITHUB_OUTPUT
 
       - name: Rename APK
+        env:
+          APK_PATH: ${{ steps.apk.outputs.path }}
         run: |
-          cp ${{ steps.apk.outputs.path }} columba.apk
+          cp "$APK_PATH" columba.apk
           echo "✓ Renamed APK to columba.apk"
+
+      - name: Generate SHA256 checksum
+        run: |
+          sha256sum columba.apk > columba.apk.sha256
+          echo "✓ Generated SHA256 checksum"
+
+      - name: Read SHA256 checksum
+        id: sha256
+        run: |
+          SHA256=$(cat columba.apk.sha256)
+          echo "checksum=$SHA256" >> $GITHUB_OUTPUT
 
       - name: Determine release name
         id: release_name
+        env:
+          INPUT_NAME: ${{ github.event.inputs.release_name }}
+          VERSION: ${{ steps.version.outputs.version }}
+          SHA: ${{ steps.sha.outputs.sha }}
         run: |
-          if [ -n "${{ github.event.inputs.release_name }}" ]; then
-            echo "name=${{ github.event.inputs.release_name }}" >> $GITHUB_OUTPUT
+          if [ -n "$INPUT_NAME" ]; then
+            echo "name=$INPUT_NAME" >> $GITHUB_OUTPUT
           else
-            echo "name=Pre-Release v${{ steps.version.outputs.version }} (${{ steps.sha.outputs.sha }})" >> $GITHUB_OUTPUT
+            echo "name=Pre-Release v${VERSION} (${SHA})" >> $GITHUB_OUTPUT
           fi
 
       - name: Create Pre-Release
@@ -117,11 +152,27 @@ jobs:
 
             ${{ github.event.inputs.release_notes }}
 
+            ### Verification
+            See [SECURITY.md](https://github.com/torlando-tech/columba/blob/main/SECURITY.md) for verification instructions.
+
+            **Signing Certificate Fingerprints:**
+            ```
+            SHA-256: ${{ steps.cert.outputs.sha256 }}
+            SHA-1:   ${{ steps.cert.outputs.sha1 }}
+            ```
+
+            **SHA256 Checksum:**
+            ```
+            ${{ steps.sha256.outputs.checksum }}
+            ```
+
             ### Installation
             Download the APK below and install it on your Android device.
 
             **Note:** You may need to enable "Install from Unknown Sources" in your device settings.
-          files: columba.apk
+          files: |
+            columba.apk
+            columba.apk.sha256
           draft: false
           prerelease: true
           token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -46,23 +46,44 @@ jobs:
           ./gradlew :app:assembleRelease --no-daemon --stacktrace
           echo "✓ Release APK built successfully"
 
-      - name: Rename APK with version
+      - name: Extract signing certificate fingerprints
+        id: cert
+        env:
+          KEYSTORE_PASSWORD: ${{ secrets.KEYSTORE_PASSWORD }}
+          KEY_ALIAS: ${{ secrets.KEY_ALIAS }}
         run: |
-          VERSION=${{ steps.version.outputs.version }}
-          cp app/build/outputs/apk/release/app-release.apk \
-             columba-${VERSION}.apk
+          CERT_INFO=$(keytool -list -v -keystore app/build/keystore/release.keystore \
+            -alias "$KEY_ALIAS" -storepass "$KEYSTORE_PASSWORD")
+          SHA256=$(echo "$CERT_INFO" | grep "SHA256:" | awk '{print $2}')
+          SHA1=$(echo "$CERT_INFO" | grep "SHA1:" | awk '{print $2}')
+          if [ -z "$SHA256" ] || [ -z "$SHA1" ]; then
+            echo "::error::Failed to extract certificate fingerprints"
+            exit 1
+          fi
+          echo "sha256=$SHA256" >> $GITHUB_OUTPUT
+          echo "sha1=$SHA1" >> $GITHUB_OUTPUT
+          echo "✓ Extracted certificate fingerprints"
+
+      - name: Rename APK with version
+        env:
+          VERSION: ${{ steps.version.outputs.version }}
+        run: |
+          cp app/build/outputs/apk/release/app-release.apk "columba-${VERSION}.apk"
           echo "✓ Renamed APK to columba-${VERSION}.apk"
 
       - name: Generate SHA256 checksum
+        env:
+          VERSION: ${{ steps.version.outputs.version }}
         run: |
-          sha256sum columba-${{ steps.version.outputs.version }}.apk > \
-            columba-${{ steps.version.outputs.version }}.apk.sha256
+          sha256sum "columba-${VERSION}.apk" > "columba-${VERSION}.apk.sha256"
           echo "✓ Generated SHA256 checksum"
 
       - name: Read SHA256 checksum
         id: sha256
+        env:
+          VERSION: ${{ steps.version.outputs.version }}
         run: |
-          SHA256=$(cat columba-${{ steps.version.outputs.version }}.apk.sha256)
+          SHA256=$(cat "columba-${VERSION}.apk.sha256")
           echo "checksum=$SHA256" >> $GITHUB_OUTPUT
 
       - name: Create GitHub Release
@@ -79,6 +100,15 @@ jobs:
 
             ### Installation
             Download the APK below and install on your Android device.
+
+            ### Verification
+            See [SECURITY.md](https://github.com/torlando-tech/columba/blob/main/SECURITY.md) for verification instructions.
+
+            **Signing Certificate Fingerprints:**
+            ```
+            SHA-256: ${{ steps.cert.outputs.sha256 }}
+            SHA-1:   ${{ steps.cert.outputs.sha1 }}
+            ```
 
             **SHA256 Checksum:**
             ```

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Built with a native Android interface and Material Design 3, Columba brings mesh
 
 ## Getting Started
 
-Download the latest release from [Releases](https://github.com/torlando-tech/columba/releases) and install on your Android device.
+Download the latest release from [Releases](https://github.com/torlando-tech/columba/releases) and install on your Android device. See [SECURITY.md](./SECURITY.md) for APK verification instructions.
 
 <a href="https://apps.obtainium.imranr.dev/redirect.html?r=obtainium://add/https://github.com/torlando-tech/columba"><img src="https://raw.githubusercontent.com/ImranR98/Obtainium/main/assets/graphics/badge_obtainium.png" height="60" alt="Get it on Obtainium"></a>
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,47 @@
+# Security Policy
+
+## APK Verification
+
+All official Columba releases are signed with our release certificate:
+
+**SHA-256:**
+```
+02:2B:12:20:48:63:A3:1F:BF:07:5B:C9:F9:34:1E:33:52:78:80:2E:80:C9:27:A4:75:46:E4:7E:2F:4A:0C:5F
+```
+
+**SHA-1:**
+```
+0A:6B:AE:58:4E:D7:B5:D0:35:8B:3C:7B:65:11:D6:3A:81:21:0D:CE
+```
+
+### Verifying Before Installation
+
+With Android SDK tools installed:
+
+```bash
+apksigner verify --print-certs columba-x.x.x.apk
+```
+
+Compare the SHA-256 digest in the output with the fingerprint above.
+
+### SHA256 Checksums
+
+Release APKs include a `.sha256` file:
+
+```bash
+sha256sum -c columba-x.x.x.apk.sha256
+```
+
+### If Verification Fails
+
+Do not install. Delete the APK and download only from [GitHub Releases](https://github.com/torlando-tech/columba/releases). Report suspicious APKs via [GitHub Issues](https://github.com/torlando-tech/columba/issues).
+
+**Note:** Android automatically verifies that app updates are signed with the same certificate, so subsequent updates are protected after you've verified your first installation.
+
+## Reporting Vulnerabilities
+
+Report security issues via [GitHub Issues](https://github.com/torlando-tech/columba/issues) with the "security" label. Include steps to reproduce and potential impact. We aim to respond within 48 hours.
+
+## Supported Versions
+
+Only the latest release receives security updates.


### PR DESCRIPTION
## Summary

- Add SECURITY.md with official certificate fingerprints (SHA-256 and SHA-1) and verification instructions
- Update release workflows to extract and publish cert fingerprints from the signing keystore
- Add SHA256 checksums to pre-release builds (was missing)
- Link SECURITY.md from README.md

## Security Improvements

- Extract fingerprints from actual keystore at build time (not hardcoded)
- Use `env:` blocks for step outputs to prevent shell injection
- Validate fingerprint extraction with error handling (`exit 1` on failure)
- Use `KEY_ALIAS` secret instead of hardcoded alias
- Quote all paths and variables in shell commands

## Changes

| File | Change |
|------|--------|
| `SECURITY.md` | New - verification instructions + fingerprints |
| `README.md` | Links to SECURITY.md |
| `.github/workflows/release.yml` | Extracts + publishes cert fingerprints |
| `.github/workflows/build-prerelease-apk.yml` | Adds SHA256 checksums + cert fingerprints |

## Test plan

- [ ] Trigger manual pre-release build and verify fingerprints appear in release notes
- [ ] Download APK and verify with `apksigner verify --print-certs`
- [ ] Confirm fingerprints match SECURITY.md

🤖 Generated with [Claude Code](https://claude.com/claude-code)