### PR TITLE
chore: always create releases as drafts

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -92,7 +92,7 @@ jobs:
           files: |
             columba-${{ steps.version.outputs.version }}.apk
             columba-${{ steps.version.outputs.version }}.apk.sha256
-          draft: ${{ contains(steps.version.outputs.version, '-') }}
+          draft: true
           prerelease: ${{ contains(steps.version.outputs.version, '-') }}
           generate_release_notes: true
           body: |


### PR DESCRIPTION
## Summary
- All GitHub releases are now created as drafts instead of only pre-releases
- This gives maintainers the opportunity to review release notes and verify assets before publishing

## Test plan
- [ ] Tag a test release (e.g., `v0.6.x-test`) and verify it creates a draft
- [ ] Verify the draft contains the expected APK and checksums

🤖 Generated with [Claude Code](https://claude.com/claude-code)