### PR TITLE
fix: debounce reachable count to prevent binder saturation

### DIFF
--- a/app/src/main/java/com/lxmf/messenger/ui/screens/IdentityScreen.kt
+++ b/app/src/main/java/com/lxmf/messenger/ui/screens/IdentityScreen.kt
@@ -173,6 +173,7 @@ fun IdentityScreen(
 
             // Status Card
             StatusCard(
+                isLoading = debugInfo.isLoading,
                 initialized = debugInfo.initialized,
                 networkStatus = networkStatus,
                 error = debugInfo.error,
@@ -220,6 +221,7 @@ fun IdentityScreen(
 
 @Composable
 fun StatusCard(
+    isLoading: Boolean = false,
     initialized: Boolean,
     networkStatus: String,
     error: String?,
@@ -233,7 +235,7 @@ fun StatusCard(
             CardDefaults.cardColors(
                 containerColor =
                     when {
-                        isConnecting -> MaterialTheme.colorScheme.tertiaryContainer
+                        isLoading || isConnecting -> MaterialTheme.colorScheme.tertiaryContainer
                         initialized && error == null -> MaterialTheme.colorScheme.primaryContainer
                         else -> MaterialTheme.colorScheme.errorContainer
                     },
@@ -253,14 +255,14 @@ fun StatusCard(
                 Icon(
                     imageVector =
                         when {
-                            isConnecting -> Icons.Default.Refresh
+                            isLoading || isConnecting -> Icons.Default.Refresh
                             initialized && error == null -> Icons.Default.CheckCircle
                             else -> Icons.Default.Warning
                         },
                     contentDescription = null,
                     tint =
                         when {
-                            isConnecting -> MaterialTheme.colorScheme.onTertiaryContainer
+                            isLoading || isConnecting -> MaterialTheme.colorScheme.onTertiaryContainer
                             initialized && error == null -> MaterialTheme.colorScheme.onPrimaryContainer
                             else -> MaterialTheme.colorScheme.onErrorContainer
                         },
@@ -274,10 +276,20 @@ fun StatusCard(
 
             Divider()
 
-            InfoRow(label = "Initialized", value = if (initialized) "Yes" else "No")
-            InfoRow(label = "Network Status", value = networkStatus)
+            InfoRow(
+                label = "Initialized",
+                value =
+                    if (isLoading) {
+                        "Loading..."
+                    } else if (initialized) {
+                        "Yes"
+                    } else {
+                        "No"
+                    },
+            )
+            InfoRow(label = "Network Status", value = if (isLoading) "Loading..." else networkStatus)
 
-            if (isConnecting) {
+            if (isLoading || isConnecting) {
                 Row(
                     horizontalArrangement = Arrangement.spacedBy(8.dp),
                     verticalAlignment = Alignment.CenterVertically,
@@ -287,7 +299,7 @@ fun StatusCard(
                         strokeWidth = 2.dp,
                     )
                     Text(
-                        text = "Reconnecting to service...",
+                        text = if (isLoading) "Fetching service status..." else "Reconnecting to service...",
                         style = MaterialTheme.typography.bodySmall,
                         color = MaterialTheme.colorScheme.onTertiaryContainer,
                     )
@@ -305,8 +317,7 @@ fun StatusCard(
                             .background(
                                 MaterialTheme.colorScheme.errorContainer.copy(alpha = 0.3f),
                                 RoundedCornerShape(8.dp),
-                            )
-                            .padding(8.dp),
+                            ).padding(8.dp),
                 )
             }
         }
@@ -567,15 +578,13 @@ fun InterfaceRow(
                 .background(
                     MaterialTheme.colorScheme.surfaceVariant,
                     RoundedCornerShape(8.dp),
-                )
-                .then(
+                ).then(
                     if (onClick != null) {
                         Modifier.clickable(onClick = onClick)
                     } else {
                         Modifier
                     },
-                )
-                .padding(12.dp),
+                ).padding(12.dp),
         horizontalArrangement = Arrangement.SpaceBetween,
         verticalAlignment = Alignment.CenterVertically,
     ) {
@@ -940,8 +949,7 @@ fun BleConnectionsCard(
                                         .background(
                                             MaterialTheme.colorScheme.surfaceVariant,
                                             RoundedCornerShape(8.dp),
-                                        )
-                                        .padding(12.dp),
+                                        ).padding(12.dp),
                                 horizontalArrangement = Arrangement.SpaceEvenly,
                             ) {
                                 Column(horizontalAlignment = Alignment.CenterHorizontally) {
@@ -988,7 +996,11 @@ fun BleConnectionsCard(
                             // Signal quality indicator
                             val avgSignalQuality =
                                 if (uiState.connections.isNotEmpty()) {
-                                    val avgRssi = uiState.connections.map { it.rssi }.average().toInt()
+                                    val avgRssi =
+                                        uiState.connections
+                                            .map { it.rssi }
+                                            .average()
+                                            .toInt()
                                     when {
                                         avgRssi > -50 -> SignalQuality.EXCELLENT
                                         avgRssi > -70 -> SignalQuality.GOOD

--- a/app/src/main/java/com/lxmf/messenger/viewmodel/DebugViewModel.kt
+++ b/app/src/main/java/com/lxmf/messenger/viewmodel/DebugViewModel.kt
@@ -23,6 +23,7 @@ import javax.inject.Inject
 
 @androidx.compose.runtime.Immutable
 data class DebugInfo(
+    val isLoading: Boolean = true,
     val initialized: Boolean = false,
     val reticulumAvailable: Boolean = false,
     val storagePath: String = "",
@@ -209,6 +210,7 @@ class DebugViewModel
 
                 _debugInfo.value =
                     DebugInfo(
+                        isLoading = false,
                         initialized = json.optBoolean("initialized", false),
                         reticulumAvailable = json.optBoolean("reticulum_available", false),
                         storagePath = json.optString("storage_path", ""),
@@ -253,7 +255,7 @@ class DebugViewModel
 
                     // Reset debug info when shutdown - prevents stale "initialized: true" in UI
                     if (status is com.lxmf.messenger.reticulum.model.NetworkStatus.SHUTDOWN) {
-                        _debugInfo.value = DebugInfo()
+                        _debugInfo.value = DebugInfo(isLoading = false)
                     }
                 }
             }
@@ -307,6 +309,7 @@ class DebugViewModel
 
                     _debugInfo.value =
                         DebugInfo(
+                            isLoading = false,
                             initialized = pythonDebugInfo["initialized"] as? Boolean ?: false,
                             reticulumAvailable = pythonDebugInfo["reticulum_available"] as? Boolean ?: false,
                             storagePath = pythonDebugInfo["storage_path"] as? String ?: "",
@@ -328,10 +331,10 @@ class DebugViewModel
                         )
                 } catch (e: Exception) {
                     if (isServiceShutdown()) {
-                        _debugInfo.value = DebugInfo()
+                        _debugInfo.value = DebugInfo(isLoading = false)
                     } else {
                         Log.e(TAG, "Error fetching debug info", e)
-                        _debugInfo.value = _debugInfo.value.copy(error = e.message ?: "Service unavailable")
+                        _debugInfo.value = _debugInfo.value.copy(isLoading = false, error = e.message ?: "Service unavailable")
                     }
                 }
             }
@@ -541,7 +544,7 @@ class DebugViewModel
 
                     // Clear UI immediately so status card shows clean shutdown state
                     // (don't wait for onServiceDisconnected which has a race window)
-                    _debugInfo.value = DebugInfo()
+                    _debugInfo.value = DebugInfo(isLoading = false)
                     _networkStatus.value = "SHUTDOWN"
 
                     // Unbind FIRST to prevent auto-rebind if service process crashes


### PR DESCRIPTION
## Summary
- **Remove per-announce `updateReachableCount()` IPC call** that was flooding the binder thread pool (15 threads) when busy hubs sent announces every 1-2s, each acquiring the GIL and iterating 1100+ paths
- **Replace with `AtomicBoolean` dirty flag** set per announce, checked by the existing 30s periodic timer — reduces `get_path_table` IPC from ~60/min to at most 2/min
- **Add `isLoading` state to `DebugInfo`** so the network status card shows "Loading..." with spinner instead of a misleading red "Not Initialized" while the first IPC call is in flight

## Test plan
- [x] Build compiles: `./gradlew :app:compileNoSentryDebugKotlin`
- [x] All 100 related unit tests pass (AnnounceStreamViewModelTest + DebugViewModel*Test)
- [ ] Install on device and open announce stream screen
- [ ] Monitor logcat: `get_path_table` calls should appear at most every 30s, not on every announce
- [ ] Navigate to network status — should show "Loading..." briefly, not "Not Initialized"
- [ ] Send a test message — should succeed without long delays

🤖 Generated with [Claude Code](https://claude.com/claude-code)