### PR TITLE
fix: catch ActivityNotFoundException from file picker on OEM devices (COLUMBA-4F)

### DIFF
--- a/app/src/main/java/com/lxmf/messenger/ui/screens/MessagingScreen.kt
+++ b/app/src/main/java/com/lxmf/messenger/ui/screens/MessagingScreen.kt
@@ -1068,7 +1068,17 @@ fun MessagingScreen(
                     selectedFileAttachments = selectedFileAttachments,
                     totalAttachmentSize = totalAttachmentSize,
                     isProcessingFile = isProcessingFile,
-                    onFileAttachmentClick = { filePickerLauncher.launch(arrayOf("*/*")) },
+                    onFileAttachmentClick = {
+                        try {
+                            filePickerLauncher.launch(arrayOf("*/*"))
+                        } catch (e: android.content.ActivityNotFoundException) {
+                            Toast.makeText(
+                                context,
+                                context.getString(R.string.error_no_file_manager),
+                                Toast.LENGTH_SHORT,
+                            ).show()
+                        }
+                    },
                     onRemoveFileAttachment = { index -> viewModel.removeFileAttachment(index) },
                     onSendClick = {
                         if (messageText.isNotBlank() || selectedImageData != null || selectedFileAttachments.isNotEmpty()) {

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1,4 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <string name="app_name">Columba</string>
+    <string name="error_no_file_manager">No file manager app found on this device</string>
 </resources>


### PR DESCRIPTION
## Summary

Backport of COLUMBA-4F fix to `release/v0.8.x`.

On MIUI/HyperOS and other OEM-modified Android builds, no system app handles `ACTION_OPEN_DOCUMENT`. This causes an unhandled `ActivityNotFoundException` crash when the user taps the file attach button in the messaging screen. Reported on `v0.8.18` (Xiaomi Redmi, Android 14).

**Fix:** Catch `ActivityNotFoundException` at the `filePickerLauncher.launch()` call site and show a user-friendly toast.

> The other three issues in this batch (COLUMBA-4E, 4H, 4J) were only reported on v0.7.x and v0.9.x and are not backported.

## Test plan

- [ ] Tap file attach on a device without a document provider — shows toast instead of crashing
- [ ] Tap file attach on a normal device — file picker opens as expected
- [ ] Build succeeds on `release/v0.8.x`

🤖 Generated with [Claude Code](https://claude.com/claude-code)