### PR TITLE
fix: restore foreground notification after user swipe on Android 13+

### DIFF
--- a/app/src/main/java/com/lxmf/messenger/MainActivity.kt
+++ b/app/src/main/java/com/lxmf/messenger/MainActivity.kt
@@ -293,6 +293,19 @@ class MainActivity : ComponentActivity() {
         if (::jankStats.isInitialized) {
             jankStats.isTrackingEnabled = true
         }
+
+        // Reinforce foreground notification: on Android 13+ users can swipe it away,
+        // and only Service.startForeground() can restore it. Sending ACTION_START
+        // triggers onStartCommand which calls startForeground(this).
+        try {
+            val intent =
+                Intent(this, ReticulumService::class.java).apply {
+                    action = ReticulumService.ACTION_START
+                }
+            startForegroundService(intent)
+        } catch (e: Exception) {
+            Log.w(TAG, "Could not reinforce foreground notification", e)
+        }
     }
 
     override fun onPause() {

--- a/app/src/main/java/com/lxmf/messenger/service/ReticulumService.kt
+++ b/app/src/main/java/com/lxmf/messenger/service/ReticulumService.kt
@@ -213,6 +213,14 @@ class ReticulumService : Service() {
         return binder
     }
 
+    override fun onRebind(intent: Intent?) {
+        Log.d(TAG, "Service rebound")
+        if (::managers.isInitialized) {
+            managers.notificationManager.startForeground(this)
+            managers.broadcaster.setServiceBound(true)
+        }
+    }
+
     override fun onUnbind(intent: Intent?): Boolean {
         Log.d(TAG, "Service unbound")
 


### PR DESCRIPTION
## Summary
- On Android 13+ (API 33), users can swipe away foreground service notifications. Once dismissed, `NotificationManager.notify()` cannot restore them — only `Service.startForeground()` can
- Routes all notification updates through `startForeground()` instead of `notify()` via a new `repostNotification()` helper in `ServiceNotificationManager`
- Adds `onResume` trigger in `MainActivity` to reinforce the notification when the user reopens the app
- Adds `onRebind` in `ReticulumService` for the edge case where the binding is dropped and reestablished

## Test plan
- [x] Build: `./gradlew :app:assembleNoSentryDebug`
- [x] Existing binder tests pass: `./gradlew :app:testNoSentryDebugUnitTest --tests "*.ReticulumServiceBinderTest"`
- [x] Manual test on device: swipe notification away, reopen app, verify notification reappears

🤖 Generated with [Claude Code](https://claude.com/claude-code)