### PR TITLE
feat: restore armeabi-v7a (32-bit ARM) support

### DIFF
--- a/.github/workflows/build-prerelease-apk.yml
+++ b/.github/workflows/build-prerelease-apk.yml
@@ -107,7 +107,9 @@ jobs:
               [ -f "$apk" ] || continue
               filename=$(basename "$apk")
               
-              if echo "$filename" | grep -q "arm64-v8a"; then
+              if echo "$filename" | grep -q "armeabi-v7a"; then
+                cp "$apk" "columba-armeabi-v7a${suffix}.apk"
+              elif echo "$filename" | grep -q "arm64-v8a"; then
                 cp "$apk" "columba-arm64${suffix}.apk"
               elif echo "$filename" | grep -q "x86_64"; then
                 cp "$apk" "columba-x86_64${suffix}.apk"
@@ -171,11 +173,13 @@ jobs:
             - No debug features
 
             **APKs by architecture (standard build with crash reporting):**
+            - `columba-armeabi-v7a.apk` — Older 32-bit ARM phones (armeabi-v7a)
             - `columba-arm64.apk` — Most Android phones (arm64-v8a)
             - `columba-x86_64.apk` — Chromebooks & emulators (x86_64)
             - `columba-universal.apk` — Universal fallback (all architectures)
 
             **No-telemetry variants (privacy-focused, no Sentry):**
+            - `columba-armeabi-v7a-no-sentry.apk`
             - `columba-arm64-no-sentry.apk`
             - `columba-x86_64-no-sentry.apk`
             - `columba-universal-no-sentry.apk`

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -83,7 +83,9 @@ jobs:
             for apk in "$APK_DIR/$flavor/release/"*.apk; do
               filename=$(basename "$apk")
               
-              if echo "$filename" | grep -q "arm64-v8a"; then
+              if echo "$filename" | grep -q "armeabi-v7a"; then
+                cp "$apk" "columba-${VERSION}-armeabi-v7a${suffix}.apk"
+              elif echo "$filename" | grep -q "arm64-v8a"; then
                 cp "$apk" "columba-${VERSION}-arm64${suffix}.apk"
               elif echo "$filename" | grep -q "x86_64"; then
                 cp "$apk" "columba-${VERSION}-x86_64${suffix}.apk"
@@ -136,6 +138,7 @@ jobs:
             **Architecture-specific APKs (recommended — smaller download):**
             | APK | Architecture | Devices |
             |-----|-------------|---------|
+            | `columba-${{ steps.version.outputs.version }}-armeabi-v7a.apk` | armeabi-v7a | Older 32-bit ARM phones & tablets |
             | `columba-${{ steps.version.outputs.version }}-arm64.apk` | arm64-v8a | Most modern Android phones & tablets |
             | `columba-${{ steps.version.outputs.version }}-x86_64.apk` | x86_64 | Chromebooks, emulators, some tablets |
             | `columba-${{ steps.version.outputs.version }}-universal.apk` | All | Universal fallback (larger download) |

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -121,8 +121,8 @@ android {
         }
 
         ndk {
-            // 64-bit ABIs supported by Python 3.11 + pycodec2 wheels
-            abiFilters += listOf("arm64-v8a", "x86_64")
+            // armeabi-v7a restored: pycodec2 removed in favor of LXST (Kotlin/C++)
+            abiFilters += listOf("armeabi-v7a", "arm64-v8a", "x86_64")
         }
     }
 
@@ -257,7 +257,7 @@ android {
         abi {
             isEnable = true
             reset()
-            include("arm64-v8a", "x86_64")
+            include("armeabi-v7a", "arm64-v8a", "x86_64")
             isUniversalApk = true // Fallback APK containing all ABIs
         }
     }
@@ -297,7 +297,7 @@ android {
 // This keeps ABI variants close together (e.g. 801000, 801001, 801002) so they read as
 // the same release in Sentry and other tools. Safe because release builds always have
 // commitCount=0, leaving the ones place free for the ABI discriminator.
-val abiVersionCodes = mapOf("arm64-v8a" to 1, "x86_64" to 2)
+val abiVersionCodes = mapOf("armeabi-v7a" to 1, "arm64-v8a" to 2, "x86_64" to 3)
 androidComponents {
     onVariants { variant ->
         variant.outputs.forEach { output ->

--- a/reticulum/build.gradle.kts
+++ b/reticulum/build.gradle.kts
@@ -17,9 +17,8 @@ android {
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
 
         ndk {
-            // Python 3.11 supports 64-bit ABIs
-            // TODO: x86_64 disabled until pycodec2 wheel resolution issue is fixed
-            abiFilters += listOf("arm64-v8a")
+            // armeabi-v7a restored: pycodec2 removed in favor of LXST (Kotlin/C++)
+            abiFilters += listOf("armeabi-v7a", "arm64-v8a", "x86_64")
         }
     }
 


### PR DESCRIPTION
pycodec2 was the only dependency blocking 32-bit ARM support, and it has
since been replaced by LXST (Kotlin/C++). Re-enable armeabi-v7a across
build config, ABI splits, and CI workflows. Also re-enables x86_64 in
the reticulum module which was disabled for the same reason.

Closes #447

https://claude.ai/code/session_01GpJHeHvkyDBCTDGfdJYP2p