### PR TITLE
Add Password keyboard type to password input fields

### DIFF
--- a/app/src/main/java/com/lxmf/messenger/ui/screens/MigrationScreen.kt
+++ b/app/src/main/java/com/lxmf/messenger/ui/screens/MigrationScreen.kt
@@ -56,6 +56,8 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.foundation.text.KeyboardOptions
+import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.ui.text.input.PasswordVisualTransformation
 import androidx.compose.ui.text.input.VisualTransformation
 import androidx.compose.ui.text.style.TextAlign
@@ -856,6 +858,7 @@ internal fun PasswordDialog(
                     },
                     label = { Text("Password") },
                     singleLine = true,
+                    keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Password),
                     visualTransformation =
                         if (passwordVisible) VisualTransformation.None
                         else PasswordVisualTransformation(),
@@ -877,6 +880,7 @@ internal fun PasswordDialog(
                         },
                         label = { Text("Confirm password") },
                         singleLine = true,
+                        keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Password),
                         visualTransformation =
                             if (passwordVisible) VisualTransformation.None
                             else PasswordVisualTransformation(),


### PR DESCRIPTION
## Summary
Added proper keyboard type configuration to password input fields in the MigrationScreen's PasswordDialog to improve user experience on mobile devices.

## Key Changes
- Added `KeyboardOptions` import from `androidx.compose.foundation.text`
- Added `KeyboardType` import from `androidx.compose.ui.text.input`
- Applied `keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Password)` to the password input field
- Applied `keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Password)` to the confirm password input field

## Implementation Details
By setting the keyboard type to `KeyboardType.Password`, the on-screen keyboard will now display appropriate input options for password fields (typically hiding characters and disabling autocorrect/suggestions). This improves the user experience when entering passwords on mobile devices and follows Android/Compose best practices for sensitive input fields.

https://claude.ai/code/session_01TjG6GLMhjnTX8SNxRDQz6Q