### PR TITLE
fix: ensure "block unknown senders" privacy setting works consistently

### DIFF
--- a/app/src/main/java/com/lxmf/messenger/service/MessageCollector.kt
+++ b/app/src/main/java/com/lxmf/messenger/service/MessageCollector.kt
@@ -6,7 +6,6 @@ import com.lxmf.messenger.data.model.InterfaceType
 import com.lxmf.messenger.data.repository.AnnounceRepository
 import com.lxmf.messenger.data.repository.ContactRepository
 import com.lxmf.messenger.data.repository.ConversationRepository
-import com.lxmf.messenger.data.repository.IdentityRepository
 import com.lxmf.messenger.notifications.NotificationHelper
 import com.lxmf.messenger.reticulum.protocol.ReticulumProtocol
 import kotlinx.coroutines.CoroutineScope
@@ -18,21 +17,21 @@ import kotlinx.coroutines.launch
 import java.util.concurrent.ConcurrentHashMap
 import javax.inject.Inject
 import javax.inject.Singleton
-import com.lxmf.messenger.data.repository.Message as DataMessage
 
 /**
- * Application-level service that continuously collects messages and announces from the Reticulum protocol
- * and saves them to the database. This runs independently of any UI components, ensuring
- * messages and announces are received and stored even when no screens are open.
+ * Application-level service that monitors messages from the Reticulum protocol
+ * and shows notifications. Persistence is handled by ServicePersistenceManager
+ * in the :reticulum service process.
  *
- * This solves the issue where data was only collected when specific screens were active.
+ * This class handles:
+ * - Notifications for new messages
+ * - UI updates via repository flows (triggered by database changes)
+ * - Peer name caching from announces
  *
- * Note: As of the service-side persistence implementation, announces and messages are now
- * primarily persisted by ServicePersistenceManager in the :reticulum service process.
- * This collector serves as a fallback/safety net and handles:
- * - Notifications for new messages/announces
- * - UI updates via repository flows
- * - De-duplication to avoid double-persistence
+ * IMPORTANT: This class intentionally does NOT persist messages. All message persistence
+ * happens in ServicePersistenceManager, which enforces privacy settings like "block unknown senders".
+ * EventHandler only broadcasts messages that were successfully persisted, so if we receive a
+ * broadcast here, we can trust the message exists in the database.
  */
 @Singleton
 class MessageCollector
@@ -42,7 +41,6 @@ class MessageCollector
         private val conversationRepository: ConversationRepository,
         private val announceRepository: AnnounceRepository,
         private val contactRepository: ContactRepository,
