### PR TITLE
fix: prevent garbled propagation node names (#233)

### DIFF
--- a/app/src/test/java/com/lxmf/messenger/service/manager/EventHandlerTest.kt
+++ b/app/src/test/java/com/lxmf/messenger/service/manager/EventHandlerTest.kt
@@ -275,4 +275,9 @@ class EventHandlerTest {
 
             // No crash
         }
+
+    // Note: handleAnnounceEvent() tests require Android runtime for Base64/Log
+    // The fix for issue #233 (propagation node garbled names) is tested via:
+    // - AppDataParserTest for msgpack metadata extraction
+    // - Integration tests for end-to-end announce handling
 }


### PR DESCRIPTION
## Summary
- Fix propagation nodes displaying garbled names when Python's `LXMF.pn_name_from_app_data()` returns `None`
- Make name fallback logic node-type aware: skip UTF-8 parsing for propagation nodes (their `app_data` is msgpack binary)
- Add test case documenting the issue and fix

## Test plan
- [x] Existing unit tests pass
- [x] New test for issue #233 passes in `AppDataParserTest`
- [x] Manual test: Connect to a propagation node without a name in metadata, verify it shows "Peer XXXX..." instead of garbled text
- [x] Wait for saved contacts with garbled names to announce to see if they correct themselves

Fixes #233

🤖 Generated with [Claude Code](https://claude.com/claude-code)