### PR TITLE
fix: disable RNodeCompanionService on pre-API 31 devices

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -143,6 +143,7 @@
         <!-- System binds this service when associated RNode is in range/connected -->
         <service
             android:name=".service.RNodeCompanionService"
+            android:enabled="@bool/enable_companion_service"
             android:exported="true"
             android:permission="android.permission.BIND_COMPANION_DEVICE_SERVICE">
             <intent-filter>

--- a/app/src/main/res/values-v31/companion_service.xml
+++ b/app/src/main/res/values-v31/companion_service.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <bool name="enable_companion_service">true</bool>
+</resources>

--- a/app/src/main/res/values/companion_service.xml
+++ b/app/src/main/res/values/companion_service.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <bool name="enable_companion_service">false</bool>
+</resources>


### PR DESCRIPTION
## Summary
- Fixes crash on Samsung Galaxy S8 (API 26-28) caused by `CompanionDeviceService` class verification at startup
- Uses resource-qualified `android:enabled` attribute to gate `RNodeCompanionService` — disabled by default (`values/`), enabled on API 31+ (`values-v31/`)
- No behavior change on API 31+ devices; companion device functionality remains intact

## Context
`RNodeCompanionService` extends `CompanionDeviceService` (added in API 31), but the app's `minSdk` is 24. Samsung devices perform aggressive class verification on all manifest-declared components, crashing when the superclass doesn't exist — even though the runtime code path is already guarded with API checks.

## Test plan
- [x] Build succeeds (`assembleNoSentryDebug`)
- [x] Merged manifest includes `android:enabled="@bool/enable_companion_service"`
- [ ] Verify app launches without crash on API 26-28 device/emulator
- [ ] Verify RNode companion pairing still works on API 31+ device

🤖 Generated with [Claude Code](https://claude.com/claude-code)