### PR TITLE
Add QR code dialog UX improvements

### DIFF
--- a/app/src/main/java/com/lxmf/messenger/MainActivity.kt
+++ b/app/src/main/java/com/lxmf/messenger/MainActivity.kt
@@ -10,9 +10,9 @@ import android.hardware.usb.UsbManager
 import android.net.Uri
 import android.os.Build
 import android.os.Bundle
-import android.widget.Toast
 import android.provider.Settings
 import android.util.Log
+import android.widget.Toast
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.BackHandler
 import androidx.activity.compose.rememberLauncherForActivityResult
@@ -70,9 +70,9 @@ import com.lxmf.messenger.reticulum.ble.util.BlePermissionManager
 import com.lxmf.messenger.reticulum.protocol.ReticulumProtocol
 import com.lxmf.messenger.service.ReticulumService
 import com.lxmf.messenger.ui.components.BlePermissionBottomSheet
-import com.lxmf.messenger.ui.screens.ApkSharingScreen
 import com.lxmf.messenger.ui.screens.AnnounceDetailScreen
 import com.lxmf.messenger.ui.screens.AnnounceStreamScreen
+import com.lxmf.messenger.ui.screens.ApkSharingScreen
 import com.lxmf.messenger.ui.screens.BleConnectionStatusScreen
 import com.lxmf.messenger.ui.screens.ChatsScreen
 import com.lxmf.messenger.ui.screens.ContactsScreen
@@ -999,6 +999,10 @@ fun ColumbaNavigation(
                                 val encodedHash = Uri.encode(peerHash)
                                 navController.navigate("announce_detail/$encodedHash")
                             },
+                            onNavigateToQrScanner = {
+                                navController.navigate("qr_scanner")
+                            },
+                            settingsViewModel = settingsViewModel,
                         )
                     }
 

--- a/app/src/main/java/com/lxmf/messenger/ui/components/IdentityQrCodeDialogContent.kt
+++ b/app/src/main/java/com/lxmf/messenger/ui/components/IdentityQrCodeDialogContent.kt
@@ -1,5 +1,6 @@
 package com.lxmf.messenger.ui.components
 
