### PR TITLE
fix: swap icon foreground/background color order to match LXMF standard

### DIFF
--- a/python/reticulum_wrapper.py
+++ b/python/reticulum_wrapper.py
@@ -66,7 +66,7 @@ sys.excepthook = _global_exception_handler
 FIELD_TELEMETRY = 0x02        # Standard telemetry field for Sideband interoperability
 FIELD_TELEMETRY_STREAM = 0x03 # Bulk telemetry stream from collector [[source_hash, timestamp, packed_telemetry, appearance], ...]
 FIELD_COLUMBA_META = 0x70     # Custom field for Columba-specific metadata (cease signals, etc.)
-FIELD_ICON_APPEARANCE = 0x04  # Icon appearance [name, bg_bytes(3), fg_bytes(3)] for Sideband/MeshChat interoperability
+FIELD_ICON_APPEARANCE = 0x04  # Icon appearance [name, fg_bytes(3), bg_bytes(3)] for Sideband/MeshChat interoperability
 FIELD_FILE_ATTACHMENTS = 0x05 # LXMF standard field for file attachments
 FIELD_COMMANDS = 0x09         # LXMF standard field for commands (telemetry requests, etc.)
 FIELD_IMAGE = 0x06            # LXMF standard field for images
@@ -165,21 +165,21 @@ def appearance_from_marker_symbol(symbol_key: str) -> Optional[list]:
     """
     Build a Sideband-compatible appearance tuple from a marker symbol key.
 
-    Returns [icon_name, bg_bytes(3), fg_bytes(3)] or None if the symbol key
+    Returns [icon_name, fg_bytes(3), bg_bytes(3)] or None if the symbol key
     is not recognised.
 
     Args:
         symbol_key: The marker symbol key (e.g. "car", "rectangle")
 
     Returns:
-        Appearance list [icon_name, bg_rgb_bytes, fg_rgb_bytes] or None
+        Appearance list [icon_name, fg_rgb_bytes, bg_rgb_bytes] or None
     """
     mdi_name = MARKER_SYMBOL_REGISTRY.get(symbol_key)
     if mdi_name is None:
         return None
     bg = _color_from_symbol_key(symbol_key)
     fg = b"\xff\xff\xff"  # White foreground for readability
-    return [mdi_name, bg, fg]
+    return [mdi_name, fg, bg]
 
 
 # ============================================================================
@@ -317,7 +317,7 @@ def unpack_telemetry_stream(stream_data: List) -> List[Dict]:
     The stream format from Sideband is:
     [[source_hash, timestamp, packed_telemetry, appearance], ...]
 
-    Where appearance is optional: [icon_name, bg_bytes(3), fg_bytes(3)]
+    Where appearance is optional: [icon_name, fg_bytes(3), bg_bytes(3)]
 
     Args:
         stream_data: List of telemetry stream entries
@@ -365,12 +365,12 @@ def unpack_telemetry_stream(stream_data: List) -> List[Dict]:
             location_event['source_hash'] = source_hash_hex
 
             # Parse appearance if present
-            # Sideband format: [icon_name, background_rgb_bytes, foreground_rgb_bytes]
+            # Sideband format: [icon_name, foreground_rgb_bytes, background_rgb_bytes]
             if appearance and isinstance(appearance, list) and len(appearance) >= 3:
                 try:
                     icon_name = appearance[0]
-                    bg_bytes = appearance[1]
-                    fg_bytes = appearance[2]
+                    fg_bytes = appearance[1]
+                    bg_bytes = appearance[2]
 
                     # Validate icon name - alphanumeric, underscores, and hyphens only, max 50 chars
                     # MDI icon names use hyphens (e.g. "sail-boat", "access-point-network")
