### PR TITLE
feat: add background location permission flow in Location Sharing settings

### DIFF
--- a/app/src/main/java/com/lxmf/messenger/ui/components/BackgroundLocationPermissionBottomSheet.kt
+++ b/app/src/main/java/com/lxmf/messenger/ui/components/BackgroundLocationPermissionBottomSheet.kt
@@ -1,0 +1,110 @@
+package com.lxmf.messenger.ui.components
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.WindowInsets
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.systemBarsPadding
+import androidx.compose.foundation.layout.width
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.ShareLocation
+import androidx.compose.material3.Button
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.ModalBottomSheet
+import androidx.compose.material3.SheetState
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+
+/**
+ * Material 3 bottom sheet that explains why background location ("Allow all the time")
+ * is useful and lets the user choose whether to grant it.
+ *
+ * Shown after the user has already granted foreground location permission.
+ * On Android 10+ (API 29+), background location must be requested separately.
+ *
+ * @param onDismiss Callback when the user declines (chooses "Not Now")
+ * @param onRequestPermission Callback when the user agrees to grant background location
+ * @param sheetState The state of the bottom sheet
+ */
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun BackgroundLocationPermissionBottomSheet(
+    onDismiss: () -> Unit,
+    onRequestPermission: () -> Unit,
+    sheetState: SheetState,
+) {
+    ModalBottomSheet(
+        onDismissRequest = onDismiss,
+        sheetState = sheetState,
+        contentWindowInsets = { WindowInsets(0) },
+        modifier = Modifier.systemBarsPadding(),
+    ) {
+        Column(
+            modifier =
+                Modifier
+                    .fillMaxWidth()
+                    .padding(horizontal = 24.dp),
+            horizontalAlignment = Alignment.Start,
+        ) {
+            // Icon and title
+            Row(
+                verticalAlignment = Alignment.CenterVertically,
+                modifier = Modifier.fillMaxWidth(),
+            ) {
+                Icon(
+                    imageVector = Icons.Default.ShareLocation,
+                    contentDescription = null,
+                    tint = MaterialTheme.colorScheme.primary,
+                    modifier = Modifier.padding(end = 12.dp),
+                )
+                Text(
+                    text = "Background Location",
+                    style = MaterialTheme.typography.headlineSmall,
+                    fontWeight = FontWeight.Bold,
+                )
+            }
+
+            Spacer(modifier = Modifier.height(16.dp))
+
+            Text(
+                text =
+                    "To share your location with contacts while the app is in the background, " +
+                        "Columba needs the \"Allow all the time\" permission.\n\n" +
+                        "This lets Columba continue sending your encrypted location to chosen " +
+                        "contacts even when you switch to another app or lock your screen.\n\n" +
+                        "On the next screen, please select \"Allow all the time\".",
+                style = MaterialTheme.typography.bodyMedium,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
+
+            Spacer(modifier = Modifier.height(24.dp))
+
+            // Action buttons
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                horizontalArrangement = Arrangement.End,
+            ) {
+                TextButton(onClick = onDismiss) {
+                    Text("Not Now")
+                }
+                Spacer(modifier = Modifier.width(8.dp))
+                Button(onClick = onRequestPermission) {
+                    Text("Continue")
+                }
+            }
+
+            Spacer(modifier = Modifier.height(16.dp))
+        }
+    }
+}

