### PR TITLE
fix: move triggerSync StateFlow wait off Main thread (COLUMBA-13)

### DIFF
--- a/app/src/main/java/com/lxmf/messenger/di/InterfaceDatabaseModule.kt
+++ b/app/src/main/java/com/lxmf/messenger/di/InterfaceDatabaseModule.kt
@@ -20,7 +20,9 @@ import dagger.Provides
 import dagger.hilt.InstallIn
 import dagger.hilt.android.qualifiers.ApplicationContext
 import dagger.hilt.components.SingletonComponent
+import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.SupervisorJob
 import javax.inject.Provider
 import javax.inject.Qualifier
@@ -32,6 +34,13 @@ import javax.inject.Singleton
 @Retention(AnnotationRetention.RUNTIME)
 @Qualifier
 annotation class ApplicationScope
+
+/**
+ * Qualifier for the default coroutine dispatcher (testable alternative to hardcoding Dispatchers.Default).
+ */
+@Retention(AnnotationRetention.RUNTIME)
+@Qualifier
+annotation class DefaultDispatcher
 
 /**
  * Hilt module for providing the Interface database and related DAOs.
@@ -46,6 +55,13 @@ object InterfaceDatabaseModule {
     @Provides
     @Singleton
     fun provideApplicationScope(): CoroutineScope = CoroutineScope(SupervisorJob())
+
+    /**
+     * Provides the default dispatcher for background work that needs to be off the Main thread.
+     */
+    @DefaultDispatcher
+    @Provides
+    fun provideDefaultDispatcher(): CoroutineDispatcher = Dispatchers.Default
 
     /**
      * Provides the Interface database singleton.

--- a/app/src/test/java/com/lxmf/messenger/service/PropagationNodeManagerTest.kt
+++ b/app/src/test/java/com/lxmf/messenger/service/PropagationNodeManagerTest.kt
@@ -142,6 +142,7 @@ class PropagationNodeManagerTest {
                 announceRepository = announceRepository,
                 reticulumProtocol = reticulumProtocol,
                 scope = testScope.backgroundScope,
+                defaultDispatcher = testDispatcher,
             )
     }
 
@@ -1007,6 +1008,7 @@ class PropagationNodeManagerTest {
                     announceRepository = announceRepository,
                     reticulumProtocol = reticulumProtocol,
                     scope = backgroundScope,
+                    defaultDispatcher = testDispatcher,
                 )
 
             // Verify relay state starts as Loading
@@ -1056,6 +1058,7 @@ class PropagationNodeManagerTest {
                     announceRepository = announceRepository,
                     reticulumProtocol = reticulumProtocol,
                     scope = backgroundScope,
+                    defaultDispatcher = testDispatcher,
                 )
 
             // When: Trigger sync with silent=true
@@ -1102,6 +1105,7 @@ class PropagationNodeManagerTest {
                     announceRepository = announceRepository,
                     reticulumProtocol = reticulumProtocol,
                     scope = backgroundScope,
+                    defaultDispatcher = testDispatcher,
                 )
 
             val mockSyncState =
@@ -2214,6 +2218,7 @@ class PropagationNodeManagerTest {
                     announceRepository = announceRepository,
                     reticulumProtocol = reticulumProtocol,
                     scope = testScope.backgroundScope,
+                    defaultDispatcher = testDispatcher,
                 )
 
             // When: Start is called - exercises the nodeType logging code path
@@ -2252,6 +2257,7 @@ class PropagationNodeManagerTest {
                     announceRepository = announceRepository,
                     reticulumProtocol = reticulumProtocol,
                     scope = testScope.backgroundScope,
+                    defaultDispatcher = testDispatcher,
                 )
 
             // When: Start is called - exercises the warning log code path
@@ -2287,6 +2293,7 @@ class PropagationNodeManagerTest {
                     announceRepository = announceRepository,
                     reticulumProtocol = reticulumProtocol,
                     scope = testScope.backgroundScope,
+                    defaultDispatcher = testDispatcher,
                 )
 
             // When: Start is called (should not throw) - exercises exception handler
@@ -2333,6 +2340,7 @@ class PropagationNodeManagerTest {
                     announceRepository = announceRepository,
                     reticulumProtocol = reticulumProtocol,
                     scope = testScope.backgroundScope,
+                    defaultDispatcher = testDispatcher,
                 )
 
             // Wait for StateFlow to emit
@@ -2385,6 +2393,7 @@ class PropagationNodeManagerTest {
                     announceRepository = announceRepository,
                     reticulumProtocol = reticulumProtocol,
                     scope = testScope.backgroundScope,
+                    defaultDispatcher = testDispatcher,
                 )
 
             // Wait for StateFlow to emit


### PR DESCRIPTION
## Summary
- Wraps `currentRelayState.first { Loaded }` in `withContext(Dispatchers.Default)` inside `triggerSync()` to prevent ANR when callers dispatch on Main
- Fixes [COLUMBA-13](https://torlando-tech.sentry.io/issues/COLUMBA-13) — 33 occurrences, 18 affected users

## Root Cause
All 3 `triggerSync()` call sites use `viewModelScope.launch` which defaults to `Dispatchers.Main`. The `currentRelayState` StateFlow starts as `Loading` and only transitions to `Loaded` after a Room DB query completes. If the DB is slow or the `WhileSubscribed(5000L)` flow expired, `.first()` suspends on Main for up to 10 seconds, triggering an ANR.

## Test plan
- [ ] CI passes `PropagationNodeManagerTest` (existing tests exercise `triggerSync` with test dispatchers)
- [ ] Manual: tap "Sync Now" on Settings screen — no ANR
- [ ] Verify with `adb shell dumpsys activity anr` after testing

🤖 Generated with [Claude Code](https://claude.com/claude-code)