### PR TITLE
fix: move app initialization off main thread to prevent ANR (COLUMBA-26)

### DIFF
--- a/app/src/main/java/com/lxmf/messenger/ColumbaApplication.kt
+++ b/app/src/main/java/com/lxmf/messenger/ColumbaApplication.kt
@@ -84,9 +84,9 @@ class ColumbaApplication : Application() {
     lateinit var telemetryCollectorManager: TelemetryCollectorManager
 
     // Application-level coroutine scope for app-wide operations
-    // Uses Dispatchers.Main for lifecycle operations and UI coordination
+    // Uses Dispatchers.Default for background initialization (no main-thread work needed)
     // SupervisorJob ensures failures don't crash the entire app
-    private val applicationScope = CoroutineScope(SupervisorJob() + Dispatchers.Main)
+    private val applicationScope = CoroutineScope(SupervisorJob() + Dispatchers.Default)
 
     override fun onCreate() {
         super.onCreate()


### PR DESCRIPTION
## Summary

- Changes `ColumbaApplication.applicationScope` from `Dispatchers.Main` to `Dispatchers.Default` to prevent ANR on the `/chats` screen during app startup
- All 8 consumers of `applicationScope` were audited — none require the main thread (most already use explicit `Dispatchers.IO`)
- Addresses Sentry COLUMBA-26: 26 ANR events across 18 users on releases 0.8.1–0.8.12

## Test plan

- [x] `assembleNoSentryDebug` builds successfully
- [x] `testNoSentryDebugUnitTest` passes with no regressions
- [ ] Install on device and verify app starts, chats screen loads, service initializes
- [ ] Check logcat for init chain log messages (should appear on background thread)

🤖 Generated with [Claude Code](https://claude.com/claude-code)