### PR TITLE
fix: filter deprecated LXMF propagation nodes from sync

### DIFF
--- a/data/src/main/java/com/lxmf/messenger/data/db/dao/AnnounceDao.kt
+++ b/data/src/main/java/com/lxmf/messenger/data/db/dao/AnnounceDao.kt
@@ -128,7 +128,14 @@ interface AnnounceDao {
      * Get announces filtered by node types.
      * Returns a Flow that emits updated lists whenever the database changes.
      */
-    @Query("SELECT * FROM announces WHERE nodeType IN (:nodeTypes) ORDER BY lastSeenTimestamp DESC")
+    @Query(
+        """
+        SELECT * FROM announces
+        WHERE nodeType IN (:nodeTypes)
+        AND (nodeType != 'PROPAGATION_NODE' OR stampCostFlexibility IS NOT NULL)
+        ORDER BY lastSeenTimestamp DESC
+        """,
+    )
     fun getAnnouncesByTypes(nodeTypes: List<String>): Flow<List<AnnounceEntity>>
 
     /**
@@ -143,6 +150,7 @@ interface AnnounceDao {
         """
         SELECT * FROM announces
         WHERE nodeType = 'PROPAGATION_NODE'
+        AND stampCostFlexibility IS NOT NULL
         ORDER BY hops ASC, lastSeenTimestamp DESC
         LIMIT :limit
     """,
@@ -178,7 +186,14 @@ interface AnnounceDao {
      * Get announces filtered by node types with pagination support.
      * Returns a PagingSource for use with Paging 3 library.
      */
-    @Query("SELECT * FROM announces WHERE nodeType IN (:nodeTypes) ORDER BY lastSeenTimestamp DESC")
+    @Query(
+        """
+        SELECT * FROM announces
+        WHERE nodeType IN (:nodeTypes)
+        AND (nodeType != 'PROPAGATION_NODE' OR stampCostFlexibility IS NOT NULL)
+        ORDER BY lastSeenTimestamp DESC
+        """,
+    )
     fun getAnnouncesByTypesPaged(nodeTypes: List<String>): PagingSource<Int, AnnounceEntity>
 
     /**


### PR DESCRIPTION
## Summary
- Filters out propagation nodes running deprecated LXMF versions that cause failed syncs
- Detection is based on `stampCostFlexibility IS NOT NULL` - only set for modern announce format
- Applies to relay selection list, Announces page, and paged queries

## Test plan
- [x] Unit tests pass for `getTopPropagationNodes_excludesDeprecatedNodes`
- [x] Unit tests pass for `getAnnouncesByTypes_excludesDeprecatedPropagationNodes`
- [x] Unit tests pass for `getAnnouncesByTypes_allowsPeersWithNullStampCostFlexibility`
- [x] Manual test: verify deprecated nodes no longer appear in relay selection
- [x] Manual test: verify deprecated nodes no longer appear in Announces page when filtered for propagation nodes

🤖 Generated with [Claude Code](https://claude.com/claude-code)