### PR TITLE
fix: Respect HTTP toggle setting for map tile fetching (#285)

### DIFF
--- a/app/src/main/java/com/lxmf/messenger/repository/SettingsRepository.kt
+++ b/app/src/main/java/com/lxmf/messenger/repository/SettingsRepository.kt
@@ -112,6 +112,7 @@ class SettingsRepository
             // Map source preferences
             val MAP_SOURCE_HTTP_ENABLED = booleanPreferencesKey("map_source_http_enabled")
             val MAP_SOURCE_RMSP_ENABLED = booleanPreferencesKey("map_source_rmsp_enabled")
+            val HTTP_ENABLED_FOR_DOWNLOAD = booleanPreferencesKey("http_enabled_for_download")
         }
 
         // Cross-process SharedPreferences for service communication
@@ -1261,6 +1262,26 @@ class SettingsRepository
         suspend fun saveMapSourceRmspEnabled(enabled: Boolean) {
             context.dataStore.edit { preferences ->
                 preferences[PreferencesKeys.MAP_SOURCE_RMSP_ENABLED] = enabled
+            }
+        }
+
+        /**
+         * Flow indicating if HTTP was enabled specifically for downloading offline maps.
+         * Used to auto-disable HTTP after download completes.
+         */
+        val httpEnabledForDownloadFlow: Flow<Boolean> =
+            context.dataStore.data
+                .map { preferences ->
+                    preferences[PreferencesKeys.HTTP_ENABLED_FOR_DOWNLOAD] ?: false
+                }
+                .distinctUntilChanged()
+
+        /**
+         * Set whether HTTP was enabled specifically for downloading offline maps.
+         */
+        suspend fun setHttpEnabledForDownload(enabled: Boolean) {
+            context.dataStore.edit { preferences ->
+                preferences[PreferencesKeys.HTTP_ENABLED_FOR_DOWNLOAD] = enabled
             }
         }
 

--- a/app/src/main/java/com/lxmf/messenger/ui/screens/settings/cards/MapSourcesCard.kt
+++ b/app/src/main/java/com/lxmf/messenger/ui/screens/settings/cards/MapSourcesCard.kt
@@ -46,10 +46,10 @@ fun MapSourcesCard(
     rmspServerCount: Int = 0,
     hasOfflineMaps: Boolean = false,
 ) {
-    // At least one source must be enabled (or have offline maps)
-    // When RMSP is disabled via feature flag, only check hasOfflineMaps for HTTP toggle
+    // Allow disabling HTTP - the map screen now shows a helpful overlay when no sources enabled
+    // This lets users intentionally disable HTTP for offline-only or privacy-conscious use
     val effectiveRmspEnabled = RMSP_FEATURE_ENABLED && rmspEnabled
-    val canDisableHttp = effectiveRmspEnabled || hasOfflineMaps
+    val canDisableHttp = true // Always allow - MapScreen shows overlay when no sources available
     val canDisableRmsp = httpEnabled || hasOfflineMaps
     val showWarning = !httpEnabled && !effectiveRmspEnabled && !hasOfflineMaps
 
@@ -99,7 +99,7 @@ fun MapSourcesCard(
             )
         }
 
-        // Warning when no sources enabled
+        // Info when no sources enabled
         if (showWarning) {
             Row(
                 modifier =
@@ -115,7 +115,7 @@ fun MapSourcesCard(
                     tint = MaterialTheme.colorScheme.error,
                 )
                 Text(
-                    text = "At least one map source must be enabled",
+                    text = "No map tiles will load until a source is enabled or offline maps are downloaded",
                     style = MaterialTheme.typography.bodySmall,
                     color = MaterialTheme.colorScheme.error,
                 )

--- a/app/src/main/java/com/lxmf/messenger/viewmodel/MapViewModel.kt
+++ b/app/src/main/java/com/lxmf/messenger/viewmodel/MapViewModel.kt
@@ -147,6 +147,13 @@ class MapViewModel
                 }
             }
 
