### PR TITLE
fix: configure Sentry environment and enable for debug builds

### DIFF
--- a/app/src/main/java/com/lxmf/messenger/ColumbaApplication.kt
+++ b/app/src/main/java/com/lxmf/messenger/ColumbaApplication.kt
@@ -667,7 +667,7 @@ class ColumbaApplication : Application() {
                 options.isEnableUserInteractionBreadcrumbs = true
 
                 // App Start performance tracking (cold/warm starts)
-                options.isEnableAppStartProfiling = true
+                options.isEnableAppStartProfiling = !BuildConfig.DEBUG
 
                 // ANR Detection (Application Not Responding)
                 options.isAnrEnabled = true


### PR DESCRIPTION
## Problem

Sentry had no `environment` configured — everything showed up as `production` in the dashboard. Debug builds had Sentry completely disabled (`!BuildConfig.DEBUG`), so no crash reports from dev/testing ever reached Sentry.

## Fix

- **Set `options.environment`** to `"debug"` or `"production"` based on `BuildConfig.DEBUG`
- **Enable Sentry for debug builds** — was gated behind `!BuildConfig.DEBUG`, now enabled whenever DSN is present
- **Lower sampling for debug** — 10% traces (vs 50% production), no profiling, to reduce noise
- **Log environment on init** for easier debugging

## Result

In the Sentry dashboard you can now filter by environment:
- `production` — release builds from real users
- `debug` — your local dev builds and tester builds

The `noSentry` flavor still has an empty DSN and remains fully disabled — no change there.

## One file changed

`ColumbaApplication.kt` — `initializeSentry()` method only.