### PR TITLE
fix: QR scanning fails on LineageOS due to camera row stride mismatch

### DIFF
--- a/app/src/main/java/com/lxmf/messenger/ui/screens/QrScannerScreen.kt
+++ b/app/src/main/java/com/lxmf/messenger/ui/screens/QrScannerScreen.kt
@@ -20,7 +20,6 @@ import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Spacer
-import androidx.compose.foundation.layout.consumeWindowInsets
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
@@ -173,8 +172,7 @@ fun QrScannerScreen(
             modifier =
                 Modifier
                     .fillMaxSize()
-                    .padding(paddingValues)
-                    .consumeWindowInsets(paddingValues),
+                    .padding(paddingValues),
         ) {
             when {
                 !hasCameraPermission -> {
@@ -576,6 +574,7 @@ private class QrCodeAnalyzer(
             val hints =
                 mapOf(
                     DecodeHintType.POSSIBLE_FORMATS to listOf(BarcodeFormat.QR_CODE),
+                    DecodeHintType.TRY_HARDER to true,
                 )
             setHints(hints)
         }
@@ -600,10 +599,15 @@ private class QrCodeAnalyzer(
             val data = ByteArray(buffer.remaining())
             buffer.get(data)
 
+            // Use rowStride as dataWidth — on some devices (e.g. LineageOS/Xperia)
+            // the row stride includes padding bytes beyond the image width, and using
+            // imageProxy.width would misalign every row after the first.
+            val rowStride = plane.rowStride
+
             val source =
                 PlanarYUVLuminanceSource(
                     data,
-                    imageProxy.width,
+                    rowStride,
                     imageProxy.height,
                     0,
                     0,


### PR DESCRIPTION
## Summary
Cherry-pick of #500 onto `release/v0.8.x`.

- Use `plane.rowStride` instead of `imageProxy.width` as `dataWidth` in `PlanarYUVLuminanceSource` — fixes row misalignment on devices where the Y plane has padding bytes (e.g. Xperia 10 V / LineageOS)
- Add `TRY_HARDER` decode hint for improved QR detection reliability
- Remove `consumeWindowInsets` so bottom instruction card respects navigation bar padding on 3-button nav devices

Fixes #477

🤖 Generated with [Claude Code](https://claude.com/claude-code)