### PR TITLE
fix: handle null publicKey in MigrationExporter for pending contacts

### DIFF
--- a/app/src/main/java/com/lxmf/messenger/migration/MigrationData.kt
+++ b/app/src/main/java/com/lxmf/messenger/migration/MigrationData.kt
@@ -88,8 +88,8 @@ data class MessageExport(
 data class ContactExport(
     val destinationHash: String,
     val identityHash: String,
-    /** Base64 encoded public key */
-    val publicKey: String,
+    /** Base64 encoded public key (nullable for pending contacts) */
+    val publicKey: String?,
     val customNickname: String?,
     val notes: String?,
     val tags: String?,
@@ -97,6 +97,8 @@ data class ContactExport(
     val addedVia: String,
     val lastInteractionTimestamp: Long,
     val isPinned: Boolean,
+    /** Contact status: ACTIVE, PENDING_IDENTITY, or UNRESOLVED (nullable for backward compatibility) */
+    val status: String? = null,
 )
 
 /**

--- a/app/src/main/java/com/lxmf/messenger/migration/MigrationExporter.kt
+++ b/app/src/main/java/com/lxmf/messenger/migration/MigrationExporter.kt
@@ -199,7 +199,7 @@ class MigrationExporter
                 ContactExport(
                     destinationHash = contact.destinationHash,
                     identityHash = contact.identityHash,
-                    publicKey = Base64.encodeToString(contact.publicKey, Base64.NO_WRAP),
+                    publicKey = contact.publicKey?.let { Base64.encodeToString(it, Base64.NO_WRAP) },
                     customNickname = contact.customNickname,
                     notes = contact.notes,
                     tags = contact.tags,
@@ -207,6 +207,7 @@ class MigrationExporter
                     addedVia = contact.addedVia,
                     lastInteractionTimestamp = contact.lastInteractionTimestamp,
                     isPinned = contact.isPinned,
+                    status = contact.status.name,
                 )
             }
         }

--- a/app/src/main/java/com/lxmf/messenger/migration/MigrationImporter.kt
+++ b/app/src/main/java/com/lxmf/messenger/migration/MigrationImporter.kt
@@ -10,6 +10,7 @@ import com.lxmf.messenger.data.database.entity.InterfaceEntity
 import com.lxmf.messenger.data.db.ColumbaDatabase
 import com.lxmf.messenger.data.db.entity.AnnounceEntity
 import com.lxmf.messenger.data.db.entity.ContactEntity
+import com.lxmf.messenger.data.db.entity.ContactStatus
 import com.lxmf.messenger.data.db.entity.ConversationEntity
 import com.lxmf.messenger.data.db.entity.CustomThemeEntity
 import com.lxmf.messenger.data.db.entity.LocalIdentityEntity
@@ -303,10 +304,15 @@ class MigrationImporter
         private suspend fun importContacts(contacts: List<ContactExport>): Int {
             val entities =
                 contacts.map { contact ->
+                    // Determine status: use exported value, or infer from publicKey for backward compatibility
+                    val status = contact.status?.let {
+                        try { ContactStatus.valueOf(it) } catch (_: Exception) { null }
+                    } ?: if (contact.publicKey == null) ContactStatus.PENDING_IDENTITY else ContactStatus.ACTIVE
+
                     ContactEntity(
                         destinationHash = contact.destinationHash,
                         identityHash = contact.identityHash,
-                        publicKey = Base64.decode(contact.publicKey, Base64.NO_WRAP),
+                        publicKey = contact.publicKey?.let { Base64.decode(it, Base64.NO_WRAP) },
                         customNickname = contact.customNickname,
                         notes = contact.notes,
                         tags = contact.tags,
@@ -314,6 +320,7 @@ class MigrationImporter
                         addedVia = contact.addedVia,
                         lastInteractionTimestamp = contact.lastInteractionTimestamp,
                         isPinned = contact.isPinned,
+                        status = status,
                     )
                 }
             database.contactDao().insertContacts(entities)


### PR DESCRIPTION
## Summary
- Cherry-pick of fix from v0.6.x branch (#309) to main
- Fixes NullPointerException when exporting data with contacts in PENDING_IDENTITY status
- Makes `ContactExport.publicKey` nullable and adds status field for preserving contact resolution state

## Changes
- `MigrationData.kt`: Make publicKey nullable, add status field
- `MigrationExporter.kt`: Add null-safe Base64 encoding
- `MigrationImporter.kt`: Add null-safe Base64 decoding with status inference
- `MigrationDataTest.kt`: Add unit tests for null publicKey and status serialization

## Test plan
- [x] Unit tests pass for MigrationDataTest
- [x] ktlint and detekt checks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)