### PR TITLE
fix: RNode announces via BLE shown with Bluetooth icon

### DIFF
--- a/app/src/main/java/com/lxmf/messenger/ui/util/ReceivingInterfaceInfo.kt
+++ b/app/src/main/java/com/lxmf/messenger/ui/util/ReceivingInterfaceInfo.kt
@@ -73,11 +73,11 @@ private fun categorizeInterface(interfaceName: String): InterfaceCategory {
             lowerName.contains("auto discovery") ||
             lowerName.startsWith("auto") -> InterfaceCategory.AUTO
         lowerName.contains("tcp") || lowerName.contains("backbone") -> InterfaceCategory.TCP
+        lowerName.contains("rnode") ||
+            lowerName.contains("lora") -> InterfaceCategory.LORA
         lowerName.contains("ble") ||
             lowerName.contains("bluetooth") ||
             lowerName.contains("androidble") -> InterfaceCategory.BLUETOOTH
-        lowerName.contains("rnode") ||
-            lowerName.contains("lora") -> InterfaceCategory.LORA
         lowerName.contains("serial") -> InterfaceCategory.SERIAL
         else -> InterfaceCategory.UNKNOWN
     }

--- a/app/src/test/java/com/lxmf/messenger/ui/util/ReceivingInterfaceInfoTest.kt
+++ b/app/src/test/java/com/lxmf/messenger/ui/util/ReceivingInterfaceInfoTest.kt
@@ -178,6 +178,16 @@ class ReceivingInterfaceInfoTest {
     }
 
     @Test
+    fun `RNode connected via BLE categorized as LoRa not Bluetooth`() {
+        // RNode connected via BLE gets a name containing both "RNode" and "BLE"
+        val info = getReceivingInterfaceInfo("ColumbaRNodeInterface[RNode 5A3F BLE]")
+
+        assertEquals(Icons.Default.CellTower, info.icon)
+        assertEquals("RNode 5A3F BLE", info.text)
+        assertEquals("ColumbaRNodeInterface", info.subtitle)
+    }
+
+    @Test
     fun `RNode interface without brackets falls back to LoRa Radio`() {
         val info = getReceivingInterfaceInfo("RNodeInterface")
 

--- a/data/src/main/java/com/lxmf/messenger/data/model/InterfaceType.kt
+++ b/data/src/main/java/com/lxmf/messenger/data/model/InterfaceType.kt
@@ -27,8 +27,8 @@ enum class InterfaceType {
             return when {
                 name.contains("autointerface") -> AUTO_INTERFACE
                 name.contains("tcpclient") || name.contains("tcpinterface") || name.contains("backbone") -> TCP_CLIENT
-                name.contains("ble") || name.contains("androidble") -> ANDROID_BLE
                 name.contains("rnode") -> RNODE
+                name.contains("ble") || name.contains("androidble") -> ANDROID_BLE
                 else -> UNKNOWN
             }
         }

--- a/data/src/test/java/com/lxmf/messenger/data/model/InterfaceTypeTest.kt
+++ b/data/src/test/java/com/lxmf/messenger/data/model/InterfaceTypeTest.kt
@@ -60,6 +60,14 @@ class InterfaceTypeTest {
     }
 
     @Test
+    fun `fromInterfaceName returns RNODE for BLE-connected RNode interfaces`() {
+        // RNode connected via BLE gets a name containing both "RNode" and "BLE"
+        // Must resolve to RNODE, not ANDROID_BLE
+        assertEquals(InterfaceType.RNODE, InterfaceType.fromInterfaceName("ColumbaRNodeInterface[RNode 5A3F BLE]"))
+        assertEquals(InterfaceType.RNODE, InterfaceType.fromInterfaceName("RNodeInterface[RNode ABC1 BLE]"))
+    }
+
+    @Test
     fun `fromInterfaceName returns UNKNOWN for null`() {
         assertEquals(InterfaceType.UNKNOWN, InterfaceType.fromInterfaceName(null))
     }


### PR DESCRIPTION
## Summary
- RNode interfaces connected via BLE get names like `ColumbaRNodeInterface[RNode 5A3F BLE]`
- `fromInterfaceName()` and `categorizeInterface()` checked for `"ble"` before `"rnode"`, so these were misclassified as BLE/Bluetooth instead of RNode/LoRa
- Reorders the `when`-branches so `"rnode"` is checked before `"ble"` in both `InterfaceType.kt` and `ReceivingInterfaceInfo.kt`

Cherry-pick of the same fix from `main`.

## Test plan
- [x] Added regression test in `InterfaceTypeTest` for `"ColumbaRNodeInterface[RNode 5A3F BLE]"` → `RNODE`
- [x] Added regression test in `ReceivingInterfaceInfoTest` for same name → CellTower icon
- [x] All existing tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)