### PR TITLE
fix: add notification permission checks to settings card toggle

### DIFF
--- a/app/src/main/java/com/lxmf/messenger/util/NotificationPermissionManager.kt
+++ b/app/src/main/java/com/lxmf/messenger/util/NotificationPermissionManager.kt
@@ -1,0 +1,70 @@
+package com.lxmf.messenger.util
+
+import android.Manifest
+import android.content.Context
+import android.content.pm.PackageManager
+import android.os.Build
+import androidx.core.content.ContextCompat
+
+/**
+ * Manages notification permissions for Android 13+ (API 33).
+ *
+ * Starting with Android 13 (TIRAMISU), apps must request the POST_NOTIFICATIONS
+ * permission to show notifications. This manager provides utilities to:
+ * - Check if the permission is granted
+ * - Determine if a permission request is needed
+ * - Get the permission string for the launcher
+ *
+ * On Android 12 and below, no permission is needed and notifications work by default.
+ */
+object NotificationPermissionManager {
+    /**
+     * Check if notification permission is granted.
+     *
+     * @param context Application context
+     * @return true if permission is granted OR if running on Android 12 or below
+     *         (where no permission is needed)
+     */
+    fun hasPermission(context: Context): Boolean {
+        return if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+            ContextCompat.checkSelfPermission(
+                context,
+                Manifest.permission.POST_NOTIFICATIONS,
+            ) == PackageManager.PERMISSION_GRANTED
+        } else {
+            // No permission needed on Android 12 and below
+            true
+        }
+    }
+
+    /**
+     * Check if a permission request is needed before enabling notifications.
+     *
+     * @param context Application context
+     * @return true only if running Android 13+ AND permission is not granted
+     */
+    fun needsPermissionRequest(context: Context): Boolean {
+        return if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+            ContextCompat.checkSelfPermission(
+                context,
+                Manifest.permission.POST_NOTIFICATIONS,
+            ) != PackageManager.PERMISSION_GRANTED
+        } else {
+            // No permission needed on Android 12 and below
+            false
+        }
+    }
+
+    /**
+     * Get the permission string required for notifications.
+     *
+     * @return POST_NOTIFICATIONS permission string on Android 13+, null otherwise
+     */
+    fun getRequiredPermission(): String? {
+        return if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+            Manifest.permission.POST_NOTIFICATIONS
+        } else {
+            null
+        }
+    }
+}

