### PR TITLE
fix: use build-time config for copyright year

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -114,6 +114,7 @@ android {
 
         buildConfigField("String", "GIT_COMMIT_HASH", "\"${getGitCommitHash()}\"")
         buildConfigField("long", "BUILD_TIMESTAMP", "${System.currentTimeMillis()}L")
+        buildConfigField("String", "COPYRIGHT_YEAR", "\"2026\"")
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
         vectorDrawables {

--- a/app/src/main/java/com/lxmf/messenger/ui/screens/settings/cards/AboutCard.kt
+++ b/app/src/main/java/com/lxmf/messenger/ui/screens/settings/cards/AboutCard.kt
@@ -142,7 +142,7 @@ fun AboutCard(
                     color = MaterialTheme.colorScheme.onSurfaceVariant,
                 )
                 Text(
-                    text = "© 2025 Columba Contributors",
+                    text = "© 2025–${com.lxmf.messenger.BuildConfig.COPYRIGHT_YEAR} Columba Contributors",
                     style = MaterialTheme.typography.bodySmall,
                     color = MaterialTheme.colorScheme.onSurfaceVariant,
                 )


### PR DESCRIPTION
## Summary
- Backport: replaces hardcoded "© 2025" with `BuildConfig.COPYRIGHT_YEAR` set at build time
- Copyright year is an intentional release-time decision, not a runtime auto-update

Cherry-pick of the same fix targeting main.

## Changes
| File | Change |
|------|--------|
| `app/build.gradle.kts` | Add `COPYRIGHT_YEAR` BuildConfig field |
| `AboutCard.kt:145` | Use `BuildConfig.COPYRIGHT_YEAR` instead of hardcoded "2025" |

## Test plan
- [ ] Open Settings > About — verify copyright shows "© 2025–2026 Columba Contributors"

🤖 Generated with [Claude Code](https://claude.com/claude-code)