+            // Refresh map style when HTTP setting changes
+            viewModelScope.launch {
+                mapTileSourceManager.httpEnabledFlow.collect {
+                    refreshMapStyle()
+                }
+            }
+
             // Collect location permission sheet dismissal state
             viewModelScope.launch {
                 settingsRepository.hasDismissedLocationPermissionSheetFlow.collect { dismissed ->
@@ -291,6 +298,20 @@ class MapViewModel
         fun refreshMapStyle() {
             val location = _state.value.userLocation
             resolveMapStyle(location?.latitude, location?.longitude)
+        }
+
+        /**
+         * Enable HTTP map source and refresh the map style.
+         * Called from the "No Map Source" overlay.
+         * Clears the "enabled for download" flag since user explicitly wants HTTP enabled.
+         */
+        fun enableHttp() {
+            viewModelScope.launch {
+                // Clear the flag - user is explicitly choosing to enable HTTP
+                settingsRepository.setHttpEnabledForDownload(false)
+                mapTileSourceManager.setHttpEnabled(true)
+                refreshMapStyle()
+            }
         }
 
         /**

--- a/app/src/main/java/com/lxmf/messenger/viewmodel/SettingsViewModel.kt
+++ b/app/src/main/java/com/lxmf/messenger/viewmodel/SettingsViewModel.kt
@@ -354,6 +354,8 @@ class SettingsViewModel
                             reticulumVersion = _state.value.reticulumVersion,
                             lxmfVersion = _state.value.lxmfVersion,
                             bleReticulumVersion = _state.value.bleReticulumVersion,
+                            // Preserve card expansion states
+                            cardExpansionStates = _state.value.cardExpansionStates,
                         )
                     }.distinctUntilChanged().collect { newState ->
                         val previousState = _state.value
@@ -1580,11 +1582,7 @@ class SettingsViewModel
          * @param enabled Whether HTTP map source is enabled
          */
         fun setMapSourceHttpEnabled(enabled: Boolean) {
-            // Prevent disabling both sources (unless offline maps are available)
-            if (!enabled && !_state.value.mapSourceRmspEnabled && !_state.value.hasOfflineMaps) {
-                Log.w(TAG, "Cannot disable HTTP when RMSP is also disabled and no offline maps")
-                return
-            }
+            // Allow disabling HTTP - MapScreen now shows a helpful overlay when no sources enabled
             viewModelScope.launch {
                 settingsRepository.saveMapSourceHttpEnabled(enabled)
                 Log.d(TAG, "HTTP map source ${if (enabled) "enabled" else "disabled"}")

--- a/app/src/test/java/com/lxmf/messenger/ui/screens/offlinemaps/OfflineMapDownloadScreenTest.kt
+++ b/app/src/test/java/com/lxmf/messenger/ui/screens/offlinemaps/OfflineMapDownloadScreenTest.kt
@@ -60,6 +60,8 @@ class OfflineMapDownloadScreenTest {
                 onAddressQueryChange = {},
                 onSearchAddress = {},
                 onSelectAddressResult = {},
+                httpEnabled = true,
+                onEnableHttp = {},
                 onNext = {},
             )
         }
@@ -85,6 +87,8 @@ class OfflineMapDownloadScreenTest {
                 onAddressQueryChange = {},
                 onSearchAddress = {},
                 onSelectAddressResult = {},
+                httpEnabled = true,
+                onEnableHttp = {},
                 onNext = {},
             )
         }
@@ -109,6 +113,8 @@ class OfflineMapDownloadScreenTest {
                 onAddressQueryChange = {},
                 onSearchAddress = {},
                 onSelectAddressResult = {},
+                httpEnabled = true,
+                onEnableHttp = {},
                 onNext = {},
             )
         }
@@ -133,6 +139,8 @@ class OfflineMapDownloadScreenTest {
                 onAddressQueryChange = {},
                 onSearchAddress = {},
                 onSelectAddressResult = {},
+                httpEnabled = true,
+                onEnableHttp = {},
                 onNext = {},
             )
         }
@@ -157,6 +165,8 @@ class OfflineMapDownloadScreenTest {
                 onAddressQueryChange = {},
                 onSearchAddress = {},
                 onSelectAddressResult = {},
+                httpEnabled = true,
+                onEnableHttp = {},
                 onNext = {},
             )
         }
