### PR TITLE
feat: double-back-to-exit on root tab screens

### DIFF
--- a/app/src/main/java/com/lxmf/messenger/MainActivity.kt
+++ b/app/src/main/java/com/lxmf/messenger/MainActivity.kt
@@ -888,7 +888,7 @@ fun ColumbaNavigation(
     // second press within 2 seconds finishes the activity.
     val rootRoutes = screens.map { it.route }.toSet()
     val isOnRootScreen = currentRoute in rootRoutes
-    var backPressedOnce by remember { mutableStateOf(false) }
+    var backPressedOnce by remember(currentRoute) { mutableStateOf(false) }
 
     // Auto-reset the flag after 2 seconds
     LaunchedEffect(backPressedOnce) {


### PR DESCRIPTION
## Summary

Prevents accidental exits and annoying back-navigation between tabs. When on a root tab screen (Chats, Contacts, Map, Settings), pressing the system back button now shows a "Press back again to exit" toast instead of navigating to the previous tab. A second press within 2 seconds closes the app.

## How it works

- `BackHandler` is enabled only on root tab screens
- First press → shows a `Toast` and sets a flag
- `LaunchedEffect` auto-resets the flag after 2 seconds
- Second press within the window → `finish()` on the activity

## Files changed

- `app/src/main/java/com/lxmf/messenger/MainActivity.kt` — added `BackHandler` + `LaunchedEffect` in `ColumbaNavigation()`

## Testing

- [x] Build succeeds (`compileNoSentryDebugKotlin`)
- [x] detekt passes
- [x] ktlint passes
- [x] Manual test: back on root tab shows toast, double-back exits
- [x] Manual test: back on nested screens (messaging, settings sub-pages) still navigates normally