### PR TITLE
fix: send pending file notification eagerly on propagation fallback

### DIFF
--- a/python/reticulum_wrapper.py
+++ b/python/reticulum_wrapper.py
@@ -4801,7 +4801,7 @@ class ReticulumWrapper:
                 # propagation to succeed because: (a) propagation may fail entirely, leaving
                 # the recipient uninformed, and (b) the direct link to the recipient likely
                 # still works (the original failure was a size-limit rejection, not a path failure).
-                if hasattr(lxmf_message, 'fields') and lxmf_message.fields and 5 in lxmf_message.fields:
+                if hasattr(lxmf_message, 'fields') and lxmf_message.fields and FIELD_FILE_ATTACHMENTS in lxmf_message.fields:
                     log_info("ReticulumWrapper", "_on_message_failed",
                              f"📬 Sending pending file notification eagerly for {msg_hash[:16]}...")
                     self._send_pending_file_notification(lxmf_message)


### PR DESCRIPTION
## Summary
- When a large file exceeds the recipient's size limit and falls back to propagation, the recipient should see a "pending file" notification card in the chat. This was broken by three cascading bugs that prevented the notification from ever appearing.
- Sends the notification **eagerly** when falling back to propagation, rather than waiting for propagation to succeed (which may never happen)
- Adds Field 16 (APP_EXTENSIONS_FIELD) to the `meaningful_fields` set so the recipient doesn't filter the notification as an "empty probe message"

## Bugs fixed
1. **Ordering bug**: `_pending_file_notifications` tracking was placed after the immediate-success `return`, so synchronous propagation success skipped notification entirely
2. **Timing bug**: notification waited for propagation to succeed, but if propagation failed (`max_relay_retries_exceeded`), the notification was never sent
3. **Filter bug**: Field 16 was not in `meaningful_fields`, so `_on_lxmf_delivery` discarded the notification as a probe message

## Test plan
- [x] Send large file (55MB APK) from one phone to another with recipient's size limit set low (1MB)
- [x] Verify direct delivery is rejected and falls back to propagation
- [x] Verify "pending file notification" card appears on recipient within seconds
- [x] Verify sender logs show `📬 Sending pending file notification eagerly`
- [x] Verify recipient logs show `📨 _on_lxmf_delivery CALLED!` followed by `✅ Added message to pending_inbound queue`

Cherry-pick of the main PR for the v0.8.x release branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)