### PR TITLE
fix: use build-time config for copyright year

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -114,6 +114,7 @@ android {
 
         buildConfigField("String", "GIT_COMMIT_HASH", "\"${getGitCommitHash()}\"")
         buildConfigField("long", "BUILD_TIMESTAMP", "${System.currentTimeMillis()}L")
+        buildConfigField("String", "COPYRIGHT_YEAR", "\"2026\"")
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
         vectorDrawables {

--- a/app/src/main/java/com/lxmf/messenger/ui/screens/settings/cards/AboutCard.kt
+++ b/app/src/main/java/com/lxmf/messenger/ui/screens/settings/cards/AboutCard.kt
@@ -142,7 +142,7 @@ fun AboutCard(
                     color = MaterialTheme.colorScheme.onSurfaceVariant,
                 )
                 Text(
-                    text = "© 2025 Columba Contributors",
+                    text = "© 2025–${com.lxmf.messenger.BuildConfig.COPYRIGHT_YEAR} Columba Contributors",
                     style = MaterialTheme.typography.bodySmall,
                     color = MaterialTheme.colorScheme.onSurfaceVariant,
                 )


### PR DESCRIPTION
## Summary

Replaces the hardcoded "2025" copyright year with `BuildConfig.COPYRIGHT_YEAR`, set at build time in `build.gradle.kts`. This supersedes PRs #495 and #496 which used `Calendar.getInstance().get(Calendar.YEAR)` — a runtime approach that reads from the device's system clock, which users can set to any date.

**Why not dynamic year?**
- A user with their clock set to 2030 or 1999 would see a wrong copyright range
- Copyright years should reflect when the code was *actually written*, not what the device thinks the date is
- Build-time config is the standard approach (same pattern as `GIT_COMMIT_HASH` and `BUILD_TIMESTAMP`)

**Maintenance**: Update the `COPYRIGHT_YEAR` value in `app/build.gradle.kts` once per year.

Closes #490
Supersedes #495, #496

## Test plan

- [ ] Open Settings > About — verify copyright shows "2025–2026"
- [ ] Change device date to 2030 — copyright should still show "2025–2026"
- [ ] Change device date to 2024 — copyright should still show "2025–2026"


🤖 Generated with [Claude Code](https://claude.com/claude-code)