### PR TITLE
fix: shutdown now stops foreground service (#455)

### DIFF
--- a/app/src/main/java/com/lxmf/messenger/service/InterfaceConfigManager.kt
+++ b/app/src/main/java/com/lxmf/messenger/service/InterfaceConfigManager.kt
@@ -187,6 +187,12 @@ class InterfaceConfigManager
                 Log.d(TAG, "✓ Ports should be released")
 
                 // Step 7: Start service again (fresh process, no port conflicts)
+                // Clear user shutdown flag so the service starts normally
+                context
+                    .getSharedPreferences("columba_prefs", Context.MODE_PRIVATE)
+                    .edit()
+                    .putBoolean("is_user_shutdown", false)
+                    .commit()
                 Log.d(TAG, "Step 7: Starting ReticulumService in fresh process...")
                 val startIntent =
                     Intent(context, ReticulumService::class.java).apply {

--- a/app/src/test/java/com/lxmf/messenger/viewmodel/DebugViewModelEventDrivenTest.kt
+++ b/app/src/test/java/com/lxmf/messenger/viewmodel/DebugViewModelEventDrivenTest.kt
@@ -47,6 +47,9 @@ import org.junit.Test
 class DebugViewModelEventDrivenTest {
     private val testDispatcher = UnconfinedTestDispatcher()
 
+    @Suppress("NoRelaxedMocks") // Android Context with many system service methods
+    private val mockContext: android.content.Context = mockk(relaxed = true)
+
     private lateinit var mockProtocol: ServiceReticulumProtocol
     private lateinit var mockSettingsRepo: SettingsRepository
     private lateinit var mockIdentityRepo: IdentityRepository
@@ -119,6 +122,7 @@ class DebugViewModelEventDrivenTest {
             // Given - create ViewModel (which starts observeDebugInfo in init)
             val viewModel =
                 DebugViewModel(
+                    mockContext,
                     mockProtocol,
                     mockSettingsRepo,
                     mockIdentityRepo,
@@ -151,6 +155,7 @@ class DebugViewModelEventDrivenTest {
             // Given
             val viewModel =
                 DebugViewModel(
+                    mockContext,
                     mockProtocol,
                     mockSettingsRepo,
                     mockIdentityRepo,
@@ -175,6 +180,7 @@ class DebugViewModelEventDrivenTest {
             // Given
             val viewModel =
                 DebugViewModel(
+                    mockContext,
                     mockProtocol,
                     mockSettingsRepo,
                     mockIdentityRepo,
@@ -196,6 +202,7 @@ class DebugViewModelEventDrivenTest {
             // Given
             val viewModel =
                 DebugViewModel(
+                    mockContext,
                     mockProtocol,
                     mockSettingsRepo,
                     mockIdentityRepo,
@@ -238,6 +245,7 @@ class DebugViewModelEventDrivenTest {
             // When - create ViewModel with non-service protocol
             val viewModel =
                 DebugViewModel(
+                    mockContext,
                     nonServiceProtocol,
                     mockSettingsRepo,
                     mockIdentityRepo,
@@ -259,6 +267,7 @@ class DebugViewModelEventDrivenTest {
             // Given
             val viewModel =
                 DebugViewModel(
+                    mockContext,
                     mockProtocol,
                     mockSettingsRepo,
                     mockIdentityRepo,
@@ -297,6 +306,7 @@ class DebugViewModelEventDrivenTest {
 
             val viewModel =
                 DebugViewModel(
+                    mockContext,
                     mockProtocol,
                     mockSettingsRepo,
                     mockIdentityRepo,
@@ -324,6 +334,7 @@ class DebugViewModelEventDrivenTest {
 
             val viewModel =
                 DebugViewModel(
+                    mockContext,
                     mockProtocol,
                     mockSettingsRepo,
                     mockIdentityRepo,
@@ -350,6 +361,7 @@ class DebugViewModelEventDrivenTest {
 
             val viewModel =
                 DebugViewModel(
+                    mockContext,
                     mockProtocol,
                     mockSettingsRepo,
                     mockIdentityRepo,
@@ -377,6 +389,7 @@ class DebugViewModelEventDrivenTest {
 
             val viewModel =
                 DebugViewModel(
+                    mockContext,
                     mockProtocol,
                     mockSettingsRepo,
                     mockIdentityRepo,
@@ -404,6 +417,7 @@ class DebugViewModelEventDrivenTest {
 
             val viewModel =
                 DebugViewModel(
+                    mockContext,
                     mockProtocol,
                     mockSettingsRepo,
                     mockIdentityRepo,
@@ -428,6 +442,7 @@ class DebugViewModelEventDrivenTest {
 
             val viewModel =
                 DebugViewModel(
+                    mockContext,
                     mockProtocol,
                     mockSettingsRepo,
                     mockIdentityRepo,
@@ -454,6 +469,7 @@ class DebugViewModelEventDrivenTest {
 
             val viewModel =
                 DebugViewModel(
+                    mockContext,
                     mockProtocol,
                     mockSettingsRepo,
                     mockIdentityRepo,
@@ -494,6 +510,7 @@ class DebugViewModelEventDrivenTest {
 
             val viewModel =
                 DebugViewModel(
+                    mockContext,
                     mockProtocol,
                     mockSettingsRepo,
                     mockIdentityRepo,


### PR DESCRIPTION
## Summary
- Fixes #455: Shutdown button now properly stops the foreground service and removes the persistent notification
- Previously, pressing Shutdown only called `reticulumProtocol.shutdown()` via IPC but never sent `ACTION_STOP`, so the service kept running
- Adds `is_user_shutdown` SharedPreferences flag to prevent `START_STICKY`, `scheduleServiceRestart()`, and auto-rebind from restarting the service after user-initiated shutdown

Cherry-pick of fix/shutdown-stops-service (PR #521) for the v0.8.x release branch.

## Changes
- **SettingsViewModel/DebugViewModel**: Set shutdown flag, unbind first (prevents auto-rebind race), send `ACTION_STOP` intent
- **ReticulumService**: Check `is_user_shutdown` in `onStartCommand` (blocks `START_STICKY`), `onDestroy` (skips restart scheduling), and `ACTION_START` (clears flag)
- **InterfaceConfigManager**: Clear `is_user_shutdown` flag before interface-change restart
- **DebugViewModel**: Guard `fetchDebugInfo` against shutdown state, clear UI immediately to prevent "Unknown error"

## Test plan
- [x] Unit tests pass (143 tests)
- [ ] Shutdown: notification disappears and does not return
- [ ] Restart then Shutdown: notification disappears after restart+shutdown
- [ ] Normal restart still works
- [ ] App relaunch after shutdown: service starts normally

🤖 Generated with [Claude Code](https://claude.com/claude-code)