### PR TITLE
Fix DeadObjectException when switching identities

### DIFF
--- a/app/src/main/java/com/lxmf/messenger/reticulum/protocol/ServiceReticulumProtocol.kt
+++ b/app/src/main/java/com/lxmf/messenger/reticulum/protocol/ServiceReticulumProtocol.kt
@@ -754,6 +754,12 @@ class ServiceReticulumProtocol(
                 service?.unregisterCallback(serviceCallback)
                 context.unbindService(serviceConnection)
                 isBound = false
+                // Reset ready flag to ensure fresh bind waits for new service callback
+                // Without this, a subsequent bindService() may see the stale flag and
+                // resume immediately with a dead binder reference (DeadObjectException)
+                synchronized(bindLock) {
+                    serviceReadyBeforeContinuationSet = false
+                }
             }
         } catch (e: Exception) {
             Log.e(TAG, "Error unbinding service", e)


### PR DESCRIPTION
## Summary

Fixes service restart failure when switching identities.

**Root cause:** When unbinding from the service, the `serviceReadyBeforeContinuationSet` flag was not reset. This caused subsequent `bindService()` calls to see the stale flag and immediately resume, thinking the service was already ready. But the binder reference was to the old (dead) service process, resulting in `DeadObjectException`.

**Error from logcat:**
```
InterfaceConfigManager: Step 8: Binding to new service instance...
ServiceReticulumProtocol: Service was already ready - resuming immediately  <-- WRONG!
InterfaceConfigManager: Step 9: Initializing Reticulum with new configuration...
IPCThreadState: Binder transaction failure. id: 769276340, BR_*: 29189, error: -22
InterfaceConfigManager: Failed to initialize Reticulum
InterfaceConfigManager: android.os.DeadObjectException
```

**Fix:** Reset `serviceReadyBeforeContinuationSet = false` in `unbindService()` so fresh binds properly wait for the new service's `onServiceReady()` callback.

## Test plan

- [ ] Switch identities on device
- [ ] Verify service restarts successfully without DeadObjectException
- [ ] Verify announces and messages still work after identity switch

🤖 Generated with [Claude Code](https://claude.com/claude-code)