-        private val identityRepository: IdentityRepository,
         private val notificationHelper: NotificationHelper,
     ) {
         companion object {
@@ -86,142 +84,38 @@ class MessageCollector
                             return@collect
                         }
 
-                        // De-duplicate: Check if message already exists in database
-                        // (may have been persisted by ServicePersistenceManager in service process)
-                        val existingMessage = conversationRepository.getMessageById(receivedMessage.messageHash)
-                        if (existingMessage != null) {
-                            processedMessageIds.add(receivedMessage.messageHash) // Add to cache to avoid repeat DB checks
-                            Log.d(TAG, "Message ${receivedMessage.messageHash.take(16)} already in database - checking if notification needed")
-
-                            // Even though message is persisted, we may still need to show notification
-                            // (EventHandler in service process persists messages but can't show notifications)
-                            val sourceHash = receivedMessage.sourceHash.joinToString("") { "%02x".format(it) }
-                            val peerName = peerNames[sourceHash] ?: "Peer ${sourceHash.take(8).uppercase()}"
-                            val isFavorite =
-                                try {
-                                    announceRepository.getAnnounce(sourceHash)?.isFavorite ?: false
-                                } catch (e: Exception) {
-                                    Log.w(TAG, "Could not check if peer is favorite", e)
-                                    false
-                                }
-
-                            try {
-                                notificationHelper.notifyMessageReceived(
-                                    destinationHash = sourceHash,
-                                    peerName = peerName,
-                                    messagePreview = receivedMessage.content.take(100),
-                                    isFavorite = isFavorite,
-                                )
-                                Log.d(TAG, "Posted notification for already-persisted message from $peerName")
-                            } catch (e: Exception) {
-                                Log.e(TAG, "Failed to post notification for already-persisted message", e)
-                            }
-                            return@collect
-                        }
-
-                        // CRITICAL: Verify the message was sent to the current active identity
-                        // This prevents messages from being saved to the wrong identity after switching
-                        val activeIdentity = identityRepository.getActiveIdentitySync()
-                        if (activeIdentity == null) {
-                            Log.w(TAG, "No active identity - skipping message")
-                            return@collect
-                        }
-
-                        val messageDestHash = receivedMessage.destinationHash.joinToString("") { "%02x".format(it) }
-                        if (messageDestHash != activeIdentity.destinationHash) {
-                            Log.w(
-                                TAG,
-                                "Message destination $messageDestHash doesn't match active identity " +
-                                    "${activeIdentity.destinationHash} - skipping (sent to different identity)",
-                            )
-                            return@collect
-                        }
-
+                        // Message was broadcast by EventHandler, which only broadcasts persisted messages.
+                        // If we receive a broadcast, the message exists in the database.
+                        // No need to verify - just add to cache and show notification.
                         processedMessageIds.add(receivedMessage.messageHash)
                         _messagesCollected.value++
 
                         val sourceHash = receivedMessage.sourceHash.joinToString("") { "%02x".format(it) }
-                        Log.d(TAG, "Received new message #${_messagesCollected.value} from $sourceHash")
+                        Log.d(TAG, "Received broadcast for message ${receivedMessage.messageHash.take(16)} - posting notification")
 
-                        // Create data message for storage
-                        val dataMessage =
-                            DataMessage(
-                                id = receivedMessage.messageHash,
-                                // From sender's perspective
-                                destinationHash = sourceHash,
-                                content = receivedMessage.content,
-                                // Use local reception time for consistent ordering
-                                timestamp = System.currentTimeMillis(),
-                                isFromMe = false,
-                                status = "delivered",
-                                // LXMF attachments
-                                fieldsJson = receivedMessage.fieldsJson,
-                                // Routing info (hop count and receiving interface)
-                                receivedHopCount = receivedMessage.receivedHopCount,
-                                receivedInterface = receivedMessage.receivedInterface,
-                            )
+                        // Get peer name from cache or use fallback
+                        val peerName = peerNames[sourceHash] ?: "Peer ${sourceHash.take(8).uppercase()}"
 
-                        // Get peer name from cache, existing conversation, or use formatted hash
-                        val peerName = getPeerNameWithFallback(sourceHash)
-
-                        // Save to database - this creates/updates the conversation and adds the message
-                        try {
-                            // Prefer public key from message (directly from RNS identity cache)
-                            // Fall back to peer_identities lookup if not in message
-                            val messagePublicKey = receivedMessage.publicKey
-                            val publicKey =
-                                messagePublicKey
-                                    ?: conversationRepository.getPeerPublicKey(sourceHash)
-
-                            // Store public key to peer_identities if we got it from the message
-                            // This ensures future lookups will find it
-                            if (messagePublicKey != null) {
-                                conversationRepository.updatePeerPublicKey(sourceHash, messagePublicKey)
-                                Log.d(TAG, "Stored sender's public key for $sourceHash")
-                            }
-
-                            // Store sender's icon appearance if present (Sideband/MeshChat interop)
-                            receivedMessage.iconAppearance?.let { appearance ->
-                                try {
-                                    announceRepository.updateIconAppearance(
-                                        destinationHash = sourceHash,
-                                        iconName = appearance.iconName,
-                                        foregroundColor = appearance.foregroundColor,
-                                        backgroundColor = appearance.backgroundColor,
-                                    )
-                                    Log.d(TAG, "Updated icon appearance for $sourceHash: ${appearance.iconName}")
-                                } catch (e: Exception) {
-                                    Log.w(TAG, "Failed to update icon appearance for $sourceHash", e)
-                                }
-                            }
-
-                            conversationRepository.saveMessage(sourceHash, peerName, dataMessage, publicKey)
-                            Log.d(TAG, "Message saved to database for peer: $peerName ($sourceHash) (hasPublicKey=${publicKey != null})")
-
-                            // Check if sender is a saved peer (favorite)
-                            val isFavorite =
-                                try {
-                                    announceRepository.getAnnounce(sourceHash)?.isFavorite ?: false
-                                } catch (e: Exception) {
-                                    Log.w(TAG, "Could not check if peer is favorite", e)
-                                    false
-                                }
-
-                            // Show notification for received message
+                        // Check if sender is a saved peer (favorite)
+                        val isFavorite =
                             try {
-                                notificationHelper.notifyMessageReceived(
-                                    destinationHash = sourceHash,
-                                    peerName = peerName,
-                                    // Truncate preview
-                                    messagePreview = receivedMessage.content.take(100),
-                                    isFavorite = isFavorite,
-                                )
-                                Log.d(TAG, "Posted notification for message from $peerName (favorite: $isFavorite)")
+                                announceRepository.getAnnounce(sourceHash)?.isFavorite ?: false
                             } catch (e: Exception) {
-                                Log.e(TAG, "Failed to post message notification", e)
+                                Log.w(TAG, "Could not check if peer is favorite", e)
+                                false
                             }
+
+                        // Show notification for received message
+                        try {
+                            notificationHelper.notifyMessageReceived(
+                                destinationHash = sourceHash,
+                                peerName = peerName,
+                                messagePreview = receivedMessage.content.take(100),
+                                isFavorite = isFavorite,
+                            )
+                            Log.d(TAG, "Posted notification for message from $peerName (favorite: $isFavorite)")
                         } catch (e: Exception) {
-                            Log.e(TAG, "Failed to save message to database", e)
+                            Log.e(TAG, "Failed to post message notification", e)
                         }
                     }
                 } catch (e: Exception) {
@@ -374,57 +268,6 @@ class MessageCollector
                     Log.e(TAG, "Error observing announces for names", e)
                 }
             }
