### PR TITLE
docs: map existing codebase

### DIFF
--- a/.planning/codebase/ARCHITECTURE.md
+++ b/.planning/codebase/ARCHITECTURE.md
@@ -1,0 +1,199 @@
+# Architecture
+
+**Analysis Date:** 2026-01-23
+
+## Pattern Overview
+
+**Overall:** Multi-process Android application with clean layered architecture (UI → ViewModel → Repository → Database + Service IPC).
+
+**Key Characteristics:**
+- Clean Architecture with clear separation of concerns across modules
+- Dependency Injection (Hilt) for testability and flexibility
+- Service-based background processing for Python Reticulum networking stack
+- Protocol abstraction layer enabling future Rust/UniFFI migration
+- Cross-process communication via AIDL for reliable message passing
+- Reactive data flow using Kotlin Coroutines and StateFlow
+
+## Layers
+
+**UI Layer:**
+- Purpose: Compose-based user interface, Material Design 3 themes
+- Location: `app/src/main/java/com/lxmf/messenger/ui/`
+- Contains: Screens, Components, Theme definitions, UI models, Utilities
+- Depends on: ViewModels, Repositories, Domain models, Utilities
+- Used by: MainActivity (entry point)
+
+**ViewModel Layer:**
+- Purpose: State management, business logic orchestration, screen-specific state
+- Location: `app/src/main/java/com/lxmf/messenger/viewmodel/`
+- Contains: ViewModel classes for each major screen/feature
+- Depends on: Repositories, use case logic, Coroutines
+- Used by: UI Layer (Composables)
+
+**Repository Layer:**
+- Purpose: Data access abstraction, combining database and service sources
+- Location: `data/src/main/java/com/lxmf/messenger/data/repository/` and `app/src/main/java/com/lxmf/messenger/repository/`
+- Contains: Repository implementations for conversations, contacts, settings, identities
+- Depends on: DAOs, Services, DataStore, External protocols
+- Used by: ViewModels, Service managers
+
+**Service Layer (Background Process):**
+- Purpose: Long-running Reticulum networking service in separate `:reticulum` process
+- Location: `app/src/main/java/com/lxmf/messenger/service/`
+- Contains: ReticulumService (lifecycle shell), ServiceModule (DI), managers, state
+- Depends on: ReticulumProtocol, Database, Python/Chaquopy
+- Used by: Main app process via AIDL binder
+
+**Data/Database Layer:**
+- Purpose: Persistent data storage using Room ORM
+- Location: `data/src/main/java/com/lxmf/messenger/data/db/`
+- Contains: Database schema, DAOs, Entities, Migrations
+- Depends on: Room, SQLite
+- Used by: Repositories, Service managers
+
+**Reticulum Protocol Layer:**
+- Purpose: Network stack abstraction for mesh networking protocol
+- Location: `reticulum/src/main/java/com/lxmf/messenger/reticulum/`
+- Contains: Protocol interface, ServiceReticulumProtocol (service-based), BLE bridge, RNode USB
+- Depends on: Python/Chaquopy (via Chaquopy), Android APIs, Coroutines
+- Used by: Service managers, ViewModels
+
+**Domain/Shared Models:**
+- Purpose: Core data models and business logic
+- Location: `reticulum/src/main/java/com/lxmf/messenger/reticulum/model/` and `app/src/main/java/com/lxmf/messenger/data/model/`
+- Contains: Identity, Destination, Link, Message, AnnounceEvent, configuration models
+- Depends on: Nothing (pure data)
+- Used by: All layers
+
+## Data Flow
+
+**Initialization Flow (Cold Start):**
+
+1. `ColumbaApplication.onCreate()` initializes DI and starts core managers
+2. `MainActivity.onCreate()` sets up UI, navigates based on onboarding state
+3. `ReticulumService.onCreate()` in background process initializes:
+   - ServiceModule creates all managers (BLE, Messaging, Health Check, etc.)
+   - PythonWrapperManager initializes Chaquopy and Python Reticulum instance
+   - HealthCheckManager starts heartbeat polling (~5s intervals)
+4. `ServiceReticulumProtocol` in main process establishes AIDL connection to service
+5. UI ViewModels query repositories which delegate to service via IPC
+
+**Message Reception Flow:**
+
+1. Python Reticulum instance (in service process) receives packets
+2. EventHandler in service parses packet to domain models (ReceivedPacket, LinkEvent, etc.)
+3. CallbackBroadcaster sends broadcasts to main app process
+4. Main app broadcasts received via BroadcastReceiver
+5. Repository updates database (Message, Conversation, Announce tables)
+6. StateFlow<> in repository notifies ViewModels
+7. ViewModel recomposes UI
+
+**Message Sending Flow:**
+
+1. User composes message in ConversationScreen
+2. ChatsViewModel calls MessagingRepository.sendMessage()
+3. Repository delegates to service via AIDL (ReticulumServiceBinder)
+4. Service's MessagingManager hands to Python for LXMF delivery
+5. PacketReceipt returned via AIDL response
+6. ViewModel updates conversation with delivery status
+
+**State Management:**
+
+- **Service State:** `ServiceState` (atomic thread-safe holder) in service process
+- **UI State:** StateFlow-based repositories in main app process
+- **Cross-Process Sync:** DataStore (protocol buffers) for persistent state
+- **Network Status:** StateFlow from ReticulumProtocol, updated by HealthCheckManager
+
+## Key Abstractions
+
+**ReticulumProtocol (Interface):**
+- Purpose: Network stack contract enabling implementation swapping
+- Examples: `reticulum/src/main/java/com/lxmf/messenger/reticulum/protocol/ReticulumProtocol.kt`
+- Pattern: Strategy pattern with async/suspend functions for non-blocking ops
+- Implementations: `ServiceReticulumProtocol` (production), `MockReticulumProtocol` (testing)
+
+**ReticulumServiceBinder (AIDL):**
+- Purpose: IPC interface for main app to call service functions
+- Examples: `app/src/main/java/com/lxmf/messenger/service/binder/ReticulumServiceBinder.kt`
+- Pattern: Adapter pattern converting AIDL calls to internal manager methods
+- Converts Python results to Kotlin types via `PythonResultConverter`
+
+**Repository Pattern:**
+- Purpose: Abstract data sources (database, service, DataStore)
+- Examples: `ConversationRepository`, `IdentityRepository`, `SettingsRepository`
+- Pattern: Combines database queries with service calls, exposes StateFlow<>
+- Consistent across app - all repositories follow this structure
+
+**Manager Pattern (Service Layer):**
+- Purpose: Orchestrate complex operations, manage lifecycle
+- Examples: `PythonWrapperManager`, `HealthCheckManager`, `MessagingManager`, `NetworkChangeManager`
+- Pattern: Each manager handles one domain (Python, Health, Messaging, Network)
+- Initialized in `ServiceModule.createManagers()`, all share `ServiceState`
+
+**DAO Pattern (Database):**
+- Purpose: Type-safe database queries
+- Examples: `ConversationDao`, `MessageDao`, `PeerIdentityDao`
+- Pattern: Room @Dao annotated interfaces returning Flow<> for reactive queries
+- One DAO per entity type in `data/src/main/java/com/lxmf/messenger/data/db/dao/`
+
+## Entry Points
+
+**MainActivity:**
+- Location: `app/src/main/java/com/lxmf/messenger/MainActivity.kt`
+- Triggers: Intent.ACTION_MAIN, deep links (lxma://), USB device attached, BROADCAST_ACTION
+- Responsibilities: Set up Compose UI, handle permissions, route based on onboarding state, manage navigation
+
+**ColumbaApplication:**
+- Location: `app/src/main/java/com/lxmf/messenger/ColumbaApplication.kt`
+- Triggers: App process startup (before any activity)
+- Responsibilities: Hilt DI initialization, start core managers (MessageCollector, AutoAnnounce, Migration), error reporting (Sentry)
+
+**ReticulumService:**
+- Location: `app/src/main/java/com/lxmf/messenger/service/ReticulumService.kt`
+- Triggers: MainActivity.startService() or system launch in background
+- Responsibilities: Foreground service lifecycle, initialize managers via ServiceModule, expose AIDL binder, monitor health
+
+**RNodeCompanionService:**
+- Location: `app/src/main/java/com/lxmf/messenger/service/RNodeCompanionService.kt`
+- Triggers: Companion Device Manager (Android 12+) when RNode in range
+- Responsibilities: Register Columba as companion app for RNode devices
+
+## Error Handling
+
+**Strategy:** Defensive programming with fallbacks, observable error states, crash reporting.
+
+**Patterns:**
+
+- **Result<T> Type:** Service and protocol methods return sealed Result<Success/Failure>
+- **StateFlow Error State:** Repositories expose error flows that ViewModels observe
+- **Try-Catch in Managers:** Broad exception handling in service managers with logging
+- **Timeout Protection:** Service IPC calls use `withTimeoutOrNull()` to prevent ANR
+- **Stale Heartbeat Detection:** HealthCheckManager monitors Python responsiveness, triggers restart if stale
+- **Generation Tracking:** Race condition prevention - generation counter prevents stale async jobs from overwriting state
+- **Crash Reporting:** Sentry integration via `CrashReportManager` for production issues
+
+## Cross-Cutting Concerns
+
+**Logging:**
+- Approach: Android Log with debug tag per class (e.g., "ReticulumService", "ChatsViewModel")
+- Level: DEBUG for normal flow, WARN/ERROR for issues
+- Location: Imports `android.util.Log` throughout codebase
+
+**Validation:**
+- Approach: Input validation in ViewModels before repository calls
+- Domain validation in repositories (e.g., identity hash format)
+- Location: `app/src/main/java/com/lxmf/messenger/util/validation/`
+
+**Authentication:**
+- Approach: Identity-based mesh protocol (LXMF/Reticulum), not traditional login
+- Identity files stored locally, exported/imported via QR codes or file sharing
+- Location: Identity management in `IdentityRepository`, `IdentityManager`
+
+**Permissions:**
+- Approach: Runtime permissions via ActivityResultContracts (Camera, Location, Bluetooth, Recording)
+- Manifest declared in `AndroidManifest.xml` with detailed rationale comments
+- Location: Permission handling in MainActivity intent filters and runtime checks
+
+---
+
+*Architecture analysis: 2026-01-23*

--- a/.planning/codebase/CONCERNS.md
+++ b/.planning/codebase/CONCERNS.md
@@ -1,0 +1,266 @@
+# Codebase Concerns
+
+**Analysis Date:** 2026-01-23
+
+## Tech Debt
+
+**Build system: x86_64 architecture support disabled:**
+- Issue: x86_64 ABIs are excluded from build due to pycodec2 wheel resolution issue
+- Files: `app/build.gradle.kts:122`, `reticulum/build.gradle.kts:20`
+- Impact: Cannot run app or tests on x86_64 emulators/devices; limits testing flexibility; only arm64-v8a is compiled
+- Fix approach: Resolve or create pre-built pycodec2 wheel for x86_64 architecture and update gradle files to include x86_64 in abiFilters
+
+**Metrics infrastructure not integrated:**
+- Issue: Production metrics for BLE dual-connection race detection are tracked internally but no integration exists for monitoring
+- Files: `reticulum/src/main/java/com/lxmf/messenger/reticulum/ble/bridge/KotlinBLEBridge.kt:226`
+- Impact: Cannot observe production metrics (dualConnectionRaceCount); no observability into how often race conditions occur in deployed app
+- Fix approach: Integrate with Firebase, Grafana, or custom metrics service once available
+
+**Per-peer statistics tracking incomplete:**
+- Issue: BLE peer connection statistics are aggregated globally but individual per-peer stats (bytesReceived/bytesSent) are not tracked
+- Files: `reticulum/src/main/java/com/lxmf/messenger/reticulum/ble/service/BleConnectionManager.kt:520-521`
+- Impact: Cannot diagnose peer-specific performance issues; UI peer details show zeros for per-peer byte counts
+- Fix approach: Add per-peer byte counters to PeerConnectionDetails; track in BleGattClient/BleGattServer
+
+**Legacy settings migration with deprecated APIs:**
+- Issue: Settings migration code uses @Suppress("DEPRECATION") for MODE_MULTI_PROCESS to maintain backward compatibility, but this Android API is deprecated
+- Files: `app/src/main/java/com/lxmf/messenger/migration/LegacySettingsImporter.kt`, `repository/SettingsRepository.kt:141,1711`
+- Impact: Ongoing maintenance burden; will break if API is removed in future Android versions
+- Fix approach: Plan migration to DataStore across the entire codebase; phase out legacy SharedPreferences usage
+
+**File attachment parsing in message retry incomplete:**
+- Issue: When retrying failed messages, file attachments cannot be reconstructed from stored fieldsJson data
+- Files: `app/src/main/java/com/lxmf/messenger/viewmodel/MessagingViewModel.kt:1727`
+- Impact: Failed messages with file attachments will lose attachments on retry; only text and image content are preserved
+- Fix approach: Implement fieldsJson parsing for file attachments, similar to existing image parsing
+
+## Known Bugs
+
+**BLE dual-mode race condition in send() (TOCTOU - Time Of Check Time Of Use):**
+- Symptoms: During deduplication of dual connections (central + peripheral to same peer), a send() operation may use stale peer state
+- Files: `reticulum/src/test/java/com/lxmf/messenger/reticulum/ble/bridge/KotlinBLEBridgeSendRaceConditionTest.kt:27-54`
+- Trigger: Race between deduplicationState changes and send() state reads when one connection is closing
+- Current status: Documented in test but not yet fixed; test shows issue with testDelayAfterStateReadMs hook
+- Workaround: None; app is vulnerable to silently sending via closing connection paths
+- Fix approach: Add per-peer mutex to make state read + send operation atomic
+
+**Missing on_duplicate_identity_detected callback for Python layer:**
+- Symptoms: When same peer is detected via both central and peripheral connections, Python driver cannot be notified to handle deduplication
+- Files: `reticulum/src/test/java/com/lxmf/messenger/reticulum/ble/bridge/KotlinBLEBridgeDuplicateIdentityCallbackTest.kt:25-195`, `reticulum/src/main/java/com/lxmf/messenger/reticulum/ble/bridge/KotlinBLEBridge.kt`
+- Trigger: Detect same identityHash arriving via different BLE MAC addresses on both central and peripheral modes
+- Current status: Callback infrastructure missing (no onDuplicateIdentityDetected field, no setter); bridge handles deduplication internally but doesn't notify Python
+- Impact: Python layer cannot make intelligent decisions about which connection to keep; asymmetric behavior between dual-mode peers
+- Fix approach: Add onDuplicateIdentityDetected PyObject callback field and setters to KotlinBLEBridge; call from deduplication logic
+
+**BLE GATT Server keepalive job orphaned on disconnect:**
+- Symptoms: When central disconnects, keepalive job continues running if only removed from connectedCentrals map without cancelling
+- Files: `reticulum/src/test/java/com/lxmf/messenger/reticulum/ble/server/BleGattServerKeepaliveTest.kt:99-112`
+- Trigger: Disconnect path doesn't cancel associated keepalive coroutine
+- Current status: Pattern documented in test; vulnerable if implementation doesn't consistently cancel
+- Impact: Memory leak of orphaned coroutines; stale keepalive signals to disconnected peers
+- Fix approach: Always pair connection removal with keepaliveJobs[address]?.cancel(); ensure disconnect handler cancels before removing from map
+
+**Old RNode read thread race condition preventing restart:**
+- Symptoms: Stopping and restarting RNode interface can fail if previous read thread doesn't stop within timeout
+- Files: `python/rnode_interface.py:440`
+- Trigger: Read thread stuck in I/O or slow to notice shutdown signal; attempting to start while old thread still running
+- Current status: Explicit error handling in place (returns False), but failure message doesn't give actionable recovery path
+- Impact: RNode interface cannot be restarted without app restart; affects switching between USB and serial interfaces
+- Fix approach: Increase timeout, add forced thread termination after graceful attempt, or redesign thread lifecycle
+
+## Security Considerations
+
+**Generic exception catching in multiple layers:**
+- Risk: Swallowed exceptions hide failures and make debugging harder; potential for silent data loss
+- Files: `data/database/dao/InterfaceDao.kt:189`, `service/manager/ServiceNotificationManager.kt:114`, `service/persistence/ServicePersistenceManager.kt:320,363`, `ui/components/IconPickerDialog.kt:674`, `ui/components/ProfileIcon.kt:57,65`, `ui/model/MessageMapper.kt:91,115,152`
+- Current mitigation: Mostly marked with @Suppress("SwallowedException") and logged; exceptions in UI/parsing are intentionally silent
+- Recommendations: Audit exception handling to distinguish between "expected failures to ignore" vs "unexpected errors to report"; add metrics for swallowed exceptions
+
+**SharedPreferences multi-process mode for cross-process settings access:**
+- Risk: MODE_MULTI_PROCESS has subtle consistency issues; settings updates from one process may not be visible immediately in another
+- Files: `repository/SettingsRepository.kt:141,1711`, `service/persistence/ServiceSettingsAccessor.kt:14`
+- Current mitigation: Documentation in code; no explicit syncing logic observed
+- Recommendations: Plan migration to Jetpack DataStore which has better multi-process semantics; add explicit reload points if staying with SharedPreferences
+
+**Kotlin/Java ArrayList to Python list conversion pattern:**
+- Risk: Passing raw Kotlin ArrayList to Python via Chaquopy will fail with "'ArrayList' object is not iterable"
+- Files: Noted in CLAUDE.md project instructions
+- Current mitigation: Code review awareness (documented in project guidelines)
+- Recommendations: Create helper function for ArrayList->Python list conversion; consider linter rule or Chaquopy plugin to catch this
+
+## Performance Bottlenecks
+
+**MaterialDesignIcons.kt large generated file:**
+- Problem: Icon definitions generate 7470-line source file with repetitive structure
+- Files: `app/src/main/java/com/lxmf/messenger/ui/theme/MaterialDesignIcons.kt:7470 lines`
+- Cause: All Material Design icons compiled into single Kotlin file; likely code generation artifact
+- Impact: Slow IDE performance when navigating file; increases app binary size; slow compilation
+- Improvement path: Consider icon library (Compose Material Icons) instead of generated file; or split into multiple files with lazy initialization
+
+**Large UI screen files with complex logic:**
+- Problem: Several UI screens exceed 2000 lines with nested conditions and state management
+- Files: `app/src/main/java/com/lxmf/messenger/ui/screens/MessagingScreen.kt:2355 lines`, `app/src/main/java/com/lxmf/messenger/ui/screens/ContactsScreen.kt:1678 lines`
+- Cause: Feature-rich screens with many sub-composables and states in single file
+- Impact: Harder to test; difficult to modify one feature without affecting others; IDE slowness
+- Improvement path: Break into smaller composable functions with clear responsibilities; extract state management to ViewModels
+
+**ViewModel size and complexity:**
+- Problem: MessagingViewModel (2116 lines), SettingsViewModel (1871 lines), RNodeWizardViewModel (3293 lines) are large and handle many concerns
+- Files: `app/src/main/java/com/lxmf/messenger/viewmodel/MessagingViewModel.kt:2116`, `SettingsViewModel.kt:1871`, `RNodeWizardViewModel.kt:3293`
+- Cause: Feature accumulation without refactoring into smaller ViewModels
+- Impact: Hard to test individual features; tight coupling of unrelated concerns; slow test execution
+- Improvement path: Extract sub-features into separate ViewModels; consider MVI or MVVM++ pattern; compose ViewModels with lower-level services
+
+**RNodeRegionalPreset switch complexity:**
+- Problem: getDefaultSlot() and calculateSlotFromFrequency() methods have high cyclomatic complexity with large when expressions
+- Files: `app/src/main/java/com/lxmf/messenger/data/model/RNodeRegionalPreset.kt:569,621`
+- Cause: Supporting many regional frequency configurations in single method
+- Impact: Hard to verify correctness; difficult to add new regions; potential for copy-paste errors
+- Improvement path: Extract region data to data-driven configuration; use lookup table instead of when statement
+
+**Database query without aggregation/pagination:**
+- Problem: No evidence of result pagination for large tables; potential for loading entire Contact/Message tables
+- Impact: Memory usage spikes on large datasets; potential ANR (Application Not Responding) on slow devices
+- Improvement path: Implement infinite scroll with Flow<PagingData>; use Room Paging library; add result limits
+
+## Fragile Areas
+
+**BLE connection deduplication state machine:**
+- Files: `reticulum/src/main/java/com/lxmf/messenger/reticulum/ble/bridge/KotlinBLEBridge.kt:193-203` (DeduplicationTracker, deduplicationInProgress)
+- Why fragile: Complex state with multiple concurrent maps (peers, connectedPeers, deduplicationInProgress, processedIdentityCallbacks, pendingCentralConnections); race conditions when peer simultaneously connects as central and peripheral
+- Safe modification: Always modify deduplication state under mutex; never check state then act later (atomic check-then-act); add comprehensive logging of state transitions
+- Test coverage: Covered by KotlinBLEBridgeSendRaceConditionTest, KotlinBLEBridgeDuplicateIdentityCallbackTest, KotlinBLEBridgeTest; gaps in signal ordering and callback timing
+
+**Message retry logic with partial field reconstruction:**
+- Files: `app/src/main/java/com/lxmf/messenger/viewmodel/MessagingViewModel.kt:1715-1740`
+- Why fragile: File attachments not reconstructed; only images and text supported; next developer may lose attachments silently
+- Safe modification: Complete fieldsJson parsing before retry implementation; add unit test with file attachments; verify round-trip through storage
+- Test coverage: MessagingViewModelTest (4690 lines) but check if retry with attachments is tested
+
+**Python-Kotlin bridge with Chaquopy PyObject callbacks:**
+- Files: `reticulum/src/main/java/com/lxmf/messenger/reticulum/ble/bridge/KotlinBLEBridge.kt:230-248` (onDeviceDiscovered, onConnected, onDisconnected, onDataReceived, onIdentityReceived, onMtuNegotiated)
+- Why fragile: Callbacks can be null; no validation that Python can actually handle callback signature; Chaquopy serialization quirks (ArrayList issue)
+- Safe modification: Add non-null asserts before calling; add try-catch around callback invocation; log callback errors explicitly
+- Test coverage: Tests for callbacks exist but should verify error cases
+
+**Migration/export-import logic:**
+- Files: `app/src/main/java/com/lxmf/messenger/migration/MigrationExporter.kt:34`, `MigrationImporter.kt:36`, `LegacySettingsImporter.kt`
+- Why fragile: Multiple data sources (database, SharedPreferences, DataStore); version-dependent field mappings; @Suppress("TooManyFunctions") suggests unmaintainable
+- Safe modification: Write comprehensive migration tests with sample data from each version; add rollback capability; validate data after import
+- Test coverage: Not clear from grep; recommend adding MigrationTest
+
+**RNode interface lifecycle with thread management:**
+- Files: `python/rnode_interface.py:435-441` (read thread detection and restart)
+- Why fragile: Manual thread lifecycle management; timeout-based detection of stuck threads; no forced termination after timeout
+- Safe modification: Consider ThreadPoolExecutor for managed lifecycle; add health checks; implement thread state machine
+- Test coverage: Needs specific test for timeout and recovery scenarios
+
+## Scaling Limits
+
+**BLE connection pool capacity:**
+- Current capacity: BleConstants.MAX_CONNECTIONS (not visible but referenced in BleConnectionManager.kt:354-356)
+- Limit: Each connection consumes GATT resources and socket buffers; dual-mode operation means each peer potentially uses 2x capacity
+- Scaling path: Make MAX_CONNECTIONS configurable; implement connection prioritization/eviction; measure actual limits on different Android versions
+
+**Message/Contact database table growth:**
+- Current capacity: No explicit limits observed for message or contact retention
+- Limit: Device storage is limited; large Message/Contact tables slow down queries; no automatic cleanup
+- Scaling path: Implement message retention policies (age-based deletion); add message archiving; consider external storage for old messages
+
+**Python memory with BLE packet buffers:**
+- Current capacity: incomingPacketQueue in BleConnectionManager is unbounded ConcurrentLinkedQueue
+- Limit: No backpressure mechanism if Python can't consume packets as fast as BLE produces them
+- Scaling path: Implement bounded queue with backpressure; add metrics for queue depth; implement flow control
+
+## Dependencies at Risk
+
+**Pycodec2 wheel binary dependency:**
+- Risk: Pre-built wheel hosted on external GitHub releases; no fallback if release is deleted or becomes unavailable
+- Impact: Build will fail; cannot create new builds without wheel
+- Mitigation: None observed; single point of failure
+- Migration plan: Mirror wheel to organization repo; vendor wheel in git (large but reliable); build from source in CI; migrate to alternative codec if available
+
+**Chaquopy Python bridging (com.chaquo.python):**
+- Risk: External Gradle plugin and runtime; maintains compatibility between Python versions and Android NDK versions
+- Impact: Updates can break builds (version conflicts); complex to debug Kotlin/Python integration issues
+- Mitigation: Pinned to specific version in gradle files; good test coverage of bridge calls
+- Migration plan: Monitor for updates; keep minor version updated; document any version constraints
+
+**Room Database library (androidx.room:room-runtime):**
+- Risk: ORM abstraction may hide inefficient queries; generated code can be opaque
+- Impact: N+1 query problems; inefficient JOINs; hard to optimize without rebuilding entities
+- Mitigation: Room generates code; IDE inspection can help; Room annotations enforce compile-time safety
+- Migration plan: Monitor generated _Impl files; add query performance tests; consider raw SQL for complex queries
+
+**Reticulum Python library (core dependency):**
+- Risk: Large external dependency with deep integration throughout codebase; single point of failure for mesh networking
+- Impact: Bugs in Reticulum affect entire application; incompatible versions break interfaces
+- Mitigation: Vendored copy in python/patches/RNS/; custom extensions (Destination.py, __init__.py) documented
+- Migration plan: Keep patches directory current; add integration tests for Reticulum interface changes; consider contributing fixes upstream
+
+## Missing Critical Features
+
+**File attachment persistence and retry:**
+- Problem: Message retry doesn't reconstruct file attachments from storage
+- Blocks: Users cannot reliably retry messages with files; files are lost on failure
+- Impact: Reduces reliability of critical file transfers in mesh network
+
+**Network path request integration for pending contacts:**
+- Problem: When adding contact by hash only (no identity), app doesn't trigger network search to find identity
+- Files: `app/src/main/java/com/lxmf/messenger/viewmodel/ContactsViewModel.kt:465,498`
+- Blocks: Pending contacts may never be resolved without manual user action
+- Impact: Reduced discoverability of new contacts
+
+**Multiple identity management UI:**
+- Problem: UI for managing multiple Reticulum identities is stubbed out
+- Files: `app/src/main/java/com/lxmf/messenger/ui/screens/MyIdentityScreen.kt:192` (commented out IdentityManagementCard)
+- Blocks: Users cannot have multiple identities in same app
+- Impact: Limits use cases where different identities are needed for different purposes
+
+**Connected peer count display for TCP Server interfaces:**
+- Problem: Interface management screen doesn't show how many clients are connected to TCP Server interfaces
+- Files: `app/src/main/java/com/lxmf/messenger/ui/screens/InterfaceManagementScreen.kt:945`
+- Blocks: Users cannot monitor TCP Server status from UI
+- Impact: Harder to troubleshoot server-mode connectivity issues
+
+## Test Coverage Gaps
+
+**BLE deduplication edge cases:**
+- What's not tested: Race condition between deduplication trigger and send() call (documented but only test harness exists, not fix)
+- Files: `reticulum/src/test/java/com/lxmf/messenger/reticulum/ble/bridge/KotlinBLEBridgeSendRaceConditionTest.kt` (test exists but issue not fixed)
+- Risk: Silent data loss or corruption if message sent via closing connection
+- Priority: High
+
+**File attachment message retry:**
+- What's not tested: Retrying messages with file attachments; fieldsJson reconstruction
+- Files: `app/src/test/java/com/lxmf/messenger/viewmodel/MessagingViewModelTest.kt` (check if retry with attachments is covered)
+- Risk: File attachments silently lost on retry
+- Priority: High
+
+**Python-Kotlin bridge error cases:**
+- What's not tested: Chaquopy callback failures (Python exception in callback, missing callback method signature, ArrayList serialization)
+- Files: Various Kotlin/Python bridge classes lack error scenario tests
+- Risk: Silent callback failures with no logging; cryptic Chaquopy serialization errors
+- Priority: Medium
+
+**RNode interface restart after thread timeout:**
+- What's not tested: Specific scenario where read thread hangs and restart is attempted
+- Files: `python/rnode_interface.py` (no specific test for timeout recovery)
+- Risk: RNode interface permanently broken until app restart
+- Priority: Medium
+
+**Cross-process SharedPreferences consistency:**
+- What's not tested: Multi-process reads/writes to settings with MODE_MULTI_PROCESS; data freshness guarantees
+- Files: `repository/SettingsRepository.kt`, `service/persistence/ServiceSettingsAccessor.kt`
+- Risk: Service and UI process see stale settings; inconsistent state across processes
+- Priority: Medium
+
+**Message migration with partial data:**
+- What's not tested: Migrating messages with missing/corrupt fieldsJson; handling version format changes
+- Files: Migration code handles some deprecations but comprehensive round-trip migration test not visible
+- Risk: Data loss during version upgrades
+- Priority: Low
+
+---
+
+*Concerns audit: 2026-01-23*

--- a/.planning/codebase/CONVENTIONS.md
+++ b/.planning/codebase/CONVENTIONS.md
@@ -1,0 +1,233 @@
+# Coding Conventions
+
+**Analysis Date:** 2026-01-23
+
+## Naming Patterns
+
+**Files:**
+- `PascalCase` for class/interface files: `BleStatusRepository.kt`, `InterfaceDatabase.kt`, `MessageOrderingTest.kt`
+- Test files: `{ClassName}Test.kt` (unit tests) or `{ClassName}RaceConditionTest.kt` (specific scenario tests)
+- `camelCase` for Kotlin files with multiple internal functions (less common)
+
+**Functions:**
+- `camelCase` for all functions, both public and private: `getConnectedPeersFlow()`, `parseConnectionsJson()`, `stateToString()`
+- Test functions use backtick-quoted descriptive names: `` `messages are ordered by timestamp ascending`() ``, `` `findByParams finds SHORT_TURBO`() ``
+- Enforced by detekt rule `FunctionNaming` with pattern `[a-z][a-zA-Z0-9]*`, except for `@Composable` functions which are exempt
+
+**Variables:**
+- `camelCase` for all variables: `testPeerHash`, `adapterState`, `connectionType`
+- Private class variables with backing fields: `private val bleBridge`
+- Enforced by detekt rule `VariableNaming` with pattern `[a-z][A-Za-z0-9]*`
+
+**Types:**
+- `PascalCase` for data classes, enums, sealed classes: `BleConnectionInfo`, `ConnectionType`, `BleConnectionsState`
+- Top-level constants in `UPPER_SNAKE_CASE`: `TAG` constant (enforced by detekt rule `TopLevelPropertyNaming`)
+
+**Enums and Sealed Classes:**
+- Use descriptive enum members: `EXCELLENT`, `GOOD`, `FAIR`, `POOR` in `SignalQuality`
+- Sealed class variants use meaningful names: `BluetoothDisabled`, `Loading`, `Success`, `Error`
+
+## Code Style
+
+**Formatting:**
+- 4-space indentation (per `.editorconfig`)
+- 160-character max line length for Kotlin (enforced by detekt)
+- LF line endings, UTF-8 encoding
+- Insert final newline in all files
+- Trim trailing whitespace
+
+**Linting:**
+- Tool: `detekt` (1.23.8) with custom Columba rules
+- Tool: `ktlint` (1.0.1) in advisory mode (non-blocking)
+- Baseline: `detekt-baseline.xml` captures pre-existing issues; new code must pass checks
+- Run verification: `./gradlew detektCheck ktlintCheck`
+- Update baseline after intentional fixes: `./gradlew detektBaseline`
+
+**Quality Thresholds (detekt):**
+- Cyclomatic complexity: max 18 (ignores `@Composable`)
+- Function length: max 80 lines (ignores `@Composable`)
+- Class size: max 600 lines
+- Parameter list: 8 params (functions), 10 params (constructors) - ignored for `@Composable`
+- Nested block depth: max 5 levels
+- Functions per file: max 15 (classes), max 25 (interfaces)
+- Max line length: 200 characters (detekt override vs editorconfig's 160)
+- Return count: max 3 per function
+- Throw count: max 2 per function
+- No wildcard imports (except in test and androidTest)
+
+## Import Organization
+
+**Order:**
+1. Package declaration
+2. Blank line
+3. Standard library imports (e.g., `java.*`, `kotlin.*`)
+4. Third-party imports (Android framework, Dagger, kotlinx, etc.)
+5. Project-local imports (`com.lxmf.messenger.*`)
+6. Blank line
+7. Code
+
+**Pattern observed:** Imports grouped by origin with blank lines between groups.
+
+Example from `BleStatusRepository.kt`:
+```kotlin
+package com.lxmf.messenger.data.repository
+
+import android.bluetooth.BluetoothAdapter
+import android.content.Context
+import android.util.Log
+import com.lxmf.messenger.data.model.BleConnectionInfo
+import com.lxmf.messenger.data.model.BleConnectionsState
+import com.lxmf.messenger.reticulum.protocol.ReticulumProtocol
+import dagger.hilt.android.qualifiers.ApplicationContext
+import kotlinx.coroutines.flow.Flow
+import org.json.JSONArray
+import javax.inject.Inject
+import javax.inject.Singleton
+```
+
+**Path Aliases:**
+- Not used; fully qualified imports throughout
+
+**Wildcard Imports:**
+- Forbidden in production code (detekt enforces)
+- Allowed in test and androidTest only
+
+## Error Handling
+
+**Pattern - Try/Catch with Logging:**
+```kotlin
+try {
+    // operation
+    return result
+} catch (e: Exception) {
+    Log.e(TAG, "Error message describing what failed", e)
+    // Return default/empty value (never throw up)
+    return emptyList()
+}
+```
+
+**Pattern - Explicit Exception Types:**
+- Prefer catching specific exceptions where possible
+- Detekt enforces: `TooGenericExceptionCaught` disallows `RuntimeException`, `Throwable`, `Exception` without justification
+- Allowed with regex pattern: `_|(ignore|expected).*` (e.g., `_e` or `ignoredException`)
+
+**Pattern - Graceful Degradation:**
+- Functions return safe defaults on error: `emptyList()`, `null`, `0`
+- Never crash or throw exceptions to caller
+- Log full exception with context for debugging
+
+Example from `BleStatusRepository.kt`:
+```kotlin
+private fun parseConnectionsJson(jsonString: String): List<BleConnectionInfo> {
+    return try {
+        // parse logic
+        connections
+    } catch (e: Exception) {
+        Log.e(TAG, "Error parsing connections JSON", e)
+        emptyList()  // Safe default
+    }
+}
+```
+
+## Logging
+
+**Framework:** Android `Log` class (no third-party logging framework)
+
+**Tag Pattern:**
+- Define as companion object constant: `private const val TAG = "ClassName"`
+- Must be present in all classes that use logging (detekt custom rule: `BleLoggingTag`)
+
+**Patterns:**
+- `Log.d(TAG, "message")` - Debug: informational messages, state transitions
+- `Log.w(TAG, "message")` - Warning: unexpected but recoverable conditions
+- `Log.e(TAG, "message", exception)` - Error: failures with full exception context
+- `Log.v(TAG, "message")` - Verbose: detailed diagnostic info (only when needed)
+
+**Logging in Repositories:**
+- Log state changes: `"Bluetooth turning on - returning Loading state"`
+- Log data received: `"Event-driven: received ${connections.size} BLE connections"`
+- Log errors with context: `Log.e(TAG, "Error parsing connections JSON", e)`
+
+## Comments
+
+**When to Comment:**
+- Non-obvious logic or business rules: Explain the "why" not the "what"
+- Complex parsing or configuration: Document data format expectations
+- TODOs for future work (sparingly)
+- Do NOT comment obvious code: `val name = obj.name // set name`
+
+**JSDoc/KDoc:**
+- Use KDoc format (/** */) for public classes, interfaces, and functions
+- Include `@param` and `@return` tags for public APIs
+- Document intent and expected behavior, not implementation details
+
+Example from `BleStatusRepository.kt`:
+```kotlin
+/**
+ * Get a flow of BLE connection state that combines adapter state with connection data.
+ * Uses event-driven updates from the service (< 100ms latency).
+ *
+ * @return Flow emitting BleConnectionsState
+ */
+fun getConnectedPeersFlow(): Flow<BleConnectionsState>
+```
+
+Example from `BleConnectionInfo.kt`:
+```kotlin
+/**
+ * Returns a shortened version of the identity hash (first 8 characters).
+ */
+val shortIdentityHash: String
+    get() = identityHash.take(8)
+```
+
+## Function Design
+
+**Size Guidelines:**
+- Prefer functions under 80 lines (enforced by detekt)
+- Extract helper functions for repeated logic
+- One responsibility per function
+
+**Parameters:**
+- Max 8 parameters in regular functions, 10 in constructors (enforced by detekt)
+- Use data classes to bundle related parameters
+- Order: required params first, optional/default params last
+
+**Return Values:**
+- Prefer explicit return types on public functions
+- Max 3 return statements per function (enforced by detekt)
+- Use `sealed class` for complex return types with states: `BleConnectionsState`
+
+Example pattern from `BleConnectionInfo.kt`:
+```kotlin
+val signalQuality: SignalQuality
+    get() =
+        when {
+            rssi > -50 -> SignalQuality.EXCELLENT
+            rssi > -70 -> SignalQuality.GOOD
+            rssi > -85 -> SignalQuality.FAIR
+            else -> SignalQuality.POOR
+        }
+```
+
+## Module Design
+
+**Exports:**
+- All public classes in a module should serve a clear external API
+- Keep implementation details package-private (`internal` or default visibility)
+
+**Barrel Files:**
+- Not observed; each class in its own file
+
+**Package Organization:**
+- `data.repository`: high-level data access (repositories like `BleStatusRepository`)
+- `data.model`: data classes, enums, sealed classes representing domain concepts
+- `data.database`: Room entities, DAOs, migrations
+- `reticulum.protocol`: protocol communication abstractions
+- `di`: dependency injection (Dagger Hilt modules)
+- `service`: Android services and lifecycle management
+- `ui`: Compose screens and UI components
+
+---
+
+*Convention analysis: 2026-01-23*

--- a/.planning/codebase/INTEGRATIONS.md
+++ b/.planning/codebase/INTEGRATIONS.md
@@ -1,0 +1,218 @@
+# External Integrations
+
+**Analysis Date:** 2026-01-23
+
+## APIs & External Services
+
+**Reticulum Mesh Network:**
+- Service: Reticulum (RNS) - Decentralized wireless networking protocol
+- What it's used for: Low-bandwidth mesh networking backbone for LXMF messaging, location sharing, voice calls
+- SDK/Client: Fork at `github.com/torlando-tech/Reticulum@rebase-1.1.3`
+- Integration: Python library embedded via Chaquopy, initialized by `ReticulumService`
+
+**LXMF Protocol:**
+- Service: Long-Range eXtensible Message Format - High-level messaging protocol built on Reticulum
+- What it's used for: Encrypted message delivery, announce/discovery, delivery receipts
+- SDK/Client: Fork at `github.com/torlando-tech/LXMF@feature/receiving-interface-capture`
+- Integration: Python library with external stamp generator for Android (bypasses multiprocessing), initialized in app startup
+
+**BLE (Bluetooth Low Energy) Reticulum Interface:**
+- Service: Reticulum BLE transports - Bluetooth mesh networking
+- What it's used for: Direct BLE communication between Android devices, no WiFi required
+- SDK/Client: Fork at `github.com/torlando-tech/ble-reticulum@main`
+- Auth: Device pairing via Bluetooth link negotiation
+- Integration: Python library + KotlinBLEBridge at `reticulum/src/main/java/com/lxmf/messenger/reticulum/ble/bridge/KotlinBLEBridge.kt`
+
+**LXST (Voice Calls):**
+- Service: Long-Range eXtensible Telephony - Voice communication over Reticulum
+- What it's used for: Low-bandwidth audio calls with codec2 compression
+- SDK/Client: Fork at `github.com/torlando-tech/LXST@chaquopy-compat`
+- Integration: Python library with Chaquopy-compatible patches
+- Auth: Uses Reticulum identity authentication
+
+**Location Services:**
+- Service: Google Play Services Location (FusedLocationProviderClient)
+- What it's used for: GPS location acquisition for location sharing feature and map centering
+- Client: `com.google.android.gms:play-services-location:21.2.0`
+- Request type: LocationRequest with configured priority and interval
+- Usage: `LocationSharingManager` (`app/src/main/java/com/lxmf/messenger/service/LocationSharingManager.kt`) and `TelemetryCollectorManager` manage requests
+
+**Maps:**
+- Service: MapLibre GL Android (OpenFreeMap tiles)
+- What it's used for: Offline-capable map display with peer locations, offline map regions downloadable
+- Client: `org.maplibre.gl:android-sdk:11.5.2`
+- Usage: `MapScreen` at `app/src/main/java/com/lxmf/messenger/ui/screens/MapScreen.kt`
+- HTTP Control: `MAP_SOURCE_HTTP_ENABLED` setting controls HTTP tile fetching (default: enabled)
+- Tiles: OpenFreeMap provides tiles over HTTP/HTTPS
+
+**QR Codes:**
+- Service: ZXing (Zebra Crossing) - QR code generation and scanning
+- What it's used for: Identity QR code generation for sharing, scanning shared identities
+- Client: `com.google.zxing:core:3.5.3`
+- Integration: CameraX pipeline for real-time scanning
+
+## Data Storage
+
+**Databases:**
+- Provider: Room (SQLite on Android)
+- Location: App-private database files (encrypted by Android)
+- Client: `androidx.room:room-runtime:2.8.4`
+- Compiler: KSP-based code generation
+
+**Primary Database Entities:**
+- `InterfaceDatabase` at `app/src/main/java/com/lxmf/messenger/data/database/InterfaceDatabase.kt` - Reticulum interface configs
+- Core entities in `data/src/main/java/com/lxmf/messenger/data/db/entity/`:
+  - `ContactEntity` - Peer contacts
+  - `ConversationEntity` - Message threads
+  - `MessageEntity` - Individual messages
+  - `LocalIdentityEntity` - User identities
+  - `PeerIdentityEntity` - Peer identities
+  - `PeerIconEntity` - Peer avatar icons (dedicated table for reliable persistence)
+  - `AnnounceEntity` - Network announcements
+  - `ReceivedLocationEntity` - Shared peer locations
+  - `OfflineMapRegionEntity` - Downloaded offline map regions
+  - `RmspServerEntity` - RMSP relay server configurations
+  - `CustomThemeEntity` - User theme customizations
+
+**File Storage:**
+- Approach: Local filesystem only
+- Android internal storage (private app data)
+- Offline map tiles cached in app-private directories
+- Backup: DataStore for encrypted settings, Room handles identity/message backup via Android Backup Service
+
+**Settings Storage:**
+- Provider: DataStore (encrypted preferences)
+- Location: App-private encrypted file
+- Client: `androidx.datastore:datastore-preferences:1.1.1`
+- Key Settings:
+  - `MAP_SOURCE_HTTP_ENABLED` - Controls HTTP tile source (true by default)
+  - `HTTP_ENABLED_FOR_DOWNLOAD` - Allows HTTP for offline map downloads
+  - `LOCATION_SHARING_ENABLED` - User location sharing master toggle
+  - `LOCATION_PRECISION_RADIUS` - Obfuscation radius in meters
+
+**Caching:**
+- Approach: In-memory (Kotlin Flow, coroutine state)
+- Image caching: Coil with GIF animation support
+- Map tiles: MapLibre handles caching
+
+## Authentication & Identity
+
+**Auth Provider:**
+- Approach: Custom Reticulum-based identity system
+- Implementation: Each user creates or imports an LXMF identity (256-bit key material)
+- Identity sharing: Deep link `lxma://` URIs for identity exchange
+- No centralized auth - identities are self-sovereign and verified via Reticulum signature validation
+
+**Credentials:**
+- Storage: Encrypted in Room database (LocalIdentityEntity)
+- Transfer: Encrypted identity files can be exported/imported via migration system
+- Signature verification: LXMF protocol validates identity signatures on messages
+
+## Monitoring & Observability
+
+**Error Tracking:**
+- Service: Sentry (GlitchTip compatible)
+- Client: `io.sentry:sentry-android:7.3.0` (both app and reticulum modules)
+- Configuration: Manual initialization in Application class (auto-init disabled in `AndroidManifest.xml`)
+- DSN: Configured via Sentry initialization (not checked into repo)
+- Usage: Crash reporting, exception tracking, KotlinBLEBridge metrics
+
+**Logs:**
+- Approach: Android Log (logcat) with contextual logging
+- Files:
+  - GW2 Debug Log: App logs to standard Android system
+  - No persistent file logging in production (logs available via adb logcat)
+- Log levels: Controlled by tag filters
+
+**Analytics:**
+- Approach: None - No telemetry collection (privacy-focused)
+- Note: TODO comment in `KotlinBLEBridge.kt` indicates future metrics infrastructure possibility (Firebase/Grafana/custom)
+
+## CI/CD & Deployment
+
+**Hosting:**
+- Platform: GitHub (source)
+- Distribution: GitHub Releases (APK artifacts)
+- Installation: Direct APK installation on Android devices
+
+**CI Pipeline:**
+- Service: GitHub Actions (`.github/workflows/`)
+- Jobs defined in `ci.yml`:
+  1. **validate-wrapper** - Gradle wrapper validation
+  2. **lint** - ktlint + detekt + CPD quality checks (runs `./gradlew ktlintCheck detektCheck cpdCheck`)
+  3. **threading-audit** - Custom dispatcher architecture audit (`audit-dispatchers.sh`)
+  4. **build** - Compile release and debug APKs
+  5. **coverage** - JaCoCo test coverage report
+  6. Upload artifacts (lint reports, APKs)
+
+**Workflows:**
+- `ci.yml` - Main CI on push/PR to main or `v*.*.x` branches
+- `build-prerelease-apk.yml` - Manual prerelease builds
+- `release.yml` - Release workflow (triggered by tags)
+
+**Signing:**
+- Method: Environment variables (CI/CD only)
+- Keystore: Base64-encoded in `KEYSTORE_FILE` secret
+- Config: `app/build.gradle.kts` decodes and configures signing
+- Release builds: Minified with ProGuard rules at `app/proguard-rules.pro`
+
+## Environment Configuration
+
+**Required env vars for builds:**
+- `ANDROID_HOME` - SDK path (e.g., `$HOME/Android/Sdk`)
+- `JAVA_HOME` - Java 17 JDK (e.g., `/usr/lib/jvm/java-17-openjdk`)
+- `PYTHON_VERSION` - Python 3.11 (Chaquopy compatibility)
+
+**Required env vars for release:**
+- `KEYSTORE_FILE` - Base64-encoded .jks file
+- `KEYSTORE_PASSWORD` - Keystore password
+- `KEY_ALIAS` - Release signing key alias
+- `KEY_PASSWORD` - Key password
+
+**Gradle configuration:**
+- `gradle.properties` sets heap size, parallel builds, worker limits
+
+**Secrets location:**
+- GitHub Actions Secrets (for CI/CD)
+- Local development: `~/.gradle/gradle.properties` or environment exports
+- Template: `.envrc.example` for direnv-based setup
+
+## Webhooks & Callbacks
+
+**Incoming Webhooks:**
+- Approach: None - App is client-only, no webhook endpoints
+
+**Outgoing Callbacks:**
+- Reticulum: Callbacks for packet/announce/link events handled by `ServiceReticulumProtocol`
+- LXMF: Delivery callbacks and message receive notifications
+- Lifecycle: Android lifecycle callbacks integrated via coroutines and Flow
+
+**USB Device Callbacks:**
+- Handler: `MainActivity` receives `UsbManager.ACTION_USB_DEVICE_ATTACHED` and `ACTION_USB_DEVICE_DETACHED` intents
+- Filter: `usb_device_filter` XML defines RNode and compatible serial device VIDs/PIDs
+- Permission: Requested via `UsbManager.requestPermission()` at runtime
+
+**BLE Callbacks:**
+- Handler: `KotlinBLEBridge` manages BLE advertisement scanning and connection callbacks
+- Metrics: Sentry integration for observability
+
+## Network Configuration
+
+**Network Permissions:**
+- INTERNET - General network access
+- ACCESS_NETWORK_STATE - Network status monitoring
+- ACCESS_WIFI_STATE - WiFi status
+- CHANGE_WIFI_STATE - WiFi enable/disable (if needed)
+- CHANGE_WIFI_MULTICAST_STATE - Multicast for mesh discovery
+
+**Foreground Services:**
+- `ReticulumService` runs as foreground service with notification
+- Permissions: `FOREGROUND_SERVICE`, `FOREGROUND_SERVICE_DATA_SYNC`, `FOREGROUND_SERVICE_CONNECTED_DEVICE`, `FOREGROUND_SERVICE_MICROPHONE`
+
+**Special Requirements:**
+- Battery Optimization Exemption: `REQUEST_IGNORE_BATTERY_OPTIMIZATIONS` for background mesh networking
+- Companion Device Manager: RNode device association (Android 12+)
+
+---
+
+*Integration audit: 2026-01-23*

--- a/.planning/codebase/STACK.md
+++ b/.planning/codebase/STACK.md
@@ -1,0 +1,153 @@
+# Technology Stack
+
+**Analysis Date:** 2026-01-23
+
+## Languages
+
+**Primary:**
+- Kotlin 2.2.21 - Main application language (Android app, data layer, reticulum module)
+- Java 17 - Compilation target and compatibility
+- Python 3.11 - Reticulum networking, LXST voice calls, codec2 audio processing
+
+**Secondary:**
+- XML - Android manifest, layout resources, configuration files
+- YAML - Gradle configuration, Detekt rules, GitHub Actions workflows
+
+## Runtime
+
+**Environment:**
+- Android Runtime (targets API 35, minimum API 24)
+- Chaquopy 16.0.0 - Python interpreter embedded in Android app
+
+**Package Manager:**
+- Gradle 8.7.3 (wrapper at `./gradlew`)
+- Lockfile: `gradle/wrapper/gradle-wrapper.properties`
+- pip (for Python dependencies installed via Chaquopy)
+- NPM/npm - Not used
+
+## Frameworks
+
+**Core Android:**
+- Android SDK 35 (compileSdk)
+- AndroidX 1.0+
+- Jetpack Compose 1.7.5 - UI framework (338+ Composable functions)
+
+**Architecture & Dependency Injection:**
+- Hilt 2.57.2 - Dependency injection framework
+- KSP (Kotlin Symbol Processing) 2.2.20-2.0.4 - Code generation for Hilt
+
+**State Management & Data:**
+- Room 2.8.4 - SQLite database ORM
+- DataStore 1.1.1 - Preferences and settings (encrypted)
+- Paging 3.3.6 - List pagination
+- Coroutines 1.10.2 - Async/concurrent operations
+- Lifecycle 2.8.7 - Lifecycle-aware components
+
+**Navigation:**
+- Jetpack Navigation 2.8.4 - Compose navigation
+
+**Testing:**
+- JUnit 4.13.2 - Unit test framework
+- JUnit Jupiter 5.11.4 - Parameterized test support
+- Robolectric 4.16 - Android unit test runtime
+- Mockk 1.14.7 - Kotlin mocking library
+- Turbine 1.2.1 - Flow testing utilities
+- Espresso 3.6.1 - Instrumented UI testing
+- JaCoCo 0.8.14 - Code coverage
+
+**Build & Quality:**
+- ktlint 1.0.1 - Kotlin code linting
+- Detekt 1.23.8 - Static analysis (custom Columba rules in `detekt-rules/`)
+- CPD 7.7.0 - Copy-paste detection
+- detekt-rules module - Custom Kotlin analysis rules
+
+## Key Dependencies
+
+**Critical:**
+- Chaquopy 16.0.0 - Bridges Kotlin and Python for Reticulum mesh networking
+- Android Python Wheels - Pre-built arm64 Python packages (pycodec2 4.1.1)
+- usb-serial-for-android 3.7.0 - Serial USB support (FTDI, CP210x, PL2303, CH340, CDC-ACM protocols)
+- sentry-android 7.3.0 - Crash reporting and observability (GlitchTip compatible)
+
+**Messaging & Networking:**
+- Reticulum (RNS 1.1.3) - Fork at `torlando-tech/Reticulum@rebase-1.1.3` with patches for shared instance RPC error handling
+- LXMF - Fork at `torlando-tech/LXMF@feature/receiving-interface-capture` with external stamp generator and receiving interface capture
+- LXST - Fork at `torlando-tech/LXST@chaquopy-compat` with Chaquopy compatibility patches
+- ble-reticulum - Git fork at `torlando-tech/ble-reticulum@main`
+- u-msgpack-python - MessagePack serialization for Sideband-compatible telemetry
+- MessagePack 0.9.10 (JVM) and msgpack-core 0.9.8 (for LXMF stamp generation)
+
+**Hardware & Sensors:**
+- CameraX 1.5.2 (core, camera2, lifecycle, view) - Camera API abstraction
+- Google Play Services Location 21.2.0 - FusedLocationProviderClient for location sharing and map features
+- MapLibre 11.5.2 - Offline-capable maps
+- ZXing 3.5.3 - QR code encoding/decoding
+- Lucide Icons 1.1.0 - Icon library
+
+**Media & UI:**
+- Coil 2.6.0 - Image loading with GIF animation support
+- Material Icons Extended - Additional Material Design icons
+- Compose Material3 - Material Design 3 components
+
+**Serialization:**
+- kotlinx-serialization-json 1.9.0 - Kotlin JSON serialization (migration export/import)
+- org.json 20231013/20240303 - Real JSON for unit tests
+
+**Python Dependencies (installed via Chaquopy):**
+- numpy - Audio processing dependency for LXST
+- cryptography >=42.0.0 - Encryption for Reticulum
+- pycodec2 4.1.1 - Pre-built wheel for audio codec (pure Python ctypes wrapper)
+- audioop - Built-in on Python 3.11 (codec audio processing)
+
+## Configuration
+
+**Environment:**
+- `.envrc.example` - Template for direnv-based configuration
+- Environment variables required for CI/CD:
+  - `ANDROID_HOME` - Android SDK location
+  - `JAVA_HOME` - Java 17 JDK path
+  - `KEYSTORE_FILE` - Base64-encoded keystore for release signing
+  - `KEYSTORE_PASSWORD` - Keystore password
+  - `KEY_ALIAS` - Release key alias
+  - `KEY_PASSWORD` - Key password
+
+**Build:**
+- `build.gradle.kts` - Root project configuration with JaCoCo, ktlint, detekt, CPD
+- `app/build.gradle.kts` - App module with Compose, Chaquopy, Hilt, testing config
+- `data/build.gradle.kts` - Data layer with Room, Hilt, coroutines
+- `reticulum/build.gradle.kts` - Reticulum integration with Python, USB serial, BLE
+- `gradle/libs.versions.toml` - Centralized dependency versions
+- `gradle.properties` - JVM args, parallel builds, Kotlin code style
+- `detekt-config.yml` - Static analysis rules (`detekt-baseline.xml` captures pre-existing issues)
+
+**Kotlin Compiler:**
+- Target: JVM 17
+- Kotlin code style: official
+- Compose compiler extension: 1.7.5
+
+**Android Configuration:**
+- Namespace: `com.lxmf.messenger`
+- Application ID: `com.lxmf.messenger`
+- Supported ABIs: arm64-v8a (64-bit only, x86_64 disabled due to pycodec2 wheel resolution)
+- Features: Compose enabled, AIDL enabled, BuildConfig enabled
+- Resources: R class namespacing enabled, AndroidX enabled
+
+## Platform Requirements
+
+**Development:**
+- Android SDK 35 or later
+- Java 17 JDK (OpenJDK or compatible)
+- Python 3.8-3.11 (build-time, for Chaquopy compatibility detection)
+- Gradle 8.7.3
+- Git 2.x+ (for version detection via tags)
+
+**Production (Runtime):**
+- Android 6.0+ (API 24 minimum)
+- Android 15 (API 35 target)
+- ARM64 CPU (v8a)
+- 100+ MB storage for app and offline maps
+- Network: WiFi or mobile data for Reticulum mesh networking
+
+---
+
+*Stack analysis: 2026-01-23*

--- a/.planning/codebase/STRUCTURE.md
+++ b/.planning/codebase/STRUCTURE.md
@@ -1,0 +1,207 @@
+# Codebase Structure
+
+**Analysis Date:** 2026-01-23
+
+## Directory Layout
+
+```
+columba/
+├── app/                              # Main UI application module (Android app)
+│   ├── src/
+│   │   ├── main/
+│   │   │   ├── java/com/lxmf/messenger/
+│   │   │   │   ├── ui/                       # Compose screens, components, themes
+│   │   │   │   ├── viewmodel/                # MVVM state holders
+│   │   │   │   ├── service/                  # Background service & managers
+│   │   │   │   ├── repository/               # Data access patterns
+│   │   │   │   ├── data/                     # Local models and config
+│   │   │   │   ├── reticulum/                # Protocol implementation & BLE
+│   │   │   │   ├── util/                     # Utilities (validation, crypto, etc.)
+│   │   │   │   ├── migration/                # Data migration logic
+│   │   │   │   ├── startup/                  # Initialization managers
+│   │   │   │   ├── notifications/            # Notification & call handling
+│   │   │   │   ├── crypto/                   # Cryptographic utilities
+│   │   │   │   ├── map/                      # Map feature logic
+│   │   │   │   ├── MainActivity.kt           # Main entry point
+│   │   │   │   └── ColumbaApplication.kt     # Application initialization
+│   │   │   ├── res/                          # Resources (drawables, strings, XML)
+│   │   │   ├── aidl/                         # AIDL service interface definitions
+│   │   │   └── AndroidManifest.xml           # App manifest
+│   │   ├── test/                             # Unit tests (local, in-process)
+│   │   └── androidTest/                      # Instrumented tests (device/emulator)
+│   └── build.gradle.kts                      # App module build config
+│
+├── data/                             # Data layer library module
+│   ├── src/
+│   │   ├── main/
+│   │   │   ├── java/com/lxmf/messenger/data/
+│   │   │   │   ├── db/                       # Room database schema
+│   │   │   │   │   ├── ColumbaDatabase.kt
+│   │   │   │   │   ├── dao/                  # Data Access Objects
+│   │   │   │   │   └── entity/               # Room entity definitions
+│   │   │   │   ├── repository/               # Data repository implementations
+│   │   │   │   ├── model/                    # Data models
+│   │   │   │   ├── storage/                  # Shared preferences & DataStore
+│   │   │   │   └── di/                       # Data layer DI (DatabaseModule)
+│   │   └── test/                             # Data layer unit tests
+│   └── build.gradle.kts                      # Data module build config
+│
+├── reticulum/                        # Reticulum library module (networking)
+│   ├── src/
+│   │   ├── main/
+│   │   │   ├── java/com/lxmf/messenger/reticulum/
+│   │   │   │   ├── protocol/                 # Protocol abstraction & implementations
+│   │   │   │   ├── model/                    # Domain models (Identity, Destination, etc.)
+│   │   │   │   ├── ble/                      # Bluetooth Low Energy bridge
+│   │   │   │   ├── rnode/                    # RNode radio device support
+│   │   │   │   ├── usb/                      # USB serial communication
+│   │   │   │   ├── bridge/                   # Python bridge layer
+│   │   │   │   ├── audio/                    # Voice call audio handling
+│   │   │   │   ├── call/                     # LXST telephony (voice calls)
+│   │   │   │   └── util/                     # Protocol utilities
+│   │   └── test/                             # Reticulum module tests
+│   └── build.gradle.kts                      # Reticulum module build config
+│
+├── domain/                           # Domain module (empty structure, reserved)
+│   └── build.gradle.kts              # Domain module placeholder
+│
+├── detekt-rules/                     # Custom Detekt linting rules
+│   ├── src/
+│   │   └── main/kotlin/
+│   │       └── com/lxmf/messenger/detekt/
+│   └── build.gradle.kts
+│
+├── gradle/                           # Gradle wrapper scripts
+├── build.gradle.kts                  # Root build config (Kotlin DSL)
+├── settings.gradle.kts               # Gradle settings (module definitions)
+├── gradle.properties                 # Gradle properties (versions, flags)
+├── .editorconfig                     # IDE formatter settings
+├── detekt-config.yml                 # Detekt static analysis config
+├── .codecov.yml                      # Code coverage config
+└── CLAUDE.md                         # Project-specific instructions
+```
+
+## Directory Purposes
+
+**app/**
+- Purpose: Main application UI and orchestration
+- Contains: Kotlin Android code (Activities, ViewModels, Composables), Resources, Manifests
+- Key files: `MainActivity.kt`, `ColumbaApplication.kt`, `AndroidManifest.xml`
+
+**data/**
+- Purpose: Data layer abstraction and persistence
+- Contains: Room database, DAOs, repositories, data models, configuration storage
+- Key files: `ColumbaDatabase.kt`, entity classes, repository implementations
+
+**reticulum/**
+- Purpose: Network protocol implementation and radio device integration
+- Contains: Reticulum protocol contract, BLE/RNode/USB bridges, networking models
+- Key files: `ReticulumProtocol.kt`, `ServiceReticulumProtocol.kt`, device-specific bridges
+
+**detekt-rules/**
+- Purpose: Custom static analysis rules (pure JVM, not Android)
+- Contains: Detekt rule implementations for project-specific linting
+- Key files: Custom rule classes in Kotlin
+
+## Key File Locations
+
+**Entry Points:**
+- `app/src/main/java/com/lxmf/messenger/MainActivity.kt`: Main activity launcher
+- `app/src/main/java/com/lxmf/messenger/ColumbaApplication.kt`: Application initialization
+- `app/src/main/java/com/lxmf/messenger/service/ReticulumService.kt`: Background service
+
+**Configuration:**
+- `app/src/main/AndroidManifest.xml`: Permissions, intent filters, service definitions
+- `build.gradle.kts`: Root build script (plugin versions, detekt config)
+- `gradle.properties`: Version constants, project flags
+- `detekt-config.yml`: Code quality rules (advisory, not enforced)
+
+**Core Logic:**
+- `data/src/main/java/com/lxmf/messenger/data/db/ColumbaDatabase.kt`: Database schema
+- `app/src/main/java/com/lxmf/messenger/repository/`: Repository layer (conversations, identities, settings)
+- `app/src/main/java/com/lxmf/messenger/service/manager/`: Service managers (messaging, health, BLE)
+- `reticulum/src/main/java/com/lxmf/messenger/reticulum/protocol/ReticulumProtocol.kt`: Protocol contract
+
+**Testing:**
+- `app/src/test/`: Unit tests (JVM, mocked Android, no device needed)
+- `app/src/androidTest/`: Instrumented tests (require device/emulator)
+- `app/src/test/java/com/lxmf/messenger/test/`: Test fixtures and helpers
+- Test fixture location: `app/src/test/java/com/lxmf/messenger/test/` (e.g., `BleTestFixtures.kt`)
+
+## Naming Conventions
+
+**Files:**
+- Activities: `*Activity.kt` (e.g., `MainActivity.kt`)
+- ViewModels: `*ViewModel.kt` (e.g., `ChatsViewModel.kt`)
+- Repositories: `*Repository.kt` (e.g., `ConversationRepository.kt`)
+- Services: `*Service.kt` (e.g., `ReticulumService.kt`)
+- Managers: `*Manager.kt` (e.g., `HealthCheckManager.kt`, `PythonWrapperManager.kt`)
+- DAOs: `*Dao.kt` (e.g., `MessageDao.kt`, `ConversationDao.kt`)
+- Entities: `*Entity.kt` (e.g., `MessageEntity.kt`, `ConversationEntity.kt`)
+- Models: `*.kt` with domain name (e.g., `Identity.kt`, `Destination.kt`)
+- Screens/Composables: `*Screen.kt` or `*Composable.kt` (e.g., `ChatsScreen.kt`, `IdentityCard.kt`)
+- Tests: `*Test.kt` for unit tests (e.g., `BleConnectionInfoTest.kt`)
+- Test fixtures: `*TestFixtures.kt` or `*Fixtures.kt` (e.g., `BleTestFixtures.kt`)
+
+**Directories:**
+- Package structure mirrors domain: `com.lxmf.messenger.[feature]`
+- Feature-specific packages group related code (e.g., `ui.screens.rnode`, `service.manager`)
+- Test directories mirror source structure: `app/src/test/java/com/lxmf/messenger/[mirror-of-main]`
+
+## Where to Add New Code
+
+**New Feature (UI + Logic):**
+- Primary code: `app/src/main/java/com/lxmf/messenger/ui/screens/[feature]/` for screens
+- ViewModel: `app/src/main/java/com/lxmf/messenger/viewmodel/[Feature]ViewModel.kt`
+- Repository: `data/src/main/java/com/lxmf/messenger/data/repository/[Feature]Repository.kt`
+- Tests: Mirror structure under `app/src/test/java/` and `app/src/androidTest/java/`
+
+**New Network Protocol Feature:**
+- Implementation: `reticulum/src/main/java/com/lxmf/messenger/reticulum/[feature]/`
+- Models: `reticulum/src/main/java/com/lxmf/messenger/reticulum/model/[Model].kt`
+- Tests: `reticulum/src/test/java/com/lxmf/messenger/reticulum/[feature]/`
+
+**New Component/Composable:**
+- Implementation: `app/src/main/java/com/lxmf/messenger/ui/components/[ComponentName].kt`
+- Models: `app/src/main/java/com/lxmf/messenger/ui/model/[ComponentModel].kt`
+
+**Utilities:**
+- Shared helpers: `app/src/main/java/com/lxmf/messenger/util/`
+- Validation logic: `app/src/main/java/com/lxmf/messenger/util/validation/`
+- Reticulum utilities: `reticulum/src/main/java/com/lxmf/messenger/reticulum/util/`
+
+**Database Changes:**
+- Entity: Add to `data/src/main/java/com/lxmf/messenger/data/db/entity/[EntityName].kt`
+- DAO: Add to `data/src/main/java/com/lxmf/messenger/data/db/dao/[EntityName]Dao.kt`
+- Migration: Add `MIGRATION_X_Y` in `data/src/main/java/com/lxmf/messenger/data/di/DatabaseModule.kt`
+- Update: `ColumbaDatabase.version++`, add new entity to @Database annotation
+
+**Service Managers (Background Process):**
+- Manager: `app/src/main/java/com/lxmf/messenger/service/manager/[Feature]Manager.kt`
+- Register: Add to `ServiceModule.createManagers()` in `app/src/main/java/com/lxmf/messenger/service/di/ServiceModule.kt`
+
+## Special Directories
+
+**res/ Directory:**
+- Purpose: Android resources (strings, drawables, layouts, colors, fonts)
+- Generated: No, all committed
+- Committed: Yes
+
+**build/ Directory:**
+- Purpose: Build output and intermediate files
+- Generated: Yes, created by Gradle
+- Committed: No (in .gitignore)
+
+**src/test/resources/**
+- Purpose: Test-specific resource files
+- Generated: No, manually created for tests
+- Committed: Yes
+
+**src/androidTest/**
+- Purpose: Instrumented tests requiring device/emulator
+- Contents: Integration tests, UI tests, database tests
+- Example: `ServiceProcessInitializationTest.kt`, `PythonThreadSafetyTest.kt`
+
+---
+
+*Structure analysis: 2026-01-23*

--- a/.planning/codebase/TESTING.md
+++ b/.planning/codebase/TESTING.md
@@ -1,0 +1,391 @@
+# Testing Patterns
+
+**Analysis Date:** 2026-01-23
+
+## Test Framework
+
+**Runner:**
+- JUnit 4 with Robolectric for unit tests
+- AndroidJUnit4 (AndroidX Test) for instrumentation tests
+- Config: `app/build.gradle.kts` specifies `AndroidJUnitRunner`
+
+**Assertion Library:**
+- `org.junit.Assert.*` for all assertions
+- Common: `assertEquals()`, `assertTrue()`, `assertFalse()`, `assertNull()`, `assertNotNull()`
+
+**Async/Coroutine Testing:**
+- `kotlinx.coroutines.test.runTest` for coroutine-based tests
+- `@OptIn(ExperimentalCoroutinesApi::class)` annotation required
+- `InstantTaskExecutorRule` for LiveData/Flow testing: `@get:Rule val instantExecutorRule = InstantTaskExecutorRule()`
+- Test dispatcher setup: `val testDispatcher = StandardTestDispatcher()`
+
+**Run Commands:**
+```bash
+./gradlew testDebugUnitTest              # Run all unit tests
+./gradlew testDebugUnitTest --watch      # Watch mode (if supported)
+./gradlew jacocoTestReport               # Generate unified coverage report
+./gradlew :app:testDebugUnitTest         # Run tests for app module only
+./gradlew connectedAndroidTest           # Run instrumentation tests on device
+```
+
+## Test File Organization
+
+**Location:**
+- **Unit tests**: `app/src/test/java/com/lxmf/messenger/{feature}/` (co-located by feature)
+- **Instrumentation tests**: `app/src/androidTest/java/com/lxmf/messenger/{feature}/`
+- Tests live in same package structure as production code
+
+**Naming:**
+- `{ClassName}Test.kt` for standard unit tests
+- `{ClassName}{Scenario}Test.kt` for scenario-specific tests (e.g., `InterfaceDatabaseRaceConditionTest.kt`)
+- Test classes: `class {Name}Test { ... }`
+
+**Structure:**
+```
+app/src/
+├── test/java/com/lxmf/messenger/            # Unit tests
+│   ├── data/
+│   │   ├── MessageOrderingTest.kt
+│   │   ├── model/
+│   │   │   └── ModemPresetTest.kt
+│   │   └── repository/
+│   │       └── ConversationRepositoryTest.kt
+│   ├── service/
+│   ├── util/
+│   └── viewmodel/
+├── androidTest/java/com/lxmf/messenger/     # Integration/instrumentation tests
+│   ├── data/database/
+│   │   └── InterfaceDatabaseRaceConditionTest.kt
+│   ├── initialization/
+│   └── ui/
+└── main/
+```
+
+## Test Structure
+
+**Suite Organization:**
+```kotlin
+@OptIn(ExperimentalCoroutinesApi::class)
+class MessageOrderingTest {
+    @get:Rule
+    val instantExecutorRule = InstantTaskExecutorRule()
+
+    private lateinit var conversationRepository: ConversationRepository
+    private val testPeerHash = "abcd1234"
+    private val testPeerName = "Test Peer"
+
+    @Before
+    fun setup() {
+        conversationRepository = mockk(relaxed = true)
+    }
+
+    @After
+    fun tearDown() {
+        clearAllMocks()
+    }
+
+    @Test
+    fun `test description in backticks`() = runTest {
+        // Arrange
+        val expected = listOf(/* data */)
+
+        // Act
+        val result = conversationRepository.getMessages(testPeerHash).first()
+
+        // Assert
+        assertEquals(expected, result)
+    }
+}
+```
+
+**Patterns:**
+- `@Before` setup: Initialize mocks and test fixtures
+- `@After` teardown: Clear mocks with `clearAllMocks()`, reset dispatchers with `Dispatchers.resetMain()`
+- Backtick test names: `` `describe behavior in natural language`() ``
+- Comments in test names: Avoid; use descriptive names instead
+- Comments in setup: Explain non-obvious test data creation
+
+**Test Organization within Files:**
+- Group related tests with section comments: `// ========== Scenario Name Tests ==========`
+- Arrange-Act-Assert pattern (AAA):
+  - Arrange: Setup test data and mocks
+  - Act: Call the code being tested
+  - Assert: Verify results with assertions and explanatory messages
+
+## Mocking
+
+**Framework:** `io.mockk.mockk` (MockK)
+
+**Patterns:**
+```kotlin
+// Create relaxed mock (no need to specify every call)
+val mockRepository: ConversationRepository = mockk(relaxed = true)
+
+// Specify return value for function
+every { mockRepository.getMessages(testPeerHash) } returns flowOf(messages)
+
+// Verify function was called
+coVerify { mockRepository.saveMessage(message) }
+
+// Clear all mocks after test
+clearAllMocks()
+```
+
+**What to Mock:**
+- External dependencies: repositories, services, DAOs, network clients
+- Complex objects with many dependencies
+- Android system services passed as parameters
+- Any class marked with `@Inject` (dependencies)
+
+**What NOT to Mock:**
+- Pure data classes: `BleConnectionInfo`, `Message`, `ModemPreset`
+- Simple enums and sealed classes used as return types
+- Model objects created in test (use real instances)
+- Value objects representing test data
+
+**Mocking Async Code:**
+```kotlin
+// For suspend functions
+coEvery { mockDao.messageExists(id, hash) } returns false
+
+// For Flow-returning functions
+every { mockRepository.getMessages(hash) } returns flowOf(messages)
+
+// For LiveData (rarely used)
+every { mockLiveData.value } returns expectedValue
+```
+
+**Mock Verification:**
+```kotlin
+// Verify was called with specific args
+coVerify { mockDao.insert(message) }
+
+// Verify was called N times
+coVerify(exactly = 1) { mockDao.saveMessage(any()) }
+
+// Verify was NOT called
+coVerify(inverse = true) { mockDao.delete(any()) }
+```
+
+## Fixtures and Factories
+
+**Test Data:**
+```kotlin
+// In-test data creation - simple cases
+private val testPeerHash = "abcd1234"
+private val testPeerName = "Test Peer"
+
+private val testIdentity = LocalIdentityEntity(
+    identityHash = testIdentityHash,
+    displayName = "Test Identity",
+    destinationHash = "dest_hash",
+    filePath = "/path/to/identity",
+    createdTimestamp = 1000L,
+    lastUsedTimestamp = 2000L,
+    isActive = true,
+)
+
+// Inline list creation in test
+val messages = listOf(
+    DataMessage(
+        id = "msg1",
+        destinationHash = testPeerHash,
+        content = "First message",
+        timestamp = 1000L,
+        isFromMe = false,
+        status = "delivered",
+    ),
+    DataMessage(
+        id = "msg2",
+        destinationHash = testPeerHash,
+        content = "Second message",
+        timestamp = 2000L,
+        isFromMe = true,
+        status = "sent",
+    ),
+)
+```
+
+**Location:**
+- Test fixtures defined in `@Before` setup method or as class properties
+- Simple constants as private class properties: `private val testPeerHash = "abcd1234"`
+- Complex fixtures created in individual test methods when only used once
+
+**Factory Pattern (implicit):**
+- No dedicated factory classes found
+- Test data constructed inline in tests
+- Benefit: Test data is self-documenting; readers see exact structure being tested
+
+## Coverage
+
+**Requirements:** No minimum coverage enforced (advisory mode)
+
+**View Coverage:**
+```bash
+./gradlew jacocoTestReport
+# HTML report: app/build/reports/jacoco/jacocoTestReport/html/index.html
+```
+
+**Exclusions from Coverage** (in `build.gradle.kts`):
+- Generated classes: `R.class`, `BuildConfig.*`, `Manifest*.*`
+- Hilt-generated: `Hilt_*.*`, `*_Factory.*`, `*_MembersInjector.*`
+- Test classes: `**/*Test*.*`
+- Only debug unit tests included (Robolectric issues with release builds)
+
+## Test Types
+
+**Unit Tests:**
+- Scope: Single class or function in isolation with mocked dependencies
+- Location: `app/src/test/java/`
+- Examples:
+  - `MessageOrderingTest.kt` - Tests message ordering logic with mocked repository
+  - `ModemPresetTest.kt` - Tests enum matching and validation
+  - `ConversationRepositoryTest.kt` - Tests repository with mocked DAOs
+
+**Integration Tests:**
+- Scope: Multiple components working together; can use real database/objects
+- Location: `app/src/androidTest/java/`
+- Examples:
+  - `InterfaceDatabaseRaceConditionTest.kt` - Tests Room database with real schema
+  - `BlePermissionRestartTest.kt` - Tests BLE permission handling across app lifecycle
+  - `ServiceProcessInitializationTest.kt` - Tests service startup sequence
+
+**E2E Tests:**
+- Not observed in current codebase
+- Would test full app flows from UI through all layers
+
+## Common Patterns
+
+**Async Testing:**
+```kotlin
+@Test
+fun `async operation completes`() = runTest {
+    // runTest provides TestScope with test dispatcher
+
+    // Act: Call suspend function
+    val result = repository.getMessages(hash).first()
+
+    // Assert
+    assertEquals(expected, result)
+}
+```
+
+**Error Testing:**
+```kotlin
+@Test
+fun `invalid preset parameters return null`() {
+    val preset = ModemPreset.findByParams(
+        spreadingFactor = 12,
+        bandwidth = 500_000,  // Invalid combination
+        codingRate = 5,
+    )
+    assertNull(preset)
+}
+
+@Test
+fun `error parsing JSON returns empty list`() = runTest {
+    every { mockRepository.getMessages(any()) } throws Exception("Invalid JSON")
+
+    val result = repository.parseConnectionsJson(invalidJson)
+
+    assertEquals(emptyList(), result)
+}
+```
+
+**State Machine / Flow Testing:**
+```kotlin
+@Test
+fun `state transitions correctly`() = runTest {
+    val state = BleConnectionsState.Loading
+
+    // Act: Trigger state change
+    val nextState = when (state) {
+        BleConnectionsState.BluetoothDisabled -> BleConnectionsState.Loading
+        BleConnectionsState.Loading -> BleConnectionsState.Success(emptyList())
+        else -> state
+    }
+
+    // Assert
+    assertTrue(nextState is BleConnectionsState.Success)
+}
+```
+
+**Collection Validation:**
+```kotlin
+@Test
+fun `rapid message exchange maintains correct order`() = runTest {
+    val result = repository.getMessages(hash).first()
+
+    // Verify size
+    assertEquals(5, result.size)
+
+    // Verify ordering
+    for (i in 0 until result.size - 1) {
+        assertTrue(
+            "Message $i should come before ${i + 1}",
+            result[i].timestamp < result[i + 1].timestamp,
+        )
+    }
+}
+```
+
+**Scenario-Based Test with Narrative:**
+```kotlin
+@Test
+fun `received messages use local reception time not sender time`() = runTest {
+    // This test verifies the fix for clock skew issues
+    // Scenario:
+    // - User A sends message at 10:00:00 (their time)
+    // - User B's clock is 30 seconds behind
+    // - User B receives message at 09:59:40 (their time, if using sender's timestamp)
+    // - User B replies at 09:59:50 (their time)
+    //
+    // BUG (before fix): Reply appears ABOVE the original message (09:59:50 > 09:59:40)
+    // FIX (after fix): Reply appears BELOW using local reception time
+
+    val currentTime = System.currentTimeMillis()
+
+    val receivedMessage = DataMessage(
+        id = "msg1",
+        destinationHash = testPeerHash,
+        content = "Message from A",
+        timestamp = currentTime - 100,
+        isFromMe = false,
+        status = "delivered",
+    )
+
+    val sentMessage = DataMessage(
+        id = "msg2",
+        destinationHash = testPeerHash,
+        content = "Reply from B",
+        timestamp = currentTime,
+        isFromMe = true,
+        status = "sent",
+    )
+
+    every { mockRepository.getMessages(testPeerHash) } returns flowOf(listOf(receivedMessage, sentMessage))
+
+    val result = mockRepository.getMessages(testPeerHash).first()
+
+    assertEquals(2, result.size)
+    assertTrue("Received message should come first", result[0].timestamp < result[1].timestamp)
+    assertFalse("First message is from peer", result[0].isFromMe)
+    assertTrue("Second message is from me", result[1].isFromMe)
+}
+```
+
+## Test Discipline
+
+**Golden Rules:**
+- Tests MUST execute production code - no mocking the entire system being tested
+- Tests fail if production code breaks, not due to test setup fragility
+- Clear test names that read like requirements: `` `messages ordered by timestamp`() ``
+- Comprehensive assertions with meaningful failure messages
+
+**Ignored Tests:**
+- `@Ignore("Reason")` used for flaky timing-sensitive tests
+- Example: `InterfaceDatabaseRaceConditionTest.kt` marks timing test as ignored (flaky on CI with resource constraints)
+
+---
+
+*Testing analysis: 2026-01-23*


### PR DESCRIPTION
## Summary
- Adds structured codebase documentation in `.planning/codebase/`
- Generated by parallel gsd-codebase-mapper agents analyzing the codebase

## Documents Created
| Document | Lines | Description |
|----------|-------|-------------|
| STACK.md | 153 | Technologies and dependencies (Kotlin, Python/Chaquopy, Compose, Hilt) |
| ARCHITECTURE.md | 199 | System design and patterns (multi-process service, AIDL IPC, MVVM) |
| STRUCTURE.md | 207 | Directory layout and organization (app/data/reticulum modules) |
| CONVENTIONS.md | 233 | Code style and patterns (naming, detekt rules, error handling) |
| TESTING.md | 391 | Test structure and practices (JUnit4, Robolectric, MockK, fixtures) |
| INTEGRATIONS.md | 218 | External services and APIs (Reticulum mesh, BLE, MapLibre, Sentry) |
| CONCERNS.md | 266 | Technical debt and issues (BLE race conditions, x86_64 disabled, callback gaps) |

## Purpose
These documents serve as persistent context for future Claude Code sessions, enabling faster onboarding and planning without re-exploring the codebase each time.

🤖 Generated with [Claude Code](https://claude.com/claude-code)