### PR TITLE
Add option to unset group host in location sharing settings

### DIFF
--- a/app/src/main/java/com/lxmf/messenger/ui/screens/settings/cards/LocationSharingCard.kt
+++ b/app/src/main/java/com/lxmf/messenger/ui/screens/settings/cards/LocationSharingCard.kt
@@ -646,6 +646,10 @@ private fun TelemetryCollectorSection(
                     onCollectorAddressChange(contact.destinationHash.lowercase())
                     showContactPicker = false
                 },
+                onUnset = {
+                    onCollectorAddressChange(null)
+                    showContactPicker = false
+                },
                 onDismiss = { showContactPicker = false },
             )
         }
@@ -1213,6 +1217,7 @@ private fun GroupHostPickerDialog(
     contacts: List<EnrichedContact>,
     selectedHash: String?,
     onContactSelected: (EnrichedContact) -> Unit,
+    onUnset: () -> Unit,
     onDismiss: () -> Unit,
 ) {
     AlertDialog(
@@ -1239,6 +1244,33 @@ private fun GroupHostPickerDialog(
                     LazyColumn(
                         modifier = Modifier.heightIn(max = 350.dp),
                     ) {
+                        // "None" option to unset the group host
+                        if (selectedHash != null) {
+                            item {
+                                Row(
+                                    verticalAlignment = Alignment.CenterVertically,
+                                    modifier =
+                                        Modifier
+                                            .fillMaxWidth()
+                                            .clickable(onClick = onUnset)
+                                            .padding(horizontal = 8.dp, vertical = 12.dp),
+                                ) {
+                                    Icon(
+                                        imageVector = Icons.Default.Person,
+                                        contentDescription = null,
+                                        tint = MaterialTheme.colorScheme.onSurfaceVariant,
+                                        modifier = Modifier.size(40.dp),
+                                    )
+                                    Spacer(modifier = Modifier.width(12.dp))
+                                    Text(
+                                        text = "None",
+                                        style = MaterialTheme.typography.bodyLarge,
+                                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                                    )
+                                }
+                                HorizontalDivider()
+                            }
+                        }
                         items(contacts.sortedBy { it.displayName.lowercase() }) { contact ->
                             GroupHostContactRow(
                                 contact = contact,


### PR DESCRIPTION
## Summary
Added the ability to clear/unset the selected group host in the location sharing settings dialog by introducing a "None" option at the top of the contact picker list.

## Key Changes
- Added `onUnset` callback parameter to `GroupHostPickerDialog` function
- Implemented "None" option in the contact picker that appears when a host is currently selected
- The "None" option triggers the `onUnset` callback and closes the picker dialog
- Updated the `TelemetryCollectorSection` to pass the `onUnset` handler that clears the collector address

## Implementation Details
- The "None" option is conditionally displayed only when `selectedHash != null` to avoid showing it when no host is selected
- Uses a `Row` with a `Person` icon and "None" text, styled consistently with other contact options
- Includes a `HorizontalDivider` to visually separate the "None" option from the contact list
- The option is placed at the top of the LazyColumn before the sorted contacts list

https://claude.ai/code/session_012ee1TaQ2kHT9VRgsPaYVVa