### PR TITLE
fix: strip URI scheme prefixes from hostname input

### DIFF
--- a/app/src/main/java/com/lxmf/messenger/repository/InterfaceRepository.kt
+++ b/app/src/main/java/com/lxmf/messenger/repository/InterfaceRepository.kt
@@ -30,7 +30,8 @@ class InterfaceRepository
          * Corrupted interfaces are logged and skipped.
          */
         val allInterfaces: Flow<List<InterfaceConfig>> =
-            interfaceDao.getAllInterfaces()
+            interfaceDao
+                .getAllInterfaces()
                 .map { entities -> entities.mapNotNull { safeEntityToConfig(it) } }
 
         /**
@@ -38,20 +39,20 @@ class InterfaceRepository
          * Corrupted interfaces are logged and skipped.
          */
         val enabledInterfaces: Flow<List<InterfaceConfig>> =
-            interfaceDao.getEnabledInterfaces()
+            interfaceDao
+                .getEnabledInterfaces()
                 .map { entities -> entities.mapNotNull { safeEntityToConfig(it) } }
 
         /**
          * Safely convert an entity to config, returning null on error.
          */
-        private fun safeEntityToConfig(entity: InterfaceEntity): InterfaceConfig? {
-            return try {
+        private fun safeEntityToConfig(entity: InterfaceEntity): InterfaceConfig? =
+            try {
                 entityToConfig(entity)
             } catch (e: Exception) {
                 Log.e(TAG, "Skipping corrupted interface '${entity.name}': ${e.message}")
                 null
             }
-        }
 
         /**
          * Get all interface entities (for UI display).
@@ -69,17 +70,20 @@ class InterfaceRepository
          * discovered interfaces are connected (RNS 1.1.0+ bootstrap feature).
          */
         val bootstrapInterfaceNames: Flow<List<String>> =
-            interfaceDao.getEnabledInterfaces()
+            interfaceDao
+                .getEnabledInterfaces()
                 .map { entities ->
-                    entities.filter { entity ->
-                        entity.type == "TCPClient" && entity.enabled &&
-                            try {
-                                org.json.JSONObject(entity.configJson).optBoolean("bootstrap_only", false)
-                            } catch (e: Exception) {
-                                android.util.Log.v("InterfaceRepository", "Failed to parse configJson for ${entity.name}", e)
-                                false
-                            }
-                    }.map { it.name }
+                    entities
+                        .filter { entity ->
+                            entity.type == "TCPClient" &&
+                                entity.enabled &&
+                                try {
+                                    org.json.JSONObject(entity.configJson).optBoolean("bootstrap_only", false)
+                                } catch (e: Exception) {
+                                    android.util.Log.v("InterfaceRepository", "Failed to parse configJson for ${entity.name}", e)
+                                    false
+                                }
+                        }.map { it.name }
                 }
 
         /**
@@ -95,9 +99,7 @@ class InterfaceRepository
         /**
          * Get a specific interface by ID.
          */
-        fun getInterfaceById(id: Long): Flow<InterfaceEntity?> {
-            return interfaceDao.getInterfaceById(id)
-        }
+        fun getInterfaceById(id: Long): Flow<InterfaceEntity?> = interfaceDao.getInterfaceById(id)
 
         /**
          * Insert a new interface configuration.
@@ -176,8 +178,8 @@ class InterfaceRepository
          *
          * @throws IllegalStateException if JSON is corrupted or invalid
          */
-        fun entityToConfig(entity: InterfaceEntity): InterfaceConfig {
-            return try {
+        fun entityToConfig(entity: InterfaceEntity): InterfaceConfig =
+            try {
                 val json = JSONObject(entity.configJson)
 
                 when (entity.type) {
@@ -219,17 +221,18 @@ class InterfaceRepository
                     }
 
                     "TCPClient" -> {
-                        val targetHost = json.getString("target_host")
+                        val rawHost = json.getString("target_host")
                         val targetPort = json.getInt("target_port")
 
-                        // Validate hostname
-                        when (val hostResult = InputValidator.validateHostname(targetHost)) {
-                            is ValidationResult.Error -> {
-                                Log.e(TAG, "Invalid target host in database: $targetHost - ${hostResult.message}")
-                                error("Invalid target host: $targetHost")
+                        // Validate hostname (strips scheme prefixes like http://)
+                        val targetHost =
+                            when (val hostResult = InputValidator.validateHostname(rawHost)) {
+                                is ValidationResult.Error -> {
+                                    Log.e(TAG, "Invalid target host in database: $rawHost - ${hostResult.message}")
+                                    error("Invalid target host: $rawHost")
+                                }
+                                is ValidationResult.Success -> hostResult.value
                             }
-                            else -> {}
-                        }
 
                         // Validate port
                         if (targetPort !in 1..65535) {
@@ -392,17 +395,18 @@ class InterfaceRepository
                     }
 
                     "TCPServer" -> {
-                        val listenIp = json.optString("listen_ip", "0.0.0.0")
+                        val rawListenIp = json.optString("listen_ip", "0.0.0.0")
                         val listenPort = json.optInt("listen_port", 4242)
 
-                        // Validate listen IP
-                        when (val listenIpResult = InputValidator.validateHostname(listenIp)) {
-                            is ValidationResult.Error -> {
-                                Log.e(TAG, "Invalid listen IP in database: $listenIp - ${listenIpResult.message}")
-                                error("Invalid listen IP: $listenIp")
+                        // Validate listen IP (strips scheme prefixes like http://)
+                        val listenIp =
+                            when (val listenIpResult = InputValidator.validateHostname(rawListenIp)) {
+                                is ValidationResult.Error -> {
+                                    Log.e(TAG, "Invalid listen IP in database: $rawListenIp - ${listenIpResult.message}")
+                                    error("Invalid listen IP: $rawListenIp")
+                                }
+                                is ValidationResult.Success -> listenIpResult.value
                             }
-                            else -> {}
-                        }
 
                         // Validate port
                         if (listenPort !in 1..65535) {
@@ -428,16 +432,13 @@ class InterfaceRepository
                 Log.e(TAG, "Corrupted JSON in database for interface '${entity.name}': ${e.message}", e)
                 error("Corrupted interface configuration for '${entity.name}': ${e.message}")
             }
-        }
 
         /**
          * Find an RNode interface configured for a specific USB device ID.
          * Used to check if a USB device is already configured when it's plugged in.
          * @deprecated Use findRNodeByUsbVidPid instead - device IDs are runtime IDs that change
          */
-        suspend fun findRNodeByUsbDeviceId(usbDeviceId: Int): InterfaceEntity? {
-            return interfaceDao.findRNodeByUsbDeviceId(usbDeviceId)
-        }
+        suspend fun findRNodeByUsbDeviceId(usbDeviceId: Int): InterfaceEntity? = interfaceDao.findRNodeByUsbDeviceId(usbDeviceId)
 
         /**
          * Find an RNode interface by USB Vendor ID and Product ID.
@@ -462,17 +463,13 @@ class InterfaceRepository
          * Get an interface by ID (one-shot query, not Flow).
          * Useful for intent handling where we need immediate result.
          */
-        suspend fun getInterfaceByIdOnce(id: Long): InterfaceEntity? {
-            return interfaceDao.getInterfaceByIdOnce(id)
-        }
+        suspend fun getInterfaceByIdOnce(id: Long): InterfaceEntity? = interfaceDao.getInterfaceByIdOnce(id)
 
         /**
          * Find an interface by name.
          * Used to look up the database ID when navigating from the network status screen.
          */
-        suspend fun findInterfaceByName(name: String): InterfaceEntity? {
-            return interfaceDao.findInterfaceByName(name)
-        }
+        suspend fun findInterfaceByName(name: String): InterfaceEntity? = interfaceDao.findInterfaceByName(name)
 
         companion object {
             private const val TAG = "InterfaceRepository"

--- a/app/src/main/java/com/lxmf/messenger/util/validation/InputValidator.kt
+++ b/app/src/main/java/com/lxmf/messenger/util/validation/InputValidator.kt
@@ -130,7 +130,8 @@ object InputValidator {
         // Safe conversion
         return try {
             val bytes =
-                cleaned.chunked(2)
+                cleaned
+                    .chunked(2)
                     .map { it.toInt(16).toByte() }
                     .toByteArray()
             ValidationResult.Success(bytes)
@@ -168,7 +169,8 @@ object InputValidator {
         // Safe conversion
         return try {
             val bytes =
-                cleaned.chunked(2)
+                cleaned
+                    .chunked(2)
                     .map { it.toInt(16).toByte() }
                     .toByteArray()
             ValidationResult.Success(bytes)
@@ -280,7 +282,15 @@ object InputValidator {
      * @return ValidationResult.Success with cleaned host, or ValidationResult.Error
      */
     fun validateHostname(host: String): ValidationResult<String> {
-        val cleaned = host.trim()
+        // Strip URI scheme prefixes — users sometimes paste full URLs instead of bare hostnames
+        val cleaned =
+            host
+                .trim()
+                .removePrefix("http://")
+                .removePrefix("https://")
+                .removeSuffix("/")
+                .split("/")
+                .first() // Strip any path component after the hostname
 
         return when {
             cleaned.isEmpty() ->
@@ -446,13 +456,12 @@ object InputValidator {
      * @param paramName The parameter name to validate
      * @return ValidationResult.Success if whitelisted, or ValidationResult.Error
      */
-    fun validateConfigParameter(paramName: String): ValidationResult<String> {
-        return if (paramName in ALLOWED_INTERFACE_PARAMS) {
+    fun validateConfigParameter(paramName: String): ValidationResult<String> =
+        if (paramName in ALLOWED_INTERFACE_PARAMS) {
             ValidationResult.Success(paramName)
         } else {
             ValidationResult.Error("Unknown configuration parameter: $paramName")
         }
-    }
 
     // ========== BLE VALIDATION ==========
 
@@ -462,13 +471,12 @@ object InputValidator {
      * @param data The BLE data packet
      * @return ValidationResult.Success if within size limits, or ValidationResult.Error
      */
-    fun validateBlePacketSize(data: ByteArray): ValidationResult<ByteArray> {
-        return if (data.size > MAX_BLE_PACKET_SIZE) {
+    fun validateBlePacketSize(data: ByteArray): ValidationResult<ByteArray> =
+        if (data.size > MAX_BLE_PACKET_SIZE) {
             ValidationResult.Error("BLE packet too large (${data.size} bytes, max $MAX_BLE_PACKET_SIZE)")
         } else {
             ValidationResult.Success(data)
         }
-    }
 
     // ========== TEXT SANITIZATION ==========
 
@@ -488,13 +496,12 @@ object InputValidator {
     fun sanitizeText(
         text: String,
         maxLength: Int,
-    ): String {
-        return text
+    ): String =
+        text
             .trim()
             .replace(Regex("\\p{C}"), "") // Remove control characters
             .replace(Regex("\\s+"), " ") // Normalize whitespace
             .take(maxLength)
-    }
 
     /**
      * Extension function for safe hex string to byte array conversion.
@@ -523,7 +530,8 @@ object InputValidator {
 
         return try {
             val bytes =
-                cleaned.chunked(2)
+                cleaned
+                    .chunked(2)
                     .map { it.toInt(16).toByte() }
                     .toByteArray()
             Result.success(bytes)
@@ -537,7 +545,5 @@ object InputValidator {
      *
      * @return Lowercase hex string representation
      */
-    fun ByteArray.toHexString(): String {
-        return this.joinToString("") { "%02x".format(it) }
-    }
+    fun ByteArray.toHexString(): String = this.joinToString("") { "%02x".format(it) }
 }

--- a/app/src/main/java/com/lxmf/messenger/viewmodel/InterfaceManagementViewModel.kt
+++ b/app/src/main/java/com/lxmf/messenger/viewmodel/InterfaceManagementViewModel.kt
@@ -647,7 +647,12 @@ class InterfaceManagementViewModel
                             isValid = false
                         }
                         is ValidationResult.Success -> {
-                            _configState.value = _configState.value.copy(targetHostError = null)
+                            // Write back the cleaned hostname (strips scheme prefixes like http://)
+                            _configState.value =
+                                _configState.value.copy(
+                                    targetHostError = null,
+                                    targetHost = hostResult.value,
+                                )
                         }
                     }
 
@@ -754,7 +759,11 @@ class InterfaceManagementViewModel
                             isValid = false
                         }
                         is ValidationResult.Success -> {
-                            _configState.value = _configState.value.copy(listenIpError = null)
+                            _configState.value =
+                                _configState.value.copy(
+                                    listenIpError = null,
+                                    listenIp = ipResult.value,
+                                )
                         }
                     }
 

--- a/app/src/test/java/com/lxmf/messenger/util/validation/InputValidatorTest.kt
+++ b/app/src/test/java/com/lxmf/messenger/util/validation/InputValidatorTest.kt
@@ -236,6 +236,41 @@ class InputValidatorTest {
         assertEquals("example.com", result.getOrNull())
     }
 
+    @Test
+    fun `validateHostname - strips http scheme prefix`() {
+        val result = InputValidator.validateHostname("http://rns.soon.it")
+        assertTrue(result is ValidationResult.Success)
+        assertEquals("rns.soon.it", result.getOrNull())
+    }
+
+    @Test
+    fun `validateHostname - strips https scheme prefix`() {
+        val result = InputValidator.validateHostname("https://example.com")
+        assertTrue(result is ValidationResult.Success)
+        assertEquals("example.com", result.getOrNull())
+    }
+
+    @Test
+    fun `validateHostname - strips scheme and trailing slash`() {
+        val result = InputValidator.validateHostname("http://example.com/")
+        assertTrue(result is ValidationResult.Success)
+        assertEquals("example.com", result.getOrNull())
+    }
+
+    @Test
+    fun `validateHostname - strips scheme and path`() {
+        val result = InputValidator.validateHostname("https://example.com/some/path")
+        assertTrue(result is ValidationResult.Success)
+        assertEquals("example.com", result.getOrNull())
+    }
+
+    @Test
+    fun `validateHostname - strips scheme from IP address`() {
+        val result = InputValidator.validateHostname("http://192.168.1.1")
+        assertTrue(result is ValidationResult.Success)
+        assertEquals("192.168.1.1", result.getOrNull())
+    }
+
     // ========== PORT VALIDATION TESTS ==========
 
     @Test


### PR DESCRIPTION
## Summary
- `validateHostname()` now strips `http://` and `https://` prefixes (and any path component) before validation, so users who paste a full URL get the hostname extracted automatically
- `entityToConfig()` uses the cleaned value from validation, fixing existing poison data in the database on read
- `validateConfigState()` writes the cleaned hostname back to UI state so subsequent saves persist the sanitized value

## Context
Fixes COLUMBA-43 — users entering `http://rns.soon.it` as a TCP host caused a fatal `IllegalStateException` when editing the interface config. 5 occurrences across 2 users on v0.8.12-beta.

## Test plan
- [x] 5 new unit tests for scheme stripping (http, https, trailing slash, path, IP)
- [x] All existing `InputValidatorTest`, `InterfaceRepositoryTest`, and `InterfaceManagementViewModelTest` pass
- [ ] Manual: enter `http://rns.soon.it` as TCP host, verify it saves as `rns.soon.it`
- [ ] Manual: edit an existing interface with a scheme-prefixed host in the DB, verify no crash

🤖 Generated with [Claude Code](https://claude.com/claude-code)