### PR TITLE
fix: add @JvmOverloads to KotlinUSBBridge.connect() for USB RNode

### DIFF
--- a/reticulum/src/main/java/com/lxmf/messenger/reticulum/usb/KotlinUSBBridge.kt
+++ b/reticulum/src/main/java/com/lxmf/messenger/reticulum/usb/KotlinUSBBridge.kt
@@ -610,6 +610,7 @@ class KotlinUSBBridge(
      *   call bulkTransfer() directly without testConnection().
      * @return true if connection successful, false otherwise
      */
+    @JvmOverloads
     @Suppress("ReturnCount")
     fun connect(
         deviceId: Int,


### PR DESCRIPTION
## Summary
- Adds `@JvmOverloads` to `KotlinUSBBridge.connect()` so Chaquopy/Python callers can invoke it with 2 arguments
- The `startIoManager` parameter added in PR #508 (nRF52 DFU) removed the 2-param Java overload that `rnode_interface.py` depends on
- Without this, USB RNode interfaces silently fail to start — `connect(device_id, 115200)` throws `NoSuchMethodError`

## Root cause
Kotlin default parameters only generate overloads for Kotlin callers. Java/Chaquopy callers need `@JvmOverloads` to get bridge methods. In v0.8.9, `connect(int, int)` existed. In v0.8.10+, only `connect(int, int, boolean)` exists — breaking the Python call.

## Test plan
- [ ] Connect a USB RNode (e.g. LilyGO T3S3) and verify the interface comes online
- [ ] Verify Bluetooth RNodes still work (uses different bridge class, unaffected)
- [ ] Verify nRF52 DFU flashing still works (passes `startIoManager=false` from Kotlin)

Fixes #545

🤖 Generated with [Claude Code](https://claude.com/claude-code)