+import android.view.WindowManager
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
@@ -22,8 +23,10 @@ import androidx.compose.material3.Text
 import androidx.compose.material3.TopAppBar
 import androidx.compose.material3.TopAppBarDefaults
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.DisposableEffect
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.window.Dialog
@@ -47,10 +50,27 @@ fun IdentityQrCodeDialogContent(
     title: String = "Your Identity",
     actionsContent: @Composable ColumnScope.() -> Unit,
 ) {
+    // Capture Activity context before Dialog (inside Dialog, LocalContext is a ContextThemeWrapper)
+    val activity = LocalContext.current.findActivity()
     Dialog(
         onDismissRequest = onDismiss,
         properties = DialogProperties(usePlatformDefaultWidth = false),
     ) {
+        // Max brightness + keep screen on while showing QR code
+        DisposableEffect(Unit) {
+            val window = activity.window
+            val originalBrightness = window.attributes.screenBrightness
+            window.attributes = window.attributes.also { it.screenBrightness = 1f }
+            window.addFlags(WindowManager.LayoutParams.FLAG_KEEP_SCREEN_ON)
+            onDispose {
+                window.attributes =
+                    window.attributes.also {
+                        it.screenBrightness = originalBrightness
+                    }
+                window.clearFlags(WindowManager.LayoutParams.FLAG_KEEP_SCREEN_ON)
+            }
+        }
+
         Surface(
             modifier =
                 Modifier

--- a/app/src/main/java/com/lxmf/messenger/ui/components/QrCodeBottomSheet.kt
+++ b/app/src/main/java/com/lxmf/messenger/ui/components/QrCodeBottomSheet.kt
@@ -1,0 +1,87 @@
+package com.lxmf.messenger.ui.components
+
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.WindowInsets
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.systemBarsPadding
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.QrCode
+import androidx.compose.material.icons.filled.QrCodeScanner
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.HorizontalDivider
+import androidx.compose.material3.Icon
+import androidx.compose.material3.ListItem
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.ModalBottomSheet
+import androidx.compose.material3.Text
+import androidx.compose.material3.rememberModalBottomSheetState
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun QrCodeBottomSheet(
+    onDismiss: () -> Unit,
+    onScanQrCode: () -> Unit,
+    onShowQrCode: () -> Unit,
+) {
+    val sheetState = rememberModalBottomSheetState(skipPartiallyExpanded = true)
+
+    ModalBottomSheet(
+        onDismissRequest = onDismiss,
+        sheetState = sheetState,
+        contentWindowInsets = { WindowInsets(0) },
+        modifier = Modifier.systemBarsPadding(),
+    ) {
+        Column(
+            modifier = Modifier.fillMaxWidth(),
+        ) {
+            Text(
+                text = "QR Code",
+                style = MaterialTheme.typography.titleLarge,
+                fontWeight = FontWeight.Bold,
+                modifier = Modifier.padding(horizontal = 24.dp, vertical = 8.dp),
+            )
+
+            HorizontalDivider(modifier = Modifier.padding(vertical = 8.dp))
+
+            // Scan QR Code option
+            ListItem(
+                headlineContent = { Text("Scan QR Code") },
+                supportingContent = { Text("Scan a contact's QR code") },
+                leadingContent = {
+                    Icon(
+                        Icons.Default.QrCodeScanner,
+                        contentDescription = null,
+                    )
+                },
+                modifier =
+                    Modifier.clickable {
+                        onDismiss()
+                        onScanQrCode()
+                    },
+            )
+
+            // Show QR Code option
+            ListItem(
+                headlineContent = { Text("Show QR Code") },
+                supportingContent = { Text("Show your QR code for others to scan") },
+                leadingContent = {
+                    Icon(
+                        Icons.Default.QrCode,
+                        contentDescription = null,
+                    )
+                },
+                modifier =
+                    Modifier.clickable {
+                        onDismiss()
+                        onShowQrCode()
+                    },
+            )
+        }
+    }
+}

--- a/app/src/main/java/com/lxmf/messenger/ui/components/QrCodeComposables.kt
+++ b/app/src/main/java/com/lxmf/messenger/ui/components/QrCodeComposables.kt
@@ -1,11 +1,17 @@
 package com.lxmf.messenger.ui.components
 
+import android.app.Activity
+import android.content.Context
+import android.content.ContextWrapper
 import android.graphics.Bitmap
+import android.view.WindowManager
 import androidx.compose.foundation.Image
+import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.aspectRatio
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
@@ -22,6 +28,7 @@ import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
@@ -32,10 +39,13 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.asImageBitmap
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.text.font.FontFamily
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
+import androidx.compose.ui.window.Dialog
+import androidx.compose.ui.window.DialogProperties
 import com.google.zxing.BarcodeFormat
 import com.google.zxing.EncodeHintType
 import com.google.zxing.qrcode.QRCodeWriter
@@ -43,6 +53,16 @@ import com.google.zxing.qrcode.decoder.ErrorCorrectionLevel
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
+
+/** Unwrap a Context to find the Activity, since Dialog wraps context in ContextThemeWrapper. */
+internal fun Context.findActivity(): Activity {
+    var ctx = this
+    while (ctx is ContextWrapper) {
+        if (ctx is Activity) return ctx
+        ctx = ctx.baseContext
+    }
+    error("No Activity found in context chain")
+}
 
 /**
  * Composable that displays a QR code image generated from a data string.
@@ -60,6 +80,7 @@ fun QrCodeImage(
     var qrBitmap by remember(data) { mutableStateOf<Bitmap?>(null) }
     var isLoading by remember(data) { mutableStateOf(true) }
     var error by remember(data) { mutableStateOf<String?>(null) }
+    var expanded by remember { mutableStateOf(false) }
 
     val scope = rememberCoroutineScope()
 
@@ -90,7 +111,10 @@ fun QrCodeImage(
     }
 
     Surface(
-        modifier = modifier.size(size),
+        modifier =
+            modifier
+                .size(size)
+                .clickable(enabled = qrBitmap != null) { expanded = true },
         shape = RoundedCornerShape(12.dp),
         color = Color.White,
         shadowElevation = 4.dp,
@@ -123,6 +147,55 @@ fun QrCodeImage(
                         bitmap = qrBitmap!!.asImageBitmap(),
                         contentDescription = "QR Code",
                         modifier = Modifier.fillMaxSize(),
+                    )
+                }
+            }
+        }
+    }
+
+    // Full-screen expanded QR code overlay
+    val activity = LocalContext.current.findActivity()
+    if (expanded && qrBitmap != null) {
+        Dialog(
+            onDismissRequest = { expanded = false },
+            properties = DialogProperties(usePlatformDefaultWidth = false),
+        ) {
+            // Max brightness + keep screen on while expanded
+            DisposableEffect(Unit) {
+                val window = activity.window
+                val originalBrightness = window.attributes.screenBrightness
+                window.attributes = window.attributes.also { it.screenBrightness = 1f }
+                window.addFlags(WindowManager.LayoutParams.FLAG_KEEP_SCREEN_ON)
+                onDispose {
+                    window.attributes =
+                        window.attributes.also {
+                            it.screenBrightness = originalBrightness
+                        }
+                    window.clearFlags(WindowManager.LayoutParams.FLAG_KEEP_SCREEN_ON)
+                }
+            }
+
+            Surface(
+                modifier =
+                    Modifier
+                        .fillMaxSize()
+                        .clickable { expanded = false },
+                color = Color.White,
+            ) {
+                Box(
+                    modifier =
+                        Modifier
+                            .fillMaxSize()
+                            .padding(24.dp),
+                    contentAlignment = Alignment.Center,
+                ) {
+                    Image(
+                        bitmap = qrBitmap!!.asImageBitmap(),
+                        contentDescription = "QR Code (tap to close)",
+                        modifier =
+                            Modifier
+                                .fillMaxWidth()
+                                .aspectRatio(1f),
                     )
                 }
             }

--- a/app/src/main/java/com/lxmf/messenger/ui/screens/MyIdentityScreen.kt
+++ b/app/src/main/java/com/lxmf/messenger/ui/screens/MyIdentityScreen.kt
@@ -1,6 +1,7 @@
 package com.lxmf.messenger.ui.screens
 
 import android.content.Intent
+import android.view.WindowManager
 import androidx.compose.animation.AnimatedVisibility
 import androidx.compose.animation.core.tween
 import androidx.compose.animation.expandVertically
@@ -58,6 +59,7 @@ import androidx.compose.material3.TextButton
 import androidx.compose.material3.TopAppBar
 import androidx.compose.material3.TopAppBarDefaults
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
@@ -77,6 +79,7 @@ import com.lxmf.messenger.ui.components.IconPickerDialog
 import com.lxmf.messenger.ui.components.Identicon
 import com.lxmf.messenger.ui.components.ProfileIcon
 import com.lxmf.messenger.ui.components.QrCodeImage
+import com.lxmf.messenger.ui.components.findActivity
 import com.lxmf.messenger.viewmodel.DebugViewModel
 import com.lxmf.messenger.viewmodel.SettingsViewModel
 
@@ -916,6 +919,21 @@ private fun IdentityQrCodeDialog(
                 usePlatformDefaultWidth = false,
             ),
     ) {
+        // Max brightness + keep screen on while showing QR code
+        DisposableEffect(Unit) {
+            val window = context.findActivity().window
+            val originalBrightness = window.attributes.screenBrightness
+            window.attributes = window.attributes.also { it.screenBrightness = 1f }
+            window.addFlags(WindowManager.LayoutParams.FLAG_KEEP_SCREEN_ON)
+            onDispose {
+                window.attributes =
+                    window.attributes.also {
+                        it.screenBrightness = originalBrightness
+                    }
+                window.clearFlags(WindowManager.LayoutParams.FLAG_KEEP_SCREEN_ON)
+            }
+        }
+
         Surface(
             modifier = Modifier.fillMaxSize(),
             color = MaterialTheme.colorScheme.background,

--- a/app/src/test/java/com/lxmf/messenger/ui/screens/ChatsScreenTest.kt
+++ b/app/src/test/java/com/lxmf/messenger/ui/screens/ChatsScreenTest.kt
@@ -666,6 +666,8 @@ class ChatsScreenTest {
                 onChatClick = { _, _ -> },
                 onViewPeerDetails = {},
                 viewModel = mockViewModel,
+                settingsViewModel = createMockSettingsViewModel(),
+                debugViewModel = createMockDebugViewModel(),
             )
         }
 
@@ -687,6 +689,8 @@ class ChatsScreenTest {
                 onChatClick = { _, _ -> },
                 onViewPeerDetails = {},
                 viewModel = mockViewModel,
+                settingsViewModel = createMockSettingsViewModel(),
+                debugViewModel = createMockDebugViewModel(),
             )
         }
 
@@ -708,6 +712,8 @@ class ChatsScreenTest {
                 onChatClick = { _, _ -> },
                 onViewPeerDetails = {},
                 viewModel = mockViewModel,
+                settingsViewModel = createMockSettingsViewModel(),
+                debugViewModel = createMockDebugViewModel(),
             )
         }
 
@@ -726,6 +732,8 @@ class ChatsScreenTest {
                 onChatClick = { _, _ -> },
                 onViewPeerDetails = {},
                 viewModel = mockViewModel,
+                settingsViewModel = createMockSettingsViewModel(),
+                debugViewModel = createMockDebugViewModel(),
             )
         }
 
@@ -746,6 +754,8 @@ class ChatsScreenTest {
                 onChatClick = { _, _ -> },
                 onViewPeerDetails = {},
                 viewModel = mockViewModel,
+                settingsViewModel = createMockSettingsViewModel(),
+                debugViewModel = createMockDebugViewModel(),
             )
         }
 
@@ -770,6 +780,8 @@ class ChatsScreenTest {
                 onChatClick = { _, _ -> },
                 onViewPeerDetails = {},
                 viewModel = mockViewModel,
+                settingsViewModel = createMockSettingsViewModel(),
+                debugViewModel = createMockDebugViewModel(),
             )
         }
 
@@ -789,6 +801,8 @@ class ChatsScreenTest {
                 onChatClick = { _, _ -> },
                 onViewPeerDetails = {},
                 viewModel = mockViewModel,
+                settingsViewModel = createMockSettingsViewModel(),
+                debugViewModel = createMockDebugViewModel(),
             )
         }
 
@@ -813,6 +827,8 @@ class ChatsScreenTest {
                 onChatClick = { _, _ -> },
                 onViewPeerDetails = {},
                 viewModel = mockViewModel,
+                settingsViewModel = createMockSettingsViewModel(),
+                debugViewModel = createMockDebugViewModel(),
             )
         }
 
@@ -842,6 +858,8 @@ class ChatsScreenTest {
                 },
                 onViewPeerDetails = {},
                 viewModel = mockViewModel,
+                settingsViewModel = createMockSettingsViewModel(),
+                debugViewModel = createMockDebugViewModel(),
             )
         }
 
@@ -866,6 +884,8 @@ class ChatsScreenTest {
                 onChatClick = { _, _ -> },
                 onViewPeerDetails = {},
                 viewModel = mockViewModel,
+                settingsViewModel = createMockSettingsViewModel(),
+                debugViewModel = createMockDebugViewModel(),
             )
         }
 
@@ -894,6 +914,8 @@ class ChatsScreenTest {
                 onChatClick = { _, _ -> },
                 onViewPeerDetails = {},
                 viewModel = mockViewModel,
+                settingsViewModel = createMockSettingsViewModel(),
+                debugViewModel = createMockDebugViewModel(),
             )
         }
 
@@ -920,6 +942,8 @@ class ChatsScreenTest {
                 onChatClick = { _, _ -> },
                 onViewPeerDetails = {},
                 viewModel = mockViewModel,
+                settingsViewModel = createMockSettingsViewModel(),
+                debugViewModel = createMockDebugViewModel(),
             )
         }
 
@@ -950,6 +974,8 @@ class ChatsScreenTest {
                 onChatClick = { _, _ -> },
                 onViewPeerDetails = {},
                 viewModel = mockViewModel,
+                settingsViewModel = createMockSettingsViewModel(),
+                debugViewModel = createMockDebugViewModel(),
             )
         }
 
@@ -985,5 +1011,25 @@ class ChatsScreenTest {
         every { mockViewModel.isContactSaved(any()) } returns MutableStateFlow(false)
 
         return mockViewModel
+    }
+
+    @Suppress("NoRelaxedMocks")
+    private fun createMockSettingsViewModel(): com.lxmf.messenger.viewmodel.SettingsViewModel {
+        val mock = mockk<com.lxmf.messenger.viewmodel.SettingsViewModel>(relaxed = true)
+        every { mock.state } returns
+            MutableStateFlow(
+                com.lxmf.messenger.viewmodel
+                    .SettingsState(),
+            )
+        return mock
+    }
+
+    @Suppress("NoRelaxedMocks")
+    private fun createMockDebugViewModel(): com.lxmf.messenger.viewmodel.DebugViewModel {
+        val mock = mockk<com.lxmf.messenger.viewmodel.DebugViewModel>(relaxed = true)
+        every { mock.qrCodeData } returns MutableStateFlow(null)
+        every { mock.identityHash } returns MutableStateFlow(null)
+        every { mock.destinationHash } returns MutableStateFlow(null)
+        return mock
     }
 }


### PR DESCRIPTION

<img width="409" height="108" alt="image" src="https://github.com/user-attachments/assets/4eab2a5d-f917-4f1f-a4de-1cff0ee26790" />
<img width="406" height="283" alt="image" src="https://github.com/user-attachments/assets/9942633f-186b-4017-a680-96d1a9e80663" />
<img width="411" height="885" alt="image" src="https://github.com/user-attachments/assets/cdbf9385-7214-4462-9313-3d8aa15a246d" />


## Summary
- Set max screen brightness and `FLAG_KEEP_SCREEN_ON` when any QR code dialog is open, restoring original values on dismiss
- Add tap-to-expand on `QrCodeImage` — tapping opens a full-screen white overlay with a large QR code (tap or back to dismiss)
- Add QR code quick-access button and bottom sheet to ChatsScreen
- Add `Context.findActivity()` helper to safely unwrap `ContextThemeWrapper` inside Compose Dialogs

## Test plan
- [ ] Open any QR dialog — screen brightness should jump to max, screen stays on
- [ ] Dismiss dialog — brightness restores to previous value
- [ ] Tap the QR code image — full-screen white overlay with large QR code appears
- [ ] Tap overlay or press back — returns to normal dialog
- [ ] QR code button in ChatsScreen top bar opens bottom sheet with scan/show options

🤖 Generated with [Claude Code](https://claude.com/claude-code)