### PR TITLE
fix: make announce filter dialog scrollable on short displays

### DIFF
--- a/app/src/main/java/com/lxmf/messenger/ui/screens/AnnounceStreamScreen.kt
+++ b/app/src/main/java/com/lxmf/messenger/ui/screens/AnnounceStreamScreen.kt
@@ -17,7 +17,9 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.rememberLazyListState
+import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Campaign
 import androidx.compose.material.icons.filled.Chat
@@ -419,7 +421,7 @@ fun NodeTypeFilterDialog(
         },
         text = {
             Column(
-                modifier = Modifier.fillMaxWidth(),
+                modifier = Modifier.fillMaxWidth().verticalScroll(rememberScrollState()),
                 verticalArrangement = Arrangement.spacedBy(8.dp),
             ) {
                 Text(


### PR DESCRIPTION
## Summary
- Adds `verticalScroll` to the `NodeTypeFilterDialog` column so all 9 checkbox rows (3 node types + audio + 5 interface types) are accessible on shorter phone screens

Closes #480

## Test plan
- [ ] Open the announce filter dialog on a short-display device (or emulator with small screen)
- [ ] Verify all checkboxes (including the bottom interface type filters) are reachable by scrolling
- [ ] Verify the dialog still looks correct on larger displays (no unnecessary scrollbar)

🤖 Generated with [Claude Code](https://claude.com/claude-code)