@@ -2830,8 +2830,8 @@ class ReticulumWrapper:
                             if isinstance(icon_data, list) and len(icon_data) >= 3:
                                 location_event['appearance'] = {
                                     'icon_name': icon_data[0],
-                                    'background_color': icon_data[1].hex() if isinstance(icon_data[1], bytes) else icon_data[1],
-                                    'foreground_color': icon_data[2].hex() if isinstance(icon_data[2], bytes) else icon_data[2],
+                                    'foreground_color': icon_data[1].hex() if isinstance(icon_data[1], bytes) else icon_data[1],
+                                    'background_color': icon_data[2].hex() if isinstance(icon_data[2], bytes) else icon_data[2],
                                 }
                         except Exception:
                             pass
@@ -3088,8 +3088,8 @@ class ReticulumWrapper:
                     if isinstance(icon_data, list) and len(icon_data) >= 3:
                         icon_appearance = {
                             'icon_name': icon_data[0],
-                            'background_color': icon_data[1].hex() if isinstance(icon_data[1], bytes) else icon_data[1],
-                            'foreground_color': icon_data[2].hex() if isinstance(icon_data[2], bytes) else icon_data[2],
+                            'foreground_color': icon_data[1].hex() if isinstance(icon_data[1], bytes) else icon_data[1],
+                            'background_color': icon_data[2].hex() if isinstance(icon_data[2], bytes) else icon_data[2],
                         }
                         log_debug("ReticulumWrapper", "_on_lxmf_delivery",
                                  f"Parsed icon appearance: {icon_appearance['icon_name']}")
@@ -3517,7 +3517,7 @@ class ReticulumWrapper:
                     log_info("ReticulumWrapper", "send_lxmf_message", f"📎 Attaching {len(field_5_data)} file(s)")
 
             # Add icon appearance to outgoing messages if provided (Sideband/MeshChat interop)
-            # Format: [icon_name, bg_bytes(3), fg_bytes(3)] - same as Sideband wire format
+            # Format: [icon_name, fg_bytes(3), bg_bytes(3)] - same as Sideband wire format
             if icon_name and icon_fg_color and icon_bg_color:
                 if fields is None:
                     fields = {}
@@ -3525,8 +3525,8 @@ class ReticulumWrapper:
                 bg_bytes = bytes.fromhex(icon_bg_color)
                 fields[FIELD_ICON_APPEARANCE] = [
                     icon_name,
-                    bg_bytes,
-                    fg_bytes
+                    fg_bytes,
+                    bg_bytes
                 ]
                 log_info("ReticulumWrapper", "send_lxmf_message",
                         f"📎 Adding icon appearance: {icon_name}, fg={icon_fg_color} ({fg_bytes.hex()}), bg={icon_bg_color} ({bg_bytes.hex()})")
@@ -3822,7 +3822,7 @@ class ReticulumWrapper:
                 try:
                     fg_bytes = bytes.fromhex(icon_fg_color)
                     bg_bytes = bytes.fromhex(icon_bg_color)
-                    fields[FIELD_ICON_APPEARANCE] = [icon_name, bg_bytes, fg_bytes]
+                    fields[FIELD_ICON_APPEARANCE] = [icon_name, fg_bytes, bg_bytes]
                     log_debug("ReticulumWrapper", "send_location_telemetry",
                               f"📎 Adding icon appearance: {icon_name}")
                 except (ValueError, TypeError) as e:
@@ -4458,7 +4458,7 @@ class ReticulumWrapper:
                         f"📎 Replying to message: {reply_to_message_id[:16]}...")
 
             # Add icon appearance to outgoing messages if provided (Sideband/MeshChat interop)
-            # Format: [icon_name, bg_bytes(3), fg_bytes(3)] - same as Sideband wire format
+            # Format: [icon_name, fg_bytes(3), bg_bytes(3)] - same as Sideband wire format
             if icon_name and icon_fg_color and icon_bg_color:
                 if fields is None:
                     fields = {}
@@ -4466,8 +4466,8 @@ class ReticulumWrapper:
                 bg_bytes = bytes.fromhex(icon_bg_color)
                 fields[FIELD_ICON_APPEARANCE] = [
                     icon_name,
-                    bg_bytes,
-                    fg_bytes
+                    fg_bytes,
+                    bg_bytes
                 ]
                 log_info("ReticulumWrapper", "send_lxmf_message_with_method",
                         f"📎 Adding icon appearance: {icon_name}, fg={icon_fg_color} ({fg_bytes.hex()}), bg={icon_bg_color} ({bg_bytes.hex()})")