@@ -182,6 +192,8 @@ class OfflineMapDownloadScreenTest {
                 onAddressQueryChange = {},
                 onSearchAddress = {},
                 onSelectAddressResult = {},
+                httpEnabled = true,
+                onEnableHttp = {},
                 onNext = {},
             )
         }
@@ -206,6 +218,8 @@ class OfflineMapDownloadScreenTest {
                 onAddressQueryChange = {},
                 onSearchAddress = {},
                 onSelectAddressResult = {},
+                httpEnabled = true,
+                onEnableHttp = {},
                 onNext = {},
             )
         }
@@ -230,6 +244,8 @@ class OfflineMapDownloadScreenTest {
                 onAddressQueryChange = {},
                 onSearchAddress = {},
                 onSelectAddressResult = {},
+                httpEnabled = true,
+                onEnableHttp = {},
                 onNext = {},
             )
         }
@@ -254,6 +270,8 @@ class OfflineMapDownloadScreenTest {
                 onAddressQueryChange = {},
                 onSearchAddress = {},
                 onSelectAddressResult = {},
+                httpEnabled = true,
+                onEnableHttp = {},
                 onNext = {},
             )
         }
@@ -284,6 +302,8 @@ class OfflineMapDownloadScreenTest {
                 onAddressQueryChange = {},
                 onSearchAddress = {},
                 onSelectAddressResult = {},
+                httpEnabled = true,
+                onEnableHttp = {},
                 onNext = {},
             )
         }
@@ -309,6 +329,8 @@ class OfflineMapDownloadScreenTest {
                 onAddressQueryChange = {},
                 onSearchAddress = {},
                 onSelectAddressResult = {},
+                httpEnabled = true,
+                onEnableHttp = {},
                 onNext = {},
             )
         }
@@ -333,6 +355,8 @@ class OfflineMapDownloadScreenTest {
                 onAddressQueryChange = {},
                 onSearchAddress = {},
                 onSelectAddressResult = {},
+                httpEnabled = true,
+                onEnableHttp = {},
                 onNext = {},
             )
         }
@@ -360,6 +384,8 @@ class OfflineMapDownloadScreenTest {
                 onAddressQueryChange = {},
                 onSearchAddress = {},
                 onSelectAddressResult = {},
+                httpEnabled = true,
+                onEnableHttp = {},
                 onNext = {},
             )
         }
@@ -535,7 +561,9 @@ class OfflineMapDownloadScreenTest {
                 estimatedTileCount = 1000L,
                 estimatedSize = "15 MB",
                 name = "",
+                httpEnabled = true,
                 onNameChange = {},
+                onEnableHttp = {},
                 onStartDownload = {},
                 onBack = {},
             )
@@ -557,7 +585,9 @@ class OfflineMapDownloadScreenTest {
                 estimatedTileCount = 1000L,
                 estimatedSize = "15 MB",
                 name = "Test Region",
+                httpEnabled = true,
                 onNameChange = {},
+                onEnableHttp = {},
                 onStartDownload = {},
                 onBack = {},
             )
@@ -584,7 +614,9 @@ class OfflineMapDownloadScreenTest {
                 estimatedTileCount = 1000L,
                 estimatedSize = "15 MB",
                 name = "Test",
+                httpEnabled = true,
                 onNameChange = {},
+                onEnableHttp = {},
                 onStartDownload = {},
                 onBack = {},
             )
@@ -605,7 +637,9 @@ class OfflineMapDownloadScreenTest {
                 estimatedTileCount = 1000L,
                 estimatedSize = "15 MB",
                 name = "",
+                httpEnabled = true,
                 onNameChange = {},
+                onEnableHttp = {},
                 onStartDownload = {},
                 onBack = {},
             )
@@ -626,7 +660,9 @@ class OfflineMapDownloadScreenTest {
                 estimatedTileCount = 1000L,
                 estimatedSize = "15 MB",
                 name = "My Region",
+                httpEnabled = true,
                 onNameChange = {},
+                onEnableHttp = {},
                 onStartDownload = {},
                 onBack = {},
             )
