### PR TITLE
fix: catch RuntimeException in repostNotification (COLUMBA-4C hotfix)

### DIFF
--- a/app/src/main/java/com/lxmf/messenger/service/manager/ServiceNotificationManager.kt
+++ b/app/src/main/java/com/lxmf/messenger/service/manager/ServiceNotificationManager.kt
@@ -308,11 +308,13 @@ class ServiceNotificationManager(
                 } else {
                     svc.startForeground(NOTIFICATION_ID, notification)
                 }
-            } catch (e: RuntimeException) {
+            } catch (
                 // startForeground() makes a Binder IPC call; if the system server's ProcessRecord
-                // for this process is null (race during process teardown), it throws a
-                // RemoteException that Parcel re-wraps as RuntimeException on the client side.
-                // Fall back to a plain notify so the notification is still updated.
+                // is null (race during process teardown) it throws a RemoteException that Parcel
+                // re-wraps as RuntimeException on the client side — no more specific type exists.
+                @Suppress("TooGenericExceptionCaught")
+                e: RuntimeException,
+            ) {
                 Log.w(TAG, "startForeground failed during process teardown, falling back to notify", e)
                 notificationManager.notify(NOTIFICATION_ID, notification)
             }


### PR DESCRIPTION
## Summary

- Wraps `Service.startForeground()` in `ServiceNotificationManager.repostNotification` with `try/catch(RuntimeException)` and falls back to `notificationManager.notify()`
- This is a cherry-pick of the COLUMBA-4C fix from #563 targeting the stable release branch

## Root cause

`startForeground()` makes a Binder IPC to the system server. If the app's `ProcessRecord` is `null` on the system server side during process teardown (common on Xiaomi with aggressive memory management, observed on Android 16), the server throws an NPE. `Parcel.createExceptionOrNull` re-wraps it as a `RuntimeException` on the client — no more specific type is catchable.

## Test plan

- [ ] Confirm CI passes on `release/v0.8.x`
- [ ] Verify no regression in foreground notification behaviour on a normal device lifecycle

Fixes COLUMBA-4C

🤖 Generated with [Claude Code](https://claude.com/claude-code)