--- a/app/src/test/java/com/lxmf/messenger/util/NotificationPermissionManagerTest.kt
+++ b/app/src/test/java/com/lxmf/messenger/util/NotificationPermissionManagerTest.kt
@@ -1,0 +1,181 @@
+package com.lxmf.messenger.util
+
+import android.Manifest
+import android.app.Application
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.RuntimeEnvironment
+import org.robolectric.Shadows.shadowOf
+import org.robolectric.annotation.Config
+
+/**
+ * Unit tests for NotificationPermissionManager.
+ *
+ * Tests cover:
+ * - hasPermission behavior on Android 12 and below (always true)
+ * - hasPermission behavior on Android 13+ (permission check)
+ * - needsPermissionRequest behavior on different API levels
+ * - getRequiredPermission return values
+ *
+ * Uses Robolectric with @Config(sdk = [...]) to test different Android versions.
+ */
+@RunWith(RobolectricTestRunner::class)
+@Config(sdk = [34], application = Application::class)
+class NotificationPermissionManagerTest {
+    // ========== hasPermission Tests - Android 12 and below ==========
+
+    @Test
+    @Config(sdk = [31]) // Android 12
+    fun `hasPermission returns true on Android 12 regardless of permission state`() {
+        val context = RuntimeEnvironment.getApplication()
+
+        // Even without granting permission, should return true on Android 12
+        val result = NotificationPermissionManager.hasPermission(context)
+
+        assertTrue("hasPermission should return true on Android 12", result)
+    }
+
+    @Test
+    @Config(sdk = [30]) // Android 11
+    fun `hasPermission returns true on Android 11`() {
+        val context = RuntimeEnvironment.getApplication()
+
+        val result = NotificationPermissionManager.hasPermission(context)
+
+        assertTrue("hasPermission should return true on Android 11", result)
+    }
+
+    // ========== hasPermission Tests - Android 13+ ==========
+
+    @Test
+    @Config(sdk = [33]) // Android 13
+    fun `hasPermission returns true on Android 13 when permission granted`() {
+        val context = RuntimeEnvironment.getApplication()
+        val app = shadowOf(context as Application)
+        app.grantPermissions(Manifest.permission.POST_NOTIFICATIONS)
+
+        val result = NotificationPermissionManager.hasPermission(context)
+
+        assertTrue("hasPermission should return true when permission is granted", result)
+    }
+
+    @Test
+    @Config(sdk = [33]) // Android 13
+    fun `hasPermission returns false on Android 13 when permission not granted`() {
+        val context = RuntimeEnvironment.getApplication()
+        val app = shadowOf(context as Application)
+        app.denyPermissions(Manifest.permission.POST_NOTIFICATIONS)
+
+        val result = NotificationPermissionManager.hasPermission(context)
+
+        assertFalse("hasPermission should return false when permission is not granted", result)
+    }
+
+    @Test
+    @Config(sdk = [34]) // Android 14
+    fun `hasPermission returns false on Android 14 when permission not granted`() {
+        val context = RuntimeEnvironment.getApplication()
+        val app = shadowOf(context as Application)
+        app.denyPermissions(Manifest.permission.POST_NOTIFICATIONS)
+
+        val result = NotificationPermissionManager.hasPermission(context)
+
+        assertFalse("hasPermission should return false on Android 14 without permission", result)
+    }
+
+    // ========== needsPermissionRequest Tests ==========
+
+    @Test
+    @Config(sdk = [31]) // Android 12
+    fun `needsPermissionRequest returns false on Android 12`() {
+        val context = RuntimeEnvironment.getApplication()
+
+        val result = NotificationPermissionManager.needsPermissionRequest(context)
+
+        assertFalse("needsPermissionRequest should return false on Android 12", result)
+    }
+
+    @Test
+    @Config(sdk = [30]) // Android 11
+    fun `needsPermissionRequest returns false on Android 11`() {
+        val context = RuntimeEnvironment.getApplication()
+
+        val result = NotificationPermissionManager.needsPermissionRequest(context)
+
+        assertFalse("needsPermissionRequest should return false on Android 11", result)
+    }
+
+    @Test
+    @Config(sdk = [33]) // Android 13
+    fun `needsPermissionRequest returns true on Android 13 when permission not granted`() {
+        val context = RuntimeEnvironment.getApplication()
+        val app = shadowOf(context as Application)
+        app.denyPermissions(Manifest.permission.POST_NOTIFICATIONS)
+
+        val result = NotificationPermissionManager.needsPermissionRequest(context)
+
+        assertTrue("needsPermissionRequest should return true on Android 13 without permission", result)
+    }
+
+    @Test
+    @Config(sdk = [33]) // Android 13
+    fun `needsPermissionRequest returns false on Android 13 when permission granted`() {
+        val context = RuntimeEnvironment.getApplication()
+        val app = shadowOf(context as Application)
+        app.grantPermissions(Manifest.permission.POST_NOTIFICATIONS)
+
+        val result = NotificationPermissionManager.needsPermissionRequest(context)
+
+        assertFalse("needsPermissionRequest should return false when permission already granted", result)
+    }
+
+    // ========== getRequiredPermission Tests ==========
+
+    @Test
+    @Config(sdk = [31]) // Android 12
+    fun `getRequiredPermission returns null on Android 12`() {
+        val result = NotificationPermissionManager.getRequiredPermission()
+
+        assertNull("getRequiredPermission should return null on Android 12", result)
+    }
+
+    @Test
+    @Config(sdk = [30]) // Android 11
+    fun `getRequiredPermission returns null on Android 11`() {
+        val result = NotificationPermissionManager.getRequiredPermission()
+
+        assertNull("getRequiredPermission should return null on Android 11", result)
+    }
+
+    @Test
+    @Config(sdk = [33]) // Android 13
+    fun `getRequiredPermission returns POST_NOTIFICATIONS on Android 13`() {
+        val result = NotificationPermissionManager.getRequiredPermission()
+
+        assertNotNull("getRequiredPermission should return a value on Android 13", result)
+        assertEquals(
+            "getRequiredPermission should return POST_NOTIFICATIONS",
+            Manifest.permission.POST_NOTIFICATIONS,
+            result,
+        )
+    }
+
+    @Test
+    @Config(sdk = [34]) // Android 14
+    fun `getRequiredPermission returns POST_NOTIFICATIONS on Android 14`() {
+        val result = NotificationPermissionManager.getRequiredPermission()
+
+        assertNotNull("getRequiredPermission should return a value on Android 14", result)
+        assertEquals(
+            "getRequiredPermission should return POST_NOTIFICATIONS",
+            Manifest.permission.POST_NOTIFICATIONS,
+            result,
+        )
+    }
+}

