### PR TITLE
fix(aidl): make setConversationActive oneway to prevent ANR

### DIFF
--- a/app/src/main/aidl/com/lxmf/messenger/IReticulumService.aidl
+++ b/app/src/main/aidl/com/lxmf/messenger/IReticulumService.aidl
@@ -248,9 +248,12 @@ interface IReticulumService {
      * When a conversation is active, message polling uses a faster 1-second interval
      * for lower latency. When inactive, standard adaptive polling (2-30s) is used.
      *
+     * This is a fire-and-forget call (oneway) to prevent ANRs when called during
+     * ViewModel cleanup on the main thread. See: COLUMBA-1E
+     *
      * @param active true if a conversation screen is currently open and active
      */
-    void setConversationActive(boolean active);
+    oneway void setConversationActive(boolean active);
 
     /**
      * Get BLE connection details for all currently connected peers.

--- a/app/src/test/java/com/lxmf/messenger/reticulum/protocol/ServiceReticulumProtocolTest.kt
+++ b/app/src/test/java/com/lxmf/messenger/reticulum/protocol/ServiceReticulumProtocolTest.kt
@@ -1109,4 +1109,37 @@ class ServiceReticulumProtocolTest {
         assertEquals(0x3f.toByte(), result.sourceHash[1])
         assertEquals(0xfd.toByte(), result.sourceHash[2])
     }
+
+    // ========== setConversationActive() Tests ==========
+    // Documents fire-and-forget behavior after COLUMBA-1E fix.
+    // Note: Full service binding tests are in instrumented tests.
+    // The AIDL 'oneway' modifier makes this call non-blocking at Binder level.
+
+    @Test
+    fun `setConversationActive handles null service gracefully - COLUMBA-1E`() {
+        // Arrange: Service not bound (protocol created but not connected)
+        // This is the state during app startup or after service disconnect
+
+        // Act & Assert: Should not throw when service is null
+        // This is critical for ViewModel.onCleared() - must not crash during cleanup
+        val result = runCatching { protocol.setConversationActive(false) }
+
+        assertTrue(
+            "setConversationActive must handle null service gracefully. " +
+                "Called during ViewModel.onCleared() which runs on main thread. " +
+                "See: COLUMBA-1E (ANR fix - made AIDL method 'oneway')",
+            result.isSuccess
+        )
+    }
+
+    @Test
+    fun `setConversationActive with true handles null service gracefully`() {
+        // Act & Assert: Both true and false values should be safe with null service
+        val result = runCatching { protocol.setConversationActive(true) }
+
+        assertTrue(
+            "setConversationActive(true) must handle null service gracefully",
+            result.isSuccess
+        )
+    }
 }


### PR DESCRIPTION
## Summary
- Make `setConversationActive` AIDL method `oneway` to prevent ANR during ViewModel cleanup
- Add unit tests documenting the fire-and-forget behavior

## Problem
When `MessagingViewModel.onCleared()` is called during navigation, it calls `setConversationActive(false)` via synchronous Binder IPC on the main thread. If the service is busy, this blocks the UI thread long enough to trigger an ANR.

## Solution
The `oneway` AIDL modifier makes the call return immediately without waiting for the service response. This is safe because:
- The method returns `void` (no return value needed)
- The operation just sets an `AtomicBoolean`
- We don't need confirmation of completion

## Test plan
- [x] Unit tests pass for `setConversationActive` null service handling
- [x] All `EventHandlerTest` tests pass
- [x] Manual: Navigate away from messaging screen rapidly - no ANR

Fixes COLUMBA-1E

🤖 Generated with [claude-flow](https://github.com/ruvnet/claude-flow)