### PR TITLE
fix: remove hardcoded VID filter from nRF52 EEPROM wipe reconnect

### DIFF
--- a/reticulum/src/main/java/com/lxmf/messenger/reticulum/flasher/RNodeFlasher.kt
+++ b/reticulum/src/main/java/com/lxmf/messenger/reticulum/flasher/RNodeFlasher.kt
@@ -875,12 +875,9 @@ class RNodeFlasher(
                             break
                         }
 
-                        // Scan for re-enumerated device (nRF52 boards use Adafruit VID 0x239A)
+                        // Scan for re-enumerated device (new ID after reboot)
                         val devices = usbBridge.getConnectedUsbDevices()
-                        val reEnumeratedDevice =
-                            devices.find {
-                                it.deviceId != actualDeviceId && it.vendorId == 0x239A
-                            }
+                        val reEnumeratedDevice = devices.find { it.deviceId != actualDeviceId }
                         if (reEnumeratedDevice != null) {
                             if (usbBridge.connect(reEnumeratedDevice.deviceId, RNodeConstants.BAUD_RATE_DEFAULT)) {
                                 actualDeviceId = reEnumeratedDevice.deviceId


### PR DESCRIPTION
## Summary
- Removes hardcoded `0x239A` VID filter from the nRF52 EEPROM wipe reconnect loop
- `getConnectedUsbDevices()` already filters by `SUPPORTED_VIDS` + serial driver match, so the extra VID check was unnecessarily restrictive
- Prevents breakage if future nRF52 boards use different VIDs

## Context
Follow-up to PR #555. Greptile review flagged the hardcoded VID as fragile — the underlying concern is valid even though the specific VID suggestion (Nordic `0x1915`) was incorrect.

## Test plan
- [ ] Flash an nRF52 board (RAK4631, T114, or T-Echo) and verify EEPROM provisioning completes successfully
- [ ] Verify device reconnection works after EEPROM wipe

🤖 Generated with [Claude Code](https://claude.com/claude-code)