--- a/app/src/main/java/com/lxmf/messenger/ui/screens/MapScreen.kt
+++ b/app/src/main/java/com/lxmf/messenger/ui/screens/MapScreen.kt
@@ -259,7 +259,7 @@ fun MapScreen(
     // Platform LocationListener for cleanup when not using GMS (issue #456)
     var platformLocationListener by remember { mutableStateOf<android.location.LocationListener?>(null) }
 
-    // Permission launcher
+    // Permission launcher (foreground location)
     val permissionLauncher =
         rememberLauncherForActivityResult(
             contract = ActivityResultContracts.RequestMultiplePermissions(),
@@ -1083,7 +1083,7 @@ fun MapScreen(
         }
     }
 
-    // Permission bottom sheet
+    // Permission bottom sheet (foreground location)
     if (showPermissionSheet) {
         LocationPermissionBottomSheet(
             onDismiss = {

--- a/app/src/main/java/com/lxmf/messenger/ui/screens/SettingsScreen.kt
+++ b/app/src/main/java/com/lxmf/messenger/ui/screens/SettingsScreen.kt
@@ -6,6 +6,8 @@ import android.content.ClipboardManager
 import android.content.Context
 import android.content.Intent
 import android.net.Uri
+import android.provider.Settings
+import android.widget.Toast
 import androidx.activity.compose.rememberLauncherForActivityResult
 import androidx.activity.result.contract.ActivityResultContracts
 import androidx.compose.foundation.layout.Arrangement
@@ -34,6 +36,7 @@ import androidx.compose.material3.TopAppBar
 import androidx.compose.material3.TopAppBarDefaults
 import androidx.compose.material3.rememberModalBottomSheetState
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
@@ -46,7 +49,10 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.LifecycleEventObserver
 import androidx.lifecycle.compose.LocalLifecycleOwner
+import com.lxmf.messenger.ui.components.BackgroundLocationPermissionBottomSheet
 import com.lxmf.messenger.ui.components.LocationPermissionBottomSheet
 import com.lxmf.messenger.ui.screens.settings.cards.AboutCard
 import com.lxmf.messenger.ui.screens.settings.cards.AutoAnnounceCard
@@ -107,9 +113,19 @@ fun SettingsScreen(
     var showCrashDialog by remember { mutableStateOf(false) }
     var pendingCrashReport by remember { mutableStateOf<CrashReport?>(null) }
 
+    // Location permission state (for indicator in LocationSharingCard)
+    var hasForegroundPermission by remember {
+        mutableStateOf(LocationPermissionManager.hasPermission(context))
+    }
+    var hasBackgroundPermission by remember {
+        mutableStateOf(LocationPermissionManager.hasBackgroundLocationPermission(context))
+    }
+
     // Location permission state for telemetry collector
     var showTelemetryPermissionSheet by remember { mutableStateOf(false) }
+    var showBackgroundLocationSheet by remember { mutableStateOf(false) }
     val telemetryPermissionSheetState = rememberModalBottomSheetState(skipPartiallyExpanded = true)
+    val backgroundLocationSheetState = rememberModalBottomSheetState(skipPartiallyExpanded = true)
     // Track what action to take after permission is granted
     var pendingTelemetryAction by remember { mutableStateOf<(() -> Unit)?>(null) }
 
@@ -118,6 +134,7 @@ fun SettingsScreen(
         rememberLauncherForActivityResult(
             contract = ActivityResultContracts.RequestPermission(),
         ) { granted ->
+            hasBackgroundPermission = granted
             if (granted) {
                 pendingTelemetryAction?.invoke()
             }
@@ -136,14 +153,26 @@ fun SettingsScreen(
                     pendingTelemetryAction?.invoke()
                     pendingTelemetryAction = null
                 } else {
-                    // Now request background before enabling telemetry
-                    telemetryBackgroundPermissionLauncher.launch(Manifest.permission.ACCESS_BACKGROUND_LOCATION)
+                    // Show custom bottom sheet before requesting background
+                    showBackgroundLocationSheet = true
                     // pendingTelemetryAction is preserved for the background launcher
                 }
             } else {
                 pendingTelemetryAction = null
             }
         }
+
+    // Refresh background permission state on lifecycle resume (e.g. returning from system settings)
+    DisposableEffect(lifecycleOwner) {
+        val observer = LifecycleEventObserver { _, event ->
+            if (event == Lifecycle.Event.ON_RESUME) {
+                hasForegroundPermission = LocationPermissionManager.hasPermission(context)
+                hasBackgroundPermission = LocationPermissionManager.hasBackgroundLocationPermission(context)
+            }
+        }
+        lifecycleOwner.lifecycle.addObserver(observer)
+        onDispose { lifecycleOwner.lifecycle.removeObserver(observer) }
+    }
 
     // Check for pending crash report on launch
     LaunchedEffect(Unit) {
@@ -300,9 +329,9 @@ fun SettingsScreen(
                             if (LocationPermissionManager.hasTelemetryBackgroundPermission(context)) {
                                 viewModel.setTelemetryCollectorEnabled(true)
                             } else if (LocationPermissionManager.hasPermission(context)) {
-                                // Foreground location is granted, now request background access.
+                                // Foreground location is granted, show background permission sheet.
                                 pendingTelemetryAction = { viewModel.setTelemetryCollectorEnabled(true) }
-                                telemetryBackgroundPermissionLauncher.launch(Manifest.permission.ACCESS_BACKGROUND_LOCATION)
+                                showBackgroundLocationSheet = true
                             } else {
                                 // Show permission sheet, then enable after permission granted
                                 pendingTelemetryAction = { viewModel.setTelemetryCollectorEnabled(true) }
@@ -345,6 +374,31 @@ fun SettingsScreen(
                     localIconName = state.iconName,
                     localIconForegroundColor = state.iconForegroundColor,
                     localIconBackgroundColor = state.iconBackgroundColor,
+                    // Background location permission indicator
+                    hasForegroundLocationPermission = hasForegroundPermission,
+                    hasBackgroundLocationPermission = hasBackgroundPermission,
+                    onBackgroundPermissionClick = {
+                        if (hasBackgroundPermission) {
+                            // Already granted — open app info, guide user to Permissions > Location
+                            Toast.makeText(
+                                context,
+                                "Go to Permissions > Location to change",
+                                Toast.LENGTH_LONG,
+                            ).show()
+                            val intent = Intent(
+                                Settings.ACTION_APPLICATION_DETAILS_SETTINGS,
+                                Uri.fromParts("package", context.packageName, null),
+                            )
+                            context.startActivity(intent)
+                        } else if (LocationPermissionManager.hasPermission(context)) {
+                            // Foreground granted but not background — show our custom sheet
+                            showBackgroundLocationSheet = true
+                        } else {
+                            // No foreground either — show foreground sheet first
+                            pendingTelemetryAction = null
+                            showTelemetryPermissionSheet = true
+                        }
+                    },
                 )
 
                 MapSourcesCard(
@@ -575,6 +629,21 @@ fun SettingsScreen(
                         )
                     }
                 },
+            )
+        }
+
+        // Background Location Permission Bottom Sheet (shared for Telemetry Collector and Location Sharing flows)
+        if (showBackgroundLocationSheet && isLifecycleActive) {
+            BackgroundLocationPermissionBottomSheet(
+                onDismiss = {
+                    showBackgroundLocationSheet = false
+                    pendingTelemetryAction = null
+                },
+                onRequestPermission = {
+                    showBackgroundLocationSheet = false
+                    telemetryBackgroundPermissionLauncher.launch(Manifest.permission.ACCESS_BACKGROUND_LOCATION)
+                },
+                sheetState = backgroundLocationSheetState,
             )
         }
 

--- a/app/src/main/java/com/lxmf/messenger/ui/screens/settings/cards/LocationSharingCard.kt
+++ b/app/src/main/java/com/lxmf/messenger/ui/screens/settings/cards/LocationSharingCard.kt
@@ -52,6 +52,7 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.semantics.Role
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import com.lxmf.messenger.data.model.EnrichedContact
@@ -117,6 +118,10 @@ fun LocationSharingCard(
     localIconName: String? = null,
     localIconForegroundColor: String? = null,
     localIconBackgroundColor: String? = null,
+    // Background location permission status
+    hasForegroundLocationPermission: Boolean = false,
+    hasBackgroundLocationPermission: Boolean = false,
+    onBackgroundPermissionClick: () -> Unit = {},
 ) {
     var showDurationPicker by remember { mutableStateOf(false) }
     var showPrecisionPicker by remember { mutableStateOf(false) }
@@ -141,6 +146,66 @@ fun LocationSharingCard(
             style = MaterialTheme.typography.bodyMedium,
             color = MaterialTheme.colorScheme.onSurfaceVariant,
         )
+
+        // Background location permission status indicator
+        Row(
+            modifier =
+                Modifier
+                    .fillMaxWidth()
+                    .clickable(
+                        onClick = onBackgroundPermissionClick,
+                        role = Role.Button,
+                    )
+                    .padding(vertical = 4.dp),
+            verticalAlignment = Alignment.CenterVertically,
+            horizontalArrangement = Arrangement.spacedBy(8.dp),
+        ) {
+            Icon(
+                imageVector = Icons.Default.LocationOn,
+                contentDescription = null,
+                tint =
+                    if (hasBackgroundLocationPermission) {
+                        MaterialTheme.colorScheme.primary
+                    } else if (hasForegroundLocationPermission) {
+                        MaterialTheme.colorScheme.tertiary
+                    } else {
+                        MaterialTheme.colorScheme.error
+                    },
+                modifier = Modifier.size(18.dp),
+            )
+            Column(modifier = Modifier.weight(1f)) {
+                Text(
+                    text =
+                        if (hasBackgroundLocationPermission) {
+                            "Background location: Always"
+                        } else if (hasForegroundLocationPermission) {
+                            "Background location: While using"
+                        } else {
+                            "Background location: Not granted"
+                        },
+                    style = MaterialTheme.typography.bodyMedium,
+                    fontWeight = FontWeight.Medium,
+                )
+                Text(
+                    text =
+                        if (hasBackgroundLocationPermission) {
+                            "Tap to change (Permissions > Location)"
+                        } else if (hasForegroundLocationPermission) {
+                            "Tap to enable background location"
+                        } else {
+                            "Tap to grant location permission"
+                        },
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                )
+            }
+            Icon(
+                imageVector = Icons.Default.ChevronRight,
+                contentDescription = "Change",
+                tint = MaterialTheme.colorScheme.onSurfaceVariant,
+                modifier = Modifier.size(20.dp),
+            )
+        }
 
         // Active sessions section (only shown when enabled and there are sessions)
         if (enabled && activeSessions.isNotEmpty()) {

--- a/app/src/test/java/com/lxmf/messenger/ui/screens/settings/cards/LocationSharingCardTest.kt
+++ b/app/src/test/java/com/lxmf/messenger/ui/screens/settings/cards/LocationSharingCardTest.kt
@@ -1,10 +1,15 @@
 package com.lxmf.messenger.ui.screens.settings.cards
 
 import android.app.Application
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.ui.Modifier
 import androidx.compose.ui.test.assertIsDisplayed
 import androidx.compose.ui.test.junit4.createComposeRule
 import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.performClick
+import androidx.compose.ui.test.performScrollTo
 import com.lxmf.messenger.service.SharingSession
 import com.lxmf.messenger.test.RegisterComponentActivityRule
 import org.junit.Assert.assertEquals
@@ -533,44 +538,49 @@ class LocationSharingCardTest {
             )
 
         composeTestRule.setContent {
-            LocationSharingCard(
-                isExpanded = true,
-                onExpandedChange = {},
-                enabled = true,
-                onEnabledChange = {},
-                activeSessions = sessions,
-                onStopSharing = {},
-                onStopAllSharing = {},
-                defaultDuration = "ONE_HOUR",
-                onDefaultDurationChange = {},
-                locationPrecisionRadius = 0,
-                onLocationPrecisionRadiusChange = {},
-                // Telemetry props
-                telemetryCollectorEnabled = false,
-                telemetryCollectorAddress = null,
-                telemetrySendIntervalSeconds = 300,
-                lastTelemetrySendTime = null,
-                isSendingTelemetry = false,
-                onTelemetryEnabledChange = {},
-                onTelemetryCollectorAddressChange = {},
-                onTelemetrySendIntervalChange = {},
-                onTelemetrySendNow = {},
-                telemetryRequestEnabled = false,
-                telemetryRequestIntervalSeconds = 900,
-                lastTelemetryRequestTime = null,
-                isRequestingTelemetry = false,
-                onTelemetryRequestEnabledChange = {},
-                onTelemetryRequestIntervalChange = {},
-                onRequestTelemetryNow = {},
-                telemetryHostModeEnabled = false,
-                onTelemetryHostModeEnabledChange = {},
-                telemetryAllowedRequesters = emptySet(),
-                contacts = emptyList(),
-                onTelemetryAllowedRequestersChange = {},
-            )
+            val scrollState = rememberScrollState()
+            Column(
+                modifier = Modifier.verticalScroll(scrollState),
+            ) {
+                LocationSharingCard(
+                    isExpanded = true,
+                    onExpandedChange = {},
+                    enabled = true,
+                    onEnabledChange = {},
+                    activeSessions = sessions,
+                    onStopSharing = {},
+                    onStopAllSharing = {},
+                    defaultDuration = "ONE_HOUR",
+                    onDefaultDurationChange = {},
+                    locationPrecisionRadius = 0,
+                    onLocationPrecisionRadiusChange = {},
+                    // Telemetry props
+                    telemetryCollectorEnabled = false,
+                    telemetryCollectorAddress = null,
+                    telemetrySendIntervalSeconds = 300,
+                    lastTelemetrySendTime = null,
+                    isSendingTelemetry = false,
+                    onTelemetryEnabledChange = {},
+                    onTelemetryCollectorAddressChange = {},
+                    onTelemetrySendIntervalChange = {},
+                    onTelemetrySendNow = {},
+                    telemetryRequestEnabled = false,
+                    telemetryRequestIntervalSeconds = 900,
+                    lastTelemetryRequestTime = null,
+                    isRequestingTelemetry = false,
+                    onTelemetryRequestEnabledChange = {},
+                    onTelemetryRequestIntervalChange = {},
+                    onRequestTelemetryNow = {},
+                    telemetryHostModeEnabled = false,
+                    onTelemetryHostModeEnabledChange = {},
+                    telemetryAllowedRequesters = emptySet(),
+                    contacts = emptyList(),
+                    onTelemetryAllowedRequestersChange = {},
+                )
+            }
         }
 
-        composeTestRule.onNodeWithText("Stop All Sharing").assertIsDisplayed()
+        composeTestRule.onNodeWithText("Stop All Sharing").performScrollTo().assertIsDisplayed()
     }
 
     @Test
@@ -593,44 +603,49 @@ class LocationSharingCardTest {
             )
 
         composeTestRule.setContent {
-            LocationSharingCard(
-                isExpanded = true,
-                onExpandedChange = {},
-                enabled = true,
-                onEnabledChange = {},
-                activeSessions = sessions,
-                onStopSharing = {},
-                onStopAllSharing = { stopAllCalled = true },
-                defaultDuration = "ONE_HOUR",
-                onDefaultDurationChange = {},
-                locationPrecisionRadius = 0,
-                onLocationPrecisionRadiusChange = {},
-                // Telemetry props
-                telemetryCollectorEnabled = false,
-                telemetryCollectorAddress = null,
-                telemetrySendIntervalSeconds = 300,
-                lastTelemetrySendTime = null,
-                isSendingTelemetry = false,
-                onTelemetryEnabledChange = {},
-                onTelemetryCollectorAddressChange = {},
-                onTelemetrySendIntervalChange = {},
-                onTelemetrySendNow = {},
-                telemetryRequestEnabled = false,
-                telemetryRequestIntervalSeconds = 900,
-                lastTelemetryRequestTime = null,
-                isRequestingTelemetry = false,
-                onTelemetryRequestEnabledChange = {},
-                onTelemetryRequestIntervalChange = {},
-                onRequestTelemetryNow = {},
-                telemetryHostModeEnabled = false,
-                onTelemetryHostModeEnabledChange = {},
-                telemetryAllowedRequesters = emptySet(),
-                contacts = emptyList(),
-                onTelemetryAllowedRequestersChange = {},
-            )
+            val scrollState = rememberScrollState()
+            Column(
+                modifier = Modifier.verticalScroll(scrollState),
+            ) {
+                LocationSharingCard(
+                    isExpanded = true,
+                    onExpandedChange = {},
+                    enabled = true,
+                    onEnabledChange = {},
+                    activeSessions = sessions,
+                    onStopSharing = {},
+                    onStopAllSharing = { stopAllCalled = true },
+                    defaultDuration = "ONE_HOUR",
+                    onDefaultDurationChange = {},
+                    locationPrecisionRadius = 0,
+                    onLocationPrecisionRadiusChange = {},
+                    // Telemetry props
+                    telemetryCollectorEnabled = false,
+                    telemetryCollectorAddress = null,
+                    telemetrySendIntervalSeconds = 300,
+                    lastTelemetrySendTime = null,
+                    isSendingTelemetry = false,
+                    onTelemetryEnabledChange = {},
+                    onTelemetryCollectorAddressChange = {},
+                    onTelemetrySendIntervalChange = {},
+                    onTelemetrySendNow = {},
+                    telemetryRequestEnabled = false,
+                    telemetryRequestIntervalSeconds = 900,
+                    lastTelemetryRequestTime = null,
+                    isRequestingTelemetry = false,
+                    onTelemetryRequestEnabledChange = {},
+                    onTelemetryRequestIntervalChange = {},
+                    onRequestTelemetryNow = {},
+                    telemetryHostModeEnabled = false,
+                    onTelemetryHostModeEnabledChange = {},
+                    telemetryAllowedRequesters = emptySet(),
+                    contacts = emptyList(),
+                    onTelemetryAllowedRequestersChange = {},
+                )
+            }
         }
 
-        composeTestRule.onNodeWithText("Stop All Sharing").performClick()
+        composeTestRule.onNodeWithText("Stop All Sharing").performScrollTo().performClick()
 
         assertTrue(stopAllCalled)
     }


### PR DESCRIPTION
## Problem

A previous PR resolved issues with background location sending for the Group Tracker feature. However, there was no way for the user to manage the background location permission from within the app. On Android 10+, background location ("Allow all the time") requires a separate permission grant from the standard foreground permission, and the system does not provide a direct intent to open the location permission settings page for an app.

This meant:
- Users had no visibility into whether background location was enabled
- There was no in-app path to grant or review the "Allow all the time" permission
- The background permission was silently requested without explaining why it was needed

## Solution

### Custom bottom sheet for background permission
A new `BackgroundLocationPermissionBottomSheet` component explains to the user why "Allow all the time" is needed (encrypted location sharing in the background) and guides them through the two-step Android permission flow. The user explicitly chooses to proceed or dismiss.

### Permission status indicator in Location Sharing card
A clickable row in the Location Sharing settings card shows the current background permission state:
- **"Background location: Always"** (green) — tap opens app info with a toast guiding to Permissions > Location
- **"Background location: While using"** (amber) — tap shows the custom bottom sheet then the system permission dialog

The indicator refreshes automatically when returning from system settings (lifecycle ON_RESUME).

## Behavior matrix

| Permission state | Tap on indicator | Enable Group Tracker |
|-----------------|-----------------|---------------------|
| No permission at all | Foreground permission sheet | Foreground sheet → background sheet → system dialog |
| Foreground only | Background bottom sheet → system dialog | Background bottom sheet → system dialog |
| Always (background granted) | Opens app info + toast guidance | Enables directly |

## Changes
- **New**: `BackgroundLocationPermissionBottomSheet.kt`
- **Modified**: `SettingsScreen.kt` — permission flow wiring + lifecycle refresh
- **Modified**: `LocationSharingCard.kt` — clickable permission status indicator
- **Modified**: `LocationSharingCardTest.kt` — added scrollable wrapper for viewport-sensitive tests