### PR TITLE
fix: harden GMS initialization to prevent crash on GrapheneOS and non-GMS devices (#567) [v0.8.x backport]

### DIFF
--- a/app/src/main/java/com/lxmf/messenger/service/LocationSharingManager.kt
+++ b/app/src/main/java/com/lxmf/messenger/service/LocationSharingManager.kt
@@ -82,8 +82,18 @@ class LocationSharingManager
             private const val CLEANUP_INTERVAL_MS = 5 * 60 * 1000L // 5 minutes
         }
 
-        private val fusedLocationClient: FusedLocationProviderClient =
-            LocationServices.getFusedLocationProviderClient(context)
+        // Wrapped in try-catch(Throwable) because GMS shim layers on non-GMS devices
+        // (e.g. GrapheneOS GmsCompatLib) can throw Error subclasses like NoClassDefFoundError
+        // during Hilt singleton creation, crashing the app (#567).
+        private val fusedLocationClient: FusedLocationProviderClient? =
+            try {
+                LocationServices.getFusedLocationProviderClient(context)
+            } catch (
+                @Suppress("TooGenericExceptionCaught") e: Throwable,
+            ) {
+                Log.w(TAG, "GMS location client unavailable, location sharing disabled", e)
+                null
+            }
 
         // Active outgoing sharing sessions
         private val _activeSessions = MutableStateFlow<List<SharingSession>>(emptyList())
@@ -159,7 +169,7 @@ class LocationSharingManager
             Log.d(TAG, "Started sharing with ${newSessions.size} contacts, duration=$duration")
 
             // Send last known location immediately (don't wait for first GPS update)
