### PR TITLE
fix(build): unify app ID across sentry and noSentry variants

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -138,8 +138,6 @@ android {
             dimension = "telemetry"
             // Empty DSN - Sentry fully disabled (no init, no network calls)
             buildConfigField("String", "SENTRY_DSN", "\"\"")
-            // Suffix to distinguish APK in app drawer
-            applicationIdSuffix = ".nosentry"
         }
     }
 


### PR DESCRIPTION
Remove applicationIdSuffix from noSentry flavor so both variants
share the same application ID (com.lxmf.messenger). This allows
users to switch between variants without reinstalling.

https://claude.ai/code/session_0166C31mc3zj27huuYkWTjPN