### PR TITLE
fix: shutdown now stops foreground service (#455)

### DIFF
--- a/app/src/main/java/com/lxmf/messenger/service/InterfaceConfigManager.kt
+++ b/app/src/main/java/com/lxmf/messenger/service/InterfaceConfigManager.kt
@@ -187,6 +187,12 @@ class InterfaceConfigManager
                 Log.d(TAG, "✓ Ports should be released")
 
                 // Step 7: Start service again (fresh process, no port conflicts)
+                // Clear user shutdown flag so the service starts normally
+                context
+                    .getSharedPreferences("columba_prefs", Context.MODE_PRIVATE)
+                    .edit()
+                    .putBoolean("is_user_shutdown", false)
+                    .commit()
                 Log.d(TAG, "Step 7: Starting ReticulumService in fresh process...")
                 val startIntent =
                     Intent(context, ReticulumService::class.java).apply {

--- a/app/src/main/java/com/lxmf/messenger/viewmodel/DebugViewModel.kt
+++ b/app/src/main/java/com/lxmf/messenger/viewmodel/DebugViewModel.kt
@@ -92,6 +92,7 @@ data class TestAnnounceResult(
 class DebugViewModel
     @Inject
     constructor(
+        @dagger.hilt.android.qualifiers.ApplicationContext private val context: android.content.Context,
         private val reticulumProtocol: ReticulumProtocol,
         private val settingsRepository: SettingsRepository,
         private val identityRepository: com.lxmf.messenger.data.repository.IdentityRepository,
@@ -264,19 +265,26 @@ class DebugViewModel
             fetchDebugInfo()
         }
 
+        /** Check if the service has been shut down (by network status or SharedPreferences flag). */
+        private fun isServiceShutdown(): Boolean {
+            val status = reticulumProtocol.networkStatus.value
+            if (status is com.lxmf.messenger.reticulum.model.NetworkStatus.SHUTDOWN) return true
+            // Also check SharedPreferences flag — onServiceDisconnected may not have fired yet
+            return context
+                .getSharedPreferences("columba_prefs", android.content.Context.MODE_PRIVATE)
+                .getBoolean("is_user_shutdown", false)
+        }
+
         private fun fetchDebugInfo() {
             viewModelScope.launch {
                 try {
-                    // Fetch debug info on IO thread to avoid blocking main thread
-                    // (service.debugInfo is a synchronous AIDL IPC call)
+                    if (isServiceShutdown()) return@launch
+
                     val (pythonDebugInfo, failedInterfaces) =
                         withContext(Dispatchers.IO) {
-                            val debugInfo = reticulumProtocol.getDebugInfo()
-                            val failed = reticulumProtocol.getFailedInterfaces()
-                            Pair(debugInfo, failed)
+                            Pair(reticulumProtocol.getDebugInfo(), reticulumProtocol.getFailedInterfaces())
                         }
 
-                    // Extract interface information (runs on main thread - just data transformation)
                     @Suppress("UNCHECKED_CAST")
                     val interfacesData = pythonDebugInfo["interfaces"] as? List<Map<String, Any>> ?: emptyList()
                     val activeInterfaces =
@@ -287,41 +295,13 @@ class DebugViewModel
                                 online = ifaceMap["online"] as? Boolean ?: false,
                             )
                         }
-
                     val failedInterfaceInfos =
                         failedInterfaces.map { failed ->
-                            InterfaceInfo(
-                                name = failed.name,
-                                // Use name as type since we don't have detailed type info
-                                type = failed.name,
-                                online = false,
-                                error = failed.error,
-                            )
+                            InterfaceInfo(name = failed.name, type = failed.name, online = false, error = failed.error)
                         }
-
-                    // Combine active and failed interfaces
                     val interfaces = activeInterfaces + failedInterfaceInfos
-
-                    // Get status
                     val status = reticulumProtocol.networkStatus.value
-
-                    @Suppress("UNUSED_VARIABLE")
-                    val statusString =
-                        when (status) {
-                            is com.lxmf.messenger.reticulum.model.NetworkStatus.READY -> "READY"
-                            is com.lxmf.messenger.reticulum.model.NetworkStatus.INITIALIZING -> "INITIALIZING"
-                            is com.lxmf.messenger.reticulum.model.NetworkStatus.SHUTDOWN -> "SHUTDOWN"
-                            is com.lxmf.messenger.reticulum.model.NetworkStatus.ERROR -> "ERROR: ${status.message}"
-                            else -> status.toString()
-                        }
-
-                    // Build debug info
                     val wakeLockHeld = pythonDebugInfo["wake_lock_held"] as? Boolean ?: false
-                    Log.d(
-                        TAG,
-                        "DebugViewModel: wake_lock_held from service = $wakeLockHeld, " +
-                            "raw value = ${pythonDebugInfo["wake_lock_held"]}",
-                    )
 
                     _debugInfo.value =
                         DebugInfo(
@@ -336,7 +316,6 @@ class DebugViewModel
                             error =
                                 pythonDebugInfo["error"] as? String
                                     ?: if (status is com.lxmf.messenger.reticulum.model.NetworkStatus.ERROR) status.message else null,
-                            // Process persistence debug info
                             heartbeatAgeSeconds = (pythonDebugInfo["heartbeat_age_seconds"] as? Number)?.toLong() ?: -1,
                             healthCheckRunning = pythonDebugInfo["health_check_running"] as? Boolean ?: false,
                             networkMonitorRunning = pythonDebugInfo["network_monitor_running"] as? Boolean ?: false,
@@ -345,11 +324,12 @@ class DebugViewModel
                             failedInterfaceCount = (pythonDebugInfo["failed_interface_count"] as? Number)?.toInt() ?: 0,
                         )
                 } catch (e: Exception) {
-                    Log.e(TAG, "Error fetching debug info", e)
-                    _debugInfo.value =
-                        _debugInfo.value.copy(
-                            error = e.message,
-                        )
+                    if (isServiceShutdown()) {
+                        _debugInfo.value = DebugInfo()
+                    } else {
+                        Log.e(TAG, "Error fetching debug info", e)
+                        _debugInfo.value = _debugInfo.value.copy(error = e.message ?: "Service unavailable")
+                    }
                 }
             }
         }
@@ -548,7 +528,32 @@ class DebugViewModel
             viewModelScope.launch {
                 try {
                     Log.i(TAG, "User requested service shutdown")
-                    reticulumProtocol.shutdown()
+
+                    // Set shutdown flag so restart mechanisms (onDestroy, START_STICKY) stay stopped
+                    context
+                        .getSharedPreferences("columba_prefs", android.content.Context.MODE_PRIVATE)
+                        .edit()
+                        .putBoolean("is_user_shutdown", true)
+                        .commit()
+
+                    // Clear UI immediately so status card shows clean shutdown state
+                    // (don't wait for onServiceDisconnected which has a race window)
+                    _debugInfo.value = DebugInfo()
+                    _networkStatus.value = "SHUTDOWN"
+
+                    // Unbind FIRST to prevent auto-rebind if service process crashes
+                    if (reticulumProtocol is com.lxmf.messenger.reticulum.protocol.ServiceReticulumProtocol) {
+                        (reticulumProtocol as com.lxmf.messenger.reticulum.protocol.ServiceReticulumProtocol)
+                            .unbindService()
+                    }
+
+                    // Send ACTION_STOP to stop the foreground service and remove notification
+                    val stopIntent =
+                        android.content.Intent(context, com.lxmf.messenger.service.ReticulumService::class.java).apply {
+                            action = com.lxmf.messenger.service.ReticulumService.ACTION_STOP
+                        }
+                    context.startForegroundService(stopIntent)
+
                     Log.i(TAG, "Service shutdown complete")
                 } catch (e: Exception) {
                     Log.e(TAG, "Error shutting down service", e)

--- a/app/src/main/java/com/lxmf/messenger/viewmodel/SettingsViewModel.kt
+++ b/app/src/main/java/com/lxmf/messenger/viewmodel/SettingsViewModel.kt
@@ -12,6 +12,7 @@ import com.lxmf.messenger.repository.InterfaceRepository
 import com.lxmf.messenger.repository.SettingsRepository
 import com.lxmf.messenger.reticulum.model.NetworkStatus
 import com.lxmf.messenger.reticulum.protocol.ReticulumProtocol
+import com.lxmf.messenger.reticulum.protocol.ServiceReticulumProtocol
 import com.lxmf.messenger.service.AvailableRelaysState
 import com.lxmf.messenger.service.PropagationNodeManager
 import com.lxmf.messenger.service.RelayInfo
@@ -162,6 +163,7 @@ class SettingsViewModel
     @Suppress("LongParameterList") // ViewModel with many DI dependencies is expected
     @Inject
     constructor(
+        @dagger.hilt.android.qualifiers.ApplicationContext private val context: android.content.Context,
         private val settingsRepository: SettingsRepository,
         private val identityRepository: IdentityRepository,
         private val reticulumProtocol: ReticulumProtocol,
@@ -835,7 +837,32 @@ class SettingsViewModel
             viewModelScope.launch {
                 try {
                     Log.i(TAG, "User requested service shutdown")
-                    reticulumProtocol.shutdown()
+
+                    // Set shutdown flag so restart mechanisms (onDestroy, START_STICKY) stay stopped
+                    // Use commit() to ensure flag is on disk before service process reads it
+                    context
+                        .getSharedPreferences("columba_prefs", android.content.Context.MODE_PRIVATE)
+                        .edit()
+                        .putBoolean("is_user_shutdown", true)
+                        .commit()
+
+                    // Unbind FIRST to prevent auto-rebind if the service process crashes.
+                    // Do NOT call reticulumProtocol.shutdown() — its async Python cleanup can
+                    // crash the service process before ACTION_STOP is delivered, triggering
+                    // ServiceReticulumProtocol's auto-rebind which restarts the service.
+                    // ACTION_STOP will handle shutdown internally in the service process.
+                    if (reticulumProtocol is com.lxmf.messenger.reticulum.protocol.ServiceReticulumProtocol) {
+                        (reticulumProtocol as com.lxmf.messenger.reticulum.protocol.ServiceReticulumProtocol)
+                            .unbindService()
+                    }
+
+                    // Send ACTION_STOP to actually stop the foreground service and remove notification
+                    val stopIntent =
+                        android.content.Intent(context, com.lxmf.messenger.service.ReticulumService::class.java).apply {
+                            action = com.lxmf.messenger.service.ReticulumService.ACTION_STOP
+                        }
+                    context.startForegroundService(stopIntent)
+
                     Log.i(TAG, "Service shutdown complete")
                 } catch (e: Exception) {
                     Log.e(TAG, "Error shutting down service", e)

--- a/app/src/test/java/com/lxmf/messenger/viewmodel/DebugViewModelEventDrivenTest.kt
+++ b/app/src/test/java/com/lxmf/messenger/viewmodel/DebugViewModelEventDrivenTest.kt
@@ -47,6 +47,9 @@ import org.junit.Test
 class DebugViewModelEventDrivenTest {
     private val testDispatcher = UnconfinedTestDispatcher()
 
+    @Suppress("NoRelaxedMocks") // Android Context with many system service methods
+    private val mockContext: android.content.Context = mockk(relaxed = true)
+
     private lateinit var mockProtocol: ServiceReticulumProtocol
     private lateinit var mockSettingsRepo: SettingsRepository
     private lateinit var mockIdentityRepo: IdentityRepository
@@ -119,6 +122,7 @@ class DebugViewModelEventDrivenTest {
             // Given - create ViewModel (which starts observeDebugInfo in init)
             val viewModel =
                 DebugViewModel(
+                    mockContext,
                     mockProtocol,
                     mockSettingsRepo,
                     mockIdentityRepo,
@@ -151,6 +155,7 @@ class DebugViewModelEventDrivenTest {
             // Given
             val viewModel =
                 DebugViewModel(
+                    mockContext,
                     mockProtocol,
                     mockSettingsRepo,
                     mockIdentityRepo,
@@ -175,6 +180,7 @@ class DebugViewModelEventDrivenTest {
             // Given
             val viewModel =
                 DebugViewModel(
+                    mockContext,
                     mockProtocol,
                     mockSettingsRepo,
                     mockIdentityRepo,
@@ -196,6 +202,7 @@ class DebugViewModelEventDrivenTest {
             // Given
             val viewModel =
                 DebugViewModel(
+                    mockContext,
                     mockProtocol,
                     mockSettingsRepo,
                     mockIdentityRepo,
@@ -238,6 +245,7 @@ class DebugViewModelEventDrivenTest {
             // When - create ViewModel with non-service protocol
             val viewModel =
                 DebugViewModel(
+                    mockContext,
                     nonServiceProtocol,
                     mockSettingsRepo,
                     mockIdentityRepo,
@@ -259,6 +267,7 @@ class DebugViewModelEventDrivenTest {
             // Given
             val viewModel =
                 DebugViewModel(
+                    mockContext,
                     mockProtocol,
                     mockSettingsRepo,
                     mockIdentityRepo,
@@ -297,6 +306,7 @@ class DebugViewModelEventDrivenTest {
 
             val viewModel =
                 DebugViewModel(
+                    mockContext,
                     mockProtocol,
                     mockSettingsRepo,
                     mockIdentityRepo,
@@ -324,6 +334,7 @@ class DebugViewModelEventDrivenTest {
 
             val viewModel =
                 DebugViewModel(
+                    mockContext,
                     mockProtocol,
                     mockSettingsRepo,
                     mockIdentityRepo,
@@ -350,6 +361,7 @@ class DebugViewModelEventDrivenTest {
 
             val viewModel =
                 DebugViewModel(
+                    mockContext,
                     mockProtocol,
                     mockSettingsRepo,
                     mockIdentityRepo,
@@ -377,6 +389,7 @@ class DebugViewModelEventDrivenTest {
 
             val viewModel =
                 DebugViewModel(
+                    mockContext,
                     mockProtocol,
                     mockSettingsRepo,
                     mockIdentityRepo,
@@ -404,6 +417,7 @@ class DebugViewModelEventDrivenTest {
 
             val viewModel =
                 DebugViewModel(
+                    mockContext,
                     mockProtocol,
                     mockSettingsRepo,
                     mockIdentityRepo,
@@ -428,6 +442,7 @@ class DebugViewModelEventDrivenTest {
 
             val viewModel =
                 DebugViewModel(
+                    mockContext,
                     mockProtocol,
                     mockSettingsRepo,
                     mockIdentityRepo,
@@ -454,6 +469,7 @@ class DebugViewModelEventDrivenTest {
 
             val viewModel =
                 DebugViewModel(
+                    mockContext,
                     mockProtocol,
                     mockSettingsRepo,
                     mockIdentityRepo,
@@ -494,6 +510,7 @@ class DebugViewModelEventDrivenTest {
 
             val viewModel =
                 DebugViewModel(
+                    mockContext,
                     mockProtocol,
                     mockSettingsRepo,
                     mockIdentityRepo,


### PR DESCRIPTION
## Summary
- Fixes #455: Shutdown button now properly stops the foreground service and removes the persistent notification
- Previously, pressing Shutdown only called `reticulumProtocol.shutdown()` via IPC but never sent `ACTION_STOP`, so the service kept running
- Adds `is_user_shutdown` SharedPreferences flag to prevent `START_STICKY`, `scheduleServiceRestart()`, and auto-rebind from restarting the service after user-initiated shutdown

## Changes
- **SettingsViewModel/DebugViewModel**: Set shutdown flag, unbind first (prevents auto-rebind race), send `ACTION_STOP` intent
- **ReticulumService**: Check `is_user_shutdown` in `onStartCommand` (blocks `START_STICKY`), `onDestroy` (skips restart scheduling), and `ACTION_START` (clears flag)
- **InterfaceConfigManager**: Clear `is_user_shutdown` flag before interface-change restart
- **DebugViewModel**: Guard `fetchDebugInfo` against shutdown state, clear UI immediately to prevent "Unknown error"

## Test plan
- [x] Unit tests pass (143 tests)
- [ ] Shutdown: notification disappears and does not return
- [ ] Restart then Shutdown: notification disappears after restart+shutdown
- [ ] Normal restart still works
- [ ] App relaunch after shutdown: service starts normally

🤖 Generated with [Claude Code](https://claude.com/claude-code)