### PR TITLE
fix: prevent crash when leaving WiFi range

### DIFF
--- a/app/src/main/java/com/lxmf/messenger/service/di/ServiceModule.kt
+++ b/app/src/main/java/com/lxmf/messenger/service/di/ServiceModule.kt
@@ -94,9 +94,10 @@ object ServiceModule {
         // Started after initialization completes (see ReticulumServiceBinder)
         val healthCheckManager = HealthCheckManager(wrapperManager, scope, onStaleHeartbeat)
 
-        // Phase 4: Network change monitoring (depends on lockManager)
+        // Phase 4: Network change monitoring (depends on lockManager, scope)
         // Reacquires locks and triggers announce on network changes
-        val networkChangeManager = NetworkChangeManager(context, lockManager, onNetworkChanged)
+        // Uses scope for debounced callbacks to prevent race conditions
+        val networkChangeManager = NetworkChangeManager(context, lockManager, scope, onNetworkChanged)
 
         // Phase 5: Business logic (depends on wrapperManager)
         val identityManager = IdentityManager(wrapperManager)

--- a/app/src/test/java/com/lxmf/messenger/service/manager/NetworkChangeCallbackRaceTest.kt
+++ b/app/src/test/java/com/lxmf/messenger/service/manager/NetworkChangeCallbackRaceTest.kt
@@ -1,0 +1,189 @@
+package com.lxmf.messenger.service.manager
+
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import java.util.concurrent.atomic.AtomicInteger
+
+/**
+ * Reproduces the crash that occurs when leaving WiFi range.
+ *
+ * Root cause: Network change callbacks fire rapidly on Binder threads while
+ * the wrapper is being shut down, causing TOCTOU race conditions.
+ */
+class NetworkChangeCallbackRaceTest {
+    class MockWrapper(val id: Int) {
+        @Volatile
+        var isShutdown = false
+
+        fun callMethod(): String {
+            if (isShutdown) error("Wrapper is shutdown!")
+            return "success-$id"
+        }
+
+        fun shutdown() {
+            isShutdown = true
+        }
+    }
+
+    /**
+     * Simulates the CURRENT (unsafe) pattern:
+     * - Callback runs on uncontrolled thread
+     * - No synchronization with wrapper lifecycle
+     * - No debouncing
+     */
+    class UnsafeNetworkCallbackSimulator {
+        @Volatile
+        var wrapper: MockWrapper? = null
+        private var wrapperIdCounter = AtomicInteger(0)
+        private val crashCount = AtomicInteger(0)
+
+        fun initialize() {
+            wrapper = MockWrapper(wrapperIdCounter.incrementAndGet())
+        }
+
+        fun shutdown() {
+            wrapper?.shutdown()
+            wrapper = null
+        }
+
+        // Simulates: if (::binder.isInitialized) { binder.announceLxmfDestination() }
+        @Suppress("SwallowedException") // Intentional: counting crashes for test assertions
+        fun onNetworkChanged() {
+            val w = wrapper
+            if (w != null) { // Check passes
+                try {
+                    // Longer window to reliably create race conditions in tests
+                    Thread.sleep(5)
+                    w.callMethod() // May throw if shutdown happened between check and use
+                } catch (e: IllegalStateException) {
+                    crashCount.incrementAndGet()
+                }
+            }
+        }
+
+        fun getCrashCount() = crashCount.get()
+    }
+
+    /**
+     * Simulates the FIXED pattern:
+     * - Callback debounced and runs on controlled coroutine scope
+     * - State check verifies wrapper is fully ready
+     */
+    class SafeNetworkCallbackSimulator(private val scope: CoroutineScope) {
+        private val mutex = Mutex()
+
+        @Volatile
+        var wrapper: MockWrapper? = null
+        private var wrapperIdCounter = AtomicInteger(0)
+        private val crashCount = AtomicInteger(0)
+        private var debounceJob: Job? = null
+
+        suspend fun initialize() {
+            mutex.withLock {
+                wrapper = MockWrapper(wrapperIdCounter.incrementAndGet())
+            }
+        }
+
+        suspend fun shutdown() {
+            mutex.withLock {
+                wrapper?.shutdown()
+                wrapper = null
+            }
+        }
+
+        fun isInitialized(): Boolean = wrapper?.isShutdown == false
+
+        // Fixed: debounced, runs on scope, checks state properly
+        @Suppress("SwallowedException") // Intentional: counting crashes for test assertions
+        fun onNetworkChanged() {
+            debounceJob?.cancel()
+            debounceJob =
+                scope.launch {
+                    delay(50) // Debounce
+                    if (isInitialized()) {
+                        try {
+                            wrapper?.callMethod()
+                        } catch (e: IllegalStateException) {
+                            crashCount.incrementAndGet()
+                        }
+                    }
+                }
+        }
+
+        fun getCrashCount() = crashCount.get()
+    }
+
+    @Test
+    fun `UNSAFE - rapid network changes during shutdown causes crashes`() =
+        runBlocking {
+            val simulator = UnsafeNetworkCallbackSimulator()
+            simulator.initialize()
+
+            // Simulate rapid network callbacks (like leaving WiFi range)
+            val callbackJobs =
+                List(20) {
+                    launch(Dispatchers.Default) {
+                        repeat(10) {
+                            simulator.onNetworkChanged()
+                            delay(1)
+                        }
+                    }
+                }
+
+            // Simulate shutdown happening concurrently
+            // Longer delay to ensure callbacks are in-flight when shutdown occurs
+            val shutdownJob =
+                launch(Dispatchers.Default) {
+                    delay(20)
+                    simulator.shutdown()
+                }
+
+            callbackJobs.forEach { it.join() }
+            shutdownJob.join()
+
+            // With the unsafe pattern, crashes CAN occur due to TOCTOU race condition.
+            // The exact number depends on timing, so we just document the behavior.
+            // In production, this manifests as crashes when leaving WiFi range.
+            val crashes = simulator.getCrashCount()
+            println("Crashes with UNSAFE pattern: $crashes (race condition demonstration)")
+            // Note: We don't assert crashes > 0 because race conditions are non-deterministic.
+            // This test documents the vulnerability rather than guaranteeing reproduction.
+        }
+
+    @Test
+    fun `SAFE - debounced callbacks with state check prevents crashes`() =
+        runBlocking {
+            val testScope = CoroutineScope(Dispatchers.Default + SupervisorJob())
+            val simulator = SafeNetworkCallbackSimulator(testScope)
+            simulator.initialize()
+
+            // Simulate rapid network callbacks
+            repeat(100) {
+                simulator.onNetworkChanged()
+            }
+
+            // Give time for debounced callback to fire
+            delay(100)
+
+            // Shutdown
+            simulator.shutdown()
+
+            delay(50)
+
+            // With the safe pattern, no crashes should occur
+            assertEquals("No crashes expected with safe pattern", 0, simulator.getCrashCount())
+
+            testScope.cancel()
+        }
+}

--- a/app/src/test/java/com/lxmf/messenger/service/manager/NetworkChangeManagerTest.kt
+++ b/app/src/test/java/com/lxmf/messenger/service/manager/NetworkChangeManagerTest.kt
@@ -12,7 +12,13 @@ import io.mockk.runs
 import io.mockk.slot
 import io.mockk.unmockkConstructor
 import io.mockk.verify
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.TestScope
+import kotlinx.coroutines.test.advanceTimeBy
+import kotlinx.coroutines.test.runTest
 import org.junit.After
+import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
 import org.junit.Before
@@ -24,6 +30,7 @@ import org.junit.Test
  * Tests the network connectivity monitoring that reacquires locks and
  * triggers LXMF announce when network changes.
  */
+@OptIn(ExperimentalCoroutinesApi::class)
 class NetworkChangeManagerTest {
     private lateinit var context: Context
     private lateinit var connectivityManager: ConnectivityManager
@@ -31,6 +38,8 @@ class NetworkChangeManagerTest {
     private lateinit var networkChangeManager: NetworkChangeManager
     private var networkChangedCallCount = 0
     private val callbackSlot = slot<ConnectivityManager.NetworkCallback>()
+    private val testDispatcher = StandardTestDispatcher()
+    private val testScope = TestScope(testDispatcher)
 
     @Before
     fun setup() {
@@ -55,6 +64,7 @@ class NetworkChangeManagerTest {
             NetworkChangeManager(
                 context = context,
                 lockManager = lockManager,
+                scope = testScope,
                 onNetworkChanged = { networkChangedCallCount++ },
             )
     }
@@ -143,23 +153,29 @@ class NetworkChangeManagerTest {
     }
 
     @Test
-    fun `network change triggers callback and reacquires locks`() {
-        networkChangeManager.start()
+    fun `network change triggers callback and reacquires locks`() =
+        testScope.runTest {
+            networkChangeManager.start()
 
-        // Simulate first network
-        val network1 = mockk<android.net.Network>(relaxed = true)
-        every { network1.toString() } returns "network1"
-        callbackSlot.captured.onAvailable(network1)
+            // Simulate first network
+            val network1 = mockk<android.net.Network>(relaxed = true)
+            every { network1.toString() } returns "network1"
+            callbackSlot.captured.onAvailable(network1)
 
-        // Simulate network change
-        val network2 = mockk<android.net.Network>(relaxed = true)
-        every { network2.toString() } returns "network2"
-        callbackSlot.captured.onAvailable(network2)
+            // Simulate network change
+            val network2 = mockk<android.net.Network>(relaxed = true)
+            every { network2.toString() } returns "network2"
+            callbackSlot.captured.onAvailable(network2)
 
-        // Should trigger callback and reacquire locks
-        assertTrue("Callback should trigger on network change", networkChangedCallCount == 1)
-        verify(exactly = 1) { lockManager.acquireAll() }
-    }
+            // Locks should be reacquired immediately
+            verify(exactly = 1) { lockManager.acquireAll() }
+
+            // Callback is debounced - advance time to trigger it
+            advanceTimeBy(NetworkChangeManager.DEBOUNCE_DELAY_MS + 100)
+
+            // Should trigger callback after debounce
+            assertEquals("Callback should trigger on network change", 1, networkChangedCallCount)
+        }
 
     @Test
     fun `same network reconnecting does not trigger callback`() {
@@ -178,48 +194,57 @@ class NetworkChangeManagerTest {
     }
 
     @Test
-    fun `exception in lock acquisition does not crash`() {
-        every { lockManager.acquireAll() } throws RuntimeException("Test error")
+    fun `exception in lock acquisition does not crash`() =
+        testScope.runTest {
+            every { lockManager.acquireAll() } throws RuntimeException("Test error")
 
-        networkChangeManager.start()
+            networkChangeManager.start()
 
-        val network1 = mockk<android.net.Network>(relaxed = true)
-        every { network1.toString() } returns "network1"
-        callbackSlot.captured.onAvailable(network1)
+            val network1 = mockk<android.net.Network>(relaxed = true)
+            every { network1.toString() } returns "network1"
+            callbackSlot.captured.onAvailable(network1)
 
-        val network2 = mockk<android.net.Network>(relaxed = true)
-        every { network2.toString() } returns "network2"
+            val network2 = mockk<android.net.Network>(relaxed = true)
+            every { network2.toString() } returns "network2"
 
-        // Should not throw despite lock acquisition failure
-        callbackSlot.captured.onAvailable(network2)
+            // Should not throw despite lock acquisition failure
+            callbackSlot.captured.onAvailable(network2)
 
-        // Callback should still be invoked
-        assertTrue("Callback should still be invoked after lock error", networkChangedCallCount == 1)
-    }
+            // Advance time to trigger debounced callback
+            advanceTimeBy(NetworkChangeManager.DEBOUNCE_DELAY_MS + 100)
+
+            // Callback should still be invoked
+            assertEquals("Callback should still be invoked after lock error", 1, networkChangedCallCount)
+        }
 
     @Test
-    fun `exception in callback does not crash`() {
-        val crashingManager =
-            NetworkChangeManager(
-                context = context,
-                lockManager = lockManager,
-                onNetworkChanged = { throw IllegalStateException("Test error") },
-            )
+    fun `exception in callback does not crash`() =
+        testScope.runTest {
+            val crashingManager =
+                NetworkChangeManager(
+                    context = context,
+                    lockManager = lockManager,
+                    scope = testScope,
+                    onNetworkChanged = { throw IllegalStateException("Test error") },
+                )
 
-        crashingManager.start()
+            crashingManager.start()
 
-        val network1 = mockk<android.net.Network>(relaxed = true)
-        every { network1.toString() } returns "network1"
-        callbackSlot.captured.onAvailable(network1)
+            val network1 = mockk<android.net.Network>(relaxed = true)
+            every { network1.toString() } returns "network1"
+            callbackSlot.captured.onAvailable(network1)
 
-        val network2 = mockk<android.net.Network>(relaxed = true)
-        every { network2.toString() } returns "network2"
+            val network2 = mockk<android.net.Network>(relaxed = true)
+            every { network2.toString() } returns "network2"
 
-        // Should not throw despite callback failure
-        callbackSlot.captured.onAvailable(network2)
+            // Should not throw despite callback failure
+            callbackSlot.captured.onAvailable(network2)
 
-        crashingManager.stop()
-    }
+            // Advance time to trigger debounced callback (which will throw but be caught)
+            advanceTimeBy(NetworkChangeManager.DEBOUNCE_DELAY_MS + 100)
+
+            crashingManager.stop()
+        }
 
     @Test
     fun `registration failure is handled gracefully`() {
@@ -247,4 +272,87 @@ class NetworkChangeManagerTest {
 
         assertFalse(networkChangeManager.isMonitoring())
     }
+
+    @Test
+    fun `rapid network changes are debounced to single callback`() =
+        testScope.runTest {
+            networkChangeManager.start()
+
+            // Simulate first network (sets lastNetworkId)
+            val network1 = mockk<android.net.Network>(relaxed = true)
+            every { network1.toString() } returns "network1"
+            callbackSlot.captured.onAvailable(network1)
+
+            // Simulate rapid network changes (like leaving WiFi range)
+            repeat(5) { i ->
+                val network = mockk<android.net.Network>(relaxed = true)
+                every { network.toString() } returns "network${i + 2}"
+                callbackSlot.captured.onAvailable(network)
+            }
+
+            // Advance past debounce window
+            advanceTimeBy(NetworkChangeManager.DEBOUNCE_DELAY_MS + 100)
+
+            // Should only call callback once (debouncing coalesces rapid changes)
+            assertEquals("Should only trigger callback once due to debouncing", 1, networkChangedCallCount)
+        }
+
+    @Test
+    fun `stop cancels pending debounced callback`() =
+        testScope.runTest {
+            networkChangeManager.start()
+
+            // Simulate first network
+            val network1 = mockk<android.net.Network>(relaxed = true)
+            every { network1.toString() } returns "network1"
+            callbackSlot.captured.onAvailable(network1)
+
+            // Simulate network change (starts debounce timer)
+            val network2 = mockk<android.net.Network>(relaxed = true)
+            every { network2.toString() } returns "network2"
+            callbackSlot.captured.onAvailable(network2)
+
+            // Stop before debounce completes
+            networkChangeManager.stop()
+            advanceTimeBy(NetworkChangeManager.DEBOUNCE_DELAY_MS + 100)
+
+            // Callback should not have been called since we stopped
+            assertEquals("Callback should not trigger after stop", 0, networkChangedCallCount)
+        }
+
+    @Test
+    fun `debounce resets on each network change`() =
+        testScope.runTest {
+            networkChangeManager.start()
+
+            // Simulate first network
+            val network1 = mockk<android.net.Network>(relaxed = true)
+            every { network1.toString() } returns "network1"
+            callbackSlot.captured.onAvailable(network1)
+
+            // Simulate network change
+            val network2 = mockk<android.net.Network>(relaxed = true)
+            every { network2.toString() } returns "network2"
+            callbackSlot.captured.onAvailable(network2)
+
+            // Advance time but not past debounce
+            advanceTimeBy(NetworkChangeManager.DEBOUNCE_DELAY_MS / 2)
+
+            // Another network change - should reset debounce timer
+            val network3 = mockk<android.net.Network>(relaxed = true)
+            every { network3.toString() } returns "network3"
+            callbackSlot.captured.onAvailable(network3)
+
+            // Advance halfway again - still not past debounce from last change
+            advanceTimeBy(NetworkChangeManager.DEBOUNCE_DELAY_MS / 2)
+
+            // Callback should not have triggered yet
+            assertEquals("Callback should not trigger before debounce completes", 0, networkChangedCallCount)
+
+            // Advance past debounce from last change
+            advanceTimeBy(NetworkChangeManager.DEBOUNCE_DELAY_MS / 2 + 100)
+
+            // Now callback should have triggered once
+            assertEquals("Callback should trigger after debounce", 1, networkChangedCallCount)
+        }
 }


### PR DESCRIPTION
## Summary

- **Adds 500ms debouncing** to coalesce rapid network change callbacks into a single event
- **Moves callback execution** from Android's Binder thread to a controlled CoroutineScope
- **Adds state safety check** that verifies wrapper is fully ready before accessing (`binder.isInitialized()`)

This fixes a TOCTOU (Time-Of-Check-Time-Of-Use) race condition that caused crashes when leaving WiFi range. When walking away from WiFi, Android fires rapid, repeated network change callbacks while the Python wrapper could be shutting down or in transition.

## Root Cause

The network change callback checked `::binder.isInitialized` then called `binder.announceLxmfDestination()`, but between check and use, the wrapper could be shut down by concurrent operations. This manifested only when *leaving* WiFi range (rapid callbacks) not when manually disabling WiFi (single controlled change).

## Test plan

- [x] Unit tests for debounce behavior pass
- [x] New `NetworkChangeCallbackRaceTest` documents the race condition pattern
- [x] All existing `NetworkChangeManagerTest` tests pass with updated constructor
- [x] detekt and ktlint pass
- [ ] Manual test: Build and install on device, walk away from WiFi range, verify no crash

🤖 Generated with [Claude Code](https://claude.com/claude-code)