@@ -649,7 +685,9 @@ class OfflineMapDownloadScreenTest {
                 estimatedTileCount = 1000L,
                 estimatedSize = "15 MB",
                 name = "Test",
+                httpEnabled = true,
                 onNameChange = {},
+                onEnableHttp = {},
                 onStartDownload = { downloadStarted = true },
                 onBack = {},
             )

--- a/app/src/test/java/com/lxmf/messenger/ui/screens/settings/cards/MapSourcesCardTest.kt
+++ b/app/src/test/java/com/lxmf/messenger/ui/screens/settings/cards/MapSourcesCardTest.kt
@@ -136,26 +136,28 @@ class MapSourcesCardTest {
     }
 
     @Test
-    fun mapSourcesCard_httpCannotBeDisabledWhenOnlySource() {
-        var callbackCalled = false
+    fun mapSourcesCard_httpCanBeDisabledEvenWhenOnlySource() {
+        // HTTP can now be disabled even when it's the only source, because
+        // MapScreen shows a helpful overlay explaining no map source is enabled
+        var httpEnabledResult = true
 
         composeTestRule.setContent {
             MapSourcesCard(
                 isExpanded = true,
                 onExpandedChange = {},
                 httpEnabled = true,
-                onHttpEnabledChange = { callbackCalled = true },
+                onHttpEnabledChange = { httpEnabledResult = it },
                 rmspEnabled = false,
                 onRmspEnabledChange = {},
-                hasOfflineMaps = false, // No offline maps, HTTP is only source
+                hasOfflineMaps = false, // No offline maps, but HTTP can still be disabled
             )
         }
 
-        // Try to click to disable - Switch should be disabled
+        // Click to disable - should work now
         composeTestRule.onNode(isToggleable()).performClick()
 
-        // Callback should NOT be called because HTTP cannot be disabled
-        assertFalse("Callback should not be called when HTTP is only source", callbackCalled)
+        // Callback should be called and HTTP should be disabled
+        assertFalse("HTTP should be disabled after toggle", httpEnabledResult)
     }
 
     @Test
@@ -256,7 +258,7 @@ class MapSourcesCardTest {
             )
         }
 
-        composeTestRule.onNodeWithText("At least one map source must be enabled")
+        composeTestRule.onNodeWithText("No map tiles will load until a source is enabled or offline maps are downloaded")
             .assertDoesNotExist()
     }
 
@@ -274,7 +276,7 @@ class MapSourcesCardTest {
             )
         }
 
-        composeTestRule.onNodeWithText("At least one map source must be enabled")
+        composeTestRule.onNodeWithText("No map tiles will load until a source is enabled or offline maps are downloaded")
             .assertDoesNotExist()
     }
 
@@ -331,7 +333,7 @@ class MapSourcesCardTest {
         }
 
         // No warning when offline maps are available
-        composeTestRule.onNodeWithText("At least one map source must be enabled")
+        composeTestRule.onNodeWithText("No map tiles will load until a source is enabled or offline maps are downloaded")
             .assertDoesNotExist()
     }
 


### PR DESCRIPTION
## Summary
- When HTTP map source is disabled, show "No Map Source Enabled" overlay instead of silently loading tiles
- Use offline cached tiles via MapLibre when offline maps exist and HTTP is disabled
- Block network requests with `MapLibre.setConnected(false)` to prevent tile fetching outside downloaded regions
- Auto-disable HTTP after downloading offline maps (when enabled via download screen's "Enable HTTP" button)
- Show warning banner on download screen when HTTP is disabled
- Allow HTTP toggle to be disabled without requiring other sources

## Test plan
- [ ] Disable HTTP in Settings → Map Sources
- [ ] Open Map tab → verify overlay appears saying "No map source enabled"
- [ ] Click "Enable HTTP" on overlay → verify map loads
- [ ] Download an offline map region
- [ ] Disable HTTP again → verify cached tiles display without network requests
- [ ] Pan outside downloaded region → verify no network requests (blank tiles shown)
- [ ] On download screen with HTTP disabled, verify warning banner appears

Closes #285

🤖 Generated with [Claude Code](https://claude.com/claude-code)