### PR TITLE
fix: generic ProGuard rule for Python-Kotlin bridges

### DIFF
--- a/app/proguard-rules.pro
+++ b/app/proguard-rules.pro
@@ -72,29 +72,23 @@
 # These classes bridge between Kotlin and Python
 -keep class com.lxmf.messenger.reticulum.protocol.** { *; }
 
-# ===== Kotlin-Python Bridge =====
-# KotlinReticulumBridge is called from Python via Chaquopy
-# Python expects specific method names (notifyAnnounceReceived, etc.) that must not be obfuscated
--keep class com.lxmf.messenger.reticulum.bridge.KotlinReticulumBridge { *; }
--keepclassmembers class com.lxmf.messenger.reticulum.bridge.KotlinReticulumBridge { *; }
-
-# ===== BLE Bridge =====
-# KotlinBLEBridge is called from Python via Chaquopy
-# Python expects specific method names that must not be obfuscated
--keep class com.lxmf.messenger.reticulum.ble.bridge.KotlinBLEBridge { *; }
--keepclassmembers class com.lxmf.messenger.reticulum.ble.bridge.KotlinBLEBridge { *; }
-
-# ===== RNode Bridge =====
-# KotlinRNodeBridge is called from Python via Chaquopy for RNode LoRa interface
-# Python expects specific method names (connect, disconnect, send, etc.)
--keep class com.lxmf.messenger.reticulum.rnode.KotlinRNodeBridge { *; }
--keepclassmembers class com.lxmf.messenger.reticulum.rnode.KotlinRNodeBridge { *; }
-
-# ===== Reticulum Bridge =====
-# KotlinReticulumBridge is called from Python via Chaquopy for event notifications
-# Python expects specific method names (notifyAnnounceReceived, etc.)
--keep class com.lxmf.messenger.reticulum.bridge.KotlinReticulumBridge { *; }
--keepclassmembers class com.lxmf.messenger.reticulum.bridge.KotlinReticulumBridge { *; }
+# ===== Python-Kotlin Bridge Classes (CRITICAL) =====
+# Any class ending in "Bridge" may be called from Python via Chaquopy.
+# Python uses reflection to call methods by name, so these classes and their
+# methods MUST NOT be obfuscated. R8 would otherwise rename them, causing
+# runtime errors like "'h' object has no attribute 'onIncomingCall'".
+#
+# This generic pattern automatically protects:
+#   - KotlinReticulumBridge (announce callbacks)
+#   - KotlinBLEBridge (Bluetooth LE interface)
+#   - KotlinRNodeBridge (RNode LoRa interface)
+#   - KotlinAudioBridge (LXST audio streaming)
+#   - CallBridge (LXST voice call state)
+#   - Any future *Bridge classes
+#
+# Convention: Name any Python-callable Kotlin class with "Bridge" suffix.
+-keep class com.lxmf.messenger.**.*Bridge { *; }
+-keepclassmembers class com.lxmf.messenger.**.*Bridge { *; }
 
 # ===== MessagePack Serialization =====
 # MessagePack uses reflection to load buffer implementations


### PR DESCRIPTION
## Summary

- Replace individual `-keep` rules with a single generic pattern: `-keep class com.lxmf.messenger.**.*Bridge { *; }`
- Update verification script to dynamically discover Bridge classes from Kotlin source
- Use generic patterns to find bridge method calls in Python

## Problem

Voice calls were failing on release builds with error:
```
'h' object has no attribute 'onIncomingCall'
```

Root cause: `CallBridge` class was not in the hardcoded ProGuard keep rules, so R8 obfuscated it to `h`, breaking Python→Kotlin communication via Chaquopy.

The verification script also had a gap - it only checked hardcoded class names, missing:
- `CallBridge` (voice calls)
- `KotlinUSBBridge` (USB interface)

## Solution

**Convention over configuration:** Any Kotlin class callable from Python must be named with a `Bridge` suffix. This single pattern catches all bridges:

```proguard
-keep class com.lxmf.messenger.**.*Bridge { *; }
```

The verification script now:
1. Scans Kotlin source to find all `*Bridge` classes dynamically
2. Uses generic patterns to find bridge method calls in Python
3. Verifies all discovered classes/methods exist in the release APK

## Test Plan

- [x] Build release APK: `./gradlew :app:assembleNoSentryRelease`
- [x] Run verification: `python3 scripts/verify_proguard_bridge.py <apk>`
- [x] Verify 6/6 bridge classes found (including CallBridge)
- [x] Verify 42/42 bridge methods preserved
- [x] Test incoming voice call on release build

🤖 Generated with [claude-flow](https://github.com/ruvnet/claude-flow)