### PR TITLE
Fix duplicate contact key crash and normalize hex hashes

### DIFF
--- a/app/src/main/java/com/lxmf/messenger/migration/MigrationImporter.kt
+++ b/app/src/main/java/com/lxmf/messenger/migration/MigrationImporter.kt
@@ -353,7 +353,7 @@ class MigrationImporter
             val entities =
                 conversations.map { conv ->
                     ConversationEntity(
-                        peerHash = conv.peerHash,
+                        peerHash = conv.peerHash.lowercase(),
                         identityHash = conv.identityHash,
                         peerName = conv.peerName,
                         peerPublicKey = conv.peerPublicKey?.let { Base64.decode(it, Base64.NO_WRAP) },
@@ -376,7 +376,7 @@ class MigrationImporter
                 messages.map { msg ->
                     MessageEntity(
                         id = msg.id,
-                        conversationHash = msg.conversationHash,
+                        conversationHash = msg.conversationHash.lowercase(),
                         identityHash = msg.identityHash,
                         content = msg.content,
                         timestamp = msg.timestamp,
@@ -428,7 +428,7 @@ class MigrationImporter
                     }
 
                     ContactEntity(
-                        destinationHash = contact.destinationHash,
+                        destinationHash = contact.destinationHash.lowercase(),
                         identityHash = contact.identityHash,
                         publicKey = contact.publicKey?.let { Base64.decode(it, Base64.NO_WRAP) },
                         customNickname = contact.customNickname,
@@ -458,7 +458,7 @@ class MigrationImporter
 
                     val decodedPublicKey = Base64.decode(announce.publicKey, Base64.NO_WRAP)
                     AnnounceEntity(
-                        destinationHash = announce.destinationHash,
+                        destinationHash = announce.destinationHash.lowercase(),
                         peerName = announce.peerName,
                         publicKey = decodedPublicKey,
                         appData = announce.appData?.let { Base64.decode(it, Base64.NO_WRAP) },
@@ -732,13 +732,14 @@ class MigrationImporter
             }
 
             // Encrypt the key data with device key for secure storage
-            val (encryptedKeyData, keyVersion) = try {
-                val encrypted = keyEncryptor.encryptWithDeviceKey(keyData)
-                encrypted to IdentityKeyEncryptor.VERSION_DEVICE_ONLY.toInt()
-            } catch (e: Exception) {
-                Log.w(TAG, "Failed to encrypt key for storage", e)
-                null to 0
-            }
+            val (encryptedKeyData, keyVersion) =
+                try {
+                    val encrypted = keyEncryptor.encryptWithDeviceKey(keyData)
+                    encrypted to IdentityKeyEncryptor.VERSION_DEVICE_ONLY.toInt()
+                } catch (e: Exception) {
+                    Log.w(TAG, "Failed to encrypt key for storage", e)
+                    null to 0
+                }
 
             // Insert into database with encrypted key and profile icon data
             @Suppress("DEPRECATION")

--- a/data/src/main/java/com/lxmf/messenger/data/db/ColumbaDatabase.kt
+++ b/data/src/main/java/com/lxmf/messenger/data/db/ColumbaDatabase.kt
@@ -42,7 +42,7 @@ import com.lxmf.messenger.data.db.entity.RmspServerEntity
         RmspServerEntity::class,
         DraftEntity::class,
     ],
-    version = 39,
+    version = 40,
     exportSchema = false,
 )
 abstract class ColumbaDatabase : RoomDatabase() {

--- a/data/src/main/java/com/lxmf/messenger/data/di/DatabaseModule.kt
+++ b/data/src/main/java/com/lxmf/messenger/data/di/DatabaseModule.kt
@@ -75,6 +75,7 @@ object DatabaseModule {
             MIGRATION_36_37,
             MIGRATION_37_38,
             MIGRATION_38_39,
+            MIGRATION_39_40,
         )
     }
 
@@ -1548,6 +1549,93 @@ object DatabaseModule {
                 database.execSQL("ALTER TABLE local_identities ADD COLUMN passwordSalt BLOB")
                 // Add passwordVerificationHash for verifying password correctness
                 database.execSQL("ALTER TABLE local_identities ADD COLUMN passwordVerificationHash BLOB")
+            }
+        }
+
+    /**
+     * Migration 39→40: Normalize all hex hash columns to lowercase.
+     *
+     * Hex encoding is case-insensitive (0xABCD == 0xabcd), but SQLite string
+     * comparisons are case-sensitive. Mixed-case hashes from backup imports
+     * caused JOIN mismatches and duplicate LazyColumn keys.
+     *
+     * Strategy: disable FK checks → dedup PK columns → lowercase everything → re-enable FKs.
+     */
+    private val MIGRATION_39_40 =
+        object : Migration(39, 40) {
+            override fun migrate(database: SupportSQLiteDatabase) {
+                // Disable FK enforcement — lowercasing conversations.peerHash before
+                // messages.conversationHash would temporarily violate the FK constraint.
+                database.execSQL("PRAGMA foreign_keys = OFF")
+
+                // --- PK tables: dedup (keep lowest rowid) then lowercase ---
+
+                // contacts (composite PK: destinationHash + identityHash)
+                database.execSQL(
+                    """
+                    DELETE FROM contacts WHERE rowid NOT IN (
+                        SELECT MIN(rowid) FROM contacts GROUP BY LOWER(destinationHash), identityHash
+                    )
+                    """.trimIndent(),
+                )
+                database.execSQL("UPDATE contacts SET destinationHash = LOWER(destinationHash)")
+
+                // announces (PK: destinationHash)
+                database.execSQL(
+                    """
+                    DELETE FROM announces WHERE rowid NOT IN (
+                        SELECT MIN(rowid) FROM announces GROUP BY LOWER(destinationHash)
+                    )
+                    """.trimIndent(),
+                )
+                database.execSQL("UPDATE announces SET destinationHash = LOWER(destinationHash)")
+
+                // peer_icons (PK: destinationHash)
+                database.execSQL(
+                    """
+                    DELETE FROM peer_icons WHERE rowid NOT IN (
+                        SELECT MIN(rowid) FROM peer_icons GROUP BY LOWER(destinationHash)
+                    )
+                    """.trimIndent(),
+                )
+                database.execSQL("UPDATE peer_icons SET destinationHash = LOWER(destinationHash)")
+
+                // rmsp_servers (PK: destinationHash)
+                database.execSQL(
+                    """
+                    DELETE FROM rmsp_servers WHERE rowid NOT IN (
+                        SELECT MIN(rowid) FROM rmsp_servers GROUP BY LOWER(destinationHash)
+                    )
+                    """.trimIndent(),
+                )
+                database.execSQL("UPDATE rmsp_servers SET destinationHash = LOWER(destinationHash)")
+
+                // conversations (composite PK: peerHash + identityHash)
+                database.execSQL(
+                    """
+                    DELETE FROM conversations WHERE rowid NOT IN (
+                        SELECT MIN(rowid) FROM conversations GROUP BY LOWER(peerHash), identityHash
+                    )
+                    """.trimIndent(),
+                )
+                database.execSQL("UPDATE conversations SET peerHash = LOWER(peerHash)")
+
+                // --- FK / plain columns: no collision risk, just lowercase ---
+
+                // messages (FK: conversationHash → conversations.peerHash)
+                database.execSQL("UPDATE messages SET conversationHash = LOWER(conversationHash)")
+
+                // drafts (FK: conversationHash → conversations.peerHash)
+                database.execSQL("UPDATE drafts SET conversationHash = LOWER(conversationHash)")
+
+                // local_identities (plain column, PK is identityHash)
+                database.execSQL("UPDATE local_identities SET destinationHash = LOWER(destinationHash)")
+
+                // received_locations (plain column, PK is id)
+                database.execSQL("UPDATE received_locations SET senderHash = LOWER(senderHash)")
+
+                // Re-enable FK enforcement
+                database.execSQL("PRAGMA foreign_keys = ON")
             }
         }
 

--- a/data/src/main/java/com/lxmf/messenger/data/repository/AnnounceRepository.kt
+++ b/data/src/main/java/com/lxmf/messenger/data/repository/AnnounceRepository.kt
@@ -234,13 +234,14 @@ class AnnounceRepository
             peeringCost: Int? = null,
             propagationTransferLimitKb: Int? = null,
         ) {
+            val normalizedHash = destinationHash.lowercase()
             // Preserve favorite status if announce already exists
             // Note: Icons are stored separately in peer_icons table (from LXMF messages)
-            val existing = announceDao.getAnnounce(destinationHash)
+            val existing = announceDao.getAnnounce(normalizedHash)
 
             val entity =
                 AnnounceEntity(
-                    destinationHash = destinationHash,
+                    destinationHash = normalizedHash,
                     peerName = peerName,
                     publicKey = publicKey,
                     appData = appData,

--- a/data/src/main/java/com/lxmf/messenger/data/repository/ContactRepository.kt
+++ b/data/src/main/java/com/lxmf/messenger/data/repository/ContactRepository.kt
@@ -114,6 +114,7 @@ class ContactRepository
             destinationHash: String,
             publicKey: ByteArray,
         ): Result<Unit> {
+            val normalizedHash = destinationHash.lowercase()
             return try {
                 // Get active identity hash
                 val activeIdentity =
@@ -122,7 +123,7 @@ class ContactRepository
 
                 val contact =
                     ContactEntity(
-                        destinationHash = destinationHash,
+                        destinationHash = normalizedHash,
                         identityHash = activeIdentity.identityHash,
                         publicKey = publicKey,
                         customNickname = null, // Let displayName fall through to announce name
@@ -152,6 +153,7 @@ class ContactRepository
             publicKey: ByteArray,
             nickname: String? = null,
         ): Result<Unit> {
+            val normalizedHash = destinationHash.lowercase()
             return try {
                 // Get active identity hash
                 val activeIdentity =
@@ -160,7 +162,7 @@ class ContactRepository
 
                 val contact =
                     ContactEntity(
-                        destinationHash = destinationHash,
+                        destinationHash = normalizedHash,
                         identityHash = activeIdentity.identityHash,
                         publicKey = publicKey,
                         customNickname = nickname,
@@ -190,6 +192,7 @@ class ContactRepository
             publicKey: ByteArray,
             nickname: String? = null,
         ): Result<Unit> {
+            val normalizedHash = destinationHash.lowercase()
             return try {
                 // Get active identity hash
                 val activeIdentity =
@@ -198,7 +201,7 @@ class ContactRepository
 
                 val contact =
                     ContactEntity(
-                        destinationHash = destinationHash,
+                        destinationHash = normalizedHash,
                         identityHash = activeIdentity.identityHash,
                         publicKey = publicKey,
                         customNickname = nickname,
@@ -227,6 +230,7 @@ class ContactRepository
             destinationHash: String,
             publicKey: ByteArray,
         ): Result<Unit> {
+            val normalizedHash = destinationHash.lowercase()
             return try {
                 // Get active identity hash
                 val activeIdentity =
@@ -235,7 +239,7 @@ class ContactRepository
 
                 val contact =
                     ContactEntity(
-                        destinationHash = destinationHash,
+                        destinationHash = normalizedHash,
                         identityHash = activeIdentity.identityHash,
                         publicKey = publicKey,
                         customNickname = null, // Let displayName fall through to announce/conversation name
@@ -399,6 +403,7 @@ class ContactRepository
             destinationHash: String,
             nickname: String? = null,
         ): Result<AddPendingResult> {
+            val normalizedHash = destinationHash.lowercase()
             return try {
                 val activeIdentity =
                     localIdentityDao.getActiveIdentitySync()
@@ -406,13 +411,13 @@ class ContactRepository
 
                 // Check if we already have an announce for this destination hash
                 // If so, we can resolve the contact immediately!
-                val existingAnnounce = announceDao.getAnnounce(destinationHash)
+                val existingAnnounce = announceDao.getAnnounce(normalizedHash)
 
                 if (existingAnnounce != null && existingAnnounce.publicKey.isNotEmpty()) {
                     // Great! We have the public key from a previous announce
                     val contact =
                         ContactEntity(
-                            destinationHash = destinationHash,
+                            destinationHash = normalizedHash,
                             identityHash = activeIdentity.identityHash,
                             publicKey = existingAnnounce.publicKey,
                             customNickname = nickname,
@@ -430,7 +435,7 @@ class ContactRepository
                     // No existing announce - add as pending
                     val contact =
                         ContactEntity(
-                            destinationHash = destinationHash,
+                            destinationHash = normalizedHash,
                             identityHash = activeIdentity.identityHash,
                             publicKey = null, // Will be filled when identity is resolved
                             customNickname = nickname,


### PR DESCRIPTION
## Summary
- Fix `LazyColumn` duplicate key crash in ContactsScreen caused by mixed-case hex hashes (`"ABCD"` vs `"abcd"`) representing the same peer
- Add Room migration 39→40 that lowercases all hex hash columns across 9 tables with FK-safe deduplication
- Add write-path `.lowercase()` normalization at repository and importer boundaries to prevent future mixed-case data

## Root Cause
`MigrationImporter` passed backup JSON hashes through without normalization, so imported contacts could have uppercase hex while Kotlin `%02x` formatting always produces lowercase. SQLite string comparisons are case-sensitive, causing JOIN mismatches and duplicate Compose keys.

## Changes
| File | Change |
|------|--------|
| `ContactsScreen.kt` | Lowercase LazyColumn keys (immediate crash fix) |
| `ContactsViewModel.kt` | `distinctBy` dedup in ViewModel (defense-in-depth) |
| `DatabaseModule.kt` | Migration 39→40: dedup + `LOWER()` on 9 hash columns across 9 tables |
| `ColumbaDatabase.kt` | Bump version 39→40 |
| `ContactRepository.kt` | `.lowercase()` in 5 write methods |
| `AnnounceRepository.kt` | `.lowercase()` in `saveAnnounce()` |
| `MigrationImporter.kt` | `.lowercase()` on all hash fields from backup JSON |

## Test plan
- [x] `ContactsViewModelTest` — all tests pass
- [x] `:data:compileDebugKotlin` — builds clean
- [x] `:app:compileNoSentryDebugKotlin` — builds clean
- [ ] Manual: install on device, open Contacts, verify no crashes and all contacts display correctly
- [ ] Manual: import a Sideband backup with uppercase hashes, verify normalization

🤖 Generated with [Claude Code](https://claude.com/claude-code)