### PR TITLE
fix: truncate collector address in debug log

### DIFF
--- a/app/src/main/java/com/lxmf/messenger/service/TelemetryCollectorManager.kt
+++ b/app/src/main/java/com/lxmf/messenger/service/TelemetryCollectorManager.kt
@@ -1,7 +1,6 @@
 package com.lxmf.messenger.service
 
 import android.content.Context
-import android.location.Location
 import android.util.Log
 import com.google.android.gms.location.FusedLocationProviderClient
 import com.google.android.gms.location.LocationServices
@@ -209,7 +208,7 @@ class TelemetryCollectorManager
                             }
                         }
                         _collectorAddress.value = address
-                        Log.d(TAG, "Collector address updated: ${address ?: "none"}")
+                        Log.d(TAG, "Collector address updated: ${address?.take(16) ?: "none"}")
                         restartPeriodicSend()
                         restartPeriodicRequest()
                         locationTracker.update(shouldTrackLocation())
@@ -319,8 +318,7 @@ class TelemetryCollectorManager
             periodicRequestJob = null
         }
 
-        private fun shouldTrackLocation(): Boolean =
-            _isEnabled.value && _collectorAddress.value != null
+        private fun shouldTrackLocation(): Boolean = _isEnabled.value && _collectorAddress.value != null
 
         /**
          * Update the collector address.


### PR DESCRIPTION
## Summary
- Restore truncation of collector destination hash to 16 chars in debug log output
- The full 32-char hash was inadvertently exposed in logcat after PR #593

## Context
PR #593 changed `address?.take(16)` to `address` in a `Log.d()` call. While logcat is app-private since Android 4.1, the previous truncation was more conservative and consistent with how other hashes are logged throughout the codebase.

🤖 Generated with [Claude Code](https://claude.com/claude-code)