### PR TITLE
fix: Store peer icons in dedicated table for reliable persistence

### DIFF
--- a/app/src/main/java/com/lxmf/messenger/service/manager/EventHandler.kt
+++ b/app/src/main/java/com/lxmf/messenger/service/manager/EventHandler.kt
@@ -341,6 +341,7 @@ class EventHandler(
             val propagationTransferLimitKb = propagationMetadata?.transferLimitKb
 
             // Persist to database first (survives app process death)
+            // Note: Icons are stored separately in peer_icons table (from LXMF messages)
             if (persistenceManager != null && publicKey != null) {
                 persistenceManager.persistAnnounce(
                     destinationHash = destinationHashHex,
@@ -356,10 +357,6 @@ class EventHandler(
                     stampCost = stampCost,
                     stampCostFlexibility = stampCostFlexibility,
                     peeringCost = peeringCost,
-                    // Icon appearance updated via message field 4
-                    iconName = null,
-                    iconForegroundColor = null,
-                    iconBackgroundColor = null,
                     propagationTransferLimitKb = propagationTransferLimitKb,
                 )
 

--- a/app/src/main/java/com/lxmf/messenger/service/persistence/ServicePersistenceManager.kt
+++ b/app/src/main/java/com/lxmf/messenger/service/persistence/ServicePersistenceManager.kt
@@ -44,7 +44,8 @@ class ServicePersistenceManager(
      * Persist an announce to the database.
      * Called from EventHandler.handleAnnounceEvent() in the service process.
      *
-     * This preserves existing favorite status and icon appearance.
+     * This preserves existing favorite status.
+     * Note: Icons are stored separately in peer_icons table (from LXMF messages).
      */
     @Suppress("LongParameterList") // Parameters mirror AnnounceEntity fields for direct persistence
     fun persistAnnounce(
@@ -61,14 +62,11 @@ class ServicePersistenceManager(
         stampCost: Int?,
         stampCostFlexibility: Int?,
         peeringCost: Int?,
-        iconName: String?,
-        iconForegroundColor: String?,
-        iconBackgroundColor: String?,
         propagationTransferLimitKb: Int?,
     ) {
         scope.launch {
             try {
-                // Preserve favorite status and existing icon appearance if announce already exists
+                // Preserve favorite status if announce already exists
                 val existing = announceDao.getAnnounce(destinationHash)
 
                 val entity =
@@ -88,10 +86,6 @@ class ServicePersistenceManager(
                         stampCost = stampCost,
                         stampCostFlexibility = stampCostFlexibility,
                         peeringCost = peeringCost,
-                        // Prefer new icon appearance if provided, otherwise preserve existing
-                        iconName = iconName ?: existing?.iconName,
-                        iconForegroundColor = iconForegroundColor ?: existing?.iconForegroundColor,
-                        iconBackgroundColor = iconBackgroundColor ?: existing?.iconBackgroundColor,
                         propagationTransferLimitKb = propagationTransferLimitKb,
                     )
 

--- a/app/src/main/java/com/lxmf/messenger/viewmodel/MapViewModel.kt
+++ b/app/src/main/java/com/lxmf/messenger/viewmodel/MapViewModel.kt
@@ -7,6 +7,7 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.lxmf.messenger.data.db.dao.AnnounceDao
 import com.lxmf.messenger.data.db.dao.ReceivedLocationDao
+import com.lxmf.messenger.data.model.EnrichedAnnounce
 import com.lxmf.messenger.data.model.EnrichedContact
 import com.lxmf.messenger.data.repository.ContactRepository
 import com.lxmf.messenger.map.MapStyleResult
@@ -169,7 +170,7 @@ class MapViewModel
                 combine(
                     receivedLocationDao.getLatestLocationsPerSenderUnfiltered(),
                     contacts,
-                    announceDao.getAllAnnounces(),
+                    announceDao.getEnrichedAnnounces(),
                     _refreshTrigger,
                 ) { locations, contactList, announceList, _ ->
                     val currentTime = System.currentTimeMillis()

--- a/app/src/test/java/com/lxmf/messenger/service/MessageCollectorTest.kt
+++ b/app/src/test/java/com/lxmf/messenger/service/MessageCollectorTest.kt
@@ -1,5 +1,6 @@
 package com.lxmf.messenger.service
 
+import com.lxmf.messenger.data.db.dao.PeerIconDao
 import com.lxmf.messenger.data.db.entity.LocalIdentityEntity
 import com.lxmf.messenger.data.repository.AnnounceRepository
 import com.lxmf.messenger.data.repository.ContactRepository
@@ -33,6 +34,7 @@ class MessageCollectorTest {
     private lateinit var contactRepository: ContactRepository
     private lateinit var identityRepository: IdentityRepository
     private lateinit var notificationHelper: NotificationHelper
+    private lateinit var peerIconDao: PeerIconDao
     private lateinit var messageCollector: MessageCollector
 
     // Use extraBufferCapacity to ensure emissions aren't dropped before collector is ready
@@ -52,6 +54,7 @@ class MessageCollectorTest {
         contactRepository = mockk()
         identityRepository = mockk()
         notificationHelper = mockk(relaxed = true)
+        peerIconDao = mockk(relaxed = true)
 
         messageFlow = MutableSharedFlow(extraBufferCapacity = 10)
 
@@ -90,6 +93,7 @@ class MessageCollectorTest {
                 contactRepository = contactRepository,
                 identityRepository = identityRepository,
                 notificationHelper = notificationHelper,
+                peerIconDao = peerIconDao,
             )
     }
 

--- a/app/src/test/java/com/lxmf/messenger/service/persistence/ServicePersistenceManagerTest.kt
+++ b/app/src/test/java/com/lxmf/messenger/service/persistence/ServicePersistenceManagerTest.kt
@@ -108,9 +108,6 @@ class ServicePersistenceManagerTest {
                 stampCost = null,
                 stampCostFlexibility = null,
                 peeringCost = null,
-                iconName = null,
-                iconForegroundColor = null,
-                iconBackgroundColor = null,
                 propagationTransferLimitKb = null,
             )
 
@@ -153,9 +150,6 @@ class ServicePersistenceManagerTest {
                 stampCost = null,
                 stampCostFlexibility = null,
                 peeringCost = null,
-                iconName = null,
-                iconForegroundColor = null,
-                iconBackgroundColor = null,
                 propagationTransferLimitKb = null,
             )
 
@@ -170,113 +164,8 @@ class ServicePersistenceManagerTest {
             }
         }
 
-    @Test
-    fun `persistAnnounce preserves existing icon appearance when not provided`() =
-        runTest {
-            val existingAnnounce =
-                AnnounceEntity(
-                    destinationHash = testDestinationHash,
-                    peerName = "Test Peer",
-                    publicKey = testPublicKey,
-                    appData = null,
-                    hops = 1,
-                    lastSeenTimestamp = System.currentTimeMillis(),
-                    nodeType = "LXMF_PEER",
-                    receivingInterface = "BLE",
-                    iconName = "home",
-                    iconForegroundColor = "#FFFFFF",
-                    iconBackgroundColor = "#000000",
-                )
-
-            coEvery { announceDao.getAnnounce(testDestinationHash) } returns existingAnnounce
-            coEvery { announceDao.upsertAnnounce(any()) } just Runs
-
-            persistenceManager.persistAnnounce(
-                destinationHash = testDestinationHash,
-                peerName = "Test Peer",
-                publicKey = testPublicKey,
-                appData = null,
-                hops = 2,
-                timestamp = System.currentTimeMillis(),
-                nodeType = "LXMF_PEER",
-                receivingInterface = null,
-                receivingInterfaceType = null,
-                aspect = null,
-                stampCost = null,
-                stampCostFlexibility = null,
-                peeringCost = null,
-                iconName = null,
-                iconForegroundColor = null,
-                iconBackgroundColor = null,
-                propagationTransferLimitKb = null,
-            )
-
-            testScope.advanceUntilIdle()
-
-            coVerify {
-                announceDao.upsertAnnounce(
-                    match { entity ->
-                        entity.iconName == "home" &&
-                            entity.iconForegroundColor == "#FFFFFF" &&
-                            entity.iconBackgroundColor == "#000000"
-                    },
-                )
-            }
-        }
-
-    @Test
-    fun `persistAnnounce updates icon appearance when provided`() =
-        runTest {
-            val existingAnnounce =
-                AnnounceEntity(
-                    destinationHash = testDestinationHash,
-                    peerName = "Test Peer",
-                    publicKey = testPublicKey,
-                    appData = null,
-                    hops = 1,
-                    lastSeenTimestamp = System.currentTimeMillis(),
-                    nodeType = "LXMF_PEER",
-                    receivingInterface = "BLE",
-                    iconName = "home",
-                    iconForegroundColor = "#FFFFFF",
-                    iconBackgroundColor = "#000000",
-                )
-
-            coEvery { announceDao.getAnnounce(testDestinationHash) } returns existingAnnounce
-            coEvery { announceDao.upsertAnnounce(any()) } just Runs
-
-            persistenceManager.persistAnnounce(
-                destinationHash = testDestinationHash,
-                peerName = "Test Peer",
-                publicKey = testPublicKey,
-                appData = null,
-                hops = 2,
-                timestamp = System.currentTimeMillis(),
-                nodeType = "LXMF_PEER",
-                receivingInterface = null,
-                receivingInterfaceType = null,
-                aspect = null,
-                stampCost = null,
-                stampCostFlexibility = null,
-                peeringCost = null,
-                iconName = "work",
-                iconForegroundColor = "#FF0000",
-                iconBackgroundColor = "#00FF00",
-                propagationTransferLimitKb = null,
-            )
-
-            testScope.advanceUntilIdle()
-
-            coVerify {
-                announceDao.upsertAnnounce(
-                    match { entity ->
-                        entity.iconName == "work" &&
-                            entity.iconForegroundColor == "#FF0000" &&
-                            entity.iconBackgroundColor == "#00FF00"
-                    },
-                )
-            }
-        }
+    // Note: Icon appearance tests removed - icons are now stored in peer_icons table,
+    // not on AnnounceEntity. See PeerIconDao for icon storage tests.
 
     @Test
     fun `persistAnnounce handles database exception gracefully`() =
@@ -298,9 +187,6 @@ class ServicePersistenceManagerTest {
                 stampCost = null,
                 stampCostFlexibility = null,
                 peeringCost = null,
-                iconName = null,
-                iconForegroundColor = null,
-                iconBackgroundColor = null,
                 propagationTransferLimitKb = null,
             )
 

--- a/app/src/test/java/com/lxmf/messenger/viewmodel/MapViewModelTest.kt
+++ b/app/src/test/java/com/lxmf/messenger/viewmodel/MapViewModelTest.kt
@@ -6,6 +6,7 @@ import app.cash.turbine.test
 import com.lxmf.messenger.data.db.dao.AnnounceDao
 import com.lxmf.messenger.data.db.dao.ReceivedLocationDao
 import com.lxmf.messenger.data.db.entity.ReceivedLocationEntity
+import com.lxmf.messenger.data.model.EnrichedAnnounce
 import com.lxmf.messenger.data.repository.ContactRepository
 import com.lxmf.messenger.map.MapStyleResult
 import com.lxmf.messenger.map.MapTileSourceManager
@@ -77,7 +78,7 @@ class MapViewModelTest {
         every { contactRepository.getEnrichedContacts() } returns flowOf(emptyList())
         every { receivedLocationDao.getLatestLocationsPerSenderUnfiltered() } returns flowOf(emptyList())
         every { receivedLocationDao.getLatestLocationsPerSenderUnfiltered() } returns flowOf(emptyList())
-        every { announceDao.getAllAnnounces() } returns flowOf(emptyList())
+        every { announceDao.getEnrichedAnnounces() } returns flowOf(emptyList())
         every { locationSharingManager.isSharing } returns MutableStateFlow(false)
         every { locationSharingManager.activeSessions } returns MutableStateFlow(emptyList())
         every { settingsRepository.hasDismissedLocationPermissionSheetFlow } returns flowOf(false)
@@ -811,7 +812,7 @@ class MapViewModelTest {
         runTest {
             val announces =
                 listOf(
-                    com.lxmf.messenger.data.db.entity.AnnounceEntity(
+                    EnrichedAnnounce(
                         destinationHash = "hash1",
                         peerName = "Announce Name",
                         publicKey = ByteArray(64),
@@ -820,7 +821,14 @@ class MapViewModelTest {
                         lastSeenTimestamp = System.currentTimeMillis(),
                         nodeType = "peer",
                         receivingInterface = null,
+                        receivingInterfaceType = null,
                         aspect = "lxmf.delivery",
+                        isFavorite = false,
+                        favoritedTimestamp = null,
+                        stampCost = null,
+                        stampCostFlexibility = null,
+                        peeringCost = null,
+                        propagationTransferLimitKb = null,
                     ),
                 )
             val receivedLocations =
@@ -839,7 +847,7 @@ class MapViewModelTest {
             // Empty contacts - no match
             every { contactRepository.getEnrichedContacts() } returns flowOf(emptyList())
             every { receivedLocationDao.getLatestLocationsPerSenderUnfiltered() } returns flowOf(receivedLocations)
-            every { announceDao.getAllAnnounces() } returns flowOf(announces)
+            every { announceDao.getEnrichedAnnounces() } returns flowOf(announces)
 
             viewModel = MapViewModel(contactRepository, receivedLocationDao, locationSharingManager, announceDao, settingsRepository, mapTileSourceManager)
 
@@ -869,7 +877,7 @@ class MapViewModelTest {
             // No contacts or announces
             every { contactRepository.getEnrichedContacts() } returns flowOf(emptyList())
             every { receivedLocationDao.getLatestLocationsPerSenderUnfiltered() } returns flowOf(receivedLocations)
-            every { announceDao.getAllAnnounces() } returns flowOf(emptyList())
+            every { announceDao.getEnrichedAnnounces() } returns flowOf(emptyList())
 
             viewModel = MapViewModel(contactRepository, receivedLocationDao, locationSharingManager, announceDao, settingsRepository, mapTileSourceManager)
 
@@ -893,7 +901,7 @@ class MapViewModelTest {
                 )
             val announces =
                 listOf(
-                    com.lxmf.messenger.data.db.entity.AnnounceEntity(
+                    EnrichedAnnounce(
                         destinationHash = "hash1",
                         peerName = "Announce Name",
                         publicKey = ByteArray(64),
@@ -902,7 +910,14 @@ class MapViewModelTest {
                         lastSeenTimestamp = System.currentTimeMillis(),
                         nodeType = "peer",
                         receivingInterface = null,
+                        receivingInterfaceType = null,
                         aspect = "lxmf.delivery",
+                        isFavorite = false,
+                        favoritedTimestamp = null,
+                        stampCost = null,
+                        stampCostFlexibility = null,
+                        peeringCost = null,
+                        propagationTransferLimitKb = null,
                     ),
                 )
             val receivedLocations =
@@ -920,7 +935,7 @@ class MapViewModelTest {
                 )
             every { contactRepository.getEnrichedContacts() } returns flowOf(contacts)
             every { receivedLocationDao.getLatestLocationsPerSenderUnfiltered() } returns flowOf(receivedLocations)
-            every { announceDao.getAllAnnounces() } returns flowOf(announces)
+            every { announceDao.getEnrichedAnnounces() } returns flowOf(announces)
 
             viewModel = MapViewModel(contactRepository, receivedLocationDao, locationSharingManager, announceDao, settingsRepository, mapTileSourceManager)
 
@@ -939,7 +954,7 @@ class MapViewModelTest {
         runTest {
             val announces =
                 listOf(
-                    com.lxmf.messenger.data.db.entity.AnnounceEntity(
+                    EnrichedAnnounce(
                         destinationHash = "hash1",
                         peerName = "Test User",
                         publicKey = ByteArray(64) { it.toByte() },
@@ -948,7 +963,14 @@ class MapViewModelTest {
                         lastSeenTimestamp = System.currentTimeMillis(),
                         nodeType = "peer",
                         receivingInterface = null,
+                        receivingInterfaceType = null,
                         aspect = "lxmf.delivery",
+                        isFavorite = false,
+                        favoritedTimestamp = null,
+                        stampCost = null,
+                        stampCostFlexibility = null,
+                        peeringCost = null,
+                        propagationTransferLimitKb = null,
                         iconName = "account",
                         iconForegroundColor = "FFFFFF",
                         iconBackgroundColor = "1E88E5",
@@ -969,7 +991,7 @@ class MapViewModelTest {
                 )
             every { contactRepository.getEnrichedContacts() } returns flowOf(emptyList())
             every { receivedLocationDao.getLatestLocationsPerSenderUnfiltered() } returns flowOf(receivedLocations)
-            every { announceDao.getAllAnnounces() } returns flowOf(announces)
+            every { announceDao.getEnrichedAnnounces() } returns flowOf(announces)
 
             viewModel = MapViewModel(contactRepository, receivedLocationDao, locationSharingManager, announceDao, settingsRepository, mapTileSourceManager)
 
@@ -989,7 +1011,7 @@ class MapViewModelTest {
         runTest {
             val announces =
                 listOf(
-                    com.lxmf.messenger.data.db.entity.AnnounceEntity(
+                    EnrichedAnnounce(
                         destinationHash = "hash1",
                         peerName = "Test User",
                         publicKey = ByteArray(64),
@@ -998,8 +1020,15 @@ class MapViewModelTest {
                         lastSeenTimestamp = System.currentTimeMillis(),
                         nodeType = "peer",
                         receivingInterface = null,
+                        receivingInterfaceType = null,
                         aspect = "lxmf.delivery",
-                        // No icon set on this announce
+                        isFavorite = false,
+                        favoritedTimestamp = null,
+                        stampCost = null,
+                        stampCostFlexibility = null,
+                        peeringCost = null,
+                        propagationTransferLimitKb = null,
+                        // No icon set - will be null (from peer_icons table)
                         iconName = null,
                         iconForegroundColor = null,
                         iconBackgroundColor = null,
@@ -1020,7 +1049,7 @@ class MapViewModelTest {
                 )
             every { contactRepository.getEnrichedContacts() } returns flowOf(emptyList())
             every { receivedLocationDao.getLatestLocationsPerSenderUnfiltered() } returns flowOf(receivedLocations)
-            every { announceDao.getAllAnnounces() } returns flowOf(announces)
+            every { announceDao.getEnrichedAnnounces() } returns flowOf(announces)
 
             viewModel = MapViewModel(contactRepository, receivedLocationDao, locationSharingManager, announceDao, settingsRepository, mapTileSourceManager)
 
@@ -1060,7 +1089,7 @@ class MapViewModelTest {
             // Contact exists but no announce with icon
             every { contactRepository.getEnrichedContacts() } returns flowOf(contacts)
             every { receivedLocationDao.getLatestLocationsPerSenderUnfiltered() } returns flowOf(receivedLocations)
-            every { announceDao.getAllAnnounces() } returns flowOf(emptyList())
+            every { announceDao.getEnrichedAnnounces() } returns flowOf(emptyList())
 
             viewModel = MapViewModel(contactRepository, receivedLocationDao, locationSharingManager, announceDao, settingsRepository, mapTileSourceManager)
 

--- a/data/src/main/java/com/lxmf/messenger/data/db/ColumbaDatabase.kt
+++ b/data/src/main/java/com/lxmf/messenger/data/db/ColumbaDatabase.kt
@@ -9,6 +9,7 @@ import com.lxmf.messenger.data.db.dao.CustomThemeDao
 import com.lxmf.messenger.data.db.dao.LocalIdentityDao
 import com.lxmf.messenger.data.db.dao.MessageDao
 import com.lxmf.messenger.data.db.dao.OfflineMapRegionDao
+import com.lxmf.messenger.data.db.dao.PeerIconDao
 import com.lxmf.messenger.data.db.dao.PeerIdentityDao
 import com.lxmf.messenger.data.db.dao.ReceivedLocationDao
 import com.lxmf.messenger.data.db.dao.RmspServerDao
@@ -19,6 +20,7 @@ import com.lxmf.messenger.data.db.entity.CustomThemeEntity
 import com.lxmf.messenger.data.db.entity.LocalIdentityEntity
 import com.lxmf.messenger.data.db.entity.MessageEntity
 import com.lxmf.messenger.data.db.entity.OfflineMapRegionEntity
+import com.lxmf.messenger.data.db.entity.PeerIconEntity
 import com.lxmf.messenger.data.db.entity.PeerIdentityEntity
 import com.lxmf.messenger.data.db.entity.ReceivedLocationEntity
 import com.lxmf.messenger.data.db.entity.RmspServerEntity
@@ -35,8 +37,9 @@ import com.lxmf.messenger.data.db.entity.RmspServerEntity
         ReceivedLocationEntity::class,
         OfflineMapRegionEntity::class,
         RmspServerEntity::class,
+        PeerIconEntity::class,
     ],
-    version = 30,
+    version = 31,
     exportSchema = false,
 )
 abstract class ColumbaDatabase : RoomDatabase() {
@@ -59,4 +62,6 @@ abstract class ColumbaDatabase : RoomDatabase() {
     abstract fun offlineMapRegionDao(): OfflineMapRegionDao
 
     abstract fun rmspServerDao(): RmspServerDao
+
+    abstract fun peerIconDao(): PeerIconDao
 }

--- a/data/src/main/java/com/lxmf/messenger/data/db/dao/AnnounceDao.kt
+++ b/data/src/main/java/com/lxmf/messenger/data/db/dao/AnnounceDao.kt
@@ -6,9 +6,11 @@ import androidx.room.Insert
 import androidx.room.OnConflictStrategy
 import androidx.room.Query
 import com.lxmf.messenger.data.db.entity.AnnounceEntity
+import com.lxmf.messenger.data.model.EnrichedAnnounce
 import kotlinx.coroutines.flow.Flow
 
 @Dao
+@Suppress("TooManyFunctions") // DAO provides comprehensive query interface for announces + icon enrichment
 interface AnnounceDao {
     /**
      * Insert or update an announce. If the destinationHash already exists,
@@ -178,6 +180,389 @@ interface AnnounceDao {
     )
     suspend fun countReachableAnnounces(pathTableHashes: List<String>): Int
 
+    // ==================== ENRICHED QUERIES (with peer_icons JOIN) ====================
+    // These queries include icon data from peer_icons table for UI display.
+    // Icons are an LXMF concept (Field 4 in messages), not part of Reticulum announces.
+
+    /**
+     * Get all announces with icon data, sorted by most recently seen.
+     * Joins peer_icons to get icon appearance from LXMF messages.
+     */
+    @Query(
+        """
+        SELECT
+            a.destinationHash,
+            a.peerName,
+            a.publicKey,
+            a.appData,
+            a.hops,
+            a.lastSeenTimestamp,
+            a.nodeType,
+            a.receivingInterface,
+            a.receivingInterfaceType,
+            a.aspect,
+            a.isFavorite,
+            a.favoritedTimestamp,
+            a.stampCost,
+            a.stampCostFlexibility,
+            a.peeringCost,
+            a.propagationTransferLimitKb,
+            pi.iconName as iconName,
+            pi.foregroundColor as iconForegroundColor,
+            pi.backgroundColor as iconBackgroundColor
+        FROM announces a
+        LEFT JOIN peer_icons pi ON a.destinationHash = pi.destinationHash
+        ORDER BY a.lastSeenTimestamp DESC
+        """,
+    )
+    fun getEnrichedAnnounces(): Flow<List<EnrichedAnnounce>>
+
+    /**
+     * Search announces with icon data by peer name or destination hash.
+     */
+    @Query(
+        """
+        SELECT
+            a.destinationHash,
+            a.peerName,
+            a.publicKey,
+            a.appData,
+            a.hops,
+            a.lastSeenTimestamp,
+            a.nodeType,
+            a.receivingInterface,
+            a.receivingInterfaceType,
+            a.aspect,
+            a.isFavorite,
+            a.favoritedTimestamp,
+            a.stampCost,
+            a.stampCostFlexibility,
+            a.peeringCost,
+            a.propagationTransferLimitKb,
+            pi.iconName as iconName,
+            pi.foregroundColor as iconForegroundColor,
+            pi.backgroundColor as iconBackgroundColor
+        FROM announces a
+        LEFT JOIN peer_icons pi ON a.destinationHash = pi.destinationHash
+        WHERE (a.peerName LIKE '%' || :query || '%' OR a.destinationHash LIKE '%' || :query || '%')
+        ORDER BY a.lastSeenTimestamp DESC
+        """,
+    )
+    fun searchEnrichedAnnounces(query: String): Flow<List<EnrichedAnnounce>>
+
+    /**
+     * Get announces filtered by node types with icon data.
+     */
+    @Query(
+        """
+        SELECT
+            a.destinationHash,
+            a.peerName,
+            a.publicKey,
+            a.appData,
+            a.hops,
+            a.lastSeenTimestamp,
+            a.nodeType,
+            a.receivingInterface,
+            a.receivingInterfaceType,
+            a.aspect,
+            a.isFavorite,
+            a.favoritedTimestamp,
+            a.stampCost,
+            a.stampCostFlexibility,
+            a.peeringCost,
+            a.propagationTransferLimitKb,
+            pi.iconName as iconName,
+            pi.foregroundColor as iconForegroundColor,
+            pi.backgroundColor as iconBackgroundColor
+        FROM announces a
+        LEFT JOIN peer_icons pi ON a.destinationHash = pi.destinationHash
+        WHERE a.nodeType IN (:nodeTypes)
+        AND (a.nodeType != 'PROPAGATION_NODE' OR a.stampCostFlexibility IS NOT NULL)
+        ORDER BY a.lastSeenTimestamp DESC
+        """,
+    )
+    fun getEnrichedAnnouncesByTypes(nodeTypes: List<String>): Flow<List<EnrichedAnnounce>>
+
+    /**
+     * Get all favorite announces with icon data, sorted by most recently favorited.
+     */
+    @Query(
+        """
+        SELECT
+            a.destinationHash,
+            a.peerName,
+            a.publicKey,
+            a.appData,
+            a.hops,
+            a.lastSeenTimestamp,
+            a.nodeType,
+            a.receivingInterface,
+            a.receivingInterfaceType,
+            a.aspect,
+            a.isFavorite,
+            a.favoritedTimestamp,
+            a.stampCost,
+            a.stampCostFlexibility,
+            a.peeringCost,
+            a.propagationTransferLimitKb,
+            pi.iconName as iconName,
+            pi.foregroundColor as iconForegroundColor,
+            pi.backgroundColor as iconBackgroundColor
+        FROM announces a
+        LEFT JOIN peer_icons pi ON a.destinationHash = pi.destinationHash
+        WHERE a.isFavorite = 1
+        ORDER BY a.favoritedTimestamp DESC
+        """,
+    )
+    fun getEnrichedFavoriteAnnounces(): Flow<List<EnrichedAnnounce>>
+
+    /**
+     * Search favorite announces with icon data by peer name or destination hash.
+     */
+    @Query(
+        """
+        SELECT
+            a.destinationHash,
+            a.peerName,
+            a.publicKey,
+            a.appData,
+            a.hops,
+            a.lastSeenTimestamp,
+            a.nodeType,
+            a.receivingInterface,
+            a.receivingInterfaceType,
+            a.aspect,
+            a.isFavorite,
+            a.favoritedTimestamp,
+            a.stampCost,
+            a.stampCostFlexibility,
+            a.peeringCost,
+            a.propagationTransferLimitKb,
+            pi.iconName as iconName,
+            pi.foregroundColor as iconForegroundColor,
+            pi.backgroundColor as iconBackgroundColor
+        FROM announces a
+        LEFT JOIN peer_icons pi ON a.destinationHash = pi.destinationHash
+        WHERE a.isFavorite = 1
+        AND (a.peerName LIKE '%' || :query || '%' OR a.destinationHash LIKE '%' || :query || '%')
+        ORDER BY a.favoritedTimestamp DESC
+        """,
+    )
+    fun searchEnrichedFavoriteAnnounces(query: String): Flow<List<EnrichedAnnounce>>
+
+    /**
+     * Get a specific announce with icon data as Flow.
+     */
+    @Query(
+        """
+        SELECT
+            a.destinationHash,
+            a.peerName,
+            a.publicKey,
+            a.appData,
+            a.hops,
+            a.lastSeenTimestamp,
+            a.nodeType,
+            a.receivingInterface,
+            a.receivingInterfaceType,
+            a.aspect,
+            a.isFavorite,
+            a.favoritedTimestamp,
+            a.stampCost,
+            a.stampCostFlexibility,
+            a.peeringCost,
+            a.propagationTransferLimitKb,
+            pi.iconName as iconName,
+            pi.foregroundColor as iconForegroundColor,
+            pi.backgroundColor as iconBackgroundColor
+        FROM announces a
+        LEFT JOIN peer_icons pi ON a.destinationHash = pi.destinationHash
+        WHERE a.destinationHash = :destinationHash
+        """,
+    )
+    fun getEnrichedAnnounceFlow(destinationHash: String): Flow<EnrichedAnnounce?>
+
+    /**
+     * Get top propagation nodes with icon data for relay selection.
+     */
+    @Query(
+        """
+        SELECT
+            a.destinationHash,
+            a.peerName,
+            a.publicKey,
+            a.appData,
+            a.hops,
+            a.lastSeenTimestamp,
+            a.nodeType,
+            a.receivingInterface,
+            a.receivingInterfaceType,
+            a.aspect,
+            a.isFavorite,
+            a.favoritedTimestamp,
+            a.stampCost,
+            a.stampCostFlexibility,
+            a.peeringCost,
+            a.propagationTransferLimitKb,
+            pi.iconName as iconName,
+            pi.foregroundColor as iconForegroundColor,
+            pi.backgroundColor as iconBackgroundColor
+        FROM announces a
+        LEFT JOIN peer_icons pi ON a.destinationHash = pi.destinationHash
+        WHERE a.nodeType = 'PROPAGATION_NODE'
+        AND a.stampCostFlexibility IS NOT NULL
+        ORDER BY
+            a.hops ASC,
+            CASE WHEN a.propagationTransferLimitKb IS NULL THEN 1 ELSE 0 END,
+            a.propagationTransferLimitKb DESC,
+            a.lastSeenTimestamp DESC
+        LIMIT :limit
+        """,
+    )
+    fun getEnrichedTopPropagationNodes(limit: Int = 10): Flow<List<EnrichedAnnounce>>
+
+    // Paging3 methods for infinite scroll (with peer_icons JOIN)
+
+    /**
+     * Get all announces with icon data and pagination support.
+     */
+    @Query(
+        """
+        SELECT
+            a.destinationHash,
+            a.peerName,
+            a.publicKey,
+            a.appData,
+            a.hops,
+            a.lastSeenTimestamp,
+            a.nodeType,
+            a.receivingInterface,
+            a.receivingInterfaceType,
+            a.aspect,
+            a.isFavorite,
+            a.favoritedTimestamp,
+            a.stampCost,
+            a.stampCostFlexibility,
+            a.peeringCost,
+            a.propagationTransferLimitKb,
+            pi.iconName as iconName,
+            pi.foregroundColor as iconForegroundColor,
+            pi.backgroundColor as iconBackgroundColor
+        FROM announces a
+        LEFT JOIN peer_icons pi ON a.destinationHash = pi.destinationHash
+        WHERE (a.nodeType != 'PROPAGATION_NODE' OR a.stampCostFlexibility IS NOT NULL)
+        ORDER BY a.lastSeenTimestamp DESC
+        """,
+    )
+    fun getEnrichedAnnouncesPaged(): PagingSource<Int, EnrichedAnnounce>
+
+    /**
+     * Get announces filtered by node types with icon data and pagination support.
+     */
+    @Query(
+        """
+        SELECT
+            a.destinationHash,
+            a.peerName,
+            a.publicKey,
+            a.appData,
+            a.hops,
+            a.lastSeenTimestamp,
+            a.nodeType,
+            a.receivingInterface,
+            a.receivingInterfaceType,
+            a.aspect,
+            a.isFavorite,
+            a.favoritedTimestamp,
+            a.stampCost,
+            a.stampCostFlexibility,
+            a.peeringCost,
+            a.propagationTransferLimitKb,
+            pi.iconName as iconName,
+            pi.foregroundColor as iconForegroundColor,
+            pi.backgroundColor as iconBackgroundColor
+        FROM announces a
+        LEFT JOIN peer_icons pi ON a.destinationHash = pi.destinationHash
+        WHERE a.nodeType IN (:nodeTypes)
+        AND (a.nodeType != 'PROPAGATION_NODE' OR a.stampCostFlexibility IS NOT NULL)
+        ORDER BY a.lastSeenTimestamp DESC
+        """,
+    )
+    fun getEnrichedAnnouncesByTypesPaged(nodeTypes: List<String>): PagingSource<Int, EnrichedAnnounce>
+
+    /**
+     * Search announces with icon data and pagination support.
+     */
+    @Query(
+        """
+        SELECT
+            a.destinationHash,
+            a.peerName,
+            a.publicKey,
+            a.appData,
+            a.hops,
+            a.lastSeenTimestamp,
+            a.nodeType,
+            a.receivingInterface,
+            a.receivingInterfaceType,
+            a.aspect,
+            a.isFavorite,
+            a.favoritedTimestamp,
+            a.stampCost,
+            a.stampCostFlexibility,
+            a.peeringCost,
+            a.propagationTransferLimitKb,
+            pi.iconName as iconName,
+            pi.foregroundColor as iconForegroundColor,
+            pi.backgroundColor as iconBackgroundColor
+        FROM announces a
+        LEFT JOIN peer_icons pi ON a.destinationHash = pi.destinationHash
+        WHERE (a.peerName LIKE '%' || :query || '%' OR a.destinationHash LIKE '%' || :query || '%')
+        AND (a.nodeType != 'PROPAGATION_NODE' OR a.stampCostFlexibility IS NOT NULL)
+        ORDER BY a.lastSeenTimestamp DESC
+        """,
+    )
+    fun searchEnrichedAnnouncesPaged(query: String): PagingSource<Int, EnrichedAnnounce>
+
+    /**
+     * Get announces filtered by node types AND search query with icon data and pagination.
+     */
+    @Query(
+        """
+        SELECT
+            a.destinationHash,
+            a.peerName,
+            a.publicKey,
+            a.appData,
+            a.hops,
+            a.lastSeenTimestamp,
+            a.nodeType,
+            a.receivingInterface,
+            a.receivingInterfaceType,
+            a.aspect,
+            a.isFavorite,
+            a.favoritedTimestamp,
+            a.stampCost,
+            a.stampCostFlexibility,
+            a.peeringCost,
+            a.propagationTransferLimitKb,
+            pi.iconName as iconName,
+            pi.foregroundColor as iconForegroundColor,
+            pi.backgroundColor as iconBackgroundColor
+        FROM announces a
+        LEFT JOIN peer_icons pi ON a.destinationHash = pi.destinationHash
+        WHERE a.nodeType IN (:nodeTypes)
+        AND (a.peerName LIKE '%' || :query || '%' OR a.destinationHash LIKE '%' || :query || '%')
+        AND (a.nodeType != 'PROPAGATION_NODE' OR a.stampCostFlexibility IS NOT NULL)
+        ORDER BY a.lastSeenTimestamp DESC
+        """,
+    )
+    fun getEnrichedAnnouncesByTypesAndSearchPaged(
+        nodeTypes: List<String>,
+        query: String,
+    ): PagingSource<Int, EnrichedAnnounce>
+
     // Paging3 methods for infinite scroll
 
     /**
@@ -259,22 +644,6 @@ interface AnnounceDao {
     @Query("SELECT nodeType, COUNT(*) as count FROM announces GROUP BY nodeType")
     suspend fun getNodeTypeCounts(): List<NodeTypeCount>
 
-    /**
-     * Update the icon appearance for an announce.
-     * @param destinationHash The destination hash of the announce
-     * @param iconName The icon name (e.g., Material icon name)
-     * @param foregroundColor Hex RGB color for icon foreground (e.g., "FFFFFF")
-     * @param backgroundColor Hex RGB color for icon background (e.g., "1E88E5")
-     */
-    @Query(
-        "UPDATE announces SET iconName = :iconName, iconForegroundColor = :foregroundColor, iconBackgroundColor = :backgroundColor WHERE destinationHash = :destinationHash",
-    )
-    suspend fun updateIconAppearance(
-        destinationHash: String,
-        iconName: String?,
-        foregroundColor: String?,
-        backgroundColor: String?,
-    )
 }
 
 /**

--- a/data/src/main/java/com/lxmf/messenger/data/db/dao/PeerIconDao.kt
+++ b/data/src/main/java/com/lxmf/messenger/data/db/dao/PeerIconDao.kt
@@ -1,0 +1,48 @@
+package com.lxmf.messenger.data.db.dao
+
+import androidx.room.Dao
+import androidx.room.Insert
+import androidx.room.OnConflictStrategy
+import androidx.room.Query
+import com.lxmf.messenger.data.db.entity.PeerIconEntity
+import kotlinx.coroutines.flow.Flow
+
+/**
+ * Data Access Object for peer icon appearances.
+ *
+ * Icons are received via LXMF messages (Field 4) and stored here for consistent
+ * display across all UI components (chats, announces, contacts).
+ */
+@Dao
+interface PeerIconDao {
+    /**
+     * Insert or update a peer's icon appearance.
+     * Uses REPLACE strategy to update existing icons.
+     */
+    @Insert(onConflict = OnConflictStrategy.REPLACE)
+    suspend fun upsertIcon(icon: PeerIconEntity)
+
+    /**
+     * Get a peer's icon by destination hash.
+     */
+    @Query("SELECT * FROM peer_icons WHERE destinationHash = :destinationHash")
+    suspend fun getIcon(destinationHash: String): PeerIconEntity?
+
+    /**
+     * Observe a peer's icon for reactive UI updates.
+     */
+    @Query("SELECT * FROM peer_icons WHERE destinationHash = :destinationHash")
+    fun observeIcon(destinationHash: String): Flow<PeerIconEntity?>
+
+    /**
+     * Delete a peer's icon.
+     */
+    @Query("DELETE FROM peer_icons WHERE destinationHash = :destinationHash")
+    suspend fun deleteIcon(destinationHash: String)
+
+    /**
+     * Delete all peer icons (for testing/debugging).
+     */
+    @Query("DELETE FROM peer_icons")
+    suspend fun deleteAllIcons()
+}

--- a/data/src/main/java/com/lxmf/messenger/data/db/entity/AnnounceEntity.kt
+++ b/data/src/main/java/com/lxmf/messenger/data/db/entity/AnnounceEntity.kt
@@ -29,9 +29,8 @@ data class AnnounceEntity(
     val stampCost: Int? = null,
     val stampCostFlexibility: Int? = null,
     val peeringCost: Int? = null,
-    val iconName: String? = null,
-    val iconForegroundColor: String? = null, // Hex RGB e.g., "FFFFFF"
-    val iconBackgroundColor: String? = null, // Hex RGB e.g., "1E88E5"
+    // Note: Icon fields removed - icons are now stored in peer_icons table (LXMF concept)
+    // The old columns remain in the DB but are no longer used (Room ignores extra columns)
     val propagationTransferLimitKb: Int? = null, // Per-message size limit for propagation nodes (in KB)
 ) {
     @Suppress("CyclomaticComplexMethod") // Equals must compare all fields for correctness
@@ -54,9 +53,6 @@ data class AnnounceEntity(
             stampCost == other.stampCost &&
             stampCostFlexibility == other.stampCostFlexibility &&
             peeringCost == other.peeringCost &&
-            iconName == other.iconName &&
-            iconForegroundColor == other.iconForegroundColor &&
-            iconBackgroundColor == other.iconBackgroundColor &&
             propagationTransferLimitKb == other.propagationTransferLimitKb
     }
 
@@ -84,9 +80,6 @@ data class AnnounceEntity(
         result = 31 * result + (stampCost?.hashCode() ?: 0)
         result = 31 * result + (stampCostFlexibility?.hashCode() ?: 0)
         result = 31 * result + (peeringCost?.hashCode() ?: 0)
-        result = 31 * result + (iconName?.hashCode() ?: 0)
-        result = 31 * result + (iconForegroundColor?.hashCode() ?: 0)
-        result = 31 * result + (iconBackgroundColor?.hashCode() ?: 0)
         result = 31 * result + (propagationTransferLimitKb?.hashCode() ?: 0)
         return result
     }

--- a/data/src/main/java/com/lxmf/messenger/data/db/entity/PeerIconEntity.kt
+++ b/data/src/main/java/com/lxmf/messenger/data/db/entity/PeerIconEntity.kt
@@ -1,0 +1,24 @@
+package com.lxmf.messenger.data.db.entity
+
+import androidx.room.Entity
+import androidx.room.PrimaryKey
+
+/**
+ * Entity for storing peer icon appearances received via LXMF messages.
+ *
+ * Icons are transmitted in LXMF Field 4 (FIELD_ICON_APPEARANCE) and represent
+ * the user's chosen visual identity. This is separate from announces (Reticulum
+ * network discovery) - icons are an LXMF-layer concept.
+ *
+ * This table is the single source of truth for peer icons and is joined
+ * by conversations, announces, and contacts queries to display icons consistently.
+ */
+@Entity(tableName = "peer_icons")
+data class PeerIconEntity(
+    @PrimaryKey
+    val destinationHash: String,
+    val iconName: String,
+    val foregroundColor: String, // Hex RGB e.g., "FFFFFF"
+    val backgroundColor: String, // Hex RGB e.g., "1E88E5"
+    val updatedTimestamp: Long,
+)

--- a/data/src/main/java/com/lxmf/messenger/data/model/EnrichedAnnounce.kt
+++ b/data/src/main/java/com/lxmf/messenger/data/model/EnrichedAnnounce.kt
@@ -1,0 +1,92 @@
+package com.lxmf.messenger.data.model
+
+/**
+ * Enriched announce data combining announces table with peer_icons.
+ *
+ * This model represents the result of a join query that combines:
+ * - Announce data (from announces table - Reticulum network discovery)
+ * - Profile icon (from peer_icons table - LXMF message icon appearances)
+ *
+ * Icons are an LXMF concept transmitted in message Field 4, while announces
+ * are a Reticulum concept for network peer discovery. This model bridges both.
+ */
+data class EnrichedAnnounce(
+    val destinationHash: String,
+    val peerName: String,
+    val publicKey: ByteArray,
+    val appData: ByteArray?,
+    val hops: Int,
+    val lastSeenTimestamp: Long,
+    val nodeType: String,
+    val receivingInterface: String?,
+    val receivingInterfaceType: String?,
+    val aspect: String?,
+    val isFavorite: Boolean,
+    val favoritedTimestamp: Long?,
+    val stampCost: Int?,
+    val stampCostFlexibility: Int?,
+    val peeringCost: Int?,
+    val propagationTransferLimitKb: Int?,
+    // Profile icon (from peer_icons table)
+    val iconName: String? = null,
+    val iconForegroundColor: String? = null,
+    val iconBackgroundColor: String? = null,
+) {
+    @Suppress("CyclomaticComplexMethod")
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (javaClass != other?.javaClass) return false
+
+        other as EnrichedAnnounce
+
+        if (destinationHash != other.destinationHash) return false
+        if (peerName != other.peerName) return false
+        if (!publicKey.contentEquals(other.publicKey)) return false
+        if (appData != null) {
+            if (other.appData == null) return false
+            if (!appData.contentEquals(other.appData)) return false
+        } else if (other.appData != null) {
+            return false
+        }
+        if (hops != other.hops) return false
+        if (lastSeenTimestamp != other.lastSeenTimestamp) return false
+        if (nodeType != other.nodeType) return false
+        if (receivingInterface != other.receivingInterface) return false
+        if (receivingInterfaceType != other.receivingInterfaceType) return false
+        if (aspect != other.aspect) return false
+        if (isFavorite != other.isFavorite) return false
+        if (favoritedTimestamp != other.favoritedTimestamp) return false
+        if (stampCost != other.stampCost) return false
+        if (stampCostFlexibility != other.stampCostFlexibility) return false
+        if (peeringCost != other.peeringCost) return false
+        if (propagationTransferLimitKb != other.propagationTransferLimitKb) return false
+        if (iconName != other.iconName) return false
+        if (iconForegroundColor != other.iconForegroundColor) return false
+        if (iconBackgroundColor != other.iconBackgroundColor) return false
+
+        return true
+    }
+
+    override fun hashCode(): Int {
+        var result = destinationHash.hashCode()
+        result = 31 * result + peerName.hashCode()
+        result = 31 * result + publicKey.contentHashCode()
+        result = 31 * result + (appData?.contentHashCode() ?: 0)
+        result = 31 * result + hops
+        result = 31 * result + lastSeenTimestamp.hashCode()
+        result = 31 * result + nodeType.hashCode()
+        result = 31 * result + (receivingInterface?.hashCode() ?: 0)
+        result = 31 * result + (receivingInterfaceType?.hashCode() ?: 0)
+        result = 31 * result + (aspect?.hashCode() ?: 0)
+        result = 31 * result + isFavorite.hashCode()
+        result = 31 * result + (favoritedTimestamp?.hashCode() ?: 0)
+        result = 31 * result + (stampCost?.hashCode() ?: 0)
+        result = 31 * result + (stampCostFlexibility?.hashCode() ?: 0)
+        result = 31 * result + (peeringCost?.hashCode() ?: 0)
+        result = 31 * result + (propagationTransferLimitKb?.hashCode() ?: 0)
+        result = 31 * result + (iconName?.hashCode() ?: 0)
+        result = 31 * result + (iconForegroundColor?.hashCode() ?: 0)
+        result = 31 * result + (iconBackgroundColor?.hashCode() ?: 0)
+        return result
+    }
+}

--- a/data/src/main/java/com/lxmf/messenger/data/model/EnrichedConversation.kt
+++ b/data/src/main/java/com/lxmf/messenger/data/model/EnrichedConversation.kt
@@ -1,11 +1,11 @@
 package com.lxmf.messenger.data.model
 
 /**
- * Enriched conversation data combining conversations table with announces and contacts.
+ * Enriched conversation data combining conversations table with announces, contacts, and peer icons.
  *
  * This model represents the result of a join query that combines:
  * - Conversation data (from conversations table)
- * - Profile icon (from announces table)
+ * - Profile icon (from peer_icons table - LXMF message appearances)
  * - Display name with priority: nickname > announce name > peer name > hash (from contacts + announces)
  */
 data class EnrichedConversation(
@@ -17,7 +17,7 @@ data class EnrichedConversation(
     val lastMessage: String,
     val lastMessageTimestamp: Long,
     val unreadCount: Int,
-    // Profile icon (from announces table)
+    // Profile icon (from peer_icons table)
     val iconName: String? = null,
     val iconForegroundColor: String? = null,
     val iconBackgroundColor: String? = null,

--- a/data/src/main/java/com/lxmf/messenger/data/repository/AnnounceRepository.kt
+++ b/data/src/main/java/com/lxmf/messenger/data/repository/AnnounceRepository.kt
@@ -6,6 +6,7 @@ import androidx.paging.PagingData
 import androidx.paging.map
 import com.lxmf.messenger.data.db.dao.AnnounceDao
 import com.lxmf.messenger.data.db.entity.AnnounceEntity
+import com.lxmf.messenger.data.model.EnrichedAnnounce
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.map
 import javax.inject.Inject
@@ -106,51 +107,55 @@ class AnnounceRepository
         /**
          * Get all announces as a Flow, sorted by most recently seen.
          * Automatically updates UI when announces are added or updated.
+         * Includes icon data from peer_icons table (LXMF message appearances).
          */
         fun getAnnounces(): Flow<List<Announce>> {
-            return announceDao.getAllAnnounces().map { entities ->
-                entities.map { it.toAnnounce() }
+            return announceDao.getEnrichedAnnounces().map { enriched ->
+                enriched.map { it.toAnnounce() }
             }
         }
 
         /**
          * Search announces by peer name or destination hash.
          * Automatically updates UI when matching announces are added or updated.
+         * Includes icon data from peer_icons table.
          */
         fun searchAnnounces(query: String): Flow<List<Announce>> {
-            return announceDao.searchAnnounces(query).map { entities ->
-                entities.map { it.toAnnounce() }
+            return announceDao.searchEnrichedAnnounces(query).map { enriched ->
+                enriched.map { it.toAnnounce() }
             }
         }
 
         /**
          * Get announces filtered by node types as a Flow, sorted by most recently seen.
          * Automatically updates UI when announces are added or updated.
+         * Includes icon data from peer_icons table.
          * @param nodeTypes List of node types to include (e.g., ["PEER", "NODE"])
          */
         fun getAnnouncesByTypes(nodeTypes: List<String>): Flow<List<Announce>> {
-            return announceDao.getAnnouncesByTypes(nodeTypes).map { entities ->
-                entities.map { it.toAnnounce() }
+            return announceDao.getEnrichedAnnouncesByTypes(nodeTypes).map { enriched ->
+                enriched.map { it.toAnnounce() }
             }
         }
 
         /**
          * Get top propagation nodes sorted by hop count (ascending).
          * Optimized query with LIMIT in SQL - only fetches the requested number of rows.
-         * Used for relay selection UI.
+         * Used for relay selection UI. Includes icon data from peer_icons table.
          *
          * @param limit Maximum number of nodes to return (default 10)
          * @return Flow of propagation node announces sorted by nearest first
          */
         fun getTopPropagationNodes(limit: Int = 10): Flow<List<Announce>> {
-            return announceDao.getTopPropagationNodes(limit).map { entities ->
-                entities.map { it.toAnnounce() }
+            return announceDao.getEnrichedTopPropagationNodes(limit).map { enriched ->
+                enriched.map { it.toAnnounce() }
             }
         }
 
         /**
          * Get announces with pagination support. Combines node type filtering and search query.
          * Initial load: 30 items, Page size: 30 items, Prefetch distance: 10 items.
+         * Includes icon data from peer_icons table.
          *
          * @param nodeTypes List of node types to filter by (empty = all types)
          * @param searchQuery Search query (empty = no search filter)
@@ -172,20 +177,20 @@ class AnnounceRepository
                     when {
                         // Filter by node types AND search query
                         nodeTypes.isNotEmpty() && searchQuery.isNotEmpty() ->
-                            announceDao.getAnnouncesByTypesAndSearchPaged(nodeTypes, searchQuery)
+                            announceDao.getEnrichedAnnouncesByTypesAndSearchPaged(nodeTypes, searchQuery)
                         // Filter by node types only
                         nodeTypes.isNotEmpty() ->
-                            announceDao.getAnnouncesByTypesPaged(nodeTypes)
+                            announceDao.getEnrichedAnnouncesByTypesPaged(nodeTypes)
                         // Filter by search query only
                         searchQuery.isNotEmpty() ->
-                            announceDao.searchAnnouncesPaged(searchQuery)
+                            announceDao.searchEnrichedAnnouncesPaged(searchQuery)
                         // No filters
                         else ->
-                            announceDao.getAllAnnouncesPaged()
+                            announceDao.getEnrichedAnnouncesPaged()
                     }
                 },
             ).flow.map { pagingData ->
-                pagingData.map { entity -> entity.toAnnounce() }
+                pagingData.map { enriched -> enriched.toAnnounce() }
             }
         }
 
@@ -225,12 +230,10 @@ class AnnounceRepository
             stampCost: Int? = null,
             stampCostFlexibility: Int? = null,
             peeringCost: Int? = null,
-            iconName: String? = null,
-            iconForegroundColor: String? = null,
-            iconBackgroundColor: String? = null,
             propagationTransferLimitKb: Int? = null,
         ) {
-            // Preserve favorite status and icon appearance if announce already exists
+            // Preserve favorite status if announce already exists
+            // Note: Icons are stored separately in peer_icons table (from LXMF messages)
             val existing = announceDao.getAnnounce(destinationHash)
 
             val entity =
@@ -250,9 +253,6 @@ class AnnounceRepository
                     stampCost = stampCost,
                     stampCostFlexibility = stampCostFlexibility,
                     peeringCost = peeringCost,
-                    iconName = iconName ?: existing?.iconName,
-                    iconForegroundColor = iconForegroundColor ?: existing?.iconForegroundColor,
-                    iconBackgroundColor = iconBackgroundColor ?: existing?.iconBackgroundColor,
                     propagationTransferLimitKb = propagationTransferLimitKb,
                 )
             announceDao.upsertAnnounce(entity)
@@ -296,20 +296,22 @@ class AnnounceRepository
         /**
          * Get all favorite announces as a Flow, sorted by most recently favorited.
          * Automatically updates UI when favorites are added or removed.
+         * Includes icon data from peer_icons table.
          */
         fun getFavoriteAnnounces(): Flow<List<Announce>> {
-            return announceDao.getFavoriteAnnounces().map { entities ->
-                entities.map { it.toAnnounce() }
+            return announceDao.getEnrichedFavoriteAnnounces().map { enriched ->
+                enriched.map { it.toAnnounce() }
             }
         }
 
         /**
          * Search favorite announces by peer name or destination hash.
          * Automatically updates UI when matching favorites are added or removed.
+         * Includes icon data from peer_icons table.
          */
         fun searchFavoriteAnnounces(query: String): Flow<List<Announce>> {
-            return announceDao.searchFavoriteAnnounces(query).map { entities ->
-                entities.map { it.toAnnounce() }
+            return announceDao.searchEnrichedFavoriteAnnounces(query).map { enriched ->
+                enriched.map { it.toAnnounce() }
             }
         }
 
@@ -345,10 +347,11 @@ class AnnounceRepository
 
         /**
          * Get a specific announce as Flow (for observing favorite status changes).
+         * Includes icon data from peer_icons table.
          */
         fun getAnnounceFlow(destinationHash: String): Flow<Announce?> {
-            return announceDao.getAnnounceFlow(destinationHash).map { entity ->
-                entity?.toAnnounce()
+            return announceDao.getEnrichedAnnounceFlow(destinationHash).map { enriched ->
+                enriched?.toAnnounce()
             }
         }
 
@@ -368,23 +371,32 @@ class AnnounceRepository
             return announceDao.getNodeTypeCounts().map { it.nodeType to it.count }
         }
 
-        /**
-         * Update the icon appearance for an announce.
-         * @param destinationHash The destination hash of the announce
-         * @param iconName The icon name (e.g., Material icon name)
-         * @param foregroundColor Hex RGB color for icon foreground (e.g., "FFFFFF")
-         * @param backgroundColor Hex RGB color for icon background (e.g., "1E88E5")
-         */
-        suspend fun updateIconAppearance(
-            destinationHash: String,
-            iconName: String?,
-            foregroundColor: String?,
-            backgroundColor: String?,
-        ) {
-            announceDao.updateIconAppearance(destinationHash, iconName, foregroundColor, backgroundColor)
-        }
-
+        // Note: This mapping is only used for non-UI operations (export, toggle favorite, etc.)
+        // For UI display, use enriched queries that join peer_icons for icon data
         private fun AnnounceEntity.toAnnounce() =
+            Announce(
+                destinationHash = destinationHash,
+                peerName = peerName,
+                publicKey = publicKey,
+                appData = appData,
+                hops = hops,
+                lastSeenTimestamp = lastSeenTimestamp,
+                nodeType = nodeType,
+                receivingInterface = receivingInterface,
+                receivingInterfaceType = receivingInterfaceType,
+                aspect = aspect,
+                isFavorite = isFavorite,
+                favoritedTimestamp = favoritedTimestamp,
+                stampCost = stampCost,
+                stampCostFlexibility = stampCostFlexibility,
+                peeringCost = peeringCost,
+                iconName = null, // Icon data now comes from peer_icons table via enriched queries
+                iconForegroundColor = null,
+                iconBackgroundColor = null,
+                propagationTransferLimitKb = propagationTransferLimitKb,
+            )
+
+        private fun EnrichedAnnounce.toAnnounce() =
             Announce(
                 destinationHash = destinationHash,
                 peerName = peerName,


### PR DESCRIPTION
## Summary

- **Root cause**: Icons were stored via UPDATE on the `announces` table, which failed silently when no announce existed for a peer
- **Fix**: Created dedicated `peer_icons` table with UPSERT operations that always succeed
- Icons are an **LXMF concept** (message Field 4), while announces are a **Reticulum concept** (network discovery) - separating them makes architectural sense

## Changes

- Add `peer_icons` table with UPSERT via `MIGRATION_30_31`
- `MessageCollector` saves icons using `peerIconDao.upsertIcon()`
- Add enriched queries (`getEnrichedAnnounces`, `getEnrichedConversations`) that LEFT JOIN `peer_icons`
- Remove icon fields from `AnnounceEntity` (now stored in `peer_icons`)

## Test plan

- [x] Receive message from peer who hasn't announced yet → icon displays correctly
- [x] Existing unit tests pass
- [x] App builds and installs successfully

🤖 Generated with [Claude Code](https://claude.ai/code)