### PR TITLE
fix: include host device location in hosted group telemetry stream

### DIFF
--- a/app/src/main/aidl/com/lxmf/messenger/IReticulumService.aidl
+++ b/app/src/main/aidl/com/lxmf/messenger/IReticulumService.aidl
@@ -463,6 +463,18 @@ interface IReticulumService {
      */
     String setTelemetryAllowedRequesters(String allowedHashesJson);
 
+    /**
+     * Store the host's own location in collected telemetry so it is included
+     * in FIELD_TELEMETRY_STREAM responses sent to group members.
+     *
+     * @param locationJson JSON string with location data (lat, lng, acc, ts, etc.)
+     * @param iconName Optional icon name for appearance (null if none)
+     * @param iconFgColor Optional foreground color hex string (null if none)
+     * @param iconBgColor Optional background color hex string (null if none)
+     * @return JSON string with result: {"success": true} or {"success": false, "error": "..."}
+     */
+    String storeOwnTelemetry(String locationJson, String iconName, String iconFgColor, String iconBgColor);
+
     // ==================== EMOJI REACTIONS ====================
 
     /**

--- a/app/src/main/java/com/lxmf/messenger/reticulum/protocol/ServiceReticulumProtocol.kt
+++ b/app/src/main/java/com/lxmf/messenger/reticulum/protocol/ServiceReticulumProtocol.kt
@@ -2391,6 +2391,27 @@ class ServiceReticulumProtocol(
             Log.d(TAG, "📡 Telemetry collector mode ${if (enabled) "enabled" else "disabled"}")
         }
 
+    override suspend fun storeOwnTelemetry(
+        locationJson: String,
+        iconAppearance: IconAppearance?,
+    ): Result<Unit> =
+        runCatching {
+            val service = this.service ?: throw IllegalStateException("Service not bound")
+
+            val resultJson = service.storeOwnTelemetry(
+                locationJson,
+                iconAppearance?.iconName,
+                iconAppearance?.foregroundColor,
+                iconAppearance?.backgroundColor,
+            )
+            val result = JSONObject(resultJson)
+
+            if (!result.optBoolean("success", false)) {
+                val error = result.optString("error", "Unknown error")
+                throw RuntimeException(error)
+            }
+        }
+
     override suspend fun setTelemetryAllowedRequesters(allowedHashes: Set<String>): Result<Unit> =
         runCatching {
             val service = this.service ?: throw IllegalStateException("Service not bound")

--- a/app/src/main/java/com/lxmf/messenger/service/binder/ReticulumServiceBinder.kt
+++ b/app/src/main/java/com/lxmf/messenger/service/binder/ReticulumServiceBinder.kt
@@ -949,6 +949,29 @@ class ReticulumServiceBinder(
             """{"success": false, "error": "${e.message}"}"""
         }
 
+    override fun storeOwnTelemetry(
+        locationJson: String,
+        iconName: String?,
+        iconFgColor: String?,
+        iconBgColor: String?,
+    ): String =
+        try {
+            wrapperManager.withWrapper { wrapper ->
+                val result =
+                    wrapper.callAttr(
+                        "store_own_telemetry",
+                        locationJson,
+                        iconName,
+                        iconFgColor,
+                        iconBgColor,
+                    )
+                result?.toString() ?: """{"success": false, "error": "No result from Python"}"""
+            } ?: """{"success": false, "error": "Wrapper not available"}"""
+        } catch (e: Exception) {
+            Log.e(TAG, "Error storing own telemetry", e)
+            """{"success": false, "error": "${e.message}"}"""
+        }
+
     // ===========================================
     // Emoji Reactions
     // ===========================================

--- a/app/src/main/java/com/lxmf/messenger/ui/screens/SettingsScreen.kt
+++ b/app/src/main/java/com/lxmf/messenger/ui/screens/SettingsScreen.kt
@@ -315,6 +315,12 @@ fun SettingsScreen(
                     telemetryAllowedRequesters = state.telemetryAllowedRequesters,
                     contacts = state.contacts,
                     onTelemetryAllowedRequestersChange = { viewModel.setTelemetryAllowedRequesters(it) },
+                    // Local identity for "Myself" option in host picker
+                    localDestinationHash = state.destinationHash,
+                    localDisplayName = state.displayName.ifEmpty { state.defaultDisplayName },
+                    localIconName = state.iconName,
+                    localIconForegroundColor = state.iconForegroundColor,
+                    localIconBackgroundColor = state.iconBackgroundColor,
                 )
 
                 MapSourcesCard(

--- a/app/src/main/java/com/lxmf/messenger/viewmodel/SettingsViewModel.kt
+++ b/app/src/main/java/com/lxmf/messenger/viewmodel/SettingsViewModel.kt
@@ -345,8 +345,8 @@ class SettingsViewModel
                             isManualAnnouncing = _state.value.isManualAnnouncing,
                             showManualAnnounceSuccess = _state.value.showManualAnnounceSuccess,
                             manualAnnounceError = _state.value.manualAnnounceError,
-                            identityHash = identityInfo.first,
-                            destinationHash = identityInfo.second,
+                            identityHash = identityInfo.first ?: activeIdentity?.identityHash,
+                            destinationHash = identityInfo.second ?: activeIdentity?.destinationHash,
                             showQrDialog = _state.value.showQrDialog,
                             // Profile icon from active identity
                             iconName = activeIdentity?.iconName,

--- a/app/src/test/java/com/lxmf/messenger/service/TelemetryCollectorManagerTest.kt
+++ b/app/src/test/java/com/lxmf/messenger/service/TelemetryCollectorManagerTest.kt
@@ -1,16 +1,23 @@
 package com.lxmf.messenger.service
 
 import android.content.Context
+import android.location.Location
 import app.cash.turbine.test
+import com.lxmf.messenger.data.db.entity.LocalIdentityEntity
 import com.lxmf.messenger.repository.SettingsRepository
 import com.lxmf.messenger.reticulum.model.NetworkStatus
+import com.lxmf.messenger.reticulum.protocol.MessageReceipt
 import com.lxmf.messenger.reticulum.protocol.ReticulumProtocol
+import com.lxmf.messenger.reticulum.protocol.ServiceReticulumProtocol
+import com.lxmf.messenger.util.LocationCompat
 import io.mockk.Runs
 import io.mockk.coEvery
 import io.mockk.coVerify
 import io.mockk.every
 import io.mockk.just
 import io.mockk.mockk
+import io.mockk.mockkObject
+import io.mockk.unmockkObject
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.test.StandardTestDispatcher
@@ -451,6 +458,135 @@ class TelemetryCollectorManagerTest {
             assertEquals(TelemetrySendResult.NetworkNotReady, result)
 
             manager.stop()
+        }
+
+    @Test
+    fun `sendTelemetryNow stores telemetry locally when collector is self`() =
+        testScope.runTest {
+            mockkObject(LocationCompat)
+            try {
+                every { LocationCompat.isPlayServicesAvailable(any()) } returns false
+                every { LocationCompat.getCurrentLocation(any(), any()) } answers {
+                    val callback = secondArg<(Location?) -> Unit>()
+                    val location = Location("test").apply {
+                        latitude = 48.8566
+                        longitude = 2.3522
+                        accuracy = 5f
+                        time = System.currentTimeMillis()
+                    }
+                    callback(location)
+                }
+
+                val selfHash = "a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4"
+                coEvery { mockIdentityRepository.getActiveIdentitySync() } returns
+                    LocalIdentityEntity(
+                        identityHash = "0123456789abcdef0123456789abcdef",
+                        displayName = "Me",
+                        destinationHash = selfHash,
+                        filePath = "/tmp/id",
+                        createdTimestamp = 1L,
+                        lastUsedTimestamp = 1L,
+                        isActive = true,
+                    )
+                coEvery { mockReticulumProtocol.storeOwnTelemetry(any(), any()) } returns Result.success(Unit)
+
+                manager = createManager()
+                manager.start()
+
+                collectorAddressFlow.value = selfHash
+                hostModeEnabledFlow.value = true
+                networkStatusFlow.value = NetworkStatus.READY
+                advanceUntilIdle()
+
+                val result = manager.sendTelemetryNow()
+
+                assertEquals(TelemetrySendResult.Success, result)
+                coVerify(atLeast = 1) { mockReticulumProtocol.setTelemetryCollectorMode(true) }
+                coVerify(exactly = 1) { mockReticulumProtocol.storeOwnTelemetry(any(), any()) }
+                coVerify(exactly = 0) {
+                    mockReticulumProtocol.sendLocationTelemetry(any(), any(), any(), any())
+                }
+
+                manager.stop()
+            } finally {
+                unmockkObject(LocationCompat)
+            }
+        }
+
+    @Test
+    fun `sendTelemetryNow sends via network when collector is remote`() =
+        testScope.runTest {
+            mockkObject(LocationCompat)
+            try {
+                every { LocationCompat.isPlayServicesAvailable(any()) } returns false
+                every { LocationCompat.getCurrentLocation(any(), any()) } answers {
+                    val callback = secondArg<(Location?) -> Unit>()
+                    val location = Location("test").apply {
+                        latitude = 48.8566
+                        longitude = 2.3522
+                        accuracy = 5f
+                        time = System.currentTimeMillis()
+                    }
+                    callback(location)
+                }
+
+                val serviceProtocol = mockk<ServiceReticulumProtocol>()
+                every { serviceProtocol.networkStatus } returns networkStatusFlow
+                coEvery { serviceProtocol.setTelemetryCollectorMode(any()) } returns Result.success(Unit)
+                coEvery { serviceProtocol.storeOwnTelemetry(any(), any()) } returns Result.success(Unit)
+                coEvery { serviceProtocol.getLxmfIdentity() } returns
+                    Result.success(
+                        com.lxmf.messenger.reticulum.model.Identity(
+                            hash = ByteArray(16) { 0x01 },
+                            publicKey = ByteArray(32) { 0x02 },
+                            privateKey = null,
+                        ),
+                    )
+                coEvery { serviceProtocol.sendLocationTelemetry(any(), any(), any(), any()) } returns
+                    Result.success(
+                        MessageReceipt(
+                            messageHash = ByteArray(16) { 0x11 },
+                            timestamp = System.currentTimeMillis(),
+                            destinationHash = ByteArray(16) { 0x22 },
+                        ),
+                    )
+
+                val remoteHash = "b1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4"
+                coEvery { mockIdentityRepository.getActiveIdentitySync() } returns
+                    LocalIdentityEntity(
+                        identityHash = "0123456789abcdef0123456789abcdef",
+                        displayName = "Me",
+                        destinationHash = "a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4",
+                        filePath = "/tmp/id",
+                        createdTimestamp = 1L,
+                        lastUsedTimestamp = 1L,
+                        isActive = true,
+                    )
+
+                manager =
+                    TelemetryCollectorManager(
+                        context = mockContext,
+                        settingsRepository = mockSettingsRepository,
+                        reticulumProtocol = serviceProtocol,
+                        identityRepository = mockIdentityRepository,
+                        scope = testScope,
+                    )
+                manager.start()
+
+                collectorAddressFlow.value = remoteHash
+                networkStatusFlow.value = NetworkStatus.READY
+                advanceUntilIdle()
+
+                val result = manager.sendTelemetryNow()
+
+                assertEquals(TelemetrySendResult.Success, result)
+                coVerify(exactly = 1) { serviceProtocol.sendLocationTelemetry(any(), any(), any(), any()) }
+                coVerify(exactly = 0) { serviceProtocol.storeOwnTelemetry(any(), any()) }
+
+                manager.stop()
+            } finally {
+                unmockkObject(LocationCompat)
+            }
         }
 
     // ========== TelemetrySendResult Tests ==========

--- a/python/reticulum_wrapper.py
+++ b/python/reticulum_wrapper.py
@@ -716,6 +716,75 @@ class ReticulumWrapper:
             log_error("ReticulumWrapper", "set_telemetry_allowed_requesters", str(e))
             return {'success': False, 'error': str(e)}
 
+    def store_own_telemetry(self, location_json: str,
+                            icon_name: str = None, icon_fg_color: str = None,
+                            icon_bg_color: str = None) -> Dict:
+        """
+        Store the host's own location in collected_telemetry so it is included
+        in FIELD_TELEMETRY_STREAM responses sent to group members.
+
+        Called by Kotlin TelemetryCollectorManager when host mode is active.
+
+        Args:
+            location_json: JSON string with location data (lat, lng, acc, ts, altitude, speed, bearing)
+            icon_name: Optional icon name for appearance
+            icon_fg_color: Optional foreground color hex string (3 bytes RGB)
+            icon_bg_color: Optional background color hex string (3 bytes RGB)
+
+        Returns:
+            Dict with success status
+        """
+        import time
+        try:
+            if not self.telemetry_collector_enabled:
+                return {'success': False, 'error': 'Host mode not enabled'}
+
+            if not self.local_lxmf_destination:
+                return {'success': False, 'error': 'Local LXMF destination not created'}
+
+            location_data = json.loads(location_json)
+
+            # Pack telemetry in Sideband-compatible format
+            packed_telemetry = pack_location_telemetry(
+                lat=location_data['lat'],
+                lon=location_data['lng'],
+                accuracy=location_data.get('acc', 0.0),
+                timestamp_ms=location_data.get('ts', int(time.time() * 1000)),
+                altitude=location_data.get('altitude', 0.0),
+                speed=location_data.get('speed', 0.0),
+                bearing=location_data.get('bearing', 0.0),
+            )
+
+            timestamp_s = int(location_data.get('ts', int(time.time() * 1000)) / 1000)
+
+            # Build appearance data in the same format as FIELD_ICON_APPEARANCE
+            appearance = None
+            if icon_name and icon_fg_color and icon_bg_color:
+                try:
+                    fg_bytes = bytes.fromhex(icon_fg_color)
+                    bg_bytes = bytes.fromhex(icon_bg_color)
+                    appearance = [icon_name, fg_bytes, bg_bytes]
+                except (ValueError, TypeError) as e:
+                    log_warning("ReticulumWrapper", "store_own_telemetry",
+                                f"Invalid icon color format, skipping appearance: {e}")
+
+            # Store using our own destination hash as key
+            own_hash_hex = self.local_lxmf_destination.hexhash
+            self._store_telemetry_for_collector(
+                source_hash_hex=own_hash_hex,
+                packed_telemetry=packed_telemetry,
+                timestamp=timestamp_s,
+                appearance=appearance,
+            )
+
+            log_debug("ReticulumWrapper", "store_own_telemetry",
+                      f"📍 Stored own location (hash={own_hash_hex[:16]})")
+            return {'success': True}
+
+        except Exception as e:
+            log_error("ReticulumWrapper", "store_own_telemetry", f"Failed: {e}")
+            return {'success': False, 'error': str(e)}
+
     def _cleanup_expired_telemetry(self):
         """
         Remove telemetry entries older than the retention period.

--- a/reticulum/src/main/java/com/lxmf/messenger/reticulum/protocol/MockReticulumProtocol.kt
+++ b/reticulum/src/main/java/com/lxmf/messenger/reticulum/protocol/MockReticulumProtocol.kt
@@ -407,6 +407,14 @@ class MockReticulumProtocol : ReticulumProtocol {
         return Result.success(Unit)
     }
 
+    override suspend fun storeOwnTelemetry(
+        locationJson: String,
+        iconAppearance: IconAppearance?,
+    ): Result<Unit> {
+        // Mock implementation - always succeeds
+        return Result.success(Unit)
+    }
+
     override suspend fun setTelemetryAllowedRequesters(allowedHashes: Set<String>): Result<Unit> {
         // Mock implementation - always succeeds
         return Result.success(Unit)

--- a/reticulum/src/main/java/com/lxmf/messenger/reticulum/protocol/ReticulumProtocol.kt
+++ b/reticulum/src/main/java/com/lxmf/messenger/reticulum/protocol/ReticulumProtocol.kt
@@ -352,6 +352,19 @@ interface ReticulumProtocol {
     suspend fun setTelemetryCollectorMode(enabled: Boolean): Result<Unit>
 
     /**
+     * Store the host's own location in the collected telemetry so it is included
+     * in FIELD_TELEMETRY_STREAM responses sent to group members.
+     *
+     * @param locationJson JSON string with location data (lat, lng, acc, ts, etc.)
+     * @param iconAppearance Optional icon appearance for the host
+     * @return Result indicating success
+     */
+    suspend fun storeOwnTelemetry(
+        locationJson: String,
+        iconAppearance: IconAppearance? = null,
+    ): Result<Unit>
+
+    /**
      * Set the list of identity hashes allowed to request telemetry in host mode.
      *
      * Only requesters whose identity hash is in the set will receive responses;


### PR DESCRIPTION
## Problem

When a device hosts a group (telemetry collector), its own coordinates were not reliably included in the telemetry flow.
As a result, the hosting device could be missing from the group map it was hosting.

## Root cause

The host self-location path was handled separately from the normal telemetry send flow, which introduced extra complexity and race-prone state handling (notably host mode sync with Python).

## Fix

- Added "Myself" as a selectable group host so the hosting device can be selected explicitly and included in group telemetry behavior.
- Reused the same telemetry send flow for self and remote collectors.
- If collector == local device, telemetry is stored locally via `storeOwnTelemetry(...)` instead of being sent over network.
- Before local store, Python collector mode is re-synced when host mode is enabled to prevent intermittent `Host mode not enabled`.
- Periodic send/request jobs are restarted when collector address changes to keep scheduling state consistent.
- Added/updated tests for self path, remote path, and host-mode re-sync behavior.

## UI

Group host selection and host mode activation are intentionally separate controls:
- selecting a host chooses where telemetry is collected/sent,
- hosting mode must be enabled separately in the UI.

## Validation

- TelemetryCollectorManager unit tests pass.
- `:app:detekt` passes.
- Manual end-to-end validation confirms host:
  - receives peer telemetry,
  - receives telemetry requests,
  - sends telemetry stream responses successfully.