### PR TITLE
fix: use Dispatchers.IO for EventHandler coroutines

### DIFF
--- a/app/src/main/java/com/lxmf/messenger/service/manager/EventHandler.kt
+++ b/app/src/main/java/com/lxmf/messenger/service/manager/EventHandler.kt
@@ -12,6 +12,7 @@ import com.lxmf.messenger.service.state.ServiceState
 import com.lxmf.messenger.service.util.PeerNameResolver
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
 import org.json.JSONArray
 import org.json.JSONObject
@@ -75,7 +76,7 @@ class EventHandler(
         Log.d(TAG, "Announce handling started - using event-driven callbacks (polling disabled)")
 
         // One-time drain of pending announces from startup
-        scope.launch {
+        scope.launch(Dispatchers.IO) {
             try {
                 Log.d(TAG, "Draining pending announces from startup queue...")
 
@@ -109,7 +110,7 @@ class EventHandler(
      * is handled via handleMessageReceivedEvent().
      */
     fun drainPendingMessages() {
-        scope.launch {
+        scope.launch(Dispatchers.IO) {
             try {
                 Log.d(TAG, "Draining pending messages from startup queue...")
 
@@ -190,8 +191,9 @@ class EventHandler(
         try {
             Log.d(TAG, "Message received event")
 
-            scope.launch {
+            scope.launch(Dispatchers.IO) {
                 try {
+                    Log.d(TAG, "Message coroutine started on ${Thread.currentThread().name}")
                     val json = JSONObject(messageJson)
 
                     // Check if this is a full message (truly event-driven) or just a notification


### PR DESCRIPTION
## Summary
- Cherry-pick of #516 for release/v0.8.x
- EventHandler's `scope.launch` inherited `Dispatchers.Default` from the service scope, which has only `max(2, numCPU)` threads
- During heavy operations (e.g., large file propagation), all Default threads could become saturated, causing message processing coroutines to queue indefinitely without executing — messages would be received by Python but never persisted or rendered
- Switches all three `scope.launch` calls in EventHandler to `Dispatchers.IO` (scales to 64 threads), which is appropriate for database I/O and Python wrapper calls

## Test plan
- [ ] Send messages between two devices while one is performing a heavy background operation (e.g., large file propagation)
- [ ] Verify messages are persisted and rendered on the receiving device
- [ ] Check logcat for `"Message coroutine started on DefaultDispatcher-worker-..."` confirming the coroutine body executes

🤖 Generated with [Claude Code](https://claude.com/claude-code)