### PR TITLE
fix: post-call navigation after cold start

### DIFF
--- a/app/src/main/java/com/lxmf/messenger/MainActivity.kt
+++ b/app/src/main/java/com/lxmf/messenger/MainActivity.kt
@@ -631,12 +631,17 @@ fun ColumbaNavigation(
 
     val exitCallFlow: () -> Unit = {
         val previousRoute = navController.previousBackStackEntry?.destination?.route
+        val currentRoute = navController.currentDestination?.route
         val popped = navController.popBackStack()
 
         if ((!popped || previousRoute == Screen.Welcome.route) && onboardingState.hasCompletedOnboarding) {
             Log.d("ColumbaNavigation", "Call flow finished without valid return destination, navigating to Chats")
             navController.navigate(Screen.Chats.route) {
-                popUpTo(Screen.Welcome.route) { inclusive = true }
+                if (!popped && currentRoute != null) {
+                    popUpTo(currentRoute) { inclusive = true }
+                } else {
+                    popUpTo(Screen.Welcome.route) { inclusive = true }
+                }
                 launchSingleTop = true
             }
         }


### PR DESCRIPTION
## Summary
- fix audio call exit navigation when Columba is opened directly into a call flow from a cold start
- avoid returning to the welcome/setup screen after the call ends when onboarding was already completed
- reuse the same exit fallback for active and incoming call screens

## Testing
- verified that opening Columba on an audio call and ending the call now returns to Chats instead of the setup screen