### PR TITLE
fix: prevent relay unset dialog buttons from overflowing

### DIFF
--- a/app/src/main/java/com/lxmf/messenger/ui/screens/AnnounceDetailScreen.kt
+++ b/app/src/main/java/com/lxmf/messenger/ui/screens/AnnounceDetailScreen.kt
@@ -485,12 +485,13 @@ private fun UnsetRelayConfirmationDialog(
             Text("\"$relayName\" will be removed from contacts.")
         },
         confirmButton = {
-            TextButton(onClick = onAutoSelect) {
-                Text("Remove & Auto-Select New")
-            }
-        },
-        dismissButton = {
-            Column {
+            Column(
+                modifier = Modifier.fillMaxWidth(),
+                horizontalAlignment = Alignment.End,
+            ) {
+                TextButton(onClick = onAutoSelect) {
+                    Text("Remove & Auto-Select New")
+                }
                 TextButton(onClick = onRemoveOnly) {
                     Text("Remove Only")
                 }

--- a/app/src/main/java/com/lxmf/messenger/ui/screens/ContactsScreen.kt
+++ b/app/src/main/java/com/lxmf/messenger/ui/screens/ContactsScreen.kt
@@ -775,21 +775,22 @@ fun ContactsScreen(
                 )
             },
             confirmButton = {
-                TextButton(
-                    onClick = {
-                        viewModel.unsetRelayAndDelete(
-                            currentRelayToUnset.destinationHash,
-                            autoSelectNew = true,
-                        )
-                        showUnsetRelayDialog = false
-                        relayToUnset = null
-                    },
+                Column(
+                    modifier = Modifier.fillMaxWidth(),
+                    horizontalAlignment = Alignment.End,
                 ) {
-                    Text("Remove & Auto-Select New")
-                }
-            },
-            dismissButton = {
-                Column {
+                    TextButton(
+                        onClick = {
+                            viewModel.unsetRelayAndDelete(
+                                currentRelayToUnset.destinationHash,
+                                autoSelectNew = true,
+                            )
+                            showUnsetRelayDialog = false
+                            relayToUnset = null
+                        },
+                    ) {
+                        Text("Remove & Auto-Select New")
+                    }
                     TextButton(
                         onClick = {
                             viewModel.unsetRelayAndDelete(


### PR DESCRIPTION
Move all three buttons (Remove & Auto-Select New, Remove Only, Cancel)
into a single vertically-stacked Column within the confirmButton slot
instead of splitting them across confirmButton and dismissButton. The
M3 AlertDialog FlowRow layout caused buttons to overflow the dialog
bounds when the dismissButton contained a Column of two buttons.

Fixes both instances: ContactsScreen and AnnounceDetailScreen.

https://claude.ai/code/session_01D2VCRbkzM7QHizyWNJbfc5