### PR TITLE
feat: voice message recording and send (Phase 8)

### DIFF
--- a/.planning/PROJECT.md
+++ b/.planning/PROJECT.md
@@ -28,25 +28,43 @@ Reliable off-grid messaging with a polished, responsive user experience.
 
 ### Active
 
-- [ ] **NOTF-01**: No duplicate notifications after service restart for already-read messages (#338)
-- [ ] **PERM-01**: Location permission dialog stays dismissed until app restart (#342)
-- [ ] Native memory growth investigation (~1.4 MB/min in Python layer)
+- [ ] **VM-01**: User can record a voice message by holding a mic button in the chat input
+- [ ] **VM-02**: Voice message is encoded with Opus VOICE_MEDIUM (8kbps) via LXST-kt
+- [ ] **VM-03**: Voice message is sent as FIELD_AUDIO (0x07) in LXMF message
+- [ ] **VM-04**: Voice messages render inline as a bubble with play/pause button and waveform
+- [ ] **VM-05**: Voice message playback uses LXST-kt (Opus decode + Oboe playback)
+- [ ] **VM-06**: Recording has a 30-second maximum duration (~30KB at VOICE_MEDIUM)
 
 ### Out of Scope
 
 - iOS version — Android-first approach
 - Desktop version — mobile focus
+- Voice calls over mesh — separate feature (LXST telephone already exists)
+- Audio effects/filters on voice messages — unnecessary complexity
+
+## Current Milestone: v0.10.0 Voice Messages
+
+**Goal:** Add voice message recording, sending, and inline playback to conversations.
+
+**Target features:**
+- Hold-to-record mic button in chat input area
+- Opus VOICE_MEDIUM encoding via LXST-kt (~30KB for 30s)
+- LXMF FIELD_AUDIO transport
+- Inline audio bubble with play/pause + waveform visualization
+- Playback via LXST-kt Opus decode + Oboe native playback
 
 ## Context
 
-**Current State (v0.7.3):**
+**Current State:**
 - ~205K lines of Kotlin
 - Tech stack: Kotlin, Compose, Hilt, Room, Chaquopy (Python bridge)
-- Sentry performance monitoring integrated (10% transactions, 5% profiling)
-- 137 commits, 107 files changed since v0.7.2-beta
+- LXST-kt audio library already in repo (Opus, Codec2, Oboe capture/playback)
+- FIELD_AUDIO = 0x07 already defined in Python wrapper and recognized as meaningful field
+- MessageEntity.fieldsJson already supports audio field storage
+- Sentry performance monitoring integrated
 
 **Known Issues:**
-- Native memory growth (~1.4 MB/min) in Python/Reticulum layer — needs tracemalloc investigation
+- Native memory growth (~1.4 MB/min) in Python/Reticulum layer
 - PropagationNodeManager is large class — could extract RelaySelectionStateMachine
 
 ## Constraints
@@ -68,6 +86,10 @@ Reliable off-grid messaging with a polished, responsive user experience.
 | SQL subquery for contact-aware delete | More efficient than app-side filtering | ✓ Good |
 | Cache MapLibre style JSON locally | Enables indefinite offline map rendering | ✓ Good |
 | Boolean isLoading flag pattern | Consistent with existing MapViewModel | ✓ Good |
+| Opus VOICE_MEDIUM for voice messages | 8kbps balances quality and mesh-friendly size (~30KB/30s) | — Pending |
+| Hold-to-record UX | Familiar pattern (WhatsApp/Signal), quick for short messages | — Pending |
+| 30s max voice message duration | Keeps messages under ~30KB, practical for mesh links | — Pending |
+| LXST-kt for record and playback | Already in codebase, native Oboe performance, Opus codec ready | — Pending |
 
 ---
-*Last updated: 2026-01-28 after v0.7.3 milestone*
+*Last updated: 2026-02-23 after v0.10.0 milestone start*

--- a/.planning/REQUIREMENTS.md
+++ b/.planning/REQUIREMENTS.md
@@ -1,0 +1,119 @@
+# Requirements: Columba v0.10.0 Voice Messages
+
+**Defined:** 2026-02-23
+**Core Value:** Reliable off-grid messaging with a polished, responsive user experience.
+
+## v1 Requirements
+
+Requirements for v0.10.0 release. Each maps to roadmap phases.
+
+### Recording
+
+- [ ] **REC-01**: User can record a voice message by holding the mic button in chat input
+- [ ] **REC-02**: Mic button replaces send button when text field is empty
+- [ ] **REC-03**: User can cancel recording by sliding finger left (slide-to-cancel)
+- [ ] **REC-04**: Recording timer counts up from 0:00, visible during recording
+- [ ] **REC-05**: Recording auto-stops and auto-sends at 30-second limit
+- [ ] **REC-06**: Visual recording indicator (pulsing animation) during active recording
+- [ ] **REC-07**: Recordings shorter than 300ms are discarded (prevent accidental sends)
+
+### Protocol & Transport
+
+- [x] **PROTO-01**: Voice messages encode with Opus VOICE_MEDIUM (8kbps) via LXST-kt NativeCaptureEngine + Opus codec
+- [x] **PROTO-02**: Encoded audio sent as FIELD_AUDIO (0x07) in LXMF message
+- [x] **PROTO-03**: FIELD_AUDIO (0x07) / LEGACY_LOCATION_FIELD (7) collision resolved safely
+- [x] **PROTO-04**: Waveform amplitude data stored alongside audio for rendering without re-decode
+- [x] **PROTO-05**: Received FIELD_AUDIO extracted from LXMF message and stored in MessageEntity.fieldsJson
+
+### Playback
+
+- [ ] **PLAY-01**: Voice messages render inline as audio bubble with play/pause button
+- [ ] **PLAY-02**: Waveform visualization shows audio shape in message bubble
+- [ ] **PLAY-03**: Waveform animates as progress indicator during playback
+- [ ] **PLAY-04**: Duration displayed in mm:ss format
+- [ ] **PLAY-05**: Unplayed voice messages have visual indicator (distinct from played)
+- [ ] **PLAY-06**: Only one voice message plays at a time (new play stops previous)
+- [ ] **PLAY-07**: Playback uses LXST-kt Opus decode + Oboe native output
+
+### Audio Focus & Edge Cases
+
+- [ ] **EDGE-01**: Recording requests AUDIOFOCUS_GAIN_TRANSIENT_EXCLUSIVE (silences notifications)
+- [ ] **EDGE-02**: Playback requests AUDIOFOCUS_GAIN_TRANSIENT (ducks other audio)
+- [ ] **EDGE-03**: Incoming call during recording stops and discards recording gracefully
+- [ ] **EDGE-04**: App backgrounded during recording stops and discards
+- [ ] **EDGE-05**: Headphone disconnect during playback pauses playback
+- [ ] **EDGE-06**: Corrupt/incomplete audio data shows error state in bubble (no crash)
+- [ ] **EDGE-07**: RECORD_AUDIO permission requested before first recording attempt
+
+## v2 Requirements
+
+Deferred to future release. Tracked but not in current roadmap.
+
+### Playback Enhancements
+
+- **PLAY-08**: Playback speed controls (1x / 1.5x / 2x toggle)
+- **PLAY-09**: Remember playback position within session
+- **PLAY-10**: Sequential auto-play of unplayed voice messages
+- **PLAY-11**: Proximity sensor switches audio to earpiece when held to ear
+
+### Recording Enhancements
+
+- **REC-08**: Lock recording mode (swipe up on mic to record hands-free)
+- **REC-09**: Draft preview — listen to recording before sending (requires REC-08)
+
+### System Integration
+
+- **SYS-01**: Background/out-of-chat playback with mini-player bar
+- **SYS-02**: Bluetooth audio routing for playback
+
+## Out of Scope
+
+| Feature | Reason |
+|---------|--------|
+| Voice-to-text transcription | Requires large ML models or cloud API; privacy-hostile for mesh messenger |
+| Voice message forwarding | Same as sending a new message; no protocol change needed |
+| Raise-to-speak recording | Fragile sensor fusion, high false-positive rate |
+| Self-destructing voice messages | LXMF has no deletion protocol; false sense of security |
+| Video notes (round video messages) | Video at mesh-compatible bitrates is unusable quality |
+| Audio effects / voice filters | Unnecessary complexity; Opus VOIP mode has built-in signal processing |
+| Generic audio file inline player | Voice messages (field 7) are distinct from file attachments (field 5) |
+
+## Traceability
+
+| Requirement | Phase | Status |
+|-------------|-------|--------|
+| REC-01 | Phase 8 | Pending |
+| REC-02 | Phase 10 | Pending |
+| REC-03 | Phase 10 | Pending |
+| REC-04 | Phase 10 | Pending |
+| REC-05 | Phase 8 | Pending |
+| REC-06 | Phase 10 | Pending |
+| REC-07 | Phase 8 | Pending |
+| PROTO-01 | Phase 7 | Complete |
+| PROTO-02 | Phase 7 | Complete |
+| PROTO-03 | Phase 7 | Complete |
+| PROTO-04 | Phase 7 | Complete |
+| PROTO-05 | Phase 7 | Complete |
+| PLAY-01 | Phase 9 | Pending |
+| PLAY-02 | Phase 9 | Pending |
+| PLAY-03 | Phase 9 | Pending |
+| PLAY-04 | Phase 9 | Pending |
+| PLAY-05 | Phase 9 | Pending |
+| PLAY-06 | Phase 9 | Pending |
+| PLAY-07 | Phase 9 | Pending |
+| EDGE-01 | Phase 8 | Pending |
+| EDGE-02 | Phase 9 | Pending |
+| EDGE-03 | Phase 10 | Pending |
+| EDGE-04 | Phase 10 | Pending |
+| EDGE-05 | Phase 10 | Pending |
+| EDGE-06 | Phase 9 | Pending |
+| EDGE-07 | Phase 8 | Pending |
+
+**Coverage:**
+- v1 requirements: 22 total
+- Mapped to phases: 22
+- Unmapped: 0
+
+---
+*Requirements defined: 2026-02-23*
+*Last updated: 2026-02-24 after Phase 7 completion*

--- a/.planning/ROADMAP.md
+++ b/.planning/ROADMAP.md
@@ -3,7 +3,8 @@
 ## Milestones
 
 - v0.7.3-beta (Phases 1-2.3) - shipped 2026-01-28
-- **v0.7.4-beta Bug Fixes** (Phases 3-6) - in progress
+- v0.7.4-beta Bug Fixes (Phases 3-6) - in progress
+- **v0.10.0 Voice Messages** (Phases 7-10) - planned
 
 ## Phases
 
@@ -14,25 +15,11 @@ See git history for v0.7.3-beta milestone.
 
 </details>
 
-### v0.7.4-beta Bug Fixes (In Progress)
-
-**Milestone Goal:** Address critical production issues identified via Sentry monitoring.
-
-- [x] **Phase 3: ANR Elimination** - Fix synchronous IPC on main thread
-- [x] **Phase 4: Relay Loop Resolution** - Investigate and fix COLUMBA-3 regression
-- [ ] **Phase 5: Memory Optimization** - Address OOM-causing memory growth
-- [ ] **Phase 6: Native Stability Verification** - Verify MapLibre crashes after memory fix
-
-## Phase Details
+<details>
+<summary>v0.7.4-beta Bug Fixes (Phases 3-6) - IN PROGRESS</summary>
 
 ### Phase 3: ANR Elimination
 **Goal**: ViewModel initialization never blocks the main thread
-**Depends on**: Nothing (quick win, independent)
-**Requirements**: ANR-01
-**Success Criteria** (what must be TRUE):
-  1. DebugViewModel initializes without blocking main thread (no ANR on screen open)
-  2. All IPC calls to service occur on IO dispatcher
-  3. Zero ANRs from IPC in Sentry for 48 hours post-release
 **Plans**: 1 plan
 
 Plans:
@@ -40,12 +27,6 @@ Plans:
 
 ### Phase 4: Relay Loop Resolution
 **Goal**: Relay selection completes without looping under any conditions
-**Depends on**: Nothing (independent of Phase 3)
-**Requirements**: RELAY-03
-**Success Criteria** (what must be TRUE):
-  1. Relay selection settles on a single node without add/remove/add cycles
-  2. StateFlow uses `SharingStarted.WhileSubscribed` (per Seer recommendation)
-  3. Zero "Relay selection loop detected" warnings in Sentry for 48 hours
 **Plans**: 1 plan
 
 Plans:
@@ -53,12 +34,6 @@ Plans:
 
 ### Phase 5: Memory Optimization
 **Goal**: App runs indefinitely without OOM crashes
-**Depends on**: Nothing (independent, but largest scope)
-**Requirements**: MEM-01
-**Success Criteria** (what must be TRUE):
-  1. Memory growth rate reduced to sustainable level (measurable via profiling)
-  2. App survives 5+ days continuous runtime without OOM (verified via extended testing)
-  3. Zero OOM crashes in Sentry for 7 days post-release
 **Plans**: 3 plans
 
 Plans:
@@ -68,24 +43,96 @@ Plans:
 
 ### Phase 6: Native Stability Verification
 **Goal**: Confirm MapLibre native crashes are resolved by memory optimization
-**Depends on**: Phase 5 (crashes likely secondary to memory pressure)
-**Requirements**: NATIVE-01
-**Success Criteria** (what must be TRUE):
-  1. No MapRenderer SIGSEGV crashes in extended testing
-  2. MapLibre abort crashes eliminated or reduced to near-zero
-  3. No recurring native crashes in Sentry for 7 days post-release
-**Plans**: TBD
+**Plans**: 1 plan
 
 Plans:
 - [ ] 06-01: Verify native stability after memory fix
 
+</details>
+
+### v0.10.0 Voice Messages
+
+**Milestone Goal:** Add voice message recording, sending, and inline playback to conversations, using Opus encoding via LXST-kt and LXMF FIELD_AUDIO transport.
+
+- [ ] **Phase 7: Protocol and Transport Foundation** - Wire format, field collision resolution, send/receive pipeline
+- [ ] **Phase 8: Recording and Send Path** - VoiceRecorder with Opus encoding, wired through to LXMF send
+- [ ] **Phase 9: Playback and Audio Bubble** - Opus decode, inline voice message bubble with waveform playback
+- [ ] **Phase 10: Recording UI and Edge Cases** - Hold-to-record gesture polish and interruption handling
+
+## Phase Details
+
+### Phase 7: Protocol and Transport Foundation
+**Goal**: Audio data can round-trip through the LXMF pipeline -- encoded, packed, sent, received, stored, and extracted
+**Depends on**: Nothing (foundation for all voice message work)
+**Requirements**: PROTO-01, PROTO-02, PROTO-03, PROTO-04, PROTO-05
+**Success Criteria** (what must be TRUE):
+  1. Opus VOICE_MEDIUM (8kbps, 24kHz mono) audio bytes can be packed into FIELD_AUDIO (0x07) and sent as an LXMF message
+  2. A received LXMF message containing FIELD_AUDIO is stored in MessageEntity.fieldsJson with the audio data intact and extractable
+  3. Messages with legacy location data in field 7 continue to work correctly (no misinterpretation as audio)
+  4. Waveform amplitude data is stored alongside the encoded audio bytes and can be retrieved without re-decoding
+  5. MessageMapper correctly identifies messages with audio fields and extracts audio metadata (duration, codec, waveform)
+**Plans**: 3 plans
+
+Plans:
+- [ ] 07-01-PLAN.md -- Send path plumbing: AIDL + ServiceBinder + Protocol + Python audio params and field 7 disambiguation
+- [ ] 07-02-PLAN.md -- Kotlin extraction: MessageMapper audio detection/extraction + MessageUi audio fields
+- [ ] 07-03-PLAN.md -- ViewModel wiring: buildFieldsJson field 7 support + end-to-end build verification
+
+### Phase 8: Recording and Send Path
+**Goal**: User can record a voice message from the chat screen and send it through the LXMF pipeline
+**Depends on**: Phase 7 (wire format and transport must be defined)
+**Requirements**: REC-01, REC-05, REC-07, EDGE-01, EDGE-07
+**Success Criteria** (what must be TRUE):
+  1. User can hold the mic button to record audio, and releasing sends the voice message to the conversation partner
+  2. Recording automatically stops and sends at 30 seconds
+  3. Accidental taps shorter than 300ms are silently discarded (no message sent)
+  4. RECORD_AUDIO permission is requested on first recording attempt (recording does not start without permission)
+  5. Other app audio (notifications, media) is silenced during recording via AUDIOFOCUS_GAIN_TRANSIENT_EXCLUSIVE
+**Plans**: TBD
+
+Plans:
+- [ ] 08-01: TBD
+- [ ] 08-02: TBD
+
+### Phase 9: Playback and Audio Bubble
+**Goal**: Received voice messages render inline as audio bubbles and play back with waveform progress
+**Depends on**: Phase 7 (audio extraction from fieldsJson), Phase 8 (need sent messages to test with)
+**Requirements**: PLAY-01, PLAY-02, PLAY-03, PLAY-04, PLAY-05, PLAY-06, PLAY-07, EDGE-02, EDGE-06
+**Success Criteria** (what must be TRUE):
+  1. Voice messages appear inline in the conversation as audio bubbles with a play/pause button, waveform visualization, and mm:ss duration
+  2. Tapping play decodes and plays the audio; the waveform animates left-to-right as a progress indicator during playback
+  3. Playing a new voice message automatically stops any currently playing message
+  4. Unplayed voice messages are visually distinct from played ones (indicator disappears after first play)
+  5. Corrupt or incomplete audio data renders as an error state in the bubble without crashing the app
+**Plans**: TBD
+
+Plans:
+- [ ] 09-01: TBD
+- [ ] 09-02: TBD
+
+### Phase 10: Recording UI and Edge Cases
+**Goal**: Recording interaction is polished with familiar gesture controls, and all interruption edge cases are handled gracefully
+**Depends on**: Phase 8 (recording infrastructure must work), Phase 9 (playback must work for end-to-end verification)
+**Requirements**: REC-02, REC-03, REC-04, REC-06, EDGE-03, EDGE-04, EDGE-05
+**Success Criteria** (what must be TRUE):
+  1. Mic button appears in place of the send button when the text field is empty, and the send button reappears when text is entered
+  2. User can cancel an in-progress recording by sliding their finger left (slide-to-cancel gesture with visual affordance)
+  3. A visible timer counts up from 0:00 during recording, and a pulsing animation indicates active recording
+  4. An incoming phone call during recording stops and discards the recording without crashing or sending a partial message
+  5. App being backgrounded during recording stops and discards the recording; headphone disconnect during playback pauses playback
+**Plans**: TBD
+
+Plans:
+- [ ] 10-01: TBD
+- [ ] 10-02: TBD
+
 ## Progress
 
-**Execution Order:** Phases execute in numeric order: 3 -> 4 -> 5 -> 6
+**Execution Order:** Phases execute in numeric order: 7 -> 8 -> 9 -> 10
 
 | Phase | Plans Complete | Status | Completed |
 |-------|----------------|--------|-----------|
-| 3. ANR Elimination | 1/1 | Complete | 2026-01-29 |
-| 4. Relay Loop Resolution | 1/1 | Complete | 2026-01-29 |
-| 5. Memory Optimization | 0/3 | Not started | - |
-| 6. Native Stability Verification | 0/1 | Not started | - |
+| 7. Protocol and Transport Foundation | 0/3 | Not started | - |
+| 8. Recording and Send Path | 0/TBD | Not started | - |
+| 9. Playback and Audio Bubble | 0/TBD | Not started | - |
+| 10. Recording UI and Edge Cases | 0/TBD | Not started | - |

--- a/.planning/ROADMAP.md
+++ b/.planning/ROADMAP.md
@@ -54,7 +54,7 @@ Plans:
 
 **Milestone Goal:** Add voice message recording, sending, and inline playback to conversations, using Opus encoding via LXST-kt and LXMF FIELD_AUDIO transport.
 
-- [ ] **Phase 7: Protocol and Transport Foundation** - Wire format, field collision resolution, send/receive pipeline
+- [x] **Phase 7: Protocol and Transport Foundation** - Wire format, field collision resolution, send/receive pipeline
 - [ ] **Phase 8: Recording and Send Path** - VoiceRecorder with Opus encoding, wired through to LXMF send
 - [ ] **Phase 9: Playback and Audio Bubble** - Opus decode, inline voice message bubble with waveform playback
 - [ ] **Phase 10: Recording UI and Edge Cases** - Hold-to-record gesture polish and interruption handling
@@ -74,9 +74,9 @@ Plans:
 **Plans**: 3 plans
 
 Plans:
-- [ ] 07-01-PLAN.md -- Send path plumbing: AIDL + ServiceBinder + Protocol + Python audio params and field 7 disambiguation
-- [ ] 07-02-PLAN.md -- Kotlin extraction: MessageMapper audio detection/extraction + MessageUi audio fields
-- [ ] 07-03-PLAN.md -- ViewModel wiring: buildFieldsJson field 7 support + end-to-end build verification
+- [x] 07-01-PLAN.md -- Send path plumbing: AIDL + ServiceBinder + Protocol + Python audio params and field 7 disambiguation
+- [x] 07-02-PLAN.md -- Kotlin extraction: MessageMapper audio detection/extraction + MessageUi audio fields
+- [x] 07-03-PLAN.md -- ViewModel wiring: buildFieldsJson field 7 support + end-to-end build verification
 
 ### Phase 8: Recording and Send Path
 **Goal**: User can record a voice message from the chat screen and send it through the LXMF pipeline
@@ -132,7 +132,7 @@ Plans:
 
 | Phase | Plans Complete | Status | Completed |
 |-------|----------------|--------|-----------|
-| 7. Protocol and Transport Foundation | 0/3 | Not started | - |
+| 7. Protocol and Transport Foundation | 3/3 | Complete | 2026-02-24 |
 | 8. Recording and Send Path | 0/TBD | Not started | - |
 | 9. Playback and Audio Bubble | 0/TBD | Not started | - |
 | 10. Recording UI and Edge Cases | 0/TBD | Not started | - |

--- a/.planning/ROADMAP.md
+++ b/.planning/ROADMAP.md
@@ -88,11 +88,11 @@ Plans:
   3. Accidental taps shorter than 300ms are silently discarded (no message sent)
   4. RECORD_AUDIO permission is requested on first recording attempt (recording does not start without permission)
   5. Other app audio (notifications, media) is silenced during recording via AUDIOFOCUS_GAIN_TRANSIENT_EXCLUSIVE
-**Plans**: TBD
+**Plans**: 2 plans
 
 Plans:
-- [ ] 08-01: TBD
-- [ ] 08-02: TBD
+- [ ] 08-01-PLAN.md -- VoiceMessageRecorder with Opus encoding, audio focus, and AudioPermissionManager
+- [ ] 08-02-PLAN.md -- VoiceMessageViewModel, mic button UI with hold gesture, sendMessage wiring
 
 ### Phase 9: Playback and Audio Bubble
 **Goal**: Received voice messages render inline as audio bubbles and play back with waveform progress
@@ -133,6 +133,6 @@ Plans:
 | Phase | Plans Complete | Status | Completed |
 |-------|----------------|--------|-----------|
 | 7. Protocol and Transport Foundation | 3/3 | Complete | 2026-02-24 |
-| 8. Recording and Send Path | 0/TBD | Not started | - |
+| 8. Recording and Send Path | 0/2 | Not started | - |
 | 9. Playback and Audio Bubble | 0/TBD | Not started | - |
 | 10. Recording UI and Edge Cases | 0/TBD | Not started | - |

--- a/.planning/STATE.md
+++ b/.planning/STATE.md
@@ -5,24 +5,27 @@
 See: .planning/PROJECT.md (updated 2026-02-23)
 
 **Core value:** Reliable off-grid messaging with a polished, responsive user experience.
-**Current focus:** v0.10.0 Voice Messages — Defining requirements
+**Current focus:** v0.10.0 Voice Messages -- Phase 7: Protocol and Transport Foundation
 
 ## Current Position
 
-Phase: Not started (defining requirements)
-Plan: —
-Status: Defining requirements
-Last activity: 2026-02-23 — Milestone v0.10.0 started
+Phase: 7 of 10 (Protocol and Transport Foundation)
+Plan: 2 of 3 in phase (07-02 complete)
+Status: In progress
+Last activity: 2026-02-24 -- Completed 07-02-PLAN.md (audio fields in MessageUi/MessageMapper)
 
-Progress: [░░░░░░░░░░░░] 0% — Requirements phase
+Progress: [░░░░░░░░░░░░] 0% -- 0/4 phases complete (Phase 7 in progress)
 
 ## Milestone Summary
 
-**v0.10.0 Voice Messages — Initializing**
+**v0.10.0 Voice Messages**
 
 | Phase | Goal | Requirements | Status |
 |-------|------|--------------|--------|
-| TBD | — | — | Not started |
+| 7. Protocol Foundation | Audio round-trips through LXMF pipeline | PROTO-01..05 | Not started |
+| 8. Recording + Send | Record and send voice messages | REC-01,05,07 EDGE-01,07 | Not started |
+| 9. Playback + Bubble | Inline playback with waveform | PLAY-01..07 EDGE-02,06 | Not started |
+| 10. UI Polish + Edge Cases | Gesture polish, interruption handling | REC-02..04,06 EDGE-03..05 | Not started |
 
 ## Accumulated Context
 
@@ -37,18 +40,13 @@ Progress: [░░░░░░░░░░░░] 0% — Requirements phase
 
 | Decision | Rationale | Phase |
 |----------|-----------|-------|
-| Opus VOICE_MEDIUM (8kbps) | Balances quality and mesh-friendly size (~30KB/30s) | — |
-| Hold-to-record UX | Familiar pattern (WhatsApp/Signal), quick for short messages | — |
-| 30s max duration | Keeps messages under ~30KB, practical for mesh links | — |
-| LXST-kt for record + playback | Already in codebase, native Oboe performance, Opus codec ready | — |
-| Play button + waveform UI | Rich inline experience, matches modern messenger expectations | — |
-
-### Patterns Established
-
-- **WhileSubscribed(5000L)**: Standard timeout for Room-backed StateFlows
-- **Turbine test pattern**: Keep collector active inside test block when testing StateFlow.value with WhileSubscribed
-- **BuildConfig feature flags**: Clean pattern for debug-only functionality with zero release overhead
-- **Image attachment pipeline**: FIELD_IMAGE → fieldsJson → MessageUi → inline rendering (pattern to follow for audio)
+| Opus VOICE_MEDIUM (8kbps) | Balances quality and mesh-friendly size (~30KB/30s) | 7 |
+| AudioRecord + Opus.encode() over NativeCaptureEngine | Avoids singleton conflict with voice calls; quality diff negligible for store-and-forward | 8 |
+| Length-prefixed Opus frames (no Ogg container) | Compact, simple, sufficient for Columba-to-Columba; codec_id identifies format | 7 |
+| 30s max duration | Keeps messages under ~30KB, practical for mesh links | 8 |
+| Audio detected by JSONArray format in field 7 | Distinguishes audio ["codec_id","hex"] from legacy location string data in same field | 7-02 |
+| audioDurationMs=null until Phase 9 playback | Duration in audio header requires decoding; deferred to avoid blocking toMessageUi() | 7-02 |
+| Waveform not transmitted over wire for received messages | Avoids bloating LXMF wire format; computed lazily on first view in Phase 9 | 7-02 |
 
 ### Pending Todos
 
@@ -57,9 +55,13 @@ Progress: [░░░░░░░░░░░░] 0% — Requirements phase
 - **Make discovered interfaces page event-driven** (ui)
 - **Refactor PropagationNodeManager to extract components** (architecture)
 
+### Blockers/Concerns
+
+None yet.
+
 ## Session Continuity
 
-Last session: 2026-02-23
-Stopped at: Milestone v0.10.0 initialization
+Last session: 2026-02-24T05:06:10Z
+Stopped at: Completed 07-02-PLAN.md (audio fields in MessageUi and MessageMapper)
 Resume file: None
-Next: Complete requirements → roadmap → `/gsd:plan-phase [N]`
+Next: 07-03 (audio send pipeline - encode voice messages into fieldsJson for LXMF transport)

--- a/.planning/STATE.md
+++ b/.planning/STATE.md
@@ -5,16 +5,16 @@
 See: .planning/PROJECT.md (updated 2026-02-23)
 
 **Core value:** Reliable off-grid messaging with a polished, responsive user experience.
-**Current focus:** v0.10.0 Voice Messages -- Phase 7: Protocol and Transport Foundation
+**Current focus:** v0.10.0 Voice Messages -- Phase 8: Recording and Send
 
 ## Current Position
 
-Phase: 7 of 10 (Protocol and Transport Foundation)
-Plan: 2 of 3 in phase (07-02 complete)
-Status: In progress
-Last activity: 2026-02-24 -- Completed 07-02-PLAN.md (audio fields in MessageUi/MessageMapper)
+Phase: 7 of 10 (Protocol and Transport Foundation) -- COMPLETE
+Plan: 3 of 3 in phase (07-01, 07-02, 07-03 all complete)
+Status: Phase 7 complete, ready for Phase 8
+Last activity: 2026-02-24 -- Completed 07-03-PLAN.md (ViewModel audio send flow)
 
-Progress: [░░░░░░░░░░░░] 0% -- 0/4 phases complete (Phase 7 in progress)
+Progress: [█░░░░░░░░░░░] ~8% -- Phase 7 complete (1/4 voice message phases done)
 
 ## Milestone Summary
 
@@ -22,7 +22,7 @@ Progress: [░░░░░░░░░░░░] 0% -- 0/4 phases complete (Phas
 
 | Phase | Goal | Requirements | Status |
 |-------|------|--------------|--------|
-| 7. Protocol Foundation | Audio round-trips through LXMF pipeline | PROTO-01..05 | Not started |
+| 7. Protocol Foundation | Audio round-trips through LXMF pipeline | PROTO-01..05 | **COMPLETE** |
 | 8. Recording + Send | Record and send voice messages | REC-01,05,07 EDGE-01,07 | Not started |
 | 9. Playback + Bubble | Inline playback with waveform | PLAY-01..07 EDGE-02,06 | Not started |
 | 10. UI Polish + Edge Cases | Gesture polish, interruption handling | REC-02..04,06 EDGE-03..05 | Not started |
@@ -36,6 +36,12 @@ Progress: [░░░░░░░░░░░░] 0% -- 0/4 phases complete (Phas
 - MessageEntity.fieldsJson already supports audio field storage
 - Image attachment pipeline (FIELD_IMAGE) is the closest pattern to follow
 
+### Phase 7 Delivered
+
+- **07-01:** LXMF transport pipeline -- audioData/audioCodecId through full IPC stack (Kotlin -> AIDL -> ServiceBinder -> Python -> FIELD_AUDIO)
+- **07-02:** Kotlin extraction -- MessageUi audio fields, MessageMapper.extractAudioBytes/extractAudioMetadata/hasAudioField, AudioMetadata data class
+- **07-03:** ViewModel send flow -- buildFieldsJson Field 7 packing, sendMessage audio pass-through, handleSendSuccess local storage, retryFailedMessage re-extraction
+
 ### Decisions
 
 | Decision | Rationale | Phase |
@@ -47,6 +53,10 @@ Progress: [░░░░░░░░░░░░] 0% -- 0/4 phases complete (Phas
 | Audio detected by JSONArray format in field 7 | Distinguishes audio ["codec_id","hex"] from legacy location string data in same field | 7-02 |
 | audioDurationMs=null until Phase 9 playback | Duration in audio header requires decoding; deferred to avoid blocking toMessageUi() | 7-02 |
 | Waveform not transmitted over wire for received messages | Avoids bloating LXMF wire format; computed lazily on first view in Phase 9 | 7-02 |
+| audioDataPath added to AIDL alongside audioData | Large audio files bypass Android Binder 1MB IPC limit via temp file path, same as imageDataPath pattern | 7-01 |
+| Field 7 disambiguation via isinstance on first element | list[0] is str = audio, bytes/str = legacy location JSON; no ambiguity possible | 7-01 |
+| Audio vars null in sendMessage() until Phase 8 | Placeholders declared at correct call site; Phase 8 wires VoiceMessageViewModel output in | 7-03 |
+| retryAudioCodecId falls back to "opus_vm" | Prevents retry failure on metadata parse edge case while preserving codec intent | 7-03 |
 
 ### Pending Todos
 
@@ -57,11 +67,11 @@ Progress: [░░░░░░░░░░░░] 0% -- 0/4 phases complete (Phas
 
 ### Blockers/Concerns
 
-None yet.
+None. Phase 8 can begin immediately.
 
 ## Session Continuity
 
-Last session: 2026-02-24T05:06:10Z
-Stopped at: Completed 07-02-PLAN.md (audio fields in MessageUi and MessageMapper)
+Last session: 2026-02-24T05:14:53Z
+Stopped at: Completed 07-03-PLAN.md (ViewModel audio send flow) -- Phase 7 complete
 Resume file: None
-Next: 07-03 (audio send pipeline - encode voice messages into fieldsJson for LXMF transport)
+Next: Phase 8 -- Recording and Send (AudioRecord + Opus encoding, VoiceMessageViewModel, send button wiring)

--- a/.planning/STATE.md
+++ b/.planning/STATE.md
@@ -2,84 +2,53 @@
 
 ## Project Reference
 
-See: .planning/PROJECT.md (updated 2026-01-28)
+See: .planning/PROJECT.md (updated 2026-02-23)
 
 **Core value:** Reliable off-grid messaging with a polished, responsive user experience.
-**Current focus:** v0.7.4-beta Bug Fixes - Phase 4 (Relay Loop Resolution) Complete
+**Current focus:** v0.10.0 Voice Messages — Defining requirements
 
 ## Current Position
 
-Phase: 5 of 6 (Memory Optimization)
-Plan: 01 of 03 complete
-Status: Executing Wave 2
-Last activity: 2026-01-29 - Completed 05-01-PLAN.md
+Phase: Not started (defining requirements)
+Plan: —
+Status: Defining requirements
+Last activity: 2026-02-23 — Milestone v0.10.0 started
 
-Progress: [██████░░░░░░] 50% — Phase 5 in progress (2/4 phases complete)
+Progress: [░░░░░░░░░░░░] 0% — Requirements phase
 
 ## Milestone Summary
 
-**v0.7.4-beta Bug Fixes - In Progress**
+**v0.10.0 Voice Messages — Initializing**
 
 | Phase | Goal | Requirements | Status |
 |-------|------|--------------|--------|
-| 3 | ANR Elimination | ANR-01 | **Complete** |
-| 4 | Relay Loop Resolution | RELAY-03 | **Complete** |
-| 5 | Memory Optimization | MEM-01 | **In Progress** (1/3 plans) |
-| 6 | Native Stability Verification | NATIVE-01 | Not started |
-
-## Performance Metrics
-
-**Velocity:**
-- Total plans completed: 3
-- Average duration: ~32 min
-- Total execution time: ~63 min (Phases 4-5)
-
-**By Phase:**
-
-| Phase | Plans | Total | Avg/Plan |
-|-------|-------|-------|----------|
-| 3 | 1 | - | - |
-| 4 | 1 | 54 min | 54 min |
-| 5 | 1/3 | 9 min | 9 min |
-
-*Updated after each plan completion*
+| TBD | — | — | Not started |
 
 ## Accumulated Context
 
-### Sentry Analysis (2026-01-29)
+### From Previous Milestones
 
-**COLUMBA-3 (Relay Loop):**
-- Still happening on v0.7.3-beta despite fix
-- Stacktrace: `PropagationNodeManager.recordSelection` line 840
-- Seer suggests: Use `SharingStarted.WhileSubscribed` instead of eager StateFlow
-- **FIXED in Phase 4** - Changed to WhileSubscribed(5000L), pending post-deployment verification
-
-**COLUMBA-M (ANR):**
-- `DebugViewModel.<init>` -> `loadIdentityData` -> `getOrCreateDestination`
-- Makes synchronous IPC call to service during ViewModel init on main thread
-- **FIXED in Phase 3**
-
-**COLUMBA-E (OOM):**
-- Known ~1.4 MB/min memory growth in Python/Reticulum layer
-- **INSTRUMENTED in Phase 5** - Memory profiling infrastructure added (tracemalloc + native heap monitoring)
-- Investigation pending in next phase
+- LXST-kt audio library already in codebase (Opus, Codec2, Oboe capture/playback)
+- FIELD_AUDIO = 0x07 already defined in Python wrapper
+- MessageEntity.fieldsJson already supports audio field storage
+- Image attachment pipeline (FIELD_IMAGE) is the closest pattern to follow
 
 ### Decisions
 
 | Decision | Rationale | Phase |
 |----------|-----------|-------|
-| WhileSubscribed(5000L) for relay StateFlows | Standard Android timeout - survives screen rotation without restarting upstream | 04-01 |
-| Keep state machine, debounce, loop detection | Defense-in-depth - WhileSubscribed addresses root cause, guards handle edge cases | 04-01 |
-| Use tracemalloc instead of memory_profiler | tracemalloc is stdlib (no dependencies), lower overhead, sufficient for leak detection | 05-01 |
-| 5-minute snapshot interval | Balances detection speed with overhead; leak grows at ~1.4 MB/min so 5min = ~7MB delta | 05-01 |
-| Debug-only via BuildConfig flag | Zero overhead in release builds; profiling instrumentation stays in codebase for future debugging | 05-01 |
+| Opus VOICE_MEDIUM (8kbps) | Balances quality and mesh-friendly size (~30KB/30s) | — |
+| Hold-to-record UX | Familiar pattern (WhatsApp/Signal), quick for short messages | — |
+| 30s max duration | Keeps messages under ~30KB, practical for mesh links | — |
+| LXST-kt for record + playback | Already in codebase, native Oboe performance, Opus codec ready | — |
+| Play button + waveform UI | Rich inline experience, matches modern messenger expectations | — |
 
-### Roadmap Evolution
+### Patterns Established
 
-v0.7.3 milestone complete. Next milestone (v0.7.4) will address:
-- #338: Duplicate notifications after service restart
-- #342: Location permission dialog regression
-- Native memory growth investigation
+- **WhileSubscribed(5000L)**: Standard timeout for Room-backed StateFlows
+- **Turbine test pattern**: Keep collector active inside test block when testing StateFlow.value with WhileSubscribed
+- **BuildConfig feature flags**: Clean pattern for debug-only functionality with zero release overhead
+- **Image attachment pipeline**: FIELD_IMAGE → fieldsJson → MessageUi → inline rendering (pattern to follow for audio)
 
 ### Pending Todos
 
@@ -88,22 +57,9 @@ v0.7.3 milestone complete. Next milestone (v0.7.4) will address:
 - **Make discovered interfaces page event-driven** (ui)
 - **Refactor PropagationNodeManager to extract components** (architecture)
 
-### Patterns Established
-
-- **WhileSubscribed(5000L)**: Standard timeout for Room-backed StateFlows that should stop collecting when UI is not observing
-- **Turbine test pattern**: Keep collector active inside test block when testing code that accesses StateFlow.value with WhileSubscribed
-- **BuildConfig feature flags**: Clean pattern for debug-only functionality with zero release overhead
-- **Synchronized multi-layer monitoring**: Align Python and Android monitoring intervals for easy correlation
-
-### Blockers/Concerns
-
-**Post-deployment verification needed:**
-- RELAY-03-C: 48-hour zero "Relay selection loop detected" warnings in Sentry
-- Fix is based on Sentry AI (Seer) recommendation + Android best practices
-
 ## Session Continuity
 
-Last session: 2026-01-29
-Stopped at: Phase 5 complete (memory profiling infrastructure added)
+Last session: 2026-02-23
+Stopped at: Milestone v0.10.0 initialization
 Resume file: None
-Next: `/gsd:discuss-phase 6` or `/gsd:plan-phase 6`
+Next: Complete requirements → roadmap → `/gsd:plan-phase [N]`

--- a/.planning/STATE.md
+++ b/.planning/STATE.md
@@ -9,12 +9,12 @@ See: .planning/PROJECT.md (updated 2026-02-23)
 
 ## Current Position
 
-Phase: 7 of 10 (Protocol and Transport Foundation) -- COMPLETE
-Plan: 3 of 3 in phase (07-01, 07-02, 07-03 all complete)
-Status: Phase 7 complete, ready for Phase 8
-Last activity: 2026-02-24 -- Completed 07-03-PLAN.md (ViewModel audio send flow)
+Phase: 8 of 10 (Recording and Send Path) -- IN PROGRESS
+Plan: 1 of 2 in phase (08-01 complete, 08-02 pending)
+Status: Plan 08-01 complete, ready for 08-02
+Last activity: 2026-02-24 -- Completed 08-01-PLAN.md (VoiceMessageRecorder + AudioPermissionManager)
 
-Progress: [█░░░░░░░░░░░] ~8% -- Phase 7 complete (1/4 voice message phases done)
+Progress: [██░░░░░░░░░░] ~17% -- Phase 8 plan 1/2 complete (4/8 voice message plans done)
 
 ## Milestone Summary
 
@@ -23,7 +23,7 @@ Progress: [█░░░░░░░░░░░] ~8% -- Phase 7 complete (1/4 vo
 | Phase | Goal | Requirements | Status |
 |-------|------|--------------|--------|
 | 7. Protocol Foundation | Audio round-trips through LXMF pipeline | PROTO-01..05 | **COMPLETE** |
-| 8. Recording + Send | Record and send voice messages | REC-01,05,07 EDGE-01,07 | Not started |
+| 8. Recording + Send | Record and send voice messages | REC-01,05,07 EDGE-01,07 | **In progress** (1/2 plans) |
 | 9. Playback + Bubble | Inline playback with waveform | PLAY-01..07 EDGE-02,06 | Not started |
 | 10. UI Polish + Edge Cases | Gesture polish, interruption handling | REC-02..04,06 EDGE-03..05 | Not started |
 
@@ -42,6 +42,10 @@ Progress: [█░░░░░░░░░░░] ~8% -- Phase 7 complete (1/4 vo
 - **07-02:** Kotlin extraction -- MessageUi audio fields, MessageMapper.extractAudioBytes/extractAudioMetadata/hasAudioField, AudioMetadata data class
 - **07-03:** ViewModel send flow -- buildFieldsJson Field 7 packing, sendMessage audio pass-through, handleSendSuccess local storage, retryFailedMessage re-extraction
 
+### Phase 8 Delivered (so far)
+
+- **08-01:** VoiceMessageRecorder (AudioRecord 24kHz mono + Opus VOICE_MEDIUM encoding + length-prefixed frame accumulation + 300ms discard + 30s auto-stop + audio focus + waveform peaks) and AudioPermissionManager (RECORD_AUDIO check)
+
 ### Decisions
 
 | Decision | Rationale | Phase |
@@ -57,6 +61,10 @@ Progress: [█░░░░░░░░░░░] ~8% -- Phase 7 complete (1/4 vo
 | Field 7 disambiguation via isinstance on first element | list[0] is str = audio, bytes/str = legacy location JSON; no ambiguity possible | 7-01 |
 | Audio vars null in sendMessage() until Phase 8 | Placeholders declared at correct call site; Phase 8 wires VoiceMessageViewModel output in | 7-03 |
 | retryAudioCodecId falls back to "opus_vm" | Prevents retry failure on metadata parse edge case while preserving codec intent | 7-03 |
+| Audio focus released before 300ms discard check | Ensures tap-discards release focus; prevents permanently muting other apps | 8-01 |
+| Partial final frames discarded (not zero-padded) | Avoids audible silence artifacts at recording end | 8-01 |
+| Both API 26+ and deprecated audio focus paths | minSdk is 24; need deprecated requestAudioFocus for pre-O devices | 8-01 |
+| VoiceRecording.equals uses contentEquals for ByteArray | Standard Kotlin data class pattern for array fields | 8-01 |
 
 ### Pending Todos
 
@@ -67,11 +75,11 @@ Progress: [█░░░░░░░░░░░] ~8% -- Phase 7 complete (1/4 vo
 
 ### Blockers/Concerns
 
-None. Phase 8 can begin immediately.
+None. Plan 08-02 can proceed immediately.
 
 ## Session Continuity
 
-Last session: 2026-02-24T05:14:53Z
-Stopped at: Completed 07-03-PLAN.md (ViewModel audio send flow) -- Phase 7 complete
+Last session: 2026-02-24T15:50:18Z
+Stopped at: Completed 08-01-PLAN.md (VoiceMessageRecorder + AudioPermissionManager)
 Resume file: None
-Next: Phase 8 -- Recording and Send (AudioRecord + Opus encoding, VoiceMessageViewModel, send button wiring)
+Next: Plan 08-02 -- VoiceMessageViewModel, permission launcher, mic button wiring in MessagingScreen

--- a/app/src/main/aidl/com/lxmf/messenger/IReticulumService.aidl
+++ b/app/src/main/aidl/com/lxmf/messenger/IReticulumService.aidl
@@ -396,7 +396,7 @@ interface IReticulumService {
      * @param iconBgColor Optional icon background color hex string (3 bytes RGB, e.g., "1E88E5")
      * @return JSON string with result: {"success": true, "message_hash": "...", "delivery_method": "..."}
      */
-    String sendLxmfMessageWithMethod(in byte[] destHash, String content, in byte[] sourceIdentityPrivateKey, String deliveryMethod, boolean tryPropagationOnFail, in byte[] imageData, String imageFormat, String imageDataPath, in Map fileAttachments, in Map fileAttachmentPaths, String replyToMessageId, String iconName, String iconFgColor, String iconBgColor);
+    String sendLxmfMessageWithMethod(in byte[] destHash, String content, in byte[] sourceIdentityPrivateKey, String deliveryMethod, boolean tryPropagationOnFail, in byte[] imageData, String imageFormat, String imageDataPath, in byte[] audioData, String audioCodecId, String audioDataPath, in Map fileAttachments, in Map fileAttachmentPaths, String replyToMessageId, String iconName, String iconFgColor, String iconBgColor);
 
     /**
      * Provide an alternative relay for message retry.

--- a/app/src/main/java/com/lxmf/messenger/audio/VoiceMessagePlayer.kt
+++ b/app/src/main/java/com/lxmf/messenger/audio/VoiceMessagePlayer.kt
@@ -1,0 +1,187 @@
+package com.lxmf.messenger.audio
+
+import android.media.AudioAttributes
+import android.media.AudioFormat
+import android.media.AudioTrack
+import android.util.Log
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.isActive
+import kotlinx.coroutines.withContext
+import tech.torlando.lxst.codec.Opus
+import java.nio.ByteBuffer
+
+/**
+ * Plays back voice messages encoded as 2-byte big-endian length-prefixed Opus frames.
+ *
+ * This is the inverse of [VoiceMessageRecorder]'s encoding format:
+ * each frame is `[2-byte length][opus bytes]`, decoded with [Opus.decode], and
+ * written to [AudioTrack] for speaker output.
+ *
+ * Thread-safe: [play] and [stop] dispatch blocking AudioTrack calls to [Dispatchers.IO].
+ */
+class VoiceMessagePlayer {
+    companion object {
+        private const val TAG = "Columba:VoicePlayer"
+    }
+
+    private val _state = MutableStateFlow(PlaybackUiState())
+    val state: StateFlow<PlaybackUiState> = _state.asStateFlow()
+
+    @Volatile
+    private var audioTrack: AudioTrack? = null
+
+    @Volatile
+    private var isPlaying = false
+
+    /**
+     * Play the given Opus-encoded audio bytes (length-prefixed frame format).
+     * If already playing, stops the current playback first.
+     *
+     * This is a suspend function that blocks until playback completes or [stop] is called.
+     */
+    suspend fun play(
+        audioBytes: ByteArray,
+        durationMs: Long,
+    ) {
+        stop()
+
+        withContext(Dispatchers.IO) {
+            val opus = Opus(Opus.PROFILE_VOICE_MEDIUM)
+            try {
+                // Decode all frames to PCM
+                val pcmSamples = decodeFrames(audioBytes, opus)
+                if (pcmSamples.isEmpty()) {
+                    Log.w(TAG, "No frames decoded")
+                    return@withContext
+                }
+
+                // Convert float32 to int16 for AudioTrack
+                val shortSamples =
+                    ShortArray(pcmSamples.size) { i ->
+                        (pcmSamples[i] * 32767f).toInt().coerceIn(-32768, 32767).toShort()
+                    }
+
+                val bufSize =
+                    AudioTrack.getMinBufferSize(
+                        VoiceMessageRecorder.SAMPLE_RATE,
+                        AudioFormat.CHANNEL_OUT_MONO,
+                        AudioFormat.ENCODING_PCM_16BIT,
+                    )
+
+                val track =
+                    AudioTrack
+                        .Builder()
+                        .setAudioAttributes(
+                            AudioAttributes
+                                .Builder()
+                                .setUsage(AudioAttributes.USAGE_MEDIA)
+                                .setContentType(AudioAttributes.CONTENT_TYPE_SPEECH)
+                                .build(),
+                        ).setAudioFormat(
+                            AudioFormat
+                                .Builder()
+                                .setEncoding(AudioFormat.ENCODING_PCM_16BIT)
+                                .setSampleRate(VoiceMessageRecorder.SAMPLE_RATE)
+                                .setChannelMask(AudioFormat.CHANNEL_OUT_MONO)
+                                .build(),
+                        ).setBufferSizeInBytes(maxOf(bufSize, shortSamples.size * 2))
+                        .setTransferMode(AudioTrack.MODE_STATIC)
+                        .build()
+
+                track.write(shortSamples, 0, shortSamples.size)
+                audioTrack = track
+                isPlaying = true
+                _state.value = PlaybackUiState(isPlaying = true, progressFraction = 0f)
+
+                track.play()
+
+                // Update progress while playing
+                val totalFrames = shortSamples.size
+                while (isActive && isPlaying) {
+                    val head = track.playbackHeadPosition
+                    if (head >= totalFrames) break
+                    val fraction = head.toFloat() / totalFrames
+                    _state.value = _state.value.copy(progressFraction = fraction)
+                    kotlinx.coroutines.delay(50)
+                }
+
+                // Playback complete
+                isPlaying = false
+                track.stop()
+                track.release()
+                audioTrack = null
+                _state.value = PlaybackUiState()
+            } catch (e: Exception) {
+                Log.e(TAG, "Playback failed", e)
+                isPlaying = false
+                _state.value = PlaybackUiState(error = e.message)
+            } finally {
+                opus.release()
+            }
+        }
+    }
+
+    /**
+     * Stop playback immediately.
+     */
+    fun stop() {
+        isPlaying = false
+        audioTrack?.let { track ->
+            try {
+                track.pause()
+                track.flush()
+                track.release()
+            } catch (e: Exception) {
+                Log.w(TAG, "Error stopping playback", e)
+            }
+        }
+        audioTrack = null
+        _state.value = PlaybackUiState()
+    }
+
+    /**
+     * Decode length-prefixed Opus frames to a single float32 PCM array.
+     */
+    private fun decodeFrames(
+        audioBytes: ByteArray,
+        opus: Opus,
+    ): FloatArray {
+        val buf = ByteBuffer.wrap(audioBytes)
+        val allSamples = mutableListOf<FloatArray>()
+
+        while (buf.remaining() >= 2) {
+            val frameLen = ((buf.get().toInt() and 0xFF) shl 8) or (buf.get().toInt() and 0xFF)
+            if (frameLen <= 0 || frameLen > buf.remaining()) break
+
+            val frameBytes = ByteArray(frameLen)
+            buf.get(frameBytes)
+            try {
+                allSamples.add(opus.decode(frameBytes))
+            } catch (e: Exception) {
+                Log.w(TAG, "Failed to decode frame (${frameBytes.size} bytes)", e)
+            }
+        }
+
+        // Concatenate all decoded frames
+        val totalSize = allSamples.sumOf { it.size }
+        val result = FloatArray(totalSize)
+        var offset = 0
+        for (samples in allSamples) {
+            samples.copyInto(result, offset)
+            offset += samples.size
+        }
+        return result
+    }
+}
+
+/**
+ * Observable playback state for the UI layer.
+ */
+data class PlaybackUiState(
+    val isPlaying: Boolean = false,
+    val progressFraction: Float = 0f,
+    val error: String? = null,
+)

--- a/app/src/main/java/com/lxmf/messenger/audio/VoiceMessageRecorder.kt
+++ b/app/src/main/java/com/lxmf/messenger/audio/VoiceMessageRecorder.kt
@@ -194,6 +194,7 @@ class VoiceMessageRecorder(
      * Recording loop: reads PCM frames from [AudioRecord], converts to float32,
      * encodes to Opus, and accumulates length-prefixed frames.
      */
+    @Suppress("LoopWithTooManyJumpStatements")
     private suspend fun recordingLoop(record: AudioRecord) {
         val shortBuf = ShortArray(FRAME_SIZE)
 

--- a/app/src/main/java/com/lxmf/messenger/audio/VoiceMessageRecorder.kt
+++ b/app/src/main/java/com/lxmf/messenger/audio/VoiceMessageRecorder.kt
@@ -1,0 +1,341 @@
+package com.lxmf.messenger.audio
+
+import android.annotation.SuppressLint
+import android.content.Context
+import android.media.AudioAttributes
+import android.media.AudioFocusRequest
+import android.media.AudioFormat
+import android.media.AudioManager
+import android.media.AudioRecord
+import android.media.MediaRecorder
+import android.os.Build
+import android.util.Log
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
+import tech.torlando.lxst.codec.Opus
+import java.io.ByteArrayOutputStream
+import java.util.concurrent.atomic.AtomicBoolean
+
+/**
+ * Records voice messages using [AudioRecord] at 24kHz mono, encodes to Opus
+ * via LXST-kt [Opus] encoder, and accumulates 2-byte big-endian length-prefixed
+ * frames in a [ByteArrayOutputStream].
+ *
+ * Features:
+ * - 300ms minimum duration: recordings shorter than this are silently discarded
+ * - 30s maximum duration: auto-stops and returns the recording
+ * - Audio focus: acquires [AudioManager.AUDIOFOCUS_GAIN_TRANSIENT_EXCLUSIVE] to
+ *   silence notifications during recording
+ * - Waveform peaks: captures per-frame peak amplitudes for visualization
+ * - Thread-safe: [stop] dispatches blocking [AudioRecord.stop]/[AudioRecord.release]
+ *   to [Dispatchers.IO] to avoid ANR on the main thread
+ *
+ * Lifecycle: call [start] to begin recording, [stop] to end, and [release] when
+ * the recorder is no longer needed. Permission must be checked before calling [start].
+ */
+class VoiceMessageRecorder(
+    private val context: Context,
+) {
+    companion object {
+        private const val TAG = "Columba:VoiceRecorder"
+
+        /** Sample rate matching Opus.profileSamplerate(PROFILE_VOICE_MEDIUM). */
+        const val SAMPLE_RATE = 24000
+
+        /** 20ms frame at 24kHz -- valid Opus frame duration. */
+        const val FRAME_SIZE = 480
+
+        /** Auto-stop after 30 seconds to keep messages mesh-friendly (~30KB). */
+        const val MAX_DURATION_MS = 30_000L
+
+        /** Taps shorter than 300ms are silently discarded. */
+        const val MIN_DURATION_MS = 300L
+
+        /** Codec identifier written alongside audio bytes for decoding. */
+        const val CODEC_ID = "opus_vm"
+    }
+
+    // -- Opus encoder --
+    private val opus = Opus(Opus.PROFILE_VOICE_MEDIUM)
+
+    // -- Coroutine scope for recording loop and auto-stop --
+    private val scope = CoroutineScope(Dispatchers.IO + SupervisorJob())
+
+    // -- Observable recording state --
+    private val _state = MutableStateFlow(RecordingUiState())
+    val state: StateFlow<RecordingUiState> = _state.asStateFlow()
+
+    // -- Recording state --
+    @Volatile
+    private var audioRecord: AudioRecord? = null
+    private val isRecording = AtomicBoolean(false)
+    private val encodedOutput = ByteArrayOutputStream()
+    private val waveformPeaks = mutableListOf<Float>()
+    private var startTimeMs = 0L
+    private var autoStopJob: Job? = null
+
+    // -- Audio focus --
+    private var focusRequest: AudioFocusRequest? = null
+
+    /**
+     * Start recording. Permission must be checked before calling this method;
+     * the [SuppressLint] annotation reflects that RECORD_AUDIO is verified at
+     * the UI layer before reaching here.
+     *
+     * If already recording, this is a no-op.
+     */
+    @SuppressLint("MissingPermission")
+    fun start() {
+        if (isRecording.getAndSet(true)) return
+
+        encodedOutput.reset()
+        waveformPeaks.clear()
+
+        // Acquire audio focus to silence notifications during recording
+        val focusGranted = acquireAudioFocus(context)
+        if (!focusGranted) {
+            Log.w(TAG, "Audio focus not granted; continuing anyway")
+        }
+
+        val minBuf =
+            AudioRecord.getMinBufferSize(
+                SAMPLE_RATE,
+                AudioFormat.CHANNEL_IN_MONO,
+                AudioFormat.ENCODING_PCM_16BIT,
+            )
+        val record =
+            AudioRecord(
+                MediaRecorder.AudioSource.MIC,
+                SAMPLE_RATE,
+                AudioFormat.CHANNEL_IN_MONO,
+                AudioFormat.ENCODING_PCM_16BIT,
+                maxOf(minBuf, FRAME_SIZE * 2 * 2),
+            )
+
+        if (record.state != AudioRecord.STATE_INITIALIZED) {
+            record.release()
+            isRecording.set(false)
+            _state.value = _state.value.copy(error = "Microphone unavailable")
+            releaseAudioFocus(context)
+            return
+        }
+
+        audioRecord = record
+        startTimeMs = System.currentTimeMillis()
+        record.startRecording()
+        _state.value = _state.value.copy(isRecording = true, durationMs = 0L, error = null)
+
+        // Launch recording loop on IO dispatcher
+        scope.launch { recordingLoop(record) }
+
+        // Auto-stop at MAX_DURATION_MS
+        autoStopJob =
+            scope.launch {
+                delay(MAX_DURATION_MS)
+                if (isRecording.get()) {
+                    stop(autoSend = true)
+                }
+            }
+    }
+
+    /**
+     * Stop recording and return the captured audio.
+     *
+     * This is a suspend function because [AudioRecord.stop] and [AudioRecord.release]
+     * are blocking native calls (50-200ms). They are dispatched to [Dispatchers.IO]
+     * to prevent ANR when called from the main/composition thread.
+     *
+     * @param autoSend true when called by the 30s auto-stop timer (bypasses 300ms check)
+     * @return [VoiceRecording] with encoded Opus bytes and metadata, or null if:
+     *   - Not currently recording
+     *   - Recording was shorter than [MIN_DURATION_MS] and [autoSend] is false (silent discard)
+     */
+    suspend fun stop(autoSend: Boolean = false): VoiceRecording? {
+        if (!isRecording.getAndSet(false)) return null
+        autoStopJob?.cancel()
+
+        val elapsed = System.currentTimeMillis() - startTimeMs
+
+        // Dispatch blocking AudioRecord calls to IO thread to avoid ANR
+        withContext(Dispatchers.IO) {
+            audioRecord?.stop()
+            audioRecord?.release()
+            audioRecord = null
+        }
+
+        // CRITICAL: Release audio focus BEFORE the discard check.
+        // This ensures tap-discards (< 300ms) still release focus so other apps
+        // are not permanently muted.
+        releaseAudioFocus(context)
+
+        // Silent discard for taps shorter than 300ms
+        if (elapsed < MIN_DURATION_MS && !autoSend) {
+            _state.value = RecordingUiState()
+            return null
+        }
+
+        val audioBytes = encodedOutput.toByteArray()
+        val peaks = waveformPeaks.toList()
+        _state.value = RecordingUiState()
+
+        return VoiceRecording(audioBytes, CODEC_ID, elapsed, peaks)
+    }
+
+    /**
+     * Recording loop: reads PCM frames from [AudioRecord], converts to float32,
+     * encodes to Opus, and accumulates length-prefixed frames.
+     */
+    private suspend fun recordingLoop(record: AudioRecord) {
+        val shortBuf = ShortArray(FRAME_SIZE)
+
+        while (isRecording.get()) {
+            // ShortArray overload: reads samples (not bytes)
+            val read = record.read(shortBuf, 0, FRAME_SIZE)
+            if (read <= 0) {
+                delay(5)
+                continue
+            }
+
+            // Convert int16 to float32 in [-1.0, 1.0] range
+            val floats = FloatArray(read) { i -> shortBuf[i] / 32768f }
+
+            // Only encode complete frames -- partial final frame is discarded
+            // (padding with zeros would add audible silence; Opus requires exact frame sizes)
+            if (floats.size != FRAME_SIZE) continue
+
+            val encoded = opus.encode(floats)
+
+            // 2-byte big-endian length prefix
+            encodedOutput.write((encoded.size shr 8) and 0xFF)
+            encodedOutput.write(encoded.size and 0xFF)
+            encodedOutput.write(encoded)
+
+            // Capture peak amplitude for waveform visualization
+            val peak = floats.maxOfOrNull { kotlin.math.abs(it) } ?: 0f
+            waveformPeaks.add(peak)
+
+            // Update UI state
+            val currentDuration = System.currentTimeMillis() - startTimeMs
+            _state.value =
+                _state.value.copy(
+                    durationMs = currentDuration,
+                    latestPeak = peak,
+                )
+        }
+    }
+
+    /**
+     * Acquire transient exclusive audio focus to silence notifications during recording.
+     *
+     * @return true if focus was granted
+     */
+    private fun acquireAudioFocus(context: Context): Boolean {
+        val audioManager = context.getSystemService(Context.AUDIO_SERVICE) as AudioManager
+
+        return if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+            val req =
+                AudioFocusRequest
+                    .Builder(AudioManager.AUDIOFOCUS_GAIN_TRANSIENT_EXCLUSIVE)
+                    .setAudioAttributes(
+                        AudioAttributes
+                            .Builder()
+                            .setUsage(AudioAttributes.USAGE_VOICE_COMMUNICATION)
+                            .setContentType(AudioAttributes.CONTENT_TYPE_SPEECH)
+                            .build(),
+                    ).setOnAudioFocusChangeListener { /* no-op for recording */ }
+                    .build()
+            focusRequest = req
+            audioManager.requestAudioFocus(req) == AudioManager.AUDIOFOCUS_REQUEST_GRANTED
+        } else {
+            @Suppress("DEPRECATION")
+            audioManager.requestAudioFocus(
+                { /* no-op */ },
+                AudioManager.STREAM_VOICE_CALL,
+                AudioManager.AUDIOFOCUS_GAIN_TRANSIENT_EXCLUSIVE,
+            ) == AudioManager.AUDIOFOCUS_REQUEST_GRANTED
+        }
+    }
+
+    /**
+     * Release audio focus acquired during recording.
+     * Called in [stop] BEFORE the 300ms discard check to ensure focus is released
+     * in all paths (both send and discard).
+     */
+    private fun releaseAudioFocus(context: Context) {
+        val audioManager = context.getSystemService(Context.AUDIO_SERVICE) as AudioManager
+
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+            focusRequest?.let { audioManager.abandonAudioFocusRequest(it) }
+            focusRequest = null
+        } else {
+            @Suppress("DEPRECATION")
+            audioManager.abandonAudioFocus(null)
+        }
+    }
+
+    /**
+     * Release all resources. Call when the recorder is no longer needed
+     * (e.g., ViewModel onCleared).
+     */
+    fun release() {
+        scope.launch { stop() }
+        opus.release()
+        scope.cancel()
+    }
+}
+
+/**
+ * Completed voice recording with encoded Opus audio and metadata.
+ *
+ * @property audioBytes 2-byte big-endian length-prefixed Opus frames
+ * @property codecId codec identifier (e.g., "opus_vm")
+ * @property durationMs recording duration in milliseconds
+ * @property waveformPeaks per-frame peak amplitudes for waveform visualization
+ */
+data class VoiceRecording(
+    val audioBytes: ByteArray,
+    val codecId: String,
+    val durationMs: Long,
+    val waveformPeaks: List<Float>,
+) {
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (other !is VoiceRecording) return false
+        return audioBytes.contentEquals(other.audioBytes) &&
+            codecId == other.codecId &&
+            durationMs == other.durationMs &&
+            waveformPeaks == other.waveformPeaks
+    }
+
+    override fun hashCode(): Int {
+        var result = audioBytes.contentHashCode()
+        result = 31 * result + codecId.hashCode()
+        result = 31 * result + durationMs.hashCode()
+        result = 31 * result + waveformPeaks.hashCode()
+        return result
+    }
+}
+
+/**
+ * Observable recording state for the UI layer.
+ *
+ * @property isRecording true while actively recording
+ * @property durationMs elapsed recording time in milliseconds
+ * @property latestPeak most recent frame's peak amplitude (0.0-1.0)
+ * @property error non-null if recording failed to start
+ */
+data class RecordingUiState(
+    val isRecording: Boolean = false,
+    val durationMs: Long = 0L,
+    val latestPeak: Float = 0f,
+    val error: String? = null,
+)

--- a/app/src/main/java/com/lxmf/messenger/reticulum/protocol/ServiceReticulumProtocol.kt
+++ b/app/src/main/java/com/lxmf/messenger/reticulum/protocol/ServiceReticulumProtocol.kt
@@ -2214,6 +2214,8 @@ class ServiceReticulumProtocol(
         fileAttachments: List<Pair<String, ByteArray>>?,
         replyToMessageId: String?,
         iconAppearance: IconAppearance?,
+        audioData: ByteArray?,
+        audioCodecId: String?,
     ): Result<MessageReceipt> =
         withContext(Dispatchers.IO) {
             runCatching {
@@ -2264,6 +2266,23 @@ class ServiceReticulumProtocol(
                     }
                 }
 
+                // Handle large audio by writing to temp file to bypass Binder IPC limits
+                var smallAudioData: ByteArray? = null
+                var audioDataPath: String? = null
+                if (audioData != null && audioCodecId != null) {
+                    if (audioData.size <= FileUtils.FILE_TRANSFER_THRESHOLD) {
+                        smallAudioData = audioData
+                    } else {
+                        // Write large audio to temp on IO thread and pass path
+                        val tempFile =
+                            kotlinx.coroutines.withContext(kotlinx.coroutines.Dispatchers.IO) {
+                                FileUtils.writeTempAttachment(context, "audio.$audioCodecId", audioData)
+                            }
+                        audioDataPath = tempFile.absolutePath
+                        Log.d(TAG, "Large audio (${audioData.size} bytes) written to temp file")
+                    }
+                }
+
                 val resultJson =
                     service.sendLxmfMessageWithMethod(
                         destinationHash,
@@ -2274,6 +2293,9 @@ class ServiceReticulumProtocol(
                         smallImageData,
                         imageFormat,
                         imageDataPath,
+                        smallAudioData,
+                        audioCodecId,
+                        audioDataPath,
                         smallAttachments.ifEmpty { null },
                         largeAttachmentPaths.ifEmpty { null },
                         replyToMessageId,

--- a/app/src/main/java/com/lxmf/messenger/reticulum/protocol/ServiceReticulumProtocol.kt
+++ b/app/src/main/java/com/lxmf/messenger/reticulum/protocol/ServiceReticulumProtocol.kt
@@ -2220,68 +2220,16 @@ class ServiceReticulumProtocol(
         withContext(Dispatchers.IO) {
             runCatching {
                 val service = this@ServiceReticulumProtocol.service ?: throw IllegalStateException("Service not bound")
-
                 val privateKey = sourceIdentity.privateKey ?: throw IllegalArgumentException("Source identity must have private key")
+                val methodString = deliveryMethod.toMethodString()
 
-                val methodString =
-                    when (deliveryMethod) {
-                        DeliveryMethod.OPPORTUNISTIC -> "opportunistic"
-                        DeliveryMethod.DIRECT -> "direct"
-                        DeliveryMethod.PROPAGATED -> "propagated"
-                    }
-
-                // Partition attachments into small (bytes via Binder) and large (file paths)
-                // This avoids Android Binder IPC transaction size limits (~1MB)
-                val smallAttachments = mutableMapOf<String, ByteArray>()
-                val largeAttachmentPaths = mutableMapOf<String, String>()
-
-                fileAttachments?.forEach { (filename, bytes) ->
-                    if (bytes.size <= FileUtils.FILE_TRANSFER_THRESHOLD) {
-                        smallAttachments[filename] = bytes
-                    } else {
-                        // Write large file to temp on IO thread and pass path
-                        val tempFile =
-                            kotlinx.coroutines.withContext(kotlinx.coroutines.Dispatchers.IO) {
-                                FileUtils.writeTempAttachment(context, filename, bytes)
-                            }
-                        largeAttachmentPaths[filename] = tempFile.absolutePath
-                        Log.d(TAG, "Large attachment '$filename' (${bytes.size} bytes) written to temp file")
-                    }
-                }
-
-                // Handle large images by writing to temp file to bypass Binder IPC limits
-                var smallImageData: ByteArray? = null
-                var imageDataPath: String? = null
-                if (imageData != null) {
-                    if (imageData.size <= FileUtils.FILE_TRANSFER_THRESHOLD) {
-                        smallImageData = imageData
-                    } else {
-                        // Write large image to temp on IO thread and pass path
-                        val tempFile =
-                            kotlinx.coroutines.withContext(kotlinx.coroutines.Dispatchers.IO) {
-                                FileUtils.writeTempAttachment(context, "image.$imageFormat", imageData)
-                            }
-                        imageDataPath = tempFile.absolutePath
-                        Log.d(TAG, "Large image (${imageData.size} bytes) written to temp file")
-                    }
-                }
-
-                // Handle large audio by writing to temp file to bypass Binder IPC limits
-                var smallAudioData: ByteArray? = null
-                var audioDataPath: String? = null
-                if (audioData != null && audioCodecId != null) {
-                    if (audioData.size <= FileUtils.FILE_TRANSFER_THRESHOLD) {
-                        smallAudioData = audioData
-                    } else {
-                        // Write large audio to temp on IO thread and pass path
-                        val tempFile =
-                            kotlinx.coroutines.withContext(kotlinx.coroutines.Dispatchers.IO) {
-                                FileUtils.writeTempAttachment(context, "audio.$audioCodecId", audioData)
-                            }
-                        audioDataPath = tempFile.absolutePath
-                        Log.d(TAG, "Large audio (${audioData.size} bytes) written to temp file")
-                    }
-                }
+                val (smallAttachments, largeAttachmentPaths) = partitionAttachments(fileAttachments)
+                val (smallImageData, imageDataPath) = partitionBinaryData(imageData, "image.$imageFormat")
+                val (smallAudioData, audioDataPath) =
+                    partitionBinaryData(
+                        audioData?.takeIf { audioCodecId != null },
+                        "audio.$audioCodecId",
+                    )
 
                 val resultJson =
                     service.sendLxmfMessageWithMethod(
@@ -2324,6 +2272,42 @@ class ServiceReticulumProtocol(
                 )
             }
         }
+
+    private fun DeliveryMethod.toMethodString(): String =
+        when (this) {
+            DeliveryMethod.OPPORTUNISTIC -> "opportunistic"
+            DeliveryMethod.DIRECT -> "direct"
+            DeliveryMethod.PROPAGATED -> "propagated"
+        }
+
+    private suspend fun partitionAttachments(fileAttachments: List<Pair<String, ByteArray>>?): Pair<Map<String, ByteArray>, Map<String, String>> {
+        val small = mutableMapOf<String, ByteArray>()
+        val large = mutableMapOf<String, String>()
+        fileAttachments?.forEach { (filename, bytes) ->
+            if (bytes.size <= FileUtils.FILE_TRANSFER_THRESHOLD) {
+                small[filename] = bytes
+            } else {
+                val tempFile = FileUtils.writeTempAttachment(context, filename, bytes)
+                large[filename] = tempFile.absolutePath
+                Log.d(TAG, "Large attachment '$filename' (${bytes.size} bytes) written to temp file")
+            }
+        }
+        return small to large
+    }
+
+    private suspend fun partitionBinaryData(
+        data: ByteArray?,
+        tempName: String,
+    ): Pair<ByteArray?, String?> {
+        if (data == null) return null to null
+        return if (data.size <= FileUtils.FILE_TRANSFER_THRESHOLD) {
+            data to null
+        } else {
+            val tempFile = FileUtils.writeTempAttachment(context, tempName, data)
+            Log.d(TAG, "Large binary (${data.size} bytes) written to temp file")
+            null to tempFile.absolutePath
+        }
+    }
 
     override suspend fun sendLocationTelemetry(
         destinationHash: ByteArray,

--- a/app/src/main/java/com/lxmf/messenger/service/binder/ReticulumServiceBinder.kt
+++ b/app/src/main/java/com/lxmf/messenger/service/binder/ReticulumServiceBinder.kt
@@ -825,6 +825,9 @@ class ReticulumServiceBinder(
         imageData: ByteArray?,
         imageFormat: String?,
         imageDataPath: String?,
+        audioData: ByteArray?,
+        audioCodecId: String?,
+        audioDataPath: String?,
         fileAttachments: Map<*, *>?,
         fileAttachmentPaths: Map<*, *>?,
         replyToMessageId: String?,
@@ -864,6 +867,9 @@ class ReticulumServiceBinder(
                         iconName,
                         iconFgColor,
                         iconBgColor,
+                        audioData,
+                        audioCodecId,
+                        audioDataPath,
                     )
                 // Use PythonResultConverter to properly convert Python dict to JSON
                 // (bytes values like message_hash need Base64 encoding)

--- a/app/src/main/java/com/lxmf/messenger/ui/model/MessageMapper.kt
+++ b/app/src/main/java/com/lxmf/messenger/ui/model/MessageMapper.kt
@@ -44,6 +44,9 @@ fun Message.toMessageUi(): MessageUi {
     }
     val fileAttachmentsList = if (hasFiles) parseFileAttachments(fieldsJson) else emptyList()
 
+    val hasAudio = hasAudioField(fieldsJson)
+    val audioMeta = if (hasAudio) extractAudioMetadata(fieldsJson) else null
+
     // Get reply-to message ID: prefer DB column, fallback to parsing field 16
     val replyId = replyToMessageId ?: parseReplyToFromField16(fieldsJson)
 
@@ -51,9 +54,9 @@ fun Message.toMessageUi(): MessageUi {
     val reactionsList = parseReactionsFromField16(fieldsJson)
 
     // Determine if we need to preserve fieldsJson for UI components
-    // (uncached image, file attachments, or pending file notification)
+    // (uncached image, file attachments, audio, or pending file notification)
     val hasUncachedImage = hasImage && cachedImage == null
-    val needsFieldsJson = hasUncachedImage || hasFiles || hasPendingFileNotification(fieldsJson)
+    val needsFieldsJson = hasUncachedImage || hasFiles || hasAudio || hasPendingFileNotification(fieldsJson)
 
     return MessageUi(
         id = id,
@@ -66,6 +69,10 @@ fun Message.toMessageUi(): MessageUi {
         hasImageAttachment = hasImage,
         fileAttachments = fileAttachmentsList,
         hasFileAttachments = hasFiles,
+        hasAudioAttachment = hasAudio,
+        audioDurationMs = audioMeta?.durationMs,
+        audioCodecId = audioMeta?.codecId,
+        audioWaveform = audioMeta?.waveform,
         fieldsJson = if (needsFieldsJson) fieldsJson else null,
         deliveryMethod = deliveryMethod,
         errorMessage = errorMessage,
@@ -170,6 +177,141 @@ private fun hasImageField(fieldsJson: String?): Boolean {
         }
     } catch (e: Exception) {
         false
+    }
+}
+
+/**
+ * Check if the message has an audio field (type 7, FIELD_AUDIO) in its JSON.
+ * This is a fast check that doesn't decode anything.
+ *
+ * Audio data is distinguished from legacy location data by format:
+ * - Audio: field "7" is a JSONArray starting with a string codec_id: ["opus_vm", "hex_data"]
+ * - Legacy location: field "7" is a string or bytes containing JSON with "type" key
+ * - File reference: field "7" is a JSONObject with "_file_ref" key (large audio saved to disk)
+ *
+ * Returns false for invalid JSON or legacy location data.
+ */
+@Suppress("SwallowedException")
+fun hasAudioField(fieldsJson: String?): Boolean {
+    if (fieldsJson == null) return false
+    return try {
+        val fields = JSONObject(fieldsJson)
+        val field7 = fields.opt("7")
+        when {
+            // File reference format: large audio stored on disk
+            field7 is JSONObject && field7.has(FILE_REF_KEY) -> true
+            // Array format from Python: ["codec_id", "hex_audio_data"] or ["codec_id", "hex", [waveform]]
+            field7 is JSONArray &&
+                field7.length() >= 2 &&
+                field7.opt(0) is String &&
+                (field7.opt(0) as String).isNotEmpty() &&
+                field7.opt(1) is String &&
+                (field7.opt(1) as String).isNotEmpty() -> true
+            // NOT audio: string/other format = legacy location data
+            else -> false
+        }
+    } catch (e: Exception) {
+        false
+    }
+}
+
+/**
+ * Metadata extracted from a voice message's FIELD_AUDIO.
+ *
+ * @property codecId Codec identifier (e.g., "opus_vm")
+ * @property durationMs Duration in milliseconds (null if not in metadata)
+ * @property waveform Pre-computed amplitude peaks for visualization (null if not available)
+ */
+data class AudioMetadata(
+    val codecId: String,
+    val durationMs: Long?,
+    val waveform: List<Float>?,
+)
+
+/**
+ * Extract raw audio bytes from fields JSON.
+ *
+ * IMPORTANT: Call this from a background thread (Dispatchers.IO).
+ * Audio data may be loaded from disk for large files.
+ *
+ * @param fieldsJson The message's fields JSON containing the audio data
+ * @return Raw Opus-encoded audio bytes, or null if not found
+ */
+@Suppress("ReturnCount")
+fun extractAudioBytes(fieldsJson: String?): ByteArray? {
+    if (fieldsJson == null) return null
+    return try {
+        val fields = JSONObject(fieldsJson)
+        val field7 = fields.opt("7") ?: return null
+
+        val hexAudioData: String =
+            when {
+                // File reference: load from disk
+                field7 is JSONObject && field7.has(FILE_REF_KEY) -> {
+                    val filePath = field7.getString(FILE_REF_KEY)
+                    loadAttachmentFromDisk(filePath) ?: return null
+                }
+                // Array format: ["codec_id", "hex_audio_data"]
+                field7 is JSONArray && field7.length() >= 2 -> field7.optString(1, "")
+                else -> return null
+            }
+
+        if (hexAudioData.isEmpty()) return null
+        hexStringToByteArray(hexAudioData)
+    } catch (e: Exception) {
+        Log.e(TAG, "Failed to extract audio bytes", e)
+        null
+    }
+}
+
+/**
+ * Extract audio metadata (codec_id, duration, waveform) from fields JSON.
+ * This is fast (no hex decoding) -- only reads the array structure.
+ *
+ * @param fieldsJson The message's fields JSON
+ * @return AudioMetadata or null if no audio field
+ */
+@Suppress("SwallowedException")
+fun extractAudioMetadata(fieldsJson: String?): AudioMetadata? {
+    if (fieldsJson == null) return null
+    return try {
+        val fields = JSONObject(fieldsJson)
+        val field7 = fields.opt("7")
+
+        when {
+            field7 is JSONObject && field7.has(FILE_REF_KEY) -> {
+                // File ref: we know it's audio but can't read metadata without loading
+                AudioMetadata(codecId = "opus_vm", durationMs = null, waveform = null)
+            }
+            field7 is JSONArray && field7.length() >= 2 -> {
+                val codecId = field7.optString(0, "")
+                if (codecId.isEmpty()) return null
+
+                // Extract waveform from third element if present
+                val waveform =
+                    if (field7.length() >= 3) {
+                        val waveformArray = field7.optJSONArray(2)
+                        waveformArray?.let { arr ->
+                            (0 until arr.length()).map { i ->
+                                arr.optDouble(i, 0.0).toFloat()
+                            }
+                        }
+                    } else {
+                        null
+                    }
+
+                // Duration will be extracted from the audio header bytes in Phase 9
+                // For now, return null -- the UI will show "0:00" until playback starts
+                AudioMetadata(
+                    codecId = codecId,
+                    durationMs = null,
+                    waveform = waveform,
+                )
+            }
+            else -> null
+        }
+    } catch (e: Exception) {
+        null
     }
 }
 

--- a/app/src/main/java/com/lxmf/messenger/ui/model/MessageUi.kt
+++ b/app/src/main/java/com/lxmf/messenger/ui/model/MessageUi.kt
@@ -98,7 +98,7 @@ data class MessageUi(
     /**
      * Pre-computed waveform amplitude peaks for rendering without re-decoding.
      * Normalized floats [0.0, 1.0] representing amplitude at regular intervals.
-     * Stored as the third element in the FIELD_AUDIO array: ["codec_id", "hex", [peaks...]].
+     * Stored as the third element in the FIELD_AUDIO array (codec_id, hex, peaks).
      * Null if waveform not available (will be computed lazily on first view).
      */
     val audioWaveform: List<Float>? = null,

--- a/app/src/main/java/com/lxmf/messenger/ui/model/MessageUi.kt
+++ b/app/src/main/java/com/lxmf/messenger/ui/model/MessageUi.kt
@@ -77,6 +77,32 @@ data class MessageUi(
      */
     val hasFileAttachments: Boolean = false,
     /**
+     * Indicates whether this message has an audio attachment (LXMF field 7, FIELD_AUDIO).
+     * When true, the UI should render a voice message bubble instead of a text bubble.
+     * Distinct from legacy location data which also uses field 7 -- audio is detected
+     * by the array format ["codec_id", "hex_audio_data"].
+     */
+    val hasAudioAttachment: Boolean = false,
+    /**
+     * Duration of the audio message in milliseconds.
+     * Extracted from the audio wire format header (2-byte big-endian duration_ms).
+     * Null if not yet parsed or if the audio format doesn't include duration.
+     */
+    val audioDurationMs: Long? = null,
+    /**
+     * Codec identifier string for the audio data (e.g., "opus_vm").
+     * Used to select the correct decoder for playback.
+     * Null if no audio attachment.
+     */
+    val audioCodecId: String? = null,
+    /**
+     * Pre-computed waveform amplitude peaks for rendering without re-decoding.
+     * Normalized floats [0.0, 1.0] representing amplitude at regular intervals.
+     * Stored as the third element in the FIELD_AUDIO array: ["codec_id", "hex", [peaks...]].
+     * Null if waveform not available (will be computed lazily on first view).
+     */
+    val audioWaveform: List<Float>? = null,
+    /**
      * ID of the message this is replying to, if any.
      * Extracted from LXMF field 16 {"reply_to": "message_id"}.
      */

--- a/app/src/main/java/com/lxmf/messenger/ui/screens/MessagingScreen.kt
+++ b/app/src/main/java/com/lxmf/messenger/ui/screens/MessagingScreen.kt
@@ -1,5 +1,6 @@
 package com.lxmf.messenger.ui.screens
 
+import android.Manifest
 import android.content.Intent
 import android.graphics.BitmapFactory
 import android.os.SystemClock
@@ -29,6 +30,7 @@ import androidx.compose.foundation.content.contentReceiver
 import androidx.compose.foundation.content.hasMediaType
 import androidx.compose.foundation.gestures.awaitEachGesture
 import androidx.compose.foundation.gestures.awaitFirstDown
+import androidx.compose.foundation.gestures.detectTapGestures
 import androidx.compose.foundation.gestures.detectTransformGestures
 import androidx.compose.foundation.gestures.waitForUpOrCancellation
 import androidx.compose.foundation.interaction.MutableInteractionSource
@@ -79,6 +81,7 @@ import androidx.compose.material.icons.filled.Link
 import androidx.compose.material.icons.filled.LocationOff
 import androidx.compose.material.icons.filled.LocationOn
 import androidx.compose.material.icons.filled.Map
+import androidx.compose.material.icons.filled.Mic
 import androidx.compose.material.icons.filled.MoreVert
 import androidx.compose.material.icons.filled.Refresh
 import androidx.compose.material.icons.outlined.LocationOn
@@ -183,6 +186,7 @@ import com.lxmf.messenger.ui.model.LocationSharingState
 import com.lxmf.messenger.ui.theme.MeshConnected
 import com.lxmf.messenger.ui.theme.MeshOffline
 import com.lxmf.messenger.util.AnimatedImageLoader
+import com.lxmf.messenger.util.AudioPermissionManager
 import com.lxmf.messenger.util.FileAttachment
 import com.lxmf.messenger.util.FileUtils
 import com.lxmf.messenger.util.ImageUtils
@@ -194,6 +198,7 @@ import com.lxmf.messenger.viewmodel.ContactToggleResult
 import com.lxmf.messenger.viewmodel.MessagingViewModel
 import com.lxmf.messenger.viewmodel.SharedImageViewModel
 import com.lxmf.messenger.viewmodel.SharedTextViewModel
+import com.lxmf.messenger.viewmodel.VoiceMessageViewModel
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
@@ -325,6 +330,10 @@ fun MessagingScreen(
     onLocateOnMap: (peerHash: String) -> Unit = {},
     viewModel: MessagingViewModel = hiltViewModel(),
 ) {
+    val voiceMessageViewModel: VoiceMessageViewModel = hiltViewModel()
+    val recordingState by voiceMessageViewModel.recordingState.collectAsStateWithLifecycle()
+    val voiceCoroutineScope = rememberCoroutineScope()
+
     val pagingItems = viewModel.messages.collectAsLazyPagingItems()
     val announceInfo by viewModel.announceInfo.collectAsStateWithLifecycle()
     val conversationLinkState by viewModel.conversationLinkState.collectAsStateWithLifecycle()
@@ -698,6 +707,16 @@ fun MessagingScreen(
             if (granted) {
                 viewModel.loadRecentPhotos(context)
             }
+        }
+
+    // RECORD_AUDIO permission launcher for voice messages
+    val audioPermissionLauncher =
+        rememberLauncherForActivityResult(
+            contract = ActivityResultContracts.RequestPermission(),
+        ) { _ ->
+            // Permission result received. User needs to hold the mic button again
+            // to start recording. No auto-start on permission grant (consistent with
+            // research recommendation to avoid unexpected recording).
         }
 
     // Back handler: dismiss panel on back press
@@ -1278,6 +1297,26 @@ fun MessagingScreen(
                         }
                     },
                     isAttachmentPanelActive = inputPanelMode == InputPanelMode.PANEL,
+                    hasTextOrAttachments = messageText.isNotBlank() || selectedImageData != null || selectedFileAttachments.isNotEmpty(),
+                    isRecording = recordingState.isRecording,
+                    onMicPress = {
+                        if (AudioPermissionManager.hasPermission(context)) {
+                            voiceMessageViewModel.startRecording()
+                        } else {
+                            audioPermissionLauncher.launch(Manifest.permission.RECORD_AUDIO)
+                        }
+                    },
+                    onMicRelease = {
+                        // stopRecording() is a suspend fun (dispatches AudioRecord.stop() to
+                        // IO thread to avoid ANR). Must be launched in a coroutine.
+                        voiceCoroutineScope.launch {
+                            val recording = voiceMessageViewModel.stopRecording()
+                            if (recording != null) {
+                                viewModel.sendMessage(destinationHash, "", voiceRecording = recording)
+                            }
+                            // If null: recording was < 300ms, silently discarded
+                        }
+                    },
                 )
 
                 // Bottom space: attachment panel, keyboard spacer, or nothing
@@ -2216,6 +2255,10 @@ fun MessageInputBar(
     isSending: Boolean = false,
     onAttachmentPanelToggle: () -> Unit = {},
     isAttachmentPanelActive: Boolean = false,
+    hasTextOrAttachments: Boolean = false,
+    isRecording: Boolean = false,
+    onMicPress: () -> Unit = {},
+    onMicRelease: () -> Unit = {},
 ) {
     val context = LocalContext.current
     val scope = rememberCoroutineScope()
@@ -2440,29 +2483,60 @@ fun MessageInputBar(
                     )
                 }
 
-                FilledIconButton(
-                    onClick = onSendClick,
-                    enabled = !isSending && (messageText.isNotBlank() || selectedImageData != null || selectedFileAttachments.isNotEmpty()),
-                    modifier = Modifier.size(48.dp),
-                    shape = CircleShape,
-                    colors =
-                        IconButtonDefaults.filledIconButtonColors(
-                            containerColor = MaterialTheme.colorScheme.primary,
-                            contentColor = MaterialTheme.colorScheme.onPrimary,
-                            disabledContainerColor = MaterialTheme.colorScheme.surfaceVariant,
-                            disabledContentColor = MaterialTheme.colorScheme.onSurfaceVariant,
-                        ),
-                ) {
-                    if (isSending) {
-                        CircularProgressIndicator(
-                            modifier = Modifier.size(24.dp),
-                            strokeWidth = 2.dp,
-                            color = MaterialTheme.colorScheme.onPrimary,
-                        )
-                    } else {
+                if (hasTextOrAttachments || isRecording) {
+                    // Send button: visible when there is text/attachments or actively recording
+                    FilledIconButton(
+                        onClick = onSendClick,
+                        enabled = !isSending && (messageText.isNotBlank() || selectedImageData != null || selectedFileAttachments.isNotEmpty()),
+                        modifier = Modifier.size(48.dp),
+                        shape = CircleShape,
+                        colors =
+                            IconButtonDefaults.filledIconButtonColors(
+                                containerColor = MaterialTheme.colorScheme.primary,
+                                contentColor = MaterialTheme.colorScheme.onPrimary,
+                                disabledContainerColor = MaterialTheme.colorScheme.surfaceVariant,
+                                disabledContentColor = MaterialTheme.colorScheme.onSurfaceVariant,
+                            ),
+                    ) {
+                        if (isSending) {
+                            CircularProgressIndicator(
+                                modifier = Modifier.size(24.dp),
+                                strokeWidth = 2.dp,
+                                color = MaterialTheme.colorScheme.onPrimary,
+                            )
+                        } else {
+                            Icon(
+                                imageVector = Icons.AutoMirrored.Filled.Send,
+                                contentDescription = "Send message",
+                            )
+                        }
+                    }
+                } else {
+                    // Mic button: visible when text field is empty and no attachments
+                    IconButton(
+                        onClick = { /* no-op: gesture handled by pointerInput */ },
+                        modifier =
+                            Modifier
+                                .size(48.dp)
+                                .pointerInput(Unit) {
+                                    detectTapGestures(
+                                        onPress = {
+                                            onMicPress()
+                                            tryAwaitRelease()
+                                            onMicRelease()
+                                        },
+                                    )
+                                },
+                    ) {
                         Icon(
-                            imageVector = Icons.AutoMirrored.Filled.Send,
-                            contentDescription = "Send message",
+                            imageVector = Icons.Filled.Mic,
+                            contentDescription = "Hold to record voice message",
+                            tint =
+                                if (isRecording) {
+                                    MaterialTheme.colorScheme.error
+                                } else {
+                                    MaterialTheme.colorScheme.primary
+                                },
                         )
                     }
                 }

--- a/app/src/main/java/com/lxmf/messenger/ui/screens/MessagingScreen.kt
+++ b/app/src/main/java/com/lxmf/messenger/ui/screens/MessagingScreen.kt
@@ -19,6 +19,7 @@ import androidx.compose.animation.core.animateFloatAsState
 import androidx.compose.animation.core.infiniteRepeatable
 import androidx.compose.animation.core.rememberInfiniteTransition
 import androidx.compose.animation.core.tween
+import androidx.compose.foundation.Canvas
 import androidx.compose.foundation.ExperimentalFoundationApi
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
@@ -74,6 +75,7 @@ import androidx.compose.material.icons.filled.Circle
 import androidx.compose.material.icons.filled.Close
 import androidx.compose.material.icons.filled.CloudDownload
 import androidx.compose.material.icons.filled.ContentCopy
+import androidx.compose.material.icons.filled.Delete
 import androidx.compose.material.icons.filled.FormatSize
 import androidx.compose.material.icons.filled.Image
 import androidx.compose.material.icons.filled.Info
@@ -83,6 +85,8 @@ import androidx.compose.material.icons.filled.LocationOn
 import androidx.compose.material.icons.filled.Map
 import androidx.compose.material.icons.filled.Mic
 import androidx.compose.material.icons.filled.MoreVert
+import androidx.compose.material.icons.filled.Pause
+import androidx.compose.material.icons.filled.PlayArrow
 import androidx.compose.material.icons.filled.Refresh
 import androidx.compose.material.icons.outlined.LocationOn
 import androidx.compose.material3.AlertDialog
@@ -109,6 +113,7 @@ import androidx.compose.material3.rememberModalBottomSheetState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.derivedStateOf
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.key
@@ -333,6 +338,9 @@ fun MessagingScreen(
     val voiceMessageViewModel: VoiceMessageViewModel = hiltViewModel()
     val recordingState by voiceMessageViewModel.recordingState.collectAsStateWithLifecycle()
     val voiceCoroutineScope = rememberCoroutineScope()
+
+    // Pending voice recording awaiting user confirmation (preview state)
+    var pendingVoiceRecording by remember { mutableStateOf<com.lxmf.messenger.audio.VoiceRecording?>(null) }
 
     val pagingItems = viewModel.messages.collectAsLazyPagingItems()
     val announceInfo by viewModel.announceInfo.collectAsStateWithLifecycle()
@@ -1299,6 +1307,8 @@ fun MessagingScreen(
                     isAttachmentPanelActive = inputPanelMode == InputPanelMode.PANEL,
                     hasTextOrAttachments = messageText.isNotBlank() || selectedImageData != null || selectedFileAttachments.isNotEmpty(),
                     isRecording = recordingState.isRecording,
+                    recordingDurationMs = recordingState.durationMs,
+                    pendingVoiceRecording = pendingVoiceRecording,
                     onMicPress = {
                         if (AudioPermissionManager.hasPermission(context)) {
                             voiceMessageViewModel.startRecording()
@@ -1307,15 +1317,21 @@ fun MessagingScreen(
                         }
                     },
                     onMicRelease = {
-                        // stopRecording() is a suspend fun (dispatches AudioRecord.stop() to
-                        // IO thread to avoid ANR). Must be launched in a coroutine.
                         voiceCoroutineScope.launch {
                             val recording = voiceMessageViewModel.stopRecording()
                             if (recording != null) {
-                                viewModel.sendMessage(destinationHash, "", voiceRecording = recording)
+                                pendingVoiceRecording = recording
                             }
-                            // If null: recording was < 300ms, silently discarded
                         }
+                    },
+                    onVoiceSend = {
+                        pendingVoiceRecording?.let { recording ->
+                            viewModel.sendMessage(destinationHash, "", voiceRecording = recording)
+                            pendingVoiceRecording = null
+                        }
+                    },
+                    onVoiceDiscard = {
+                        pendingVoiceRecording = null
                     },
                 )
 
@@ -2102,6 +2118,17 @@ fun MessageBubble(
                             }
                         }
 
+                        // Display voice message if present (LXMF field 7 = AUDIO)
+                        if (message.hasAudioAttachment) {
+                            VoiceMessageBubble(
+                                durationMs = message.audioDurationMs ?: 0L,
+                                waveformPeaks = message.audioWaveform,
+                                isFromMe = isFromMe,
+                                fieldsJson = message.fieldsJson,
+                            )
+                            Spacer(modifier = Modifier.height(8.dp))
+                        }
+
                         // Display file attachments if present (LXMF field 5 = FILE_ATTACHMENTS)
                         if (message.hasFileAttachments) {
                             message.fileAttachments.forEach { fileAttachment ->
@@ -2119,11 +2146,14 @@ fun MessageBubble(
                             }
                         }
 
-                        LinkifiedMessageText(
-                            text = message.content,
-                            isFromMe = isFromMe,
-                            fontScale = fontScale,
-                        )
+                        // Hide text for voice-only messages (content is " " for Sideband compat)
+                        if (!(message.hasAudioAttachment && message.content.isBlank())) {
+                            LinkifiedMessageText(
+                                text = message.content,
+                                isFromMe = isFromMe,
+                                fontScale = fontScale,
+                            )
+                        }
                         Spacer(modifier = Modifier.height(4.dp))
                         Row(
                             horizontalArrangement = Arrangement.spacedBy(8.dp),
@@ -2257,8 +2287,12 @@ fun MessageInputBar(
     isAttachmentPanelActive: Boolean = false,
     hasTextOrAttachments: Boolean = false,
     isRecording: Boolean = false,
+    recordingDurationMs: Long = 0L,
+    pendingVoiceRecording: com.lxmf.messenger.audio.VoiceRecording? = null,
     onMicPress: () -> Unit = {},
     onMicRelease: () -> Unit = {},
+    onVoiceSend: () -> Unit = {},
+    onVoiceDiscard: () -> Unit = {},
 ) {
     val context = LocalContext.current
     val scope = rememberCoroutineScope()
@@ -2387,104 +2421,174 @@ fun MessageInputBar(
                 horizontalArrangement = Arrangement.spacedBy(8.dp),
                 verticalAlignment = Alignment.CenterVertically,
             ) {
-                // BasicTextField with contentReceiver for keyboard GIFs and clipboard paste
-                val isError = messageText.length >= ValidationConstants.MAX_MESSAGE_LENGTH - 20
-                val borderColor =
-                    when {
-                        isError -> MaterialTheme.colorScheme.error
-                        else -> Color.Transparent
-                    }
-
-                Box(
-                    modifier =
-                        Modifier
-                            .weight(1f)
-                            .heightIn(min = 48.dp, max = 120.dp)
-                            .background(
-                                MaterialTheme.colorScheme.surfaceContainerHighest,
-                                RoundedCornerShape(24.dp),
-                            ).border(1.dp, borderColor, RoundedCornerShape(24.dp))
-                            .padding(horizontal = 16.dp, vertical = 12.dp),
-                ) {
-                    BasicTextField(
-                        state = textFieldState,
+                if (isRecording) {
+                    // Recording indicator: replaces text field during recording
+                    Box(
                         modifier =
                             Modifier
-                                .fillMaxWidth()
-                                .contentReceiver { transferableContent ->
-                                    // Check if content contains images
-                                    if (!transferableContent.hasMediaType(MediaType.Image)) {
-                                        return@contentReceiver transferableContent
-                                    }
+                                .weight(1f)
+                                .heightIn(min = 48.dp)
+                                .background(
+                                    MaterialTheme.colorScheme.errorContainer,
+                                    RoundedCornerShape(24.dp),
+                                ).padding(horizontal = 16.dp, vertical = 12.dp),
+                        contentAlignment = Alignment.CenterStart,
+                    ) {
+                        Row(
+                            verticalAlignment = Alignment.CenterVertically,
+                            horizontalArrangement = Arrangement.spacedBy(8.dp),
+                        ) {
+                            // Pulsing red dot
+                            val infiniteTransition = rememberInfiniteTransition(label = "recording")
+                            val alpha by infiniteTransition.animateFloat(
+                                initialValue = 1f,
+                                targetValue = 0.2f,
+                                animationSpec =
+                                    infiniteRepeatable(
+                                        animation = tween(600, easing = LinearEasing),
+                                        repeatMode = RepeatMode.Reverse,
+                                    ),
+                                label = "recordingDot",
+                            )
+                            Box(
+                                modifier =
+                                    Modifier
+                                        .size(12.dp)
+                                        .background(
+                                            MaterialTheme.colorScheme.error.copy(alpha = alpha),
+                                            CircleShape,
+                                        ),
+                            )
 
-                                    // Process image content from keyboard or clipboard
-                                    val clipData = transferableContent.clipEntry.clipData
-                                    for (i in 0 until clipData.itemCount) {
-                                        val item = clipData.getItemAt(i)
-                                        val uri = item.uri
-                                        if (uri != null) {
-                                            scope.launch(Dispatchers.IO) {
-                                                val result =
-                                                    ImageUtils.compressImagePreservingAnimation(
-                                                        context,
-                                                        uri,
-                                                    )
-                                                result?.let { compressed ->
-                                                    withContext(Dispatchers.Main) {
-                                                        onImageContentReceived(
-                                                            compressed.data,
-                                                            compressed.format,
-                                                            compressed.isAnimated,
+                            // Duration display
+                            val seconds = (recordingDurationMs / 1000).toInt()
+                            val minutes = seconds / 60
+                            val remainingSeconds = seconds % 60
+                            Text(
+                                text = "%d:%02d".format(minutes, remainingSeconds),
+                                style = MaterialTheme.typography.bodyLarge,
+                                color = MaterialTheme.colorScheme.onErrorContainer,
+                            )
+
+                            Text(
+                                text = "Recording...",
+                                style = MaterialTheme.typography.bodyMedium,
+                                color = MaterialTheme.colorScheme.onErrorContainer.copy(alpha = 0.7f),
+                            )
+                        }
+                    }
+                } else if (pendingVoiceRecording != null) {
+                    // Voice recording preview with playback
+                    VoicePreviewBar(
+                        recording = pendingVoiceRecording,
+                        onSend = onVoiceSend,
+                        onDiscard = onVoiceDiscard,
+                        modifier = Modifier.weight(1f),
+                    )
+                } else {
+                    // BasicTextField with contentReceiver for keyboard GIFs and clipboard paste
+                    val isError = messageText.length >= ValidationConstants.MAX_MESSAGE_LENGTH - 20
+                    val borderColor =
+                        when {
+                            isError -> MaterialTheme.colorScheme.error
+                            else -> Color.Transparent
+                        }
+
+                    Box(
+                        modifier =
+                            Modifier
+                                .weight(1f)
+                                .heightIn(min = 48.dp, max = 120.dp)
+                                .background(
+                                    MaterialTheme.colorScheme.surfaceContainerHighest,
+                                    RoundedCornerShape(24.dp),
+                                ).border(1.dp, borderColor, RoundedCornerShape(24.dp))
+                                .padding(horizontal = 16.dp, vertical = 12.dp),
+                    ) {
+                        BasicTextField(
+                            state = textFieldState,
+                            modifier =
+                                Modifier
+                                    .fillMaxWidth()
+                                    .contentReceiver { transferableContent ->
+                                        // Check if content contains images
+                                        if (!transferableContent.hasMediaType(MediaType.Image)) {
+                                            return@contentReceiver transferableContent
+                                        }
+
+                                        // Process image content from keyboard or clipboard
+                                        val clipData = transferableContent.clipEntry.clipData
+                                        for (i in 0 until clipData.itemCount) {
+                                            val item = clipData.getItemAt(i)
+                                            val uri = item.uri
+                                            if (uri != null) {
+                                                scope.launch(Dispatchers.IO) {
+                                                    val result =
+                                                        ImageUtils.compressImagePreservingAnimation(
+                                                            context,
+                                                            uri,
                                                         )
+                                                    result?.let { compressed ->
+                                                        withContext(Dispatchers.Main) {
+                                                            onImageContentReceived(
+                                                                compressed.data,
+                                                                compressed.format,
+                                                                compressed.isAnimated,
+                                                            )
+                                                        }
                                                     }
                                                 }
                                             }
                                         }
+                                        null // Content consumed
+                                    },
+                            textStyle =
+                                MaterialTheme.typography.bodyLarge.copy(
+                                    color = MaterialTheme.colorScheme.onSurface,
+                                ),
+                            cursorBrush = SolidColor(MaterialTheme.colorScheme.primary),
+                            keyboardOptions =
+                                KeyboardOptions(
+                                    capitalization = KeyboardCapitalization.Sentences,
+                                ),
+                            lineLimits = TextFieldLineLimits.MultiLine(maxHeightInLines = 5),
+                            decorator = { innerTextField ->
+                                Box {
+                                    if (textFieldState.text.isEmpty()) {
+                                        Text(
+                                            text = "Type a message...",
+                                            style = MaterialTheme.typography.bodyLarge,
+                                            color = MaterialTheme.colorScheme.onSurfaceVariant,
+                                        )
                                     }
-                                    null // Content consumed
-                                },
-                        textStyle =
-                            MaterialTheme.typography.bodyLarge.copy(
-                                color = MaterialTheme.colorScheme.onSurface,
-                            ),
-                        cursorBrush = SolidColor(MaterialTheme.colorScheme.primary),
-                        keyboardOptions =
-                            KeyboardOptions(
-                                capitalization = KeyboardCapitalization.Sentences,
-                            ),
-                        lineLimits = TextFieldLineLimits.MultiLine(maxHeightInLines = 5),
-                        decorator = { innerTextField ->
-                            Box {
-                                if (textFieldState.text.isEmpty()) {
-                                    Text(
-                                        text = "Type a message...",
-                                        style = MaterialTheme.typography.bodyLarge,
-                                        color = MaterialTheme.colorScheme.onSurfaceVariant,
-                                    )
+                                    innerTextField()
                                 }
-                                innerTextField()
-                            }
-                        },
-                    )
+                            },
+                        )
+                    }
                 }
 
-                // Attachment panel toggle button - always visible
-                IconButton(
-                    onClick = onAttachmentPanelToggle,
-                    modifier =
-                        Modifier
-                            .size(48.dp)
-                            .padding(0.dp),
-                ) {
-                    Icon(
-                        imageVector = if (isAttachmentPanelActive) Icons.Default.Close else Icons.Default.Add,
-                        contentDescription = if (isAttachmentPanelActive) "Close attachments" else "Attach",
-                        modifier = Modifier.size(24.dp),
-                    )
+                // Hide attachment and send/mic buttons during recording and preview
+                // (recording indicator and preview bar have their own controls)
+                if (!isRecording && pendingVoiceRecording == null) {
+                    // Attachment panel toggle button
+                    IconButton(
+                        onClick = onAttachmentPanelToggle,
+                        modifier =
+                            Modifier
+                                .size(48.dp)
+                                .padding(0.dp),
+                    ) {
+                        Icon(
+                            imageVector = if (isAttachmentPanelActive) Icons.Default.Close else Icons.Default.Add,
+                            contentDescription = if (isAttachmentPanelActive) "Close attachments" else "Attach",
+                            modifier = Modifier.size(24.dp),
+                        )
+                    }
                 }
 
-                if (hasTextOrAttachments || isRecording) {
-                    // Send button: visible when there is text/attachments or actively recording
+                if (hasTextOrAttachments && pendingVoiceRecording == null) {
+                    // Send button: visible when there is text/attachments
                     FilledIconButton(
                         onClick = onSendClick,
                         enabled = !isSending && (messageText.isNotBlank() || selectedImageData != null || selectedFileAttachments.isNotEmpty()),
@@ -2511,10 +2615,14 @@ fun MessageInputBar(
                             )
                         }
                     }
-                } else {
-                    // Mic button: visible when text field is empty and no attachments
-                    IconButton(
-                        onClick = { /* no-op: gesture handled by pointerInput */ },
+                } else if (pendingVoiceRecording == null) {
+                    // Mic button: visible when no text/attachments and no pending recording.
+                    // MUST remain in composition during recording so tryAwaitRelease() can
+                    // detect finger lift and fire onMicRelease.
+                    // Uses Box instead of IconButton because IconButton's internal
+                    // clickable modifier consumes touch events before pointerInput
+                    // can detect press/release for hold-to-record.
+                    Box(
                         modifier =
                             Modifier
                                 .size(48.dp)
@@ -2527,10 +2635,12 @@ fun MessageInputBar(
                                         },
                                     )
                                 },
+                        contentAlignment = Alignment.Center,
                     ) {
                         Icon(
                             imageVector = Icons.Filled.Mic,
                             contentDescription = "Hold to record voice message",
+                            modifier = Modifier.size(24.dp),
                             tint =
                                 if (isRecording) {
                                     MaterialTheme.colorScheme.error
@@ -2542,6 +2652,263 @@ fun MessageInputBar(
                 }
             }
         }
+    }
+}
+
+/**
+ * Preview bar shown in [MessageInputBar] after recording completes.
+ * Allows playback, discard, and send of the recorded voice message.
+ */
+@Composable
+fun VoicePreviewBar(
+    recording: com.lxmf.messenger.audio.VoiceRecording,
+    onSend: () -> Unit,
+    onDiscard: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    val scope = rememberCoroutineScope()
+    val player =
+        remember {
+            com.lxmf.messenger.audio
+                .VoiceMessagePlayer()
+        }
+    val playbackState by player.state.collectAsState()
+
+    DisposableEffect(Unit) {
+        onDispose { player.stop() }
+    }
+
+    Box(
+        modifier =
+            modifier
+                .heightIn(min = 48.dp)
+                .background(
+                    MaterialTheme.colorScheme.secondaryContainer,
+                    RoundedCornerShape(24.dp),
+                ).padding(horizontal = 8.dp, vertical = 4.dp),
+        contentAlignment = Alignment.CenterStart,
+    ) {
+        Row(
+            verticalAlignment = Alignment.CenterVertically,
+            horizontalArrangement = Arrangement.spacedBy(4.dp),
+        ) {
+            // Discard button
+            IconButton(onClick = {
+                player.stop()
+                onDiscard()
+            }, modifier = Modifier.size(36.dp)) {
+                Icon(
+                    imageVector = Icons.Default.Delete,
+                    contentDescription = "Discard recording",
+                    modifier = Modifier.size(20.dp),
+                    tint = MaterialTheme.colorScheme.error,
+                )
+            }
+
+            // Play/pause button
+            IconButton(
+                onClick = {
+                    if (playbackState.isPlaying) {
+                        player.stop()
+                    } else {
+                        scope.launch { player.play(recording.audioBytes, recording.durationMs) }
+                    }
+                },
+                modifier = Modifier.size(36.dp),
+            ) {
+                Icon(
+                    imageVector =
+                        if (playbackState.isPlaying) Icons.Default.Pause else Icons.Default.PlayArrow,
+                    contentDescription = if (playbackState.isPlaying) "Pause" else "Play",
+                    modifier = Modifier.size(22.dp),
+                    tint = MaterialTheme.colorScheme.onSecondaryContainer,
+                )
+            }
+
+            // Duration
+            val seconds = (recording.durationMs / 1000).toInt()
+            Text(
+                text = "%d:%02d".format(seconds / 60, seconds % 60),
+                style = MaterialTheme.typography.bodyMedium,
+                color = MaterialTheme.colorScheme.onSecondaryContainer,
+            )
+
+            // Waveform with progress overlay
+            val peaks = recording.waveformPeaks
+            val progress = playbackState.progressFraction
+            if (peaks.isNotEmpty()) {
+                WaveformBar(
+                    peaks = peaks,
+                    activeColor = MaterialTheme.colorScheme.primary,
+                    inactiveColor = MaterialTheme.colorScheme.onSecondaryContainer.copy(alpha = 0.3f),
+                    progress = progress,
+                    modifier =
+                        Modifier
+                            .weight(1f)
+                            .height(32.dp),
+                )
+            } else {
+                Spacer(modifier = Modifier.weight(1f))
+            }
+
+            // Send button
+            FilledIconButton(
+                onClick = {
+                    player.stop()
+                    onSend()
+                },
+                modifier = Modifier.size(36.dp),
+                shape = CircleShape,
+                colors =
+                    IconButtonDefaults.filledIconButtonColors(
+                        containerColor = MaterialTheme.colorScheme.primary,
+                        contentColor = MaterialTheme.colorScheme.onPrimary,
+                    ),
+            ) {
+                Icon(
+                    imageVector = Icons.AutoMirrored.Filled.Send,
+                    contentDescription = "Send voice message",
+                    modifier = Modifier.size(18.dp),
+                )
+            }
+        }
+    }
+}
+
+/**
+ * Waveform bar visualization with optional progress indicator.
+ * Bars before [progress] are drawn in [activeColor], bars after in [inactiveColor].
+ */
+@Composable
+fun WaveformBar(
+    peaks: List<Float>,
+    activeColor: androidx.compose.ui.graphics.Color,
+    inactiveColor: androidx.compose.ui.graphics.Color,
+    progress: Float = 0f,
+    modifier: Modifier = Modifier,
+) {
+    Canvas(modifier = modifier) {
+        val bw = 2.5.dp.toPx()
+        val gap = 1.dp.toPx()
+        val step = bw + gap
+        val maxBars = (size.width / step).toInt()
+        val sampled =
+            if (peaks.size > maxBars) {
+                (0 until maxBars).map { i -> peaks[(i * peaks.size.toLong() / maxBars).toInt()] }
+            } else {
+                peaks
+            }
+        val totalBars = sampled.size
+        sampled.forEachIndexed { index, peak ->
+            val h = (peak.coerceIn(0.05f, 1f) * size.height)
+            val x = index * step
+            val color = if (progress > 0f && index < (totalBars * progress).toInt()) activeColor else inactiveColor
+            drawRoundRect(
+                color = color,
+                topLeft =
+                    androidx.compose.ui.geometry
+                        .Offset(x, (size.height - h) / 2),
+                size =
+                    androidx.compose.ui.geometry
+                        .Size(bw, h),
+                cornerRadius =
+                    androidx.compose.ui.geometry
+                        .CornerRadius(bw / 2),
+            )
+        }
+    }
+}
+
+/**
+ * Voice message bubble shown inside [MessageBubble] for messages with audio attachments.
+ * Displays a play/pause button, duration, and waveform visualization.
+ */
+@Composable
+fun VoiceMessageBubble(
+    durationMs: Long,
+    waveformPeaks: List<Float>?,
+    isFromMe: Boolean,
+    fieldsJson: String? = null,
+) {
+    val scope = rememberCoroutineScope()
+    val player =
+        remember {
+            com.lxmf.messenger.audio
+                .VoiceMessagePlayer()
+        }
+    val playbackState by player.state.collectAsState()
+
+    // Extract audio bytes lazily on first play
+    val audioBytes =
+        remember(fieldsJson) {
+            fieldsJson?.let {
+                com.lxmf.messenger.ui.model
+                    .extractAudioBytes(it)
+            }
+        }
+
+    DisposableEffect(Unit) {
+        onDispose { player.stop() }
+    }
+
+    val seconds = (durationMs / 1000).toInt()
+    val barColor =
+        if (isFromMe) {
+            MaterialTheme.colorScheme.onPrimaryContainer
+        } else {
+            MaterialTheme.colorScheme.onSurfaceVariant
+        }
+
+    Row(
+        verticalAlignment = Alignment.CenterVertically,
+        horizontalArrangement = Arrangement.spacedBy(8.dp),
+        modifier = Modifier.widthIn(min = 180.dp),
+    ) {
+        // Play/pause button
+        IconButton(
+            onClick = {
+                if (playbackState.isPlaying) {
+                    player.stop()
+                } else {
+                    audioBytes?.let { bytes ->
+                        scope.launch { player.play(bytes, durationMs) }
+                    }
+                }
+            },
+            enabled = audioBytes != null,
+            modifier = Modifier.size(32.dp),
+        ) {
+            Icon(
+                imageVector =
+                    if (playbackState.isPlaying) Icons.Default.Pause else Icons.Default.PlayArrow,
+                contentDescription = if (playbackState.isPlaying) "Pause" else "Play",
+                modifier = Modifier.size(22.dp),
+                tint = barColor,
+            )
+        }
+
+        // Waveform with progress
+        if (!waveformPeaks.isNullOrEmpty()) {
+            WaveformBar(
+                peaks = waveformPeaks,
+                activeColor = if (isFromMe) MaterialTheme.colorScheme.primary else MaterialTheme.colorScheme.tertiary,
+                inactiveColor = barColor.copy(alpha = 0.3f),
+                progress = playbackState.progressFraction,
+                modifier =
+                    Modifier
+                        .weight(1f)
+                        .height(28.dp),
+            )
+        } else {
+            Spacer(modifier = Modifier.weight(1f))
+        }
+
+        // Duration
+        Text(
+            text = "%d:%02d".format(seconds / 60, seconds % 60),
+            style = MaterialTheme.typography.labelMedium,
+            color = barColor.copy(alpha = 0.7f),
+        )
     }
 }
 

--- a/app/src/main/java/com/lxmf/messenger/util/AudioPermissionManager.kt
+++ b/app/src/main/java/com/lxmf/messenger/util/AudioPermissionManager.kt
@@ -1,0 +1,14 @@
+package com.lxmf.messenger.util
+
+import android.Manifest
+import android.content.Context
+import android.content.pm.PackageManager
+import androidx.core.content.ContextCompat
+
+object AudioPermissionManager {
+    fun hasPermission(context: Context): Boolean =
+        ContextCompat.checkSelfPermission(
+            context,
+            Manifest.permission.RECORD_AUDIO,
+        ) == PackageManager.PERMISSION_GRANTED
+}

--- a/app/src/main/java/com/lxmf/messenger/viewmodel/MessagingViewModel.kt
+++ b/app/src/main/java/com/lxmf/messenger/viewmodel/MessagingViewModel.kt
@@ -29,6 +29,8 @@ import com.lxmf.messenger.ui.model.LocationSharingState
 import com.lxmf.messenger.ui.model.MessageUi
 import com.lxmf.messenger.ui.model.SharingDuration
 import com.lxmf.messenger.ui.model.decodeImageWithAnimation
+import com.lxmf.messenger.ui.model.extractAudioBytes
+import com.lxmf.messenger.ui.model.extractAudioMetadata
 import com.lxmf.messenger.ui.model.getImageMetadata
 import com.lxmf.messenger.ui.model.loadFileAttachmentData
 import com.lxmf.messenger.ui.model.loadFileAttachmentMetadata
@@ -1116,6 +1118,11 @@ class MessagingViewModel
                     val imageFormat = _selectedImageFormat.value
                     val fileAttachments = _selectedFileAttachments.value
 
+                    // Audio data -- will be populated from VoiceMessageViewModel in Phase 8
+                    val audioData: ByteArray? = null
+                    val audioCodecId: String? = null
+                    val audioWaveform: List<Float>? = null
+
                     val sanitized = validateAndSanitizeContent(content, imageData, fileAttachments) ?: return@launch
                     val destHashBytes = validateDestinationHash(destinationHash) ?: return@launch
                     val identity =
@@ -1171,12 +1178,26 @@ class MessagingViewModel
                             fileAttachments = fileAttachmentPairs.ifEmpty { null },
                             replyToMessageId = replyToId,
                             iconAppearance = iconAppearance,
+                            audioData = audioData,
+                            audioCodecId = audioCodecId,
                         )
 
                     result
                         .onSuccess { receipt ->
                             // Clear pending reply and draft after successful send
-                            handleSendSuccess(receipt, sanitized, destinationHash, imageData, imageFormat, fileAttachments, deliveryMethodString, replyToId)
+                            handleSendSuccess(
+                                receipt,
+                                sanitized,
+                                destinationHash,
+                                imageData,
+                                imageFormat,
+                                fileAttachments,
+                                deliveryMethodString,
+                                replyToId,
+                                audioData = audioData,
+                                audioCodecId = audioCodecId,
+                                audioWaveform = audioWaveform,
+                            )
                             clearReplyTo()
                             draftSaveJob?.cancel()
                             lastDraftText = ""
@@ -1203,6 +1224,9 @@ class MessagingViewModel
             fileAttachments: List<FileAttachment>,
             deliveryMethodString: String,
             replyToMessageId: String? = null,
+            audioData: ByteArray? = null,
+            audioCodecId: String? = null,
+            audioWaveform: List<Float>? = null,
         ) {
             Log.d(TAG, "Message sent successfully${if (replyToMessageId != null) " (reply to ${replyToMessageId.take(16)})" else ""}")
             val fieldsJson =
@@ -1213,6 +1237,9 @@ class MessagingViewModel
                         fileAttachments,
                         replyToMessageId,
                         cacheDir = applicationContext.cacheDir,
+                        audioData = audioData,
+                        audioCodecId = audioCodecId,
+                        audioWaveform = audioWaveform,
                     )
                 } catch (e: java.io.IOException) {
                     Log.e(TAG, "Failed to build fieldsJson (attachment I/O error), saving message without attachments", e)
@@ -2133,6 +2160,15 @@ class MessagingViewModel
                     val imageData = failedMessage.fieldsJson?.let { parseImageFromFieldsJson(it) }
                     val imageFormat = if (imageData != null) "jpg" else null
 
+                    // Parse audio data from fieldsJson if present (mirrors image extraction above)
+                    val audioBytes = extractAudioBytes(failedMessage.fieldsJson)
+                    val retryAudioCodecId =
+                        if (audioBytes != null) {
+                            extractAudioMetadata(failedMessage.fieldsJson)?.codecId ?: "opus_vm"
+                        } else {
+                            null
+                        }
+
                     // Parse file attachments from fieldsJson if present
                     // For retry, we need to reconstruct file attachments from stored data
                     // TODO: Implement file attachment parsing from fieldsJson when retrying
@@ -2160,6 +2196,8 @@ class MessagingViewModel
                             imageFormat = imageFormat,
                             // Preserve reply on retry
                             replyToMessageId = failedMessage.replyToMessageId,
+                            audioData = audioBytes,
+                            audioCodecId = retryAudioCodecId,
                         )
 
                     result
@@ -2366,12 +2404,16 @@ private suspend fun buildFieldsJson(
     replyToMessageId: String? = null,
     reactions: Map<String, List<String>>? = null,
     cacheDir: java.io.File? = null,
+    audioData: ByteArray? = null,
+    audioCodecId: String? = null,
+    audioWaveform: List<Float>? = null,
 ): String? {
     val hasImage = imageData != null && imageFormat != null
     val hasFiles = fileAttachments.isNotEmpty()
     val hasReply = replyToMessageId != null
     val hasReactions = !reactions.isNullOrEmpty()
-    val hasAnyContent = hasImage || hasFiles || hasReply || hasReactions
+    val hasAudio = audioData != null && audioCodecId != null
+    val hasAnyContent = hasImage || hasFiles || hasReply || hasReactions || hasAudio
 
     if (!hasAnyContent) return null
 
@@ -2388,6 +2430,28 @@ private suspend fun buildFieldsJson(
                 json.put("6", org.json.JSONObject().put("_file_ref", hexFile.absolutePath))
             } else {
                 json.put("6", imageData.toHexString())
+            }
+        }
+
+        // Add audio field (Field 7) -- format: ["codec_id", "hex_audio_data"] or with waveform: ["codec_id", "hex", [waveform]]
+        if (hasAudio && audioData != null && audioCodecId != null) {
+            if (cacheDir != null && audioData.size > STREAM_HEX_THRESHOLD) {
+                // Large audio: write hex to temp file, store file ref
+                val hexDir = java.io.File(cacheDir, OUTGOING_HEX_DIR).apply { mkdirs() }
+                val hexFile = java.io.File(hexDir, "outgoing_audio_${System.nanoTime()}.hex")
+                audioData.streamHexToFile(hexFile)
+                json.put("7", org.json.JSONObject().put("_file_ref", hexFile.absolutePath))
+            } else {
+                val audioArray = org.json.JSONArray()
+                audioArray.put(audioCodecId)
+                audioArray.put(audioData.toHexString())
+                // Add waveform as third array element if available
+                if (audioWaveform != null) {
+                    val waveformArray = org.json.JSONArray()
+                    audioWaveform.forEach { waveformArray.put(it.toDouble()) }
+                    audioArray.put(waveformArray)
+                }
+                json.put("7", audioArray)
             }
         }
 

--- a/app/src/main/java/com/lxmf/messenger/viewmodel/MessagingViewModel.kt
+++ b/app/src/main/java/com/lxmf/messenger/viewmodel/MessagingViewModel.kt
@@ -1119,18 +1119,13 @@ class MessagingViewModel
                     val imageData = _selectedImageData.value
                     val imageFormat = _selectedImageFormat.value
                     val fileAttachments = _selectedFileAttachments.value
-
-                    // Phase 8: Wire voice recording output
-                    val audioData: ByteArray? = voiceRecording?.audioBytes
-                    val audioCodecId: String? = voiceRecording?.codecId
-                    val audioWaveform: List<Float>? = voiceRecording?.waveformPeaks
-
-                    // Voice-only messages: bypass text validation when audio is present
-                    // without text or other attachments. Uses " " (single space) for Sideband
-                    // compatibility, matching the existing image-only escape hatch pattern
-                    // inside validateAndSanitizeContent().
+                    val audioData = voiceRecording?.audioBytes
+                    val audioCodecId = voiceRecording?.codecId
+                    val audioWaveform = voiceRecording?.waveformPeaks
+                    // Voice-only: bypass text validation, use " " for Sideband compat
+                    val isVoiceOnly = voiceRecording != null && content.isBlank() && imageData == null && fileAttachments.isEmpty()
                     val sanitized =
-                        if (voiceRecording != null && content.isBlank() && imageData == null && fileAttachments.isEmpty()) {
+                        if (isVoiceOnly) {
                             " "
                         } else {
                             validateAndSanitizeContent(content, imageData, fileAttachments) ?: return@launch
@@ -1138,45 +1133,21 @@ class MessagingViewModel
                     val destHashBytes = validateDestinationHash(destinationHash) ?: return@launch
                     val identity =
                         loadIdentityIfNeeded() ?: run {
-                            Log.e(TAG, "Failed to load source identity")
+                            Log.e(TAG, "No source identity")
                             return@launch
                         }
-
                     val tryPropOnFail = settingsRepository.getTryPropagationOnFail()
-                    val defaultMethod = settingsRepository.getDefaultDeliveryMethod()
-                    val deliveryMethod = determineDeliveryMethod(sanitized, imageData, fileAttachments, defaultMethod)
+                    val deliveryMethod =
+                        determineDeliveryMethod(
+                            sanitized,
+                            imageData,
+                            fileAttachments,
+                            settingsRepository.getDefaultDeliveryMethod(),
+                        )
                     val deliveryMethodString = deliveryMethod.toStorageString()
-
-                    // Convert file attachments to protocol format: List<Pair<String, ByteArray>>
                     val fileAttachmentPairs = fileAttachments.map { it.filename to it.data }
-
-                    Log.d(
-                        TAG,
-                        "Sending LXMF message to $destinationHash " +
-                            "(${sanitized.length} chars, hasImage=${imageData != null}, " +
-                            "files=${fileAttachments.size}, method=$deliveryMethod, tryPropOnFail=$tryPropOnFail)...",
-                    )
-
-                    // Get pending reply ID if replying to a message
                     val replyToId = _pendingReplyTo.value?.messageId
-
-                    // Get user's icon appearance for Sideband/MeshChat interoperability
-                    val iconAppearance =
-                        identityRepository.getActiveIdentitySync()?.let { activeId ->
-                            val name = activeId.iconName
-                            val fg = activeId.iconForegroundColor
-                            val bg = activeId.iconBackgroundColor
-                            if (name != null && fg != null && bg != null) {
-                                com.lxmf.messenger.reticulum.protocol.IconAppearance(
-                                    iconName = name,
-                                    foregroundColor = fg,
-                                    backgroundColor = bg,
-                                )
-                            } else {
-                                null
-                            }
-                        }
-
+                    val iconAppearance = loadIconAppearance()
                     val result =
                         reticulumProtocol.sendLxmfMessageWithMethod(
                             destinationHash = destHashBytes,
@@ -1195,7 +1166,6 @@ class MessagingViewModel
 
                     result
                         .onSuccess { receipt ->
-                            // Clear pending reply and draft after successful send
                             handleSendSuccess(
                                 receipt,
                                 sanitized,
@@ -1205,15 +1175,11 @@ class MessagingViewModel
                                 fileAttachments,
                                 deliveryMethodString,
                                 replyToId,
-                                audioData = audioData,
-                                audioCodecId = audioCodecId,
-                                audioWaveform = audioWaveform,
+                                audioData,
+                                audioCodecId,
+                                audioWaveform,
                             )
-                            clearReplyTo()
-                            draftSaveJob?.cancel()
-                            lastDraftText = ""
-                            conversationRepository.clearDraft(destinationHash)
-                            _draftText.value = null
+                            clearReplyAndDraft(destinationHash)
                         }.onFailure { error ->
                             handleSendFailure(error, sanitized, destinationHash, deliveryMethodString)
                         }
@@ -1224,6 +1190,30 @@ class MessagingViewModel
                 }
             }
         }
+
+        private suspend fun clearReplyAndDraft(destinationHash: String) {
+            clearReplyTo()
+            draftSaveJob?.cancel()
+            lastDraftText = ""
+            conversationRepository.clearDraft(destinationHash)
+            _draftText.value = null
+        }
+
+        private suspend fun loadIconAppearance(): com.lxmf.messenger.reticulum.protocol.IconAppearance? =
+            identityRepository.getActiveIdentitySync()?.let { activeId ->
+                val name = activeId.iconName
+                val fg = activeId.iconForegroundColor
+                val bg = activeId.iconBackgroundColor
+                if (name != null && fg != null && bg != null) {
+                    com.lxmf.messenger.reticulum.protocol.IconAppearance(
+                        iconName = name,
+                        foregroundColor = fg,
+                        backgroundColor = bg,
+                    )
+                } else {
+                    null
+                }
+            }
 
         @Suppress("LongParameterList") // Refactoring to data class would add unnecessary complexity
         private suspend fun handleSendSuccess(
@@ -1248,9 +1238,12 @@ class MessagingViewModel
                         fileAttachments,
                         replyToMessageId,
                         cacheDir = applicationContext.cacheDir,
-                        audioData = audioData,
-                        audioCodecId = audioCodecId,
-                        audioWaveform = audioWaveform,
+                        audio =
+                            if (audioData != null && audioCodecId != null) {
+                                AudioFieldData(audioData, audioCodecId, audioWaveform)
+                            } else {
+                                null
+                            },
                     )
                 } catch (e: java.io.IOException) {
                     Log.e(TAG, "Failed to build fieldsJson (attachment I/O error), saving message without attachments", e)
@@ -2407,6 +2400,12 @@ private fun determineDeliveryMethod(
     }
 }
 
+private data class AudioFieldData(
+    val data: ByteArray,
+    val codecId: String,
+    val waveform: List<Float>?,
+)
+
 @Suppress("LongParameterList", "CyclomaticComplexMethod")
 private suspend fun buildFieldsJson(
     imageData: ByteArray?,
@@ -2415,68 +2414,65 @@ private suspend fun buildFieldsJson(
     replyToMessageId: String? = null,
     reactions: Map<String, List<String>>? = null,
     cacheDir: java.io.File? = null,
-    audioData: ByteArray? = null,
-    audioCodecId: String? = null,
-    audioWaveform: List<Float>? = null,
+    audio: AudioFieldData? = null,
 ): String? {
     val hasImage = imageData != null && imageFormat != null
     val hasFiles = fileAttachments.isNotEmpty()
     val hasReply = replyToMessageId != null
     val hasReactions = !reactions.isNullOrEmpty()
-    val hasAudio = audioData != null && audioCodecId != null
-    val hasAnyContent = hasImage || hasFiles || hasReply || hasReactions || hasAudio
+    val hasAudio = audio != null
+    val hasAnyField = hasImage || hasFiles || hasReply || hasReactions || hasAudio
+    if (!hasAnyField) return null
 
-    if (!hasAnyContent) return null
-
-    // Move hex encoding + file I/O (streamHexToFile) to background thread
     return kotlinx.coroutines.withContext(kotlinx.coroutines.Dispatchers.IO) {
         val json = org.json.JSONObject()
-
-        // Add image field (Field 6)
-        if (hasImage && imageData != null) {
-            if (cacheDir != null && imageData.size > STREAM_HEX_THRESHOLD) {
-                val hexDir = java.io.File(cacheDir, OUTGOING_HEX_DIR).apply { mkdirs() }
-                val hexFile = java.io.File(hexDir, "outgoing_img_${System.nanoTime()}.hex")
-                imageData.streamHexToFile(hexFile)
-                json.put("6", org.json.JSONObject().put("_file_ref", hexFile.absolutePath))
-            } else {
-                json.put("6", imageData.toHexString())
-            }
+        if (hasImage && imageData != null) addImageField(json, imageData, cacheDir)
+        if (hasAudio && audio != null) {
+            addAudioField(json, audio.data, audio.codecId, audio.waveform, cacheDir)
         }
-
-        // Add audio field (Field 7) -- format: ["codec_id", "hex_audio_data"] or with waveform: ["codec_id", "hex", [waveform]]
-        if (hasAudio && audioData != null && audioCodecId != null) {
-            if (cacheDir != null && audioData.size > STREAM_HEX_THRESHOLD) {
-                // Large audio: write hex to temp file, store file ref
-                val hexDir = java.io.File(cacheDir, OUTGOING_HEX_DIR).apply { mkdirs() }
-                val hexFile = java.io.File(hexDir, "outgoing_audio_${System.nanoTime()}.hex")
-                audioData.streamHexToFile(hexFile)
-                json.put("7", org.json.JSONObject().put("_file_ref", hexFile.absolutePath))
-            } else {
-                val audioArray = org.json.JSONArray()
-                audioArray.put(audioCodecId)
-                audioArray.put(audioData.toHexString())
-                // Add waveform as third array element if available
-                if (audioWaveform != null) {
-                    val waveformArray = org.json.JSONArray()
-                    audioWaveform.forEach { waveformArray.put(it.toDouble()) }
-                    audioArray.put(waveformArray)
-                }
-                json.put("7", audioArray)
-            }
-        }
-
-        // Add file attachments field (Field 5)
-        if (hasFiles) {
-            json.put("5", buildFileAttachmentsArray(fileAttachments, cacheDir))
-        }
-
-        // Add app extensions field (Field 16) for replies, reactions, and future features
-        if (hasReply || hasReactions) {
-            json.put("16", buildAppExtensions(replyToMessageId, reactions))
-        }
-
+        if (hasFiles) json.put("5", buildFileAttachmentsArray(fileAttachments, cacheDir))
+        if (hasReply || hasReactions) json.put("16", buildAppExtensions(replyToMessageId, reactions))
         json.toString()
+    }
+}
+
+private fun addImageField(
+    json: org.json.JSONObject,
+    imageData: ByteArray,
+    cacheDir: java.io.File?,
+) {
+    if (cacheDir != null && imageData.size > STREAM_HEX_THRESHOLD) {
+        val hexDir = java.io.File(cacheDir, OUTGOING_HEX_DIR).apply { mkdirs() }
+        val hexFile = java.io.File(hexDir, "outgoing_img_${System.nanoTime()}.hex")
+        imageData.streamHexToFile(hexFile)
+        json.put("6", org.json.JSONObject().put("_file_ref", hexFile.absolutePath))
+    } else {
+        json.put("6", imageData.toHexString())
+    }
+}
+
+private fun addAudioField(
+    json: org.json.JSONObject,
+    audioData: ByteArray,
+    audioCodecId: String,
+    audioWaveform: List<Float>?,
+    cacheDir: java.io.File?,
+) {
+    if (cacheDir != null && audioData.size > STREAM_HEX_THRESHOLD) {
+        val hexDir = java.io.File(cacheDir, OUTGOING_HEX_DIR).apply { mkdirs() }
+        val hexFile = java.io.File(hexDir, "outgoing_audio_${System.nanoTime()}.hex")
+        audioData.streamHexToFile(hexFile)
+        json.put("7", org.json.JSONObject().put("_file_ref", hexFile.absolutePath))
+    } else {
+        val audioArray = org.json.JSONArray()
+        audioArray.put(audioCodecId)
+        audioArray.put(audioData.toHexString())
+        if (audioWaveform != null) {
+            val waveformArray = org.json.JSONArray()
+            audioWaveform.forEach { waveformArray.put(it.toDouble()) }
+            audioArray.put(waveformArray)
+        }
+        json.put("7", audioArray)
     }
 }
 

--- a/app/src/main/java/com/lxmf/messenger/viewmodel/MessagingViewModel.kt
+++ b/app/src/main/java/com/lxmf/messenger/viewmodel/MessagingViewModel.kt
@@ -9,6 +9,7 @@ import androidx.lifecycle.viewModelScope
 import androidx.paging.PagingData
 import androidx.paging.cachedIn
 import androidx.paging.map
+import com.lxmf.messenger.audio.VoiceRecording
 import com.lxmf.messenger.data.model.EnrichedContact
 import com.lxmf.messenger.data.model.ImageCompressionPreset
 import com.lxmf.messenger.data.repository.ReceivedLocationRepository
@@ -1110,6 +1111,7 @@ class MessagingViewModel
         fun sendMessage(
             destinationHash: String,
             content: String,
+            voiceRecording: VoiceRecording? = null,
         ) {
             viewModelScope.launch {
                 _isSending.value = true
@@ -1118,12 +1120,21 @@ class MessagingViewModel
                     val imageFormat = _selectedImageFormat.value
                     val fileAttachments = _selectedFileAttachments.value
 
-                    // Audio data -- will be populated from VoiceMessageViewModel in Phase 8
-                    val audioData: ByteArray? = null
-                    val audioCodecId: String? = null
-                    val audioWaveform: List<Float>? = null
+                    // Phase 8: Wire voice recording output
+                    val audioData: ByteArray? = voiceRecording?.audioBytes
+                    val audioCodecId: String? = voiceRecording?.codecId
+                    val audioWaveform: List<Float>? = voiceRecording?.waveformPeaks
 
-                    val sanitized = validateAndSanitizeContent(content, imageData, fileAttachments) ?: return@launch
+                    // Voice-only messages: bypass text validation when audio is present
+                    // without text or other attachments. Uses " " (single space) for Sideband
+                    // compatibility, matching the existing image-only escape hatch pattern
+                    // inside validateAndSanitizeContent().
+                    val sanitized =
+                        if (voiceRecording != null && content.isBlank() && imageData == null && fileAttachments.isEmpty()) {
+                            " "
+                        } else {
+                            validateAndSanitizeContent(content, imageData, fileAttachments) ?: return@launch
+                        }
                     val destHashBytes = validateDestinationHash(destinationHash) ?: return@launch
                     val identity =
                         loadIdentityIfNeeded() ?: run {

--- a/app/src/main/java/com/lxmf/messenger/viewmodel/VoiceMessageViewModel.kt
+++ b/app/src/main/java/com/lxmf/messenger/viewmodel/VoiceMessageViewModel.kt
@@ -1,0 +1,68 @@
+package com.lxmf.messenger.viewmodel
+
+import android.content.Context
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.lxmf.messenger.audio.RecordingUiState
+import com.lxmf.messenger.audio.VoiceMessageRecorder
+import com.lxmf.messenger.audio.VoiceRecording
+import dagger.hilt.android.lifecycle.HiltViewModel
+import dagger.hilt.android.qualifiers.ApplicationContext
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.launch
+import javax.inject.Inject
+
+/**
+ * Thin ViewModel that owns the [VoiceMessageRecorder] lifecycle and exposes
+ * recording state to the UI layer.
+ *
+ * The composable launches a coroutine to call [stopRecording] (which is a suspend
+ * fun because AudioRecord.stop()/release() are blocking native calls dispatched to
+ * Dispatchers.IO) and passes the resulting [VoiceRecording] to
+ * [MessagingViewModel.sendMessage].
+ */
+@HiltViewModel
+class VoiceMessageViewModel
+    @Inject
+    constructor(
+        @ApplicationContext private val context: Context,
+    ) : ViewModel() {
+        private val recorder = VoiceMessageRecorder(context)
+
+        /** Observable recording state for the UI (isRecording, durationMs, latestPeak, error). */
+        val recordingState: StateFlow<RecordingUiState> = recorder.state
+
+        /**
+         * Start recording. Permission must be checked at the UI layer before calling this.
+         * If already recording, this is a no-op.
+         */
+        fun startRecording() {
+            recorder.start()
+        }
+
+        /**
+         * Stop recording and return the captured audio.
+         *
+         * This is a suspend fun because [VoiceMessageRecorder.stop] dispatches
+         * AudioRecord.stop()/release() to Dispatchers.IO to avoid ANR when called
+         * from the main/composition thread.
+         *
+         * @return [VoiceRecording] with encoded Opus bytes and metadata, or null if:
+         *   - Not currently recording
+         *   - Recording was shorter than 300ms (silent discard)
+         */
+        suspend fun stopRecording(): VoiceRecording? = recorder.stop()
+
+        /**
+         * Cancel recording without sending. Launches a coroutine to call the suspend
+         * [VoiceMessageRecorder.stop] and discards the result.
+         */
+        fun cancelRecording() {
+            viewModelScope.launch { recorder.stop() }
+        }
+
+        override fun onCleared() {
+            recorder.release()
+            super.onCleared()
+        }
+    }

--- a/python/reticulum_wrapper.py
+++ b/python/reticulum_wrapper.py
@@ -2933,19 +2933,29 @@ class ReticulumWrapper:
                     telemetry_source = "Legacy field 7"
                     try:
                         legacy_data = lxmf_message.fields[LEGACY_LOCATION_FIELD]
-                        log_info("ReticulumWrapper", "_on_lxmf_delivery",
-                                f"📍 Legacy location telemetry received in field 7")
 
-                        # Legacy format: JSON string as bytes or string
-                        if isinstance(legacy_data, bytes):
-                            location_json = legacy_data.decode('utf-8')
-                        elif isinstance(legacy_data, str):
-                            location_json = legacy_data
+                        # Disambiguate: audio data arrives as [codec_id, audio_bytes] (list/tuple
+                        # with a string as first element), while legacy location is JSON bytes/string.
+                        # Without this check, audio messages would be mis-parsed as location JSON.
+                        if isinstance(legacy_data, (list, tuple)) and len(legacy_data) >= 2 and isinstance(legacy_data[0], str):
+                            # This is FIELD_AUDIO data (codec_id, audio_bytes), not legacy location
+                            log_info("ReticulumWrapper", "_on_lxmf_delivery",
+                                    f"Field 7 contains audio data (codec={legacy_data[0]}), skipping legacy location parse")
                         else:
-                            location_json = None
+                            # Original legacy location handling
+                            log_info("ReticulumWrapper", "_on_lxmf_delivery",
+                                    f"📍 Legacy location telemetry received in field 7")
 
-                        if location_json:
-                            location_event = json.loads(location_json)
+                            # Legacy format: JSON string as bytes or string
+                            if isinstance(legacy_data, bytes):
+                                location_json = legacy_data.decode('utf-8')
+                            elif isinstance(legacy_data, str):
+                                location_json = legacy_data
+                            else:
+                                location_json = None
+
+                            if location_json:
+                                location_event = json.loads(location_json)
                     except Exception as e:
                         log_warning("ReticulumWrapper", "_on_lxmf_delivery",
                                    f"Failed to parse legacy field 7: {e}")
@@ -4378,7 +4388,9 @@ class ReticulumWrapper:
                                        image_data_path: str = None,
                                        file_attachments: list = None, file_attachment_paths: list = None,
                                        reply_to_message_id: str = None,
-                                       icon_name: str = None, icon_fg_color: str = None, icon_bg_color: str = None) -> Dict:
+                                       icon_name: str = None, icon_fg_color: str = None, icon_bg_color: str = None,
+                                       audio_data: bytes = None, audio_codec_id: str = None,
+                                       audio_data_path: str = None) -> Dict:
         """
         Send an LXMF message with explicit delivery method.
 
@@ -4619,6 +4631,40 @@ class ReticulumWrapper:
                 ]
                 log_info("ReticulumWrapper", "send_lxmf_message_with_method",
                         f"📎 Adding icon appearance: {icon_name}, fg={icon_fg_color} ({fg_bytes.hex()}), bg={icon_bg_color} ({bg_bytes.hex()})")
+
+            # If audio_data_path is provided, read from file (for large audio bypassing Binder IPC)
+            if audio_data_path and audio_codec_id:
+                import os
+                try:
+                    with open(audio_data_path, 'rb') as f:
+                        audio_data = f.read()
+                    log_info("ReticulumWrapper", "send_lxmf_message_with_method",
+                             f"🎤 Read large audio from temp file: {len(audio_data)} bytes")
+                except Exception as e:
+                    log_error("ReticulumWrapper", "send_lxmf_message_with_method",
+                              f"Failed to read audio from temp file: {e}")
+                    return {"success": False, "error": f"Failed to read audio file: {e}", "delivery_method": None}
+                finally:
+                    # Always try to delete temp file (best effort cleanup)
+                    try:
+                        if os.path.exists(audio_data_path):
+                            os.remove(audio_data_path)
+                            log_debug("ReticulumWrapper", "send_lxmf_message_with_method",
+                                      f"Deleted temp audio file: {audio_data_path}")
+                    except Exception as del_err:
+                        log_warning("ReticulumWrapper", "send_lxmf_message_with_method",
+                                   f"Failed to delete temp audio file: {del_err}")
+
+            # Add audio field (FIELD_AUDIO = 0x07) if provided
+            # Format: [codec_id, audio_bytes] - codec_id identifies the encoding (e.g., "opus_vm")
+            if audio_data and audio_codec_id:
+                if hasattr(audio_data, '__iter__') and not isinstance(audio_data, (bytes, bytearray)):
+                    audio_data = bytes(audio_data)
+                if fields is None:
+                    fields = {}
+                fields[FIELD_AUDIO] = [audio_codec_id, audio_data]
+                log_info("ReticulumWrapper", "send_lxmf_message_with_method",
+                        f"🎤 Attaching audio: {len(audio_data)} bytes, codec={audio_codec_id}")
 
             # Create LXMF message with specified delivery method
             lxmf_message = LXMF.LXMessage(

--- a/reticulum/src/main/java/com/lxmf/messenger/reticulum/protocol/MockReticulumProtocol.kt
+++ b/reticulum/src/main/java/com/lxmf/messenger/reticulum/protocol/MockReticulumProtocol.kt
@@ -359,6 +359,8 @@ class MockReticulumProtocol : ReticulumProtocol {
         fileAttachments: List<Pair<String, ByteArray>>?,
         replyToMessageId: String?,
         iconAppearance: IconAppearance?,
+        audioData: ByteArray?,
+        audioCodecId: String?,
     ): Result<MessageReceipt> {
         // Mock implementation - same as sendLxmfMessage
         return Result.success(

--- a/reticulum/src/main/java/com/lxmf/messenger/reticulum/protocol/ReticulumProtocol.kt
+++ b/reticulum/src/main/java/com/lxmf/messenger/reticulum/protocol/ReticulumProtocol.kt
@@ -302,6 +302,8 @@ interface ReticulumProtocol {
         fileAttachments: List<Pair<String, ByteArray>>? = null,
         replyToMessageId: String? = null,
         iconAppearance: IconAppearance? = null,
+        audioData: ByteArray? = null,
+        audioCodecId: String? = null,
     ): Result<MessageReceipt>
 
     /**


### PR DESCRIPTION
## Summary
- Add `VoiceMessageRecorder` with Opus encoding (24kHz mono, VOICE_MEDIUM profile) via LXST-kt
- Add `AudioPermissionManager` for RECORD_AUDIO permission checks
- Add `VoiceMessageViewModel` (Hilt) wrapping the recorder
- Wire mic button with hold-to-record gesture into `MessagingScreen`
- Wire `sendMessage()` to accept `VoiceRecording` with audio data passthrough

### Features
- 300ms minimum duration (tap-to-discard)
- 30s auto-stop for mesh-friendly message sizes (~30KB)
- Audio focus management (silences notifications during recording)
- Per-frame waveform peak capture for future visualization

## Test plan
- [ ] On-device: hold mic button, record, release → message sends with audio
- [ ] Tap mic briefly (< 300ms) → silently discarded, no message sent
- [ ] Record for 30s → auto-stops and sends
- [ ] Verify audio focus acquired/released (notifications silenced during recording)
- [ ] Verify RECORD_AUDIO permission prompt on first use

🤖 Generated with [Claude Code](https://claude.com/claude-code)