### PR TITLE
fix(ble): stabilize dual connections by detecting legitimate dual-connection scenarios

### DIFF
--- a/dispatcher-audit-report.txt
+++ b/dispatcher-audit-report.txt
@@ -1,0 +1,26 @@
+Dispatcher Audit Report - Thu Jan 29 06:51:14 PM EST 2026
+========================================
+
+
+═══════════════════════════════════════
+1. Checking for runBlocking in Production Code
+═══════════════════════════════════════
+✅ PASS: No runBlocking found in production code (or all instances are allowed)
+
+═══════════════════════════════════════
+2. Checking for Forbidden Patterns
+═══════════════════════════════════════
+✅ PASS: No GlobalScope usage found
+✅ PASS: No Dispatchers.Unconfined usage found
+
+═══════════════════════════════════════
+3. Checking Python Initialization Uses Main.immediate
+═══════════════════════════════════════
+✅ PASS: Python initialization uses Dispatchers.Main.immediate
+
+═══════════════════════════════════════
+4. Summary - CI Optimized Check Complete
+═══════════════════════════════════════
+ℹ️  INFO: Sections 5-9 skipped for CI performance (non-critical checks)
+ℹ️  INFO: All critical threading violations checked (runBlocking, GlobalScope, Unconfined, Python init)
+ℹ️  INFO: For comprehensive analysis, run audit-dispatchers-full.sh locally

--- a/reticulum/src/main/java/com/lxmf/messenger/reticulum/ble/model/BleConstants.kt
+++ b/reticulum/src/main/java/com/lxmf/messenger/reticulum/ble/model/BleConstants.kt
@@ -217,9 +217,22 @@ object BleConstants {
 
     /**
      * Connection keepalive interval in milliseconds.
-     * Send periodic packet every 15 seconds to prevent Android BLE supervision timeout.
-     * Android BLE connections timeout after 20-30 seconds of inactivity (status code 8).
-     * Keepalive packets keep the connection alive during idle periods.
+     * Send periodic packet every 7 seconds to prevent Android BLE idle disconnects.
+     *
+     * Android has multiple timeout mechanisms:
+     * - GATT supervision timeout: 20-30 seconds of inactivity (status code 8)
+     * - L2CAP idle timer: ~20 seconds with no active logical channels
+     *
+     * The L2CAP idle timer (`l2cu_no_dynamic_ccbs`) is more aggressive and can
+     * trigger even when data is being received if outgoing GATT operations fail.
+     * 7 seconds provides sufficient margin for both timeout mechanisms.
      */
-    const val CONNECTION_KEEPALIVE_INTERVAL_MS = 15000L // 15 seconds
+    const val CONNECTION_KEEPALIVE_INTERVAL_MS = 7000L // 7 seconds
+
+    /**
+     * Maximum consecutive keepalive write failures before disconnecting.
+     * Write failures indicate the GATT session is degraded even if data is still
+     * being received. Disconnect early to allow reconnection.
+     */
+    const val MAX_KEEPALIVE_WRITE_FAILURES = 2
 }


### PR DESCRIPTION
## Summary
- Fixes BLE connection flakiness where dual connections (same peer as both central and peripheral) were being incorrectly rejected
- Connections now stable for 20+ minutes (vs 1.5-12 seconds before)
- Re-enables Kotlin-side identity detection for peripheral connections to properly track dual connection state

## Changes
- **KotlinBLEBridge.kt**: Added dual connection detection before calling Python's duplicate identity check - allows legitimate dual connections while still detecting MAC rotation
- **BleGattServer.kt**: Re-enabled Kotlin-side identity tracking for peripheral connections (was commented out 2026-01-17)

## Test plan
- [x] Manual testing with two Columba phones
- [x] Verified connections remain stable for 20+ minutes
- [ ] Verify MAC rotation still triggers reconnection (expected every ~15 mins)

🤖 Generated with [Claude Code](https://claude.com/claude-code)