### PR TITLE
fix: stop changing phone's Bluetooth device name during BLE advertising

### DIFF
--- a/reticulum/src/main/java/com/lxmf/messenger/reticulum/ble/server/BleAdvertiser.kt
+++ b/reticulum/src/main/java/com/lxmf/messenger/reticulum/ble/server/BleAdvertiser.kt
@@ -388,7 +388,7 @@ class BleAdvertiser(
      * This ensures advertising is actually active even if Android silently stopped it.
      */
     private suspend fun refreshAdvertising() {
-        val name = currentDeviceName ?: return
+        if (currentDeviceName == null) return
         if (bluetoothAdapter.isEnabled != true) {
             Log.w(TAG, "Cannot refresh advertising - Bluetooth disabled")
             return
@@ -409,7 +409,7 @@ class BleAdvertiser(
 
             // Restart advertising
             withContext(Dispatchers.Main) {
-                startAdvertisingInternal(name)
+                startAdvertisingInternal()
             }
             Log.d(TAG, "Advertising refreshed successfully")
         } catch (e: Exception) {
@@ -424,7 +424,7 @@ class BleAdvertiser(
      * Used by refresh to restart advertising.
      */
     @SuppressLint("MissingPermission")
-    private fun startAdvertisingInternal(deviceName: String) {
+    private fun startAdvertisingInternal() {
         if (bluetoothLeAdvertiser == null) {
             Log.e(TAG, "Cannot start advertising - advertiser not available")
             return


### PR DESCRIPTION
BleAdvertiser was temporarily setting bluetoothAdapter.name to
"RNS-{identity}" before each advertising start and refresh, then
restoring it after a 1-second delay. This caused the phone's visible
Bluetooth device name to change, which was unexpected and disruptive.

Remove all bluetoothAdapter.name assignments and set
setIncludeDeviceName(false) in the scan response. Device discovery
relies on the service UUID in the advertise data, not the device name.

https://claude.ai/code/session_018JqnJit5nfabGBysYU8QZ6