### PR TITLE
fix: Add database migration 31→32 to drop orphaned icon columns from announces table

### DIFF
--- a/data/src/main/java/com/lxmf/messenger/data/db/ColumbaDatabase.kt
+++ b/data/src/main/java/com/lxmf/messenger/data/db/ColumbaDatabase.kt
@@ -39,7 +39,7 @@ import com.lxmf.messenger.data.db.entity.RmspServerEntity
         OfflineMapRegionEntity::class,
         RmspServerEntity::class,
     ],
-    version = 33,
+    version = 34,
     exportSchema = false,
 )
 abstract class ColumbaDatabase : RoomDatabase() {


### PR DESCRIPTION
## Summary

- Fixes crash on app startup for users upgrading from v0.5.0+ who have icon data in the `announces` table
- Inserts new `MIGRATION_31_32` to drop orphaned icon columns and renumbers existing migrations

## Root Cause

`MIGRATION_30_31` created the `peer_icons` table and migrated icon data, but failed to drop the original icon columns (`iconName`, `iconForegroundColor`, `iconBackgroundColor`) from `announces`. Room's strict schema validation detected the mismatch and threw `IllegalStateException` during database open.

## Changes

This PR inserts the fix as the new 31→32 migration and renumbers existing migrations:

| Migration | Before | After |
|-----------|--------|-------|
| Drop icon columns from announces | — | **31→32** (new) |
| Add receivedRssi/receivedSnr to messages | 31→32 | **32→33** |
| Add receivedHopCount/receivedInterface to messages | 32→33 | **33→34** |

- **DatabaseModule.kt**: Added new MIGRATION_31_32, renumbered existing migrations
- **ColumbaDatabase.kt**: Bumped version from 33 → 34

## Test Plan

- [x] Verified fix on v0.6.x branch (PR #335)
- [x] Installed v0.6.10-beta (with bug) on device
- [x] Confirmed crash with `IllegalStateException` in logs
- [x] Installed build with fix
- [x] App launched successfully, database operations working
- [x] All 10 announce records preserved after migration

## Related

- PR #335 (same fix for v0.6.x branch)

🤖 Generated with [Claude Code](https://claude.com/claude-code)