-            fusedLocationClient.lastLocation.addOnSuccessListener { location ->
+            fusedLocationClient?.lastLocation?.addOnSuccessListener { location ->
                 location?.let {
                     Log.d(TAG, "Sending immediate location to new recipients")
                     sendLocationToRecipients(it)
@@ -199,7 +209,7 @@ class LocationSharingManager
                 Log.d(TAG, "Sending immediate update with cached location")
                 sendLocationToRecipients(lastLocation!!)
             } else {
-                fusedLocationClient.lastLocation.addOnSuccessListener { location ->
+                fusedLocationClient?.lastLocation?.addOnSuccessListener { location ->
                     location?.let {
                         Log.d(TAG, "Sending immediate update with fresh location")
                         lastLocation = it
@@ -319,7 +329,7 @@ class LocationSharingManager
                                     setMinUpdateIntervalMillis(LOCATION_MIN_UPDATE_INTERVAL_MS)
                                 }.build()
 
-                        fusedLocationClient.requestLocationUpdates(
+                        fusedLocationClient?.requestLocationUpdates(
                             locationRequest,
                             locationCallback,
                             context.mainLooper,
@@ -336,7 +346,7 @@ class LocationSharingManager
         private fun stopLocationUpdates() {
             locationUpdateJob?.cancel()
             locationUpdateJob = null
-            fusedLocationClient.removeLocationUpdates(locationCallback)
+            fusedLocationClient?.removeLocationUpdates(locationCallback)
             Log.d(TAG, "Location updates stopped")
         }
 

--- a/app/src/main/java/com/lxmf/messenger/service/TelemetryCollectorManager.kt
+++ b/app/src/main/java/com/lxmf/messenger/service/TelemetryCollectorManager.kt
@@ -100,8 +100,18 @@ class TelemetryCollectorManager
         private val identityRepository: com.lxmf.messenger.data.repository.IdentityRepository,
         @ApplicationScope private val scope: CoroutineScope,
     ) {
-        private val fusedLocationClient: FusedLocationProviderClient =
-            LocationServices.getFusedLocationProviderClient(context)
+        // Wrapped in try-catch(Throwable) because GMS shim layers on non-GMS devices
+        // (e.g. GrapheneOS GmsCompatLib) can throw Error subclasses like NoClassDefFoundError
+        // during Hilt singleton creation, crashing the app (#567).
+        private val fusedLocationClient: FusedLocationProviderClient? =
+            try {
+                LocationServices.getFusedLocationProviderClient(context)
+            } catch (
+                @Suppress("TooGenericExceptionCaught") e: Throwable,
+            ) {
+                Log.w(TAG, "GMS location client unavailable, telemetry location disabled", e)
+                null
+            }
 
         companion object {
             private const val TAG = "TelemetryCollectorManager"
@@ -719,6 +729,10 @@ class TelemetryCollectorManager
 
                 // Check if already cancelled before making the request
                 if (continuation.isActive) {
+                    if (fusedLocationClient == null) {
+                        continuation.resume(null)
+                        return@suspendCancellableCoroutine
+                    }
                     try {
                         fusedLocationClient
                             .getCurrentLocation(

--- a/app/src/main/java/com/lxmf/messenger/ui/screens/DiscoveredInterfacesScreen.kt
+++ b/app/src/main/java/com/lxmf/messenger/ui/screens/DiscoveredInterfacesScreen.kt
@@ -125,16 +125,23 @@ fun DiscoveredInterfacesScreen(
             ) == android.content.pm.PackageManager.PERMISSION_GRANTED
 
         if (hasCoarsePermission || hasFinePermission) {
-            val fusedClient = LocationServices.getFusedLocationProviderClient(context)
-            fusedClient
-                .getCurrentLocation(
-                    Priority.PRIORITY_BALANCED_POWER_ACCURACY,
-                    CancellationTokenSource().token,
-                ).addOnSuccessListener { location ->
-                    location?.let {
-                        viewModel.setUserLocation(it.latitude, it.longitude)
+            try {
+                val fusedClient = LocationServices.getFusedLocationProviderClient(context)
+                fusedClient
+                    .getCurrentLocation(
+                        Priority.PRIORITY_BALANCED_POWER_ACCURACY,
+                        CancellationTokenSource().token,
+                    ).addOnSuccessListener { location ->
+                        location?.let {
+                            viewModel.setUserLocation(it.latitude, it.longitude)
+                        }
                     }
-                }
+            } catch (
+                @Suppress("TooGenericExceptionCaught") e: Throwable,
+            ) {
+                // GMS shim can throw Error subclasses on non-GMS devices (#567)
+                android.util.Log.w("DiscoveredInterfacesScreen", "GMS location unavailable (#567)", e)
+            }
         }
     }
 

--- a/app/src/main/java/com/lxmf/messenger/ui/screens/MapScreen.kt
+++ b/app/src/main/java/com/lxmf/messenger/ui/screens/MapScreen.kt
@@ -249,8 +249,19 @@ fun MapScreen(
         mapStyleLoaded = true
     }
 
-    // Location client
-    val fusedLocationClient = remember { LocationServices.getFusedLocationProviderClient(context) }
+    // Location client — wrapped in try-catch(Throwable) because GMS shim layers on non-GMS
+    // devices (e.g. GrapheneOS) can throw Error subclasses at creation time (#567).
+    val fusedLocationClient =
+        remember {
+            try {
+                LocationServices.getFusedLocationProviderClient(context)
+            } catch (
+                @Suppress("TooGenericExceptionCaught") e: Throwable,
+            ) {
+                Log.w("MapScreen", "GMS location client unavailable (#567)", e)
+                null
+            }
+        }
 
     // Permission launcher
     val permissionLauncher =
@@ -260,7 +271,7 @@ fun MapScreen(
             val granted = permissions.values.all { it }
             viewModel.onPermissionResult(granted)
             if (granted) {
-                startLocationUpdates(fusedLocationClient, viewModel)
+                fusedLocationClient?.let { startLocationUpdates(it, viewModel) }
             }
         }
 
@@ -269,7 +280,7 @@ fun MapScreen(
         MapLibre.getInstance(context)
         if (LocationPermissionManager.hasPermission(context)) {
             viewModel.onPermissionResult(true)
-            startLocationUpdates(fusedLocationClient, viewModel)
+            fusedLocationClient?.let { startLocationUpdates(it, viewModel) }
         }
         // Permission sheet visibility is now managed by ViewModel state
     }

--- a/app/src/main/java/com/lxmf/messenger/ui/screens/offlinemaps/OfflineMapDownloadScreen.kt
+++ b/app/src/main/java/com/lxmf/messenger/ui/screens/offlinemaps/OfflineMapDownloadScreen.kt
@@ -292,8 +292,8 @@ fun LocationSelectionStep(
 
             if (hasPermission) {
                 isGettingLocation = true
-                val fusedClient = LocationServices.getFusedLocationProviderClient(context)
                 try {
+                    val fusedClient = LocationServices.getFusedLocationProviderClient(context)
                     fusedClient
                         .getCurrentLocation(
                             Priority.PRIORITY_HIGH_ACCURACY,
@@ -306,8 +306,11 @@ fun LocationSelectionStep(
                         }.addOnFailureListener {
                             isGettingLocation = false
                         }
-                } catch (e: SecurityException) {
-                    Log.w(TAG, "Location permission denied", e)
+                } catch (
+                    @Suppress("TooGenericExceptionCaught") e: Throwable,
+                ) {
+                    // GMS shim can throw Error subclasses on non-GMS devices (#567)
+                    Log.w(TAG, "GMS location failed (#567)", e)
                     isGettingLocation = false
                 }
             }


### PR DESCRIPTION
## Summary

Backport of #570 to `release/v0.8.x`.

The v0.8.x branch is missing `LocationCompat` GMS guards entirely, causing `TelemetryCollectorManager` and `LocationSharingManager` to call `LocationServices.getFusedLocationProviderClient()` unconditionally during Hilt singleton creation at app startup. On devices without Google Play Services (GrapheneOS, LineageOS, Huawei, etc.), this crashes the app immediately on launch.

**Changes:**
- `LocationSharingManager` & `TelemetryCollectorManager`: wrap `getFusedLocationProviderClient()` in `try-catch(Throwable)`, making the client nullable so Hilt init cannot throw
- `MapScreen`, `DiscoveredInterfacesScreen`, `OfflineMapDownloadScreen`: wrap all direct GMS client calls in `try-catch(Throwable)`

GMS shim layers (e.g. GrapheneOS `GmsCompatLib`) can throw `Error` subclasses like `NoClassDefFoundError` or `LinkageError` that bypass `catch(Exception)`.

Fixes #567

## Test plan

- [ ] Install on a non-GMS device (GrapheneOS, stock AOSP emulator) — app should open without crashing
- [ ] Install on a standard GMS device — location features should work normally
- [ ] Map screen, Discovered Interfaces screen, Offline Map Download screen — location requests should gracefully degrade on non-GMS devices

🤖 Generated with [Claude Code](https://claude.com/claude-code)