### PR TITLE
fix: replace SIGKILL with graceful ACTION_STOP during service restart

### DIFF
--- a/app/src/main/java/com/lxmf/messenger/service/InterfaceConfigManager.kt
+++ b/app/src/main/java/com/lxmf/messenger/service/InterfaceConfigManager.kt
@@ -135,7 +135,11 @@ class InterfaceConfigManager
                             Intent(context, ReticulumService::class.java).apply {
                                 action = ReticulumService.ACTION_STOP
                             }
-                        context.startService(stopIntent)
+                        if (android.os.Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.O) {
+                            context.startForegroundService(stopIntent)
+                        } else {
+                            context.startService(stopIntent)
+                        }
                     } else {
                         Log.d(TAG, "Service process not found (may have already stopped)")
                     }


### PR DESCRIPTION
## Summary

- Replace `Process.killProcess()` (SIGKILL) with `ACTION_STOP` intent in `InterfaceConfigManager.applyInterfaceChanges()`, allowing Chaquopy's Python VM to finalize cleanly via `System.exit(0)` shutdown hooks
- Retain SIGKILL as a 5-second timeout fallback for deadlock scenarios, instead of throwing an exception that aborts the restart flow

Resolves [COLUMBA-2C](https://torlando-tech.sentry.io/issues/COLUMBA-2C) — `SIGSEGV` in `PyGILState_Ensure` on Infinix X6716 (Android 13, v0.8.1-beta) during service restart from interface management screen.

## Root cause

`Process.killProcess()` sends SIGKILL, which gives zero cleanup time. If any thread is mid-JNI into Python (e.g. acquiring the GIL via `PyGILState_Ensure`), the Python VM's memory is freed instantly, causing a segfault.

## Test plan

- [x] `./gradlew :app:compileNoSentryDebugKotlin` — builds clean
- [x] `./gradlew :app:testNoSentryDebugUnitTest --tests "*.InterfaceConfigManagerTest"` — all existing tests pass
- [x] On-device: toggled interface config, confirmed logcat shows graceful `ACTION_STOP` → `Reticulum shutdown complete` → `Service process confirmed dead after 500ms` with no crash

🤖 Generated with [Claude Code](https://claude.com/claude-code)