### PR TITLE
fix: ABI version code collision across patch releases

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -293,7 +293,10 @@ android {
 }
 
 // Assign unique version codes per ABI so app stores can serve the right APK.
-// Universal APK gets base versionCode; per-ABI APKs get (abiMultiplier * 1000 + base).
+// Universal APK gets base versionCode; per-ABI APKs add the ABI offset to the ones place.
+// This keeps ABI variants close together (e.g. 801000, 801001, 801002) so they read as
+// the same release in Sentry and other tools. Safe because release builds always have
+// commitCount=0, leaving the ones place free for the ABI discriminator.
 val abiVersionCodes = mapOf("arm64-v8a" to 1, "x86_64" to 2)
 androidComponents {
     onVariants { variant ->
@@ -304,7 +307,7 @@ androidComponents {
                 }
             if (abiFilter != null) {
                 output.versionCode.set(
-                    (abiVersionCodes[abiFilter.identifier] ?: 0) * 1000 + versionCodeValue,
+                    (abiVersionCodes[abiFilter.identifier] ?: 0) + versionCodeValue,
                 )
             }
         }


### PR DESCRIPTION
## Summary
- Changed ABI split version code offset from `abiCode * 1000` to `abiCode * 1` (ones place)
- Fixes issue where arm64 builds of one release collided with universal builds of the next patch release (e.g. v0.8.1 arm64 = 802,000 = v0.8.2 universal), causing duplicate version entries in Sentry
- Release builds always have `commitCount=0`, so the ones place is free for ABI discrimination

**Before:** `801000` (universal), `802000` (arm64) — looks like two different releases
**After:** `801000` (universal), `801001` (arm64) — clearly the same release

## Test plan
- [x] `assembleNoSentryDebug` builds successfully
- [ ] Verify Sentry groups versions correctly after next release

🤖 Generated with [Claude Code](https://claude.com/claude-code)