### PR TITLE
fix: use colon count instead of IPv6 regex for port-stripping guard

### DIFF
--- a/app/src/main/java/com/lxmf/messenger/util/validation/InputValidator.kt
+++ b/app/src/main/java/com/lxmf/messenger/util/validation/InputValidator.kt
@@ -293,8 +293,10 @@ object InputValidator {
                 .first() // Strip any path component after the hostname
 
         // Strip trailing :port (e.g. "example.com:8080" → "example.com")
-        // but not from IPv6 addresses which use colons extensively
-        if (!cleaned.startsWith("[") && !IPV6_REGEX.matches(cleaned) && cleaned.matches(Regex("^.+:\\d+$"))) {
+        // IPv6 addresses always have multiple colons; hostname:port has exactly one.
+        // This is safer than relying on IPV6_REGEX which may not cover all compressed forms.
+        val colonCount = cleaned.count { it == ':' }
+        if (colonCount == 1 && cleaned.matches(Regex("^.+:\\d+$"))) {
             cleaned = cleaned.substringBeforeLast(":")
         }
 


### PR DESCRIPTION
## Summary
- Replaces `!IPV6_REGEX.matches()` guard with a colon-count check (`colonCount == 1`) for port stripping in `validateHostname()`
- Compressed IPv6 addresses like `::1` and `fe80::1` aren't matched by the existing `IPV6_REGEX`, so they were being corrupted by the port-stripping logic
- Simpler invariant: IPv6 always has 2+ colons; `hostname:port` has exactly one

Follow-up to #537 addressing Greptile review feedback on #538.

## Test plan
- [x] Existing test: `validateHostname - does not strip segments from IPv6 address` (full-form)
- [x] New test: `validateHostname - does not corrupt compressed IPv6 addresses` (`::1`, `fe80::1`)
- [x] Existing port-stripping tests still pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)