-        }
-
-        /**
-         * Get a display name for a peer, using cached name or formatted hash
-         */
-        private fun getPeerName(peerHash: String): String {
-            // Check if we have a cached name from announces
-            peerNames[peerHash]?.let { return it }
-
-            // Format the hash as a short, readable identifier
-            return if (peerHash.length >= 8) {
-                "Peer ${peerHash.take(8).uppercase()}"
-            } else {
-                "Unknown Peer"
-            }
-        }
-
-        /**
-         * Get peer name with fallback - checks cache, database, then uses formatted hash
-         */
-        private suspend fun getPeerNameWithFallback(peerHash: String): String {
-            // First check our in-memory cache from announces
-            peerNames[peerHash]?.let {
-                Log.d(TAG, "Found peer name in cache: $it")
-                return it
-            }
-
-            // Check if we have an existing conversation with this peer
-            try {
-                val existingConversation = conversationRepository.getConversation(peerHash)
-                if (existingConversation != null && existingConversation.peerName != "Unknown" &&
-                    !existingConversation.peerName.startsWith("Peer ")
-                ) {
-                    // Cache it for future use
-                    peerNames[peerHash] = existingConversation.peerName
-                    Log.d(TAG, "Found peer name in database: ${existingConversation.peerName}")
-                    return existingConversation.peerName
-                }
-            } catch (e: Exception) {
-                Log.w(TAG, "Error checking database for peer name", e)
-            }
-
-            // Fall back to formatted hash
-            val fallbackName =
-                if (peerHash.length >= 8) {
-                    "Peer ${peerHash.take(8).uppercase()}"
-                } else {
-                    "Unknown Peer"
-                }
-            Log.d(TAG, "Using fallback name for peer: $fallbackName")
-            return fallbackName
         }
 
         /**

--- a/app/src/test/java/com/lxmf/messenger/service/MessageCollectorTest.kt
+++ b/app/src/test/java/com/lxmf/messenger/service/MessageCollectorTest.kt
@@ -1,10 +1,8 @@
 package com.lxmf.messenger.service
 
-import com.lxmf.messenger.data.db.entity.LocalIdentityEntity
 import com.lxmf.messenger.data.repository.AnnounceRepository
 import com.lxmf.messenger.data.repository.ContactRepository
 import com.lxmf.messenger.data.repository.ConversationRepository
-import com.lxmf.messenger.data.repository.IdentityRepository
 import com.lxmf.messenger.notifications.NotificationHelper
 import com.lxmf.messenger.reticulum.protocol.ReceivedMessage
 import com.lxmf.messenger.reticulum.protocol.ReticulumProtocol
@@ -24,14 +22,17 @@ import org.junit.Test
 
 /**
  * Unit tests for MessageCollector.
- * Tests message collection, public key extraction, and database persistence.
+ * Tests notification behavior for messages that were persisted by ServicePersistenceManager.
+ *
+ * Note: MessageCollector no longer persists messages itself - all persistence happens in
+ * ServicePersistenceManager which enforces privacy settings like "block unknown senders".
+ * MessageCollector only shows notifications for messages that exist in the database.
  */
 class MessageCollectorTest {
     private lateinit var reticulumProtocol: ReticulumProtocol
     private lateinit var conversationRepository: ConversationRepository
     private lateinit var announceRepository: AnnounceRepository
     private lateinit var contactRepository: ContactRepository
-    private lateinit var identityRepository: IdentityRepository
     private lateinit var notificationHelper: NotificationHelper
     private lateinit var messageCollector: MessageCollector
 
@@ -41,8 +42,6 @@ class MessageCollectorTest {
     private val testSourceHash = ByteArray(16) { it.toByte() }
     private val testDestHash = ByteArray(16) { (it + 16).toByte() }
     private val testSourceHashHex = testSourceHash.joinToString("") { "%02x".format(it) }
-    private val testDestHashHex = testDestHash.joinToString("") { "%02x".format(it) }
-    private val testPublicKey = ByteArray(64) { it.toByte() }
 
     @Before
     fun setup() {
@@ -50,7 +49,6 @@ class MessageCollectorTest {
         conversationRepository = mockk()
         announceRepository = mockk()
         contactRepository = mockk()
-        identityRepository = mockk()
         notificationHelper = mockk(relaxed = true)
 
         messageFlow = MutableSharedFlow(extraBufferCapacity = 10)
@@ -59,25 +57,13 @@ class MessageCollectorTest {
         every { reticulumProtocol.observeMessages() } returns messageFlow
         every { reticulumProtocol.observeAnnounces() } returns flowOf() // Empty flow for announces
 
-        // Mock identity repository to return active identity matching test destination
-        coEvery { identityRepository.getActiveIdentitySync() } returns
-            LocalIdentityEntity(
-                identityHash = "test_identity_hash",
-                displayName = "Test",
-                destinationHash = testDestHashHex,
-                filePath = "/test/path",
-                createdTimestamp = System.currentTimeMillis(),
-                lastUsedTimestamp = System.currentTimeMillis(),
-                isActive = true,
-            )
-
         // Mock conversation repository default behaviors
+        // Note: getMessageById is no longer called - MessageCollector trusts broadcasts
         coEvery { conversationRepository.getPeerPublicKey(any()) } returns null
         coEvery { conversationRepository.updatePeerPublicKey(any(), any()) } just Runs
         coEvery { conversationRepository.saveMessage(any(), any(), any(), any()) } just Runs
         coEvery { conversationRepository.getConversation(any()) } returns null
         coEvery { conversationRepository.updatePeerName(any(), any()) } just Runs
-        coEvery { conversationRepository.getMessageById(any()) } returns null // For de-duplication check
 
         // Mock announce repository
         coEvery { announceRepository.getAnnounce(any()) } returns null
@@ -88,7 +74,6 @@ class MessageCollectorTest {
                 conversationRepository = conversationRepository,
                 announceRepository = announceRepository,
                 contactRepository = contactRepository,
-                identityRepository = identityRepository,
                 notificationHelper = notificationHelper,
             )
     }
@@ -99,152 +84,18 @@ class MessageCollectorTest {
         clearAllMocks()
     }
 
-    @Test
-    fun `processMessage with publicKey stores key to database`() =
-        runBlocking {
-            // Given: A message with public key
-            val testMessage =
-                ReceivedMessage(
-                    messageHash = "test_message_123",
-                    content = "Hello world",
-                    sourceHash = testSourceHash,
-                    destinationHash = testDestHash,
-                    timestamp = System.currentTimeMillis(),
-                    fieldsJson = null,
-                    publicKey = testPublicKey,
-                )
-
-            // When: Start collecting
-            messageCollector.startCollecting()
-
-            // Wait for collector to be ready on IO dispatcher
-            kotlinx.coroutines.delay(50)
-
-            // Emit message
-            messageFlow.emit(testMessage)
-
-            // Wait for IO dispatcher to process
-            kotlinx.coroutines.delay(200)
-
-            // Then: updatePeerPublicKey should be called
-            coVerify(timeout = 2000) {
-                conversationRepository.updatePeerPublicKey(testSourceHashHex, testPublicKey)
-            }
-
-            // And: saveMessage should be called with the message's public key
-            coVerify(timeout = 2000) {
-                conversationRepository.saveMessage(
-                    peerHash = testSourceHashHex,
-                    peerName = any(),
-                    message = any(),
-                    peerPublicKey = testPublicKey,
-                )
-            }
-        }
-
-    @Test
-    fun `processMessage without publicKey uses database fallback`() =
-        runBlocking {
-            // Given: A message without public key, but database has public key
-            // No public key in message
-            val testMessage =
-                ReceivedMessage(
-                    messageHash = "test_message_456",
-                    content = "Hello world",
-                    sourceHash = testSourceHash,
-                    destinationHash = testDestHash,
-                    timestamp = System.currentTimeMillis(),
-                    fieldsJson = null,
-                    publicKey = null,
-                )
-
-            val databasePublicKey = ByteArray(64) { (it + 100).toByte() }
-            coEvery { conversationRepository.getPeerPublicKey(testSourceHashHex) } returns databasePublicKey
-
-            // When: Start collecting
-            messageCollector.startCollecting()
-
-            // Wait for collector to be ready on IO dispatcher
-            kotlinx.coroutines.delay(50)
-
-            // Emit message
-            messageFlow.emit(testMessage)
-
-            // Wait for IO dispatcher to process
-            kotlinx.coroutines.delay(200)
-
-            // Then: getPeerPublicKey should be called as fallback
-            coVerify(timeout = 2000) {
-                conversationRepository.getPeerPublicKey(testSourceHashHex)
-            }
-
-            // And: updatePeerPublicKey should NOT be called (no message key to store)
-            coVerify(exactly = 0, timeout = 2000) {
-                conversationRepository.updatePeerPublicKey(any(), any())
-            }
-
-            // And: saveMessage should be called with the database's public key
-            coVerify(timeout = 2000) {
-                conversationRepository.saveMessage(
-                    peerHash = testSourceHashHex,
-                    peerName = any(),
-                    message = any(),
-                    peerPublicKey = databasePublicKey,
-                )
-            }
-        }
-
-    @Test
-    fun `processMessage without publicKey passes null when database also has no key`() =
-        runBlocking {
-            // Given: A message without public key and database also has no key
-            // No public key in message
-            val testMessage =
-                ReceivedMessage(
-                    messageHash = "test_message_789",
-                    content = "Hello world",
-                    sourceHash = testSourceHash,
-                    destinationHash = testDestHash,
-                    timestamp = System.currentTimeMillis(),
-                    fieldsJson = null,
-                    publicKey = null,
-                )
-
-            coEvery { conversationRepository.getPeerPublicKey(testSourceHashHex) } returns null
-
-            // When: Start collecting
-            messageCollector.startCollecting()
-
-            // Wait for collector to be ready on IO dispatcher
-            kotlinx.coroutines.delay(50)
-
-            // Emit message
-            messageFlow.emit(testMessage)
-
-            // Wait for IO dispatcher to process
-            kotlinx.coroutines.delay(200)
-
-            // Then: saveMessage should be called with null public key
-            coVerify(timeout = 2000) {
-                conversationRepository.saveMessage(
-                    peerHash = testSourceHashHex,
-                    peerName = any(),
-                    message = any(),
-                    peerPublicKey = null,
-                )
-            }
-        }
-
     // ========== De-duplication Tests ==========
+    // Note: Blocking tests are handled at the EventHandler/ServicePersistenceManager level.
+    // MessageCollector only receives broadcasts for messages that were already persisted.
 
     @Test
-    fun `processMessage skips duplicate message already in database`() =
+    fun `processMessage shows notification for broadcast message`() =
         runBlocking {
-            // Given: A message that already exists in the database
+            // Given: A message broadcast from EventHandler (already persisted by service)
             val testMessage =
                 ReceivedMessage(
-                    messageHash = "existing_message",
-                    content = "Already exists",
+                    messageHash = "persisted_message",
+                    content = "This was persisted",
                     sourceHash = testSourceHash,
                     destinationHash = testDestHash,
                     timestamp = System.currentTimeMillis(),
@@ -252,22 +103,24 @@ class MessageCollectorTest {
                     publicKey = null,
                 )
 
-            // Message already exists in database (persisted by service)
-            coEvery { conversationRepository.getMessageById("existing_message") } returns mockk()
-
-            // When: Start collecting
+            // When: Start collecting and emit message
             messageCollector.startCollecting()
-
-            // Wait for collector to be ready
             kotlinx.coroutines.delay(50)
 
-            // Emit message
             messageFlow.emit(testMessage)
-
-            // Wait for processing
             kotlinx.coroutines.delay(200)
 
-            // Then: saveMessage should NOT be called (duplicate skipped)
+            // Then: Notification should be shown
+            coVerify(timeout = 2000) {
+                notificationHelper.notifyMessageReceived(
+                    destinationHash = testSourceHashHex,
+                    peerName = any(),
+                    messagePreview = any(),
+                    isFavorite = any(),
+                )
+            }
+
+            // And: No persistence should be attempted (service already persisted)
             coVerify(exactly = 0) {
                 conversationRepository.saveMessage(
                     peerHash = any(),
@@ -281,7 +134,7 @@ class MessageCollectorTest {
     @Test
     fun `processMessage skips in-memory duplicate`() =
         runBlocking {
-            // Given: A message that we've already processed
+            // Given: A message broadcast from EventHandler
             val testMessage =
                 ReceivedMessage(
                     messageHash = "duplicate_message",
@@ -293,8 +146,6 @@ class MessageCollectorTest {
                     publicKey = null,
                 )
 
-            coEvery { conversationRepository.getMessageById(any()) } returns null
-
             // When: Start collecting and emit the same message twice
             messageCollector.startCollecting()
             kotlinx.coroutines.delay(50)
@@ -302,13 +153,13 @@ class MessageCollectorTest {
             messageFlow.emit(testMessage)
             kotlinx.coroutines.delay(200)
 
-            // First message should be saved
+            // First message should trigger notification
             coVerify(exactly = 1, timeout = 2000) {
-                conversationRepository.saveMessage(
-                    peerHash = testSourceHashHex,
+                notificationHelper.notifyMessageReceived(
+                    destinationHash = testSourceHashHex,
                     peerName = any(),
-                    message = any(),
-                    peerPublicKey = any(),
+                    messagePreview = any(),
+                    isFavorite = any(),
                 )
             }
 
@@ -316,82 +167,13 @@ class MessageCollectorTest {
             messageFlow.emit(testMessage)
             kotlinx.coroutines.delay(200)
 
-            // Second message should be skipped (in-memory cache)
+            // Second message should be skipped (in-memory cache) - still only 1 notification
             coVerify(exactly = 1, timeout = 2000) {
-                conversationRepository.saveMessage(
-                    peerHash = testSourceHashHex,
+                notificationHelper.notifyMessageReceived(
+                    destinationHash = testSourceHashHex,
                     peerName = any(),
-                    message = any(),
-                    peerPublicKey = any(),
-                )
-            }
-        }
-
-    @Test
-    fun `processMessage skips message for wrong identity`() =
-        runBlocking {
-            // Given: A message sent to a different identity
-            val wrongDestHash = ByteArray(16) { (it + 100).toByte() }
-            val testMessage =
-                ReceivedMessage(
-                    messageHash = "wrong_dest_message",
-                    content = "Wrong destination",
-                    sourceHash = testSourceHash,
-                    destinationHash = wrongDestHash,
-                    timestamp = System.currentTimeMillis(),
-                    fieldsJson = null,
-                    publicKey = null,
-                )
-
-            // When: Start collecting
-            messageCollector.startCollecting()
-            kotlinx.coroutines.delay(50)
-
-            messageFlow.emit(testMessage)
-            kotlinx.coroutines.delay(200)
-
-            // Then: Message should NOT be saved (wrong identity)
-            coVerify(exactly = 0) {
-                conversationRepository.saveMessage(
-                    peerHash = any(),
-                    peerName = any(),
-                    message = any(),
-                    peerPublicKey = any(),
-                )
-            }
-        }
-
-    @Test
-    fun `processMessage skips when no active identity`() =
-        runBlocking {
-            // Given: No active identity
-            coEvery { identityRepository.getActiveIdentitySync() } returns null
-
-            val testMessage =
-                ReceivedMessage(
-                    messageHash = "no_identity_message",
-                    content = "Hello",
-                    sourceHash = testSourceHash,
-                    destinationHash = testDestHash,
-                    timestamp = System.currentTimeMillis(),
-                    fieldsJson = null,
-                    publicKey = null,
-                )
-
-            // When: Start collecting
-            messageCollector.startCollecting()
-            kotlinx.coroutines.delay(50)
-
-            messageFlow.emit(testMessage)
-            kotlinx.coroutines.delay(200)
-
-            // Then: Message should NOT be saved
-            coVerify(exactly = 0) {
-                conversationRepository.saveMessage(
-                    peerHash = any(),
-                    peerName = any(),
-                    message = any(),
-                    peerPublicKey = any(),
+                    messagePreview = any(),
+                    isFavorite = any(),
                 )
             }
         }
@@ -465,56 +247,9 @@ class MessageCollectorTest {
     // ========== Notification for Pre-Persisted Messages Tests ==========
 
     @Test
-    fun `processMessage posts notification for message already in database`() =
-        runBlocking {
-            // Given: A message that was already persisted by ServicePersistenceManager
-            val testMessage =
-                ReceivedMessage(
-                    messageHash = "service_persisted_msg",
-                    content = "Already persisted by service",
-                    sourceHash = testSourceHash,
-                    destinationHash = testDestHash,
-                    timestamp = System.currentTimeMillis(),
-                    fieldsJson = null,
-                    publicKey = null,
-                )
-
-            // Message already exists in database (persisted by service process)
-            coEvery { conversationRepository.getMessageById("service_persisted_msg") } returns mockk()
-
-            // When: Start collecting
-            messageCollector.startCollecting()
-            kotlinx.coroutines.delay(50)
-
-            // Emit message
-            messageFlow.emit(testMessage)
-            kotlinx.coroutines.delay(200)
-
-            // Then: Notification should still be posted even though message is duplicate
-            coVerify(timeout = 2000) {
-                notificationHelper.notifyMessageReceived(
-                    destinationHash = testSourceHashHex,
-                    peerName = any(),
-                    messagePreview = any(),
-                    isFavorite = any(),
-                )
-            }
-
-            // And: Message should NOT be saved again (it's a duplicate)
-            coVerify(exactly = 0) {
-                conversationRepository.saveMessage(
-                    peerHash = any(),
-                    peerName = any(),
-                    message = any(),
-                    peerPublicKey = any(),
-                )
-            }
-        }
-
-    @Test
     fun `processMessage uses favorite status from announce for notification`() =
         runBlocking {
-            // Given: A pre-persisted message from a favorite peer
+            // Given: A message from a favorite peer
             val testMessage =
                 ReceivedMessage(
                     messageHash = "favorite_msg",
@@ -525,9 +260,6 @@ class MessageCollectorTest {
                     fieldsJson = null,
                     publicKey = null,
                 )
-
-            // Message already in database
-            coEvery { conversationRepository.getMessageById("favorite_msg") } returns mockk()
 
             // Peer is a favorite
             coEvery { announceRepository.getAnnounce(testSourceHashHex) } returns
@@ -555,7 +287,7 @@ class MessageCollectorTest {
     @Test
     fun `processMessage handles announce lookup failure gracefully for notifications`() =
         runBlocking {
-            // Given: A pre-persisted message where announce lookup fails
+            // Given: A message where announce lookup fails
             val testMessage =
                 ReceivedMessage(
                     messageHash = "announce_error_msg",
@@ -566,9 +298,6 @@ class MessageCollectorTest {
                     fieldsJson = null,
                     publicKey = null,
                 )
-
-            // Message already in database
-            coEvery { conversationRepository.getMessageById("announce_error_msg") } returns mockk()
 
             // Announce lookup throws exception
             coEvery { announceRepository.getAnnounce(testSourceHashHex) } throws RuntimeException("DB error")
@@ -597,7 +326,6 @@ class MessageCollectorTest {
             messageCollector.updatePeerName(testSourceHashHex, "Cached Peer Name")
             kotlinx.coroutines.delay(100)
 
-            // Message already in database
             val testMessage =
                 ReceivedMessage(
                     messageHash = "cached_name_msg",
@@ -608,8 +336,6 @@ class MessageCollectorTest {
                     fieldsJson = null,
                     publicKey = null,
                 )
-
-            coEvery { conversationRepository.getMessageById("cached_name_msg") } returns mockk()
 
             // When: Start collecting and emit
             messageCollector.startCollecting()
@@ -643,9 +369,6 @@ class MessageCollectorTest {
                     fieldsJson = null,
                     publicKey = null,
                 )
-
-            // Message already in database
-            coEvery { conversationRepository.getMessageById("long_content_msg") } returns mockk()
 
             // When: Start collecting and emit
             messageCollector.startCollecting()


### PR DESCRIPTION
## Summary
- Fixed race condition where `MessageCollector` would persist messages that `ServicePersistenceManager` had blocked, bypassing the privacy setting
- Changed `ServicePersistenceManager.persistMessage()` to return `Boolean` indicating success/failure
- Updated `EventHandler` to only broadcast messages that were actually persisted (not blocked)
- Simplified `MessageCollector` to trust broadcasts - it no longer persists messages, only shows notifications

## Root Cause
When the "block unknown senders" privacy setting was enabled:
1. `ServicePersistenceManager.shouldBlockUnknownSender()` correctly blocked the message (didn't persist)
2. `EventHandler` broadcast the message to the app process anyway
3. `MessageCollector` received the broadcast, checked the DB (not found because blocked!), and **persisted the message anyway**

Result: Blocked messages still got saved and displayed.

## Solution
Make `persistMessage()` return a Boolean indicating whether the message was actually persisted. `EventHandler` now only broadcasts messages when persistence succeeds. This ensures blocked messages never reach the app process.

## Test plan
- [x] Unit tests for `ServicePersistenceManager.persistMessage()` return value behavior (6 new tests)
- [x] Unit tests for `EventHandler` conditional broadcast behavior (4 new tests)
- [x] Updated `MessageCollectorTest` for new simplified behavior
- [x] All existing tests pass
- [x] Static analysis (detekt, ktlint) passes
- [ ] Manual testing: Enable "Block unknown senders" → message from unknown sender should NOT appear

🤖 Generated with [Claude Code](https://claude.com/claude-code)