### PR TITLE
fix: prevent delivered message status from regressing

### DIFF
--- a/app/src/main/java/com/lxmf/messenger/viewmodel/MessagingViewModel.kt
+++ b/app/src/main/java/com/lxmf/messenger/viewmodel/MessagingViewModel.kt
@@ -741,6 +741,18 @@ class MessagingViewModel
                 }
 
                 if (message != null) {
+                    // Guard: 'delivered' is terminal — never regress to any other state.
+                    // LXMF may fire spurious failure/sent callbacks after delivery confirmation,
+                    // which can trigger propagation retries that overwrite 'delivered' with 'propagated'.
+                    if (message.status == "delivered" && update.status != "delivered") {
+                        Log.w(
+                            TAG,
+                            "Blocking status regression from 'delivered' to '${update.status}' " +
+                                "for message ${update.messageHash.take(16)}...",
+                        )
+                        return
+                    }
+
                     // Guard: Don't degrade from terminal success states to failed (Issue #257 fix)
                     // This provides defense-in-depth in case Python layer misses the spurious callback
                     if (update.status == "failed" && isTerminalSuccessStatus(message.status)) {

--- a/app/src/test/java/com/lxmf/messenger/viewmodel/MessagingViewModelTest.kt
+++ b/app/src/test/java/com/lxmf/messenger/viewmodel/MessagingViewModelTest.kt
@@ -1541,6 +1541,176 @@ class MessagingViewModelTest {
             }
         }
 
+    // ========== DELIVERED TERMINAL STATE TESTS ==========
+
+    @Test
+    fun `propagated status is blocked when message is already delivered`() =
+        runViewModelTest {
+            val deliveryStatusFlow = MutableSharedFlow<DeliveryStatusUpdate>()
+            every { reticulumProtocol.observeDeliveryStatus() } returns deliveryStatusFlow
+
+            val testMessageHash = "delivered_msg_spurious_propagated"
+            val existingMessage =
+                MessageEntity(
+                    id = testMessageHash,
+                    conversationHash = testPeerHash,
+                    identityHash = "test_identity_hash",
+                    content = "Test message",
+                    timestamp = 1000L,
+                    isFromMe = true,
+                    status = "delivered",
+                )
+            coEvery { conversationRepository.getMessageById(testMessageHash) } returns existingMessage
+            coEvery { conversationRepository.updateMessageDeliveryDetails(any(), any(), any()) } just Runs
+
+            @Suppress("UnusedPrivateProperty")
+            val testViewModel =
+                MessagingViewModel(
+                    applicationContext,
+                    reticulumProtocol,
+                    conversationRepository,
+                    announceRepository,
+                    contactRepository,
+                    activeConversationManager,
+                    settingsRepository,
+                    propagationNodeManager,
+                    locationSharingManager,
+                    identityRepository,
+                    conversationLinkManager,
+                )
+            advanceUntilIdle()
+
+            val emitResult =
+                runCatching {
+                    deliveryStatusFlow.emit(
+                        DeliveryStatusUpdate(
+                            messageHash = testMessageHash,
+                            status = "propagated",
+                            timestamp = System.currentTimeMillis(),
+                        ),
+                    )
+                }
+            advanceUntilIdle()
+
+            assertTrue("Status update emission should complete without error", emitResult.isSuccess)
+
+            coVerify(exactly = 0) {
+                conversationRepository.updateMessageStatus(testMessageHash, "propagated")
+            }
+        }
+
+    @Test
+    fun `retrying_propagated status is blocked when message is already delivered`() =
+        runViewModelTest {
+            val deliveryStatusFlow = MutableSharedFlow<DeliveryStatusUpdate>()
+            every { reticulumProtocol.observeDeliveryStatus() } returns deliveryStatusFlow
+
+            val testMessageHash = "delivered_msg_spurious_retrying"
+            val existingMessage =
+                MessageEntity(
+                    id = testMessageHash,
+                    conversationHash = testPeerHash,
+                    identityHash = "test_identity_hash",
+                    content = "Test message",
+                    timestamp = 1000L,
+                    isFromMe = true,
+                    status = "delivered",
+                )
+            coEvery { conversationRepository.getMessageById(testMessageHash) } returns existingMessage
+            coEvery { conversationRepository.updateMessageDeliveryDetails(any(), any(), any()) } just Runs
+
+            @Suppress("UnusedPrivateProperty")
+            val testViewModel =
+                MessagingViewModel(
+                    applicationContext,
+                    reticulumProtocol,
+                    conversationRepository,
+                    announceRepository,
+                    contactRepository,
+                    activeConversationManager,
+                    settingsRepository,
+                    propagationNodeManager,
+                    locationSharingManager,
+                    identityRepository,
+                    conversationLinkManager,
+                )
+            advanceUntilIdle()
+
+            val emitResult =
+                runCatching {
+                    deliveryStatusFlow.emit(
+                        DeliveryStatusUpdate(
+                            messageHash = testMessageHash,
+                            status = "retrying_propagated",
+                            timestamp = System.currentTimeMillis(),
+                        ),
+                    )
+                }
+            advanceUntilIdle()
+
+            assertTrue("Status update emission should complete without error", emitResult.isSuccess)
+
+            coVerify(exactly = 0) {
+                conversationRepository.updateMessageStatus(testMessageHash, "retrying_propagated")
+            }
+        }
+
+    @Test
+    fun `sent status is blocked when message is already delivered`() =
+        runViewModelTest {
+            val deliveryStatusFlow = MutableSharedFlow<DeliveryStatusUpdate>()
+            every { reticulumProtocol.observeDeliveryStatus() } returns deliveryStatusFlow
+
+            val testMessageHash = "delivered_msg_spurious_sent"
+            val existingMessage =
+                MessageEntity(
+                    id = testMessageHash,
+                    conversationHash = testPeerHash,
+                    identityHash = "test_identity_hash",
+                    content = "Test message",
+                    timestamp = 1000L,
+                    isFromMe = true,
+                    status = "delivered",
+                )
+            coEvery { conversationRepository.getMessageById(testMessageHash) } returns existingMessage
+            coEvery { conversationRepository.updateMessageDeliveryDetails(any(), any(), any()) } just Runs
+
+            @Suppress("UnusedPrivateProperty")
+            val testViewModel =
+                MessagingViewModel(
+                    applicationContext,
+                    reticulumProtocol,
+                    conversationRepository,
+                    announceRepository,
+                    contactRepository,
+                    activeConversationManager,
+                    settingsRepository,
+                    propagationNodeManager,
+                    locationSharingManager,
+                    identityRepository,
+                    conversationLinkManager,
+                )
+            advanceUntilIdle()
+
+            val emitResult =
+                runCatching {
+                    deliveryStatusFlow.emit(
+                        DeliveryStatusUpdate(
+                            messageHash = testMessageHash,
+                            status = "sent",
+                            timestamp = System.currentTimeMillis(),
+                        ),
+                    )
+                }
+            advanceUntilIdle()
+
+            assertTrue("Status update emission should complete without error", emitResult.isSuccess)
+
+            coVerify(exactly = 0) {
+                conversationRepository.updateMessageStatus(testMessageHash, "sent")
+            }
+        }
+
     // ========== CONTACT TOGGLE TESTS ==========
 
     @Test

--- a/python/reticulum_wrapper.py
+++ b/python/reticulum_wrapper.py
@@ -543,6 +543,7 @@ class ReticulumWrapper:
         # that successfully reached SENT state with PROPAGATED method, and ignore any
         # subsequent failure callbacks for these messages.
         self._successfully_propagated = {}  # {msg_hash_hex: timestamp} - messages that reached relay
+        self._successfully_delivered = {}  # {msg_hash_hex: timestamp} - messages confirmed by recipient
         self._propagated_tracking_ttl_seconds = 86400  # 24 hours - cleanup old entries
 
         # Pending file notifications for propagated messages with attachments
@@ -4659,10 +4660,17 @@ class ReticulumWrapper:
         try:
             msg_hash = lxmf_message.hash.hex() if lxmf_message.hash else "unknown"
 
+            # Guard: if this message was already confirmed delivered, don't regress
+            if msg_hash in self._successfully_delivered:
+                log_info("ReticulumWrapper", "_on_message_delivered",
+                        f"⚠️ Message {msg_hash[:16]}... already delivered, ignoring subsequent callback")
+                return
+
             # Determine status based on LXMF message state
             # LXMF sets state=DELIVERED for direct, state=SENT for propagated
             if lxmf_message.state == LXMF.LXMessage.DELIVERED:
                 status = 'delivered'
+                self._successfully_delivered[msg_hash] = time.time()
                 log_info("ReticulumWrapper", "_on_message_delivered",
                         f"✅ Message {msg_hash[:16]}... DELIVERED (confirmed by recipient)")
             else:
@@ -4719,6 +4727,13 @@ class ReticulumWrapper:
         """
         try:
             msg_hash = lxmf_message.hash.hex() if lxmf_message.hash else "unknown"
+
+            # Guard: if this message was already confirmed delivered by recipient,
+            # don't retry via propagation — that would regress the status
+            if msg_hash in self._successfully_delivered:
+                log_info("ReticulumWrapper", "_on_message_failed",
+                        f"⚠️ Message {msg_hash[:16]}... already delivered, ignoring spurious failure callback")
+                return  # Do NOT retry - already confirmed by recipient
 
             # CRITICAL FIX for issue #257: Guard against spurious failure callbacks
             # LXMF may call failure callback for propagated messages because it expects
@@ -5118,6 +5133,12 @@ class ReticulumWrapper:
         try:
             msg_hash = lxmf_message.hash.hex() if lxmf_message.hash else "unknown"
 
+            # Guard: if this message was already confirmed delivered, don't regress to sent/propagated
+            if msg_hash in self._successfully_delivered:
+                log_info("ReticulumWrapper", "_on_message_sent",
+                        f"⚠️ Message {msg_hash[:16]}... already delivered, ignoring sent callback")
+                return
+
             # For PROPAGATED messages, SENT state means relay stored the message
             # LXMF doesn't reliably call delivery callback for relay acceptance
             if hasattr(lxmf_message, 'desired_method') and lxmf_message.desired_method == LXMF.LXMessage.PROPAGATED:
@@ -5415,27 +5436,28 @@ class ReticulumWrapper:
 
     def _cleanup_stale_propagated_tracking(self):
         """
-        Remove entries from _successfully_propagated that are older than TTL.
-        This prevents memory leaks in long-running service.
+        Remove entries from _successfully_propagated and _successfully_delivered
+        that are older than TTL. This prevents memory leaks in long-running service.
 
         Called periodically from _opportunistic_timeout_loop (Issue #257 fix).
         """
-        if not self._successfully_propagated:
-            return  # Nothing to clean up
-
         now = time.time()
-        stale = []
 
-        for msg_hash, timestamp in list(self._successfully_propagated.items()):
-            age = now - timestamp
-            if age >= self._propagated_tracking_ttl_seconds:
-                stale.append(msg_hash)
-
-        if stale:
-            for msg_hash in stale:
-                del self._successfully_propagated[msg_hash]
-            log_debug("ReticulumWrapper", "_cleanup_stale_propagated_tracking",
-                     f"Cleaned up {len(stale)} stale propagated tracking entries")
+        for tracking_dict, label in [
+            (self._successfully_propagated, "propagated"),
+            (self._successfully_delivered, "delivered"),
+        ]:
+            if not tracking_dict:
+                continue
+            stale = [
+                msg_hash for msg_hash, timestamp in list(tracking_dict.items())
+                if now - timestamp >= self._propagated_tracking_ttl_seconds
+            ]
+            if stale:
+                for msg_hash in stale:
+                    del tracking_dict[msg_hash]
+                log_debug("ReticulumWrapper", "_cleanup_stale_propagated_tracking",
+                         f"Cleaned up {len(stale)} stale {label} tracking entries")
 
     def get_transport_identity_hash(self) -> bytes:
         """


### PR DESCRIPTION
## Summary
Cherry-pick of the main fix to `release/v0.8.x`.

- LXMF fires spurious failure/sent callbacks after a message is already confirmed delivered, triggering propagation retries that overwrite `delivered` (double checkmark) with `propagated` (single checkmark)
- **Python**: adds `_successfully_delivered` tracking set to guard `_on_message_delivered`, `_on_message_failed`, and `_on_message_sent` from regressing already-delivered messages
- **Kotlin**: makes `delivered` truly terminal — blocks any status update that would change it to a non-delivered state (defense-in-depth)

## Evidence
Device logs showing the bug and fix working:
```
16:04:12  _on_message_delivered(): DELIVERED (confirmed by recipient)  ✅
16:04:49  _on_message_failed(): retrying via propagation node          ← spurious, already delivered
16:14:26  _on_message_delivered(): PROPAGATED (stored on relay)        ← overwrites delivered ✗

# After fix:
16:40:24  _on_message_delivered(): DELIVERED (confirmed by recipient)  ✅
16:40:28  Blocking status regression from 'delivered' to 'sent'        ← blocked ✅
16:40:30  Blocking status regression from 'delivered' to 'sent'        ← blocked ✅
```

## Test plan
- [x] Existing `MessageStatusIconTest` tests pass
- [x] Existing `MessagingViewModelTest` status degradation tests pass
- [x] New tests: `propagated`/`retrying_propagated`/`sent` status blocked when message already delivered
- [x] Verified on device — delivered messages stay delivered after spurious callbacks

🤖 Generated with [Claude Code](https://claude.com/claude-code)