### PR TITLE
Refresh message timestamps when app resumes from background

### DIFF
--- a/app/src/main/java/com/lxmf/messenger/viewmodel/MessagingViewModel.kt
+++ b/app/src/main/java/com/lxmf/messenger/viewmodel/MessagingViewModel.kt
@@ -900,6 +900,15 @@ class MessagingViewModel
             }
         }
 
+        /**
+         * Refresh the messages list to update relative timestamps.
+         * Called when the app resumes from background to ensure timestamps like
+         * "Just now" are recalculated based on the current time.
+         */
+        fun refreshTimestamps() {
+            _messagesRefreshTrigger.value++
+        }
+
         fun sendMessage(
             destinationHash: String,
             content: String,


### PR DESCRIPTION
## Summary
This PR ensures that relative message timestamps (e.g., "Just now", "5 minutes ago") are updated correctly when the app returns from the background. Without this fix, timestamps could become stale if the app was paused for an extended period.

## Changes
- **MessagingScreen.kt**: Added lifecycle observer that triggers a timestamp refresh when the app resumes (ON_RESUME event)
  - Imports `DisposableEffect`, `Lifecycle`, `LifecycleEventObserver`, and `LocalLifecycleOwner` from Jetpack Compose and Lifecycle libraries
  - Properly manages the lifecycle observer lifecycle with cleanup in `onDispose`

- **MessagingViewModel.kt**: Added `refreshTimestamps()` function that increments the `_messagesRefreshTrigger` to trigger a UI refresh
  - This causes the messages list to be recomposed, recalculating all relative timestamps based on the current time

## Implementation Details
- Uses Compose's `DisposableEffect` to safely manage the lifecycle observer registration and cleanup
- The refresh is triggered via the existing `_messagesRefreshTrigger` state, ensuring consistency with the app's refresh mechanism
- No additional network calls or database queries are made; the refresh simply forces UI recomposition to recalculate timestamps

https://claude.ai/code/session_01C7WZVEa3XCGLDKXxXn2Y9b