### PR TITLE
fix: upgrade MapLibre to 11.13.5 to fix MTE crash on GrapheneOS

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -445,7 +445,7 @@ dependencies {
     implementation("org.msgpack:msgpack-core:0.9.8")
 
     // MapLibre - for offline-capable maps
-    implementation("org.maplibre.gl:android-sdk:11.5.2")
+    implementation("org.maplibre.gl:android-sdk:11.13.5")
 
     // Google Play Services Location - for FusedLocationProviderClient
     implementation("com.google.android.gms:play-services-location:21.2.0")


### PR DESCRIPTION
## Summary
- Upgrades MapLibre from 11.5.2 → 11.13.5 to fix a use-after-free bug that causes crashes on devices with MTE enabled

## Problem
A user on GrapheneOS (Pixel 10) reported a native crash after ~11 hours of uptime:
```
Fatal signal 11 (SIGSEGV), code 9 (SEGV_MTESERR)
#00 pthread_mutex_lock (libc.so)
#01 std::mutex::lock() (libmaplibre.so)
#02 mbgl::android::MapRenderer::update() (libmaplibre.so)
```

This is a known MapLibre bug ([#3517](https://github.com/maplibre/maplibre-native/issues/3517)) where the MapRenderer accesses a destroyed mutex.

## Solution
Version 11.10.0+ includes fixes for MapRenderer reference safety:
- [#3522](https://github.com/maplibre/maplibre-native/pull/3522) - Ensure AndroidRendererFrontend exists before accessing
- [#3510](https://github.com/maplibre/maplibre-native/pull/3510) - Improved weak pointer usage

## Test plan
- [ ] Verify map displays correctly on the Contacts/Announces screen
- [ ] Test map interactions (pan, zoom, marker display)
- [ ] Ideally test on GrapheneOS device with MTE enabled

🤖 Generated with [Claude Code](https://claude.com/claude-code)