--- a/app/src/test/java/com/lxmf/messenger/viewmodel/SettingsViewModelIncomingMessageLimitTest.kt
+++ b/app/src/test/java/com/lxmf/messenger/viewmodel/SettingsViewModelIncomingMessageLimitTest.kt
@@ -1,5 +1,6 @@
 package com.lxmf.messenger.viewmodel
 
+import android.content.Context
 import androidx.arch.core.executor.testing.InstantTaskExecutorRule
 import com.lxmf.messenger.data.db.entity.LocalIdentityEntity
 import com.lxmf.messenger.data.repository.IdentityRepository
@@ -52,6 +53,7 @@ class SettingsViewModelIncomingMessageLimitTest {
 
     private val testDispatcher = UnconfinedTestDispatcher()
 
+    private lateinit var context: Context
     private lateinit var settingsRepository: SettingsRepository
     private lateinit var identityRepository: IdentityRepository
     private lateinit var reticulumProtocol: ReticulumProtocol
@@ -86,6 +88,7 @@ class SettingsViewModelIncomingMessageLimitTest {
         // Disable monitor coroutines during testing to avoid infinite loops
         SettingsViewModel.enableMonitors = false
 
+        context = mockk(relaxed = true)
         settingsRepository = mockk(relaxed = true)
         identityRepository = mockk(relaxed = true)
         reticulumProtocol = mockk<ServiceReticulumProtocol>(relaxed = true)
@@ -120,6 +123,7 @@ class SettingsViewModelIncomingMessageLimitTest {
         every { settingsRepository.defaultSharingDurationFlow } returns MutableStateFlow("ONE_HOUR")
         every { settingsRepository.locationPrecisionRadiusFlow } returns MutableStateFlow(0)
         every { settingsRepository.imageCompressionPresetFlow } returns MutableStateFlow(com.lxmf.messenger.data.model.ImageCompressionPreset.AUTO)
+        every { settingsRepository.notificationsEnabledFlow } returns MutableStateFlow(false)
         every { identityRepository.activeIdentity } returns activeIdentityFlow
 
         // Mock PropagationNodeManager flows (StateFlows)
@@ -147,6 +151,7 @@ class SettingsViewModelIncomingMessageLimitTest {
 
     private fun createViewModel(): SettingsViewModel {
         return SettingsViewModel(
+            context = context,
             settingsRepository = settingsRepository,
             identityRepository = identityRepository,
             reticulumProtocol = reticulumProtocol,


### PR DESCRIPTION
## Summary
- Fixes notification permission gap where settings card toggle could enable notifications without POST_NOTIFICATIONS permission on Android 13+
- Adds startup validation to auto-disable notifications if enabled but permission not granted (handles backup restore edge case)

## Changes
- Add `NotificationPermissionManager` utility for permission checks
- Add permission launcher to `NotificationSettingsCard` for Android 13+
- Add startup validation in `SettingsViewModel` to sync settings with actual permission state
- Add comprehensive unit tests (12 for manager, 4 for validation)

## Test plan
- [ ] Fresh install on Android 13+: Enable notifications from settings card → should prompt for permission
- [ ] Deny permission → notifications setting should remain OFF
- [ ] Grant permission → notifications setting should turn ON
- [ ] Pre-Android 13: Toggle should work without permission prompts
- [ ] Backup restore: If imported settings have notifications enabled but permission denied, setting should auto-disable

🤖 Generated with [Claude Code](https://claude.ai/claude-code)