@@ -6068,12 +6068,12 @@ class ReticulumWrapper:
                                                  f"Field 16: app extensions with keys {list(value.keys())}")
 
                                 elif key == 4 and isinstance(value, list) and len(value) >= 3:
-                                    # Field 4 (FIELD_ICON_APPEARANCE): [icon_name, bg_rgb, fg_rgb]
+                                    # Field 4 (FIELD_ICON_APPEARANCE): [icon_name, fg_rgb, bg_rgb]
                                     try:
                                         icon_appearance = {
                                             'icon_name': value[0],
-                                            'background_color': value[1].hex() if isinstance(value[1], bytes) else value[1],
-                                            'foreground_color': value[2].hex() if isinstance(value[2], bytes) else value[2],
+                                            'foreground_color': value[1].hex() if isinstance(value[1], bytes) else value[1],
+                                            'background_color': value[2].hex() if isinstance(value[2], bytes) else value[2],
                                         }
                                         message_event['icon_appearance'] = icon_appearance
                                         fields_serialized['4'] = icon_appearance

--- a/python/test_telemetry_host_mode.py
+++ b/python/test_telemetry_host_mode.py
@@ -214,13 +214,13 @@ class TestUnpackTelemetryStream(unittest.TestCase):
     def test_parses_valid_appearance(self):
         """Should parse valid appearance data.
 
-        Sideband format: [icon_name, bg_rgb_bytes, fg_rgb_bytes]
+        Sideband format: [icon_name, fg_rgb_bytes, bg_rgb_bytes]
         """
         source_hash = bytes.fromhex("a1" * 16)
         timestamp = 1703980800
         packed_telemetry = self._create_valid_packed_telemetry()
-        # Sideband format: [icon_name, bg_bytes, fg_bytes]
-        appearance = ["icon_name", b'\xff\x00\x00', b'\x00\xff\x00']  # Red bg, green fg
+        # Sideband format: [icon_name, fg_bytes, bg_bytes]
+        appearance = ["icon_name", b'\xff\x00\x00', b'\x00\xff\x00']  # Red fg, green bg
 
         stream = [[source_hash, timestamp, packed_telemetry, appearance]]
         result = unpack_telemetry_stream(stream)
@@ -228,8 +228,8 @@ class TestUnpackTelemetryStream(unittest.TestCase):
         self.assertEqual(len(result), 1)
         self.assertIn('appearance', result[0])
         self.assertEqual(result[0]['appearance']['icon_name'], 'icon_name')
-        self.assertEqual(result[0]['appearance']['background_color'], 'ff0000')
-        self.assertEqual(result[0]['appearance']['foreground_color'], '00ff00')
+        self.assertEqual(result[0]['appearance']['foreground_color'], 'ff0000')
+        self.assertEqual(result[0]['appearance']['background_color'], '00ff00')
 
     def test_handles_appearance_with_invalid_icon_name(self):
         """Should reject appearance with invalid icon name (special chars)."""


### PR DESCRIPTION
The LXMF icon appearance field (0x04) format used by Sideband and
MeshChat is [icon_name, fg_bytes, bg_bytes], but Columba had the
colors reversed as [icon_name, bg_bytes, fg_bytes]. This caused icons
to render with swapped colors in other LXMF clients while appearing
correct within Columba (which consistently used the wrong order for
both packing and unpacking).

Fixed all packing locations (send_lxmf_message, send_location_telemetry,
send_lxmf_message_with_method, appearance_from_marker_symbol) and all
unpacking locations (_on_lxmf_delivery, poll_received_messages,
unpack_telemetry_stream) to use the correct [name, fg, bg] order.

https://claude.ai/code/session_01XYEj7YKEJhABdHSUaXpiHy