### PR TITLE
fix: use arm64-v8a filename so Obtainium selects 64-bit APK

### DIFF
--- a/.github/workflows/build-prerelease-apk.yml
+++ b/.github/workflows/build-prerelease-apk.yml
@@ -110,7 +110,7 @@ jobs:
               if echo "$filename" | grep -q "armeabi-v7a"; then
                 cp "$apk" "columba-armeabi-v7a${suffix}.apk"
               elif echo "$filename" | grep -q "arm64-v8a"; then
-                cp "$apk" "columba-arm64${suffix}.apk"
+                cp "$apk" "columba-arm64-v8a${suffix}.apk"
               elif echo "$filename" | grep -q "x86_64"; then
                 cp "$apk" "columba-x86_64${suffix}.apk"
               elif echo "$filename" | grep -q "universal"; then
@@ -174,13 +174,13 @@ jobs:
 
             **APKs by architecture (standard build with crash reporting):**
             - `columba-armeabi-v7a.apk` — Older 32-bit ARM phones (armeabi-v7a)
-            - `columba-arm64.apk` — Most Android phones (arm64-v8a)
+            - `columba-arm64-v8a.apk` — Most modern Android phones (arm64-v8a)
             - `columba-x86_64.apk` — Chromebooks & emulators (x86_64)
             - `columba-universal.apk` — Universal fallback (all architectures)
 
             **No-telemetry variants (privacy-focused, no Sentry):**
             - `columba-armeabi-v7a-no-sentry.apk`
-            - `columba-arm64-no-sentry.apk`
+            - `columba-arm64-v8a-no-sentry.apk`
             - `columba-x86_64-no-sentry.apk`
             - `columba-universal-no-sentry.apk`
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -86,7 +86,7 @@ jobs:
               if echo "$filename" | grep -q "armeabi-v7a"; then
                 cp "$apk" "columba-${VERSION}-armeabi-v7a${suffix}.apk"
               elif echo "$filename" | grep -q "arm64-v8a"; then
-                cp "$apk" "columba-${VERSION}-arm64${suffix}.apk"
+                cp "$apk" "columba-${VERSION}-arm64-v8a${suffix}.apk"
               elif echo "$filename" | grep -q "x86_64"; then
                 cp "$apk" "columba-${VERSION}-x86_64${suffix}.apk"
               elif echo "$filename" | grep -q "universal"; then
@@ -139,14 +139,14 @@ jobs:
             | APK | Architecture | Devices |
             |-----|-------------|---------|
             | `columba-${{ steps.version.outputs.version }}-armeabi-v7a.apk` | armeabi-v7a | Older 32-bit ARM phones & tablets |
-            | `columba-${{ steps.version.outputs.version }}-arm64.apk` | arm64-v8a | Most modern Android phones & tablets |
+            | `columba-${{ steps.version.outputs.version }}-arm64-v8a.apk` | arm64-v8a | Most modern Android phones & tablets |
             | `columba-${{ steps.version.outputs.version }}-x86_64.apk` | x86_64 | Chromebooks, emulators, some tablets |
             | `columba-${{ steps.version.outputs.version }}-universal.apk` | All | Universal fallback (larger download) |
 
             **Telemetry variants:**
             Each architecture also has a `-no-sentry` variant without crash reporting for maximum privacy.
 
-            > **Not sure which to pick?** Most Android phones use **arm64**. If unsure, use the **universal** APK.
+            > **Not sure which to pick?** Most Android phones use **arm64-v8a**. If unsure, use the **universal** APK.
 
             ### Verification
             See [SECURITY.md](https://github.com/torlando-tech/columba/blob/main/SECURITY.md) for verification instructions.


### PR DESCRIPTION
## Summary

- Renames `arm64` APK output filenames to `arm64-v8a` in both `release.yml` and `build-prerelease-apk.yml`
- Updates release body text to reflect the new filenames

## Problem

Obtainium's `filterApksByArch` does a literal substring match of `device.supportedAbis` against APK filenames. On a 64-bit device, `supportedAbis` is `["arm64-v8a", "armeabi-v7a", "armeabi"]`. Our APKs were named `columba-arm64.apk`, which does **not** contain the string `arm64-v8a`, so the match fell through to `armeabi-v7a` — installing the 32-bit APK instead.

## Fix

Use the full `arm64-v8a` string in output filenames. Obtainium's first-pass ABI check now matches correctly and picks the 64-bit APK.

Fixes #567

Backport of #576 to `release/v0.8.x`.

## Test plan

- [ ] Trigger a pre-release build and confirm artifact is named `columba-arm64-v8a.apk`
- [ ] In Obtainium, add Columba from GitHub and verify it selects `arm64-v8a` on a Pixel 6/6a