### PR TITLE
Remove dead name-based dedup code after PR #630

### DIFF
--- a/docs/ble-architecture.md
+++ b/docs/ble-architecture.md
@@ -588,7 +588,7 @@ Advertising Data (31 bytes max):
 └── Service UUID (19 bytes for 128-bit UUID)
 
 Scan Response (31 bytes separate budget):
-└── Device Name: "RNS-{truncated_identity_hex}"
+└── (empty — device name not advertised)
 ```
 
 ---
@@ -619,7 +619,6 @@ Scan Response (31 bytes separate budget):
 | `connectedPeers` | MAC address | PeerConnection | Active connections |
 | `pendingConnections` | MAC address | PendingConnection | Awaiting identity |
 | `pendingCentralConnections` | Set<MAC> | - | In-progress central connects |
-| `recentlyDeduplicatedIdentities` | 32-char hex | timestamp | Dedup cooldown (60s) |
 | `processedIdentityCallbacks` | Set<key> | - | Prevent duplicate notifications |
 
 ---
@@ -710,7 +709,7 @@ def _get_fragmenter_key(self, peer_identity, address):
 | `ADVERTISING_REFRESH_INTERVAL_MS` | 60,000 ms | BleAdvertiser |
 | `_identity_cache_ttl` | 60 s | BLEInterface |
 | `_pending_detach_grace_period` | 2.0 s | BLEInterface |
-| `deduplicationCooldownMs` | 60,000 ms | KotlinBLEBridge |
+
 
 ### MTU Constants
 

--- a/reticulum/detekt-baseline-debug.xml
+++ b/reticulum/detekt-baseline-debug.xml
@@ -20,7 +20,7 @@
     <ID>LongMethod:KotlinBLEBridge.kt$KotlinBLEBridge$private suspend fun handleIdentityReceived( address: String, identityHash: String, isCentralConnection: Boolean, )</ID>
     <ID>LoopWithTooManyJumpStatements:KotlinRNodeBridge.kt$KotlinRNodeBridge$while</ID>
     <ID>MaxLineLength:AppDataParser.kt$AppDataParser$val printableRatio = str.count { it.isLetterOrDigit() || it.isWhitespace() || it in ".-_@#'\"()[]{},:;!?" } / str.length.toFloat()</ID>
-    <ID>MaxLineLength:BleAdvertiser.kt$BleAdvertiser$"RNS-${identity.take(BleConstants.IDENTITY_BYTES_IN_ADVERTISED_NAME).joinToString("") { "%02x".format(it) }}"</ID>
+
     <ID>MaxLineLength:BleAdvertiser.kt$BleAdvertiser$.</ID>
     <ID>MaxLineLength:BleAdvertiser.kt$BleAdvertiser.&lt;no name provided&gt;$Log.d(TAG, "Retrying advertising in ${backoffMs}ms (attempt $retryAttempts/$MAX_RETRY_ATTEMPTS)")</ID>
     <ID>MaxLineLength:BleGattClient.kt$BleGattClient$BleConstants.ERROR_GATT_WRITE_REQUEST_BUSY -&gt; "ERROR_GATT_WRITE_REQUEST_BUSY - BLE stack busy (should have been retried)"</ID>

--- a/reticulum/src/main/java/com/lxmf/messenger/reticulum/ble/bridge/KotlinBLEBridge.kt
+++ b/reticulum/src/main/java/com/lxmf/messenger/reticulum/ble/bridge/KotlinBLEBridge.kt
@@ -180,14 +180,6 @@ class KotlinBLEBridge(
     // This set prevents treating such connections as "stale" during deduplication.
     private val pendingCentralConnections = java.util.Collections.synchronizedSet(mutableSetOf<String>())
 
-    // Track identities that were recently deduplicated (central closed, peripheral kept)
-    // Maps identity hash -> timestamp when deduplicated
-    // Prevents scanner from reconnecting as central to a peer we just deduplicated
-    private val recentlyDeduplicatedIdentities = ConcurrentHashMap<String, Long>()
-
-    // How long to prevent reconnection after deduplication (60 seconds)
-    private val deduplicationCooldownMs = 60_000L
-
     // Track addresses that are currently in deduplication (one connection closing)
     // Maps address -> DeduplicationTracker with timestamp and which connection is closing
     // During the grace period, we don't clean up the peer for unexpected disconnects
@@ -759,7 +751,6 @@ class KotlinBLEBridge(
             pendingConnections.clear()
             processedIdentityCallbacks.clear()
             pendingCentralConnections.clear()
-            recentlyDeduplicatedIdentities.clear()
         } catch (e: Exception) {
             Log.e(TAG, "Error clearing state during cleanup", e)
         }
@@ -896,8 +887,6 @@ class KotlinBLEBridge(
         // Update all BLE components (if available)
         gattClient?.setTransportIdentity(identityBytes)
         gattServer?.setTransportIdentity(identityBytes)
-        advertiser?.setTransportIdentity(identityBytes)
-
         Log.i(TAG, "Transport identity set: ${identityBytes.joinToString("") { "%02x".format(it) }}")
 
         // Trigger any pending identity callback (e.g., from restart waiting for identity)
@@ -1012,44 +1001,6 @@ class KotlinBLEBridge(
             return false // Was not advertising, now restarting
         }
         return true // Already advertising (or no identity set)
-    }
-
-    /**
-     * Check if a discovered device should be skipped due to recent deduplication.
-     *
-     * Protocol v2.2 includes 3 bytes (6 hex chars) of identity in the advertised name.
-     * If the name matches an identity that was recently deduplicated (we're already
-     * connected as peripheral), skip the central connection attempt.
-     *
-     * @param deviceName Advertised device name (e.g., "RNS-272b4c" or "Reticulum-272b4c")
-     * @return true if the device should be skipped, false otherwise
-     */
-    @Suppress("ReturnCount")
-    private fun shouldSkipDiscoveredDevice(deviceName: String?): Boolean {
-        if (deviceName == null) return false
-
-        // Clean up old entries first
-        val now = System.currentTimeMillis()
-        recentlyDeduplicatedIdentities.entries.removeIf { now - it.value > deduplicationCooldownMs }
-
-        if (recentlyDeduplicatedIdentities.isEmpty()) return false
-
-        // Extract identity prefix from device name
-        // Protocol v2.2 format: "RNS-XXXXXX" or "Reticulum-XXXXXX" where X is hex
-        val identityPrefix =
-            when {
-                deviceName.startsWith("RNS-") -> deviceName.removePrefix("RNS-").lowercase()
-                deviceName.startsWith("Reticulum-") -> deviceName.removePrefix("Reticulum-").lowercase()
-                else -> return false
-            }
-
-        // Check if any recently deduplicated identity starts with this prefix
-        // (device name has 6 hex chars = 3 bytes, full identity is 32 hex chars)
-        val matchingIdentity = recentlyDeduplicatedIdentities.keys.find { it.startsWith(identityPrefix) }
-        if (matchingIdentity != null) {
-            Log.i(TAG, "Skipping discovered device with name '$deviceName' - matches recently deduplicated identity $matchingIdentity")
-        }
-        return matchingIdentity != null
     }
 
     /**
@@ -1604,14 +1555,10 @@ class KotlinBLEBridge(
     private fun setupCallbacks() {
         // Scanner callbacks (if available)
         scanner?.onDeviceDiscovered = { device: BleDevice ->
-            // Skip devices that match recently deduplicated identities
-            // (prevents reconnecting as central to a peer we're already connected to as peripheral)
-            if (!shouldSkipDiscoveredDevice(device.name)) {
-                Log.d(TAG, "Device discovered: ${device.address} (${device.name}) RSSI=${device.rssi}")
-                // Convert List to Array for Python compatibility (Chaquopy converts arrays to Python lists)
-                val serviceUuidsArray = device.serviceUuids?.toTypedArray()
-                onDeviceDiscovered?.callAttr("__call__", device.address, device.name, device.rssi, serviceUuidsArray)
-            }
+            Log.d(TAG, "Device discovered: ${device.address} (${device.name}) RSSI=${device.rssi}")
+            // Convert List to Array for Python compatibility (Chaquopy converts arrays to Python lists)
+            val serviceUuidsArray = device.serviceUuids?.toTypedArray()
+            onDeviceDiscovered?.callAttr("__call__", device.address, device.name, device.rssi, serviceUuidsArray)
         }
 
         // GATT Client callbacks (central mode, if available)
@@ -1778,10 +1725,6 @@ class KotlinBLEBridge(
                             dedupeAction = DedupeAction.CLOSE_CENTRAL
                         }
                     }
-                    // Add deduplication cooldown to prevent immediate reconnection as central
-                    // This prevents reconnection storms when one side keeps trying to reconnect
-                    recentlyDeduplicatedIdentities[peerIdentity] = System.currentTimeMillis()
-                    Log.d(TAG, "Added $peerIdentity to deduplication cooldown (${deduplicationCooldownMs / 1000}s)")
                 } else {
                     Log.w(TAG, "Dual connection but identity not yet available - deferring deduplication")
                 }
@@ -1952,8 +1895,6 @@ class KotlinBLEBridge(
                     if (otherAddresses.isEmpty()) {
                         // Identity fully disconnected - clean up reverse mapping
                         identityToAddress.remove(identityHash)
-                        // Allow reconnection as central again
-                        recentlyDeduplicatedIdentities.remove(identityHash)
                         // Clean up any stale entries for this identity
                         staleAddressToIdentity.entries.removeIf { it.value == identityHash }
                         Log.d(TAG, "Cleaned up all mappings for identity $identityHash")
@@ -2333,7 +2274,6 @@ class KotlinBLEBridge(
                 pendingConnections.clear()
                 processedIdentityCallbacks.clear()
                 pendingCentralConnections.clear()
-                recentlyDeduplicatedIdentities.clear()
 
                 // Stop BLE operations (but keep isStarted=true for auto-restart)
                 stopScanning()
@@ -2447,7 +2387,6 @@ class KotlinBLEBridge(
             pendingConnections.clear()
             processedIdentityCallbacks.clear()
             pendingCentralConnections.clear()
-            recentlyDeduplicatedIdentities.clear()
         } catch (e: Exception) {
             Log.e(TAG, "Error clearing state in stopImmediate", e)
         }

--- a/reticulum/src/main/java/com/lxmf/messenger/reticulum/ble/model/BleConstants.kt
+++ b/reticulum/src/main/java/com/lxmf/messenger/reticulum/ble/model/BleConstants.kt
@@ -167,21 +167,6 @@ object BleConstants {
      */
     const val DEFAULT_DEVICE_NAME_PREFIX = "Reticulum-"
 
-    /**
-     * Number of identity hash bytes to include in advertised device name.
-     *
-     * BLE advertising has a 31-byte payload limit. With flags (3 bytes) and
-     * a 128-bit service UUID (19 bytes), only ~9 bytes remain for the device name.
-     *
-     * Full identity is 16 bytes (32 hex chars), but we truncate to 3 bytes (6 hex chars)
-     * to fit within BLE advertising constraints. This results in device names like
-     * "RNS-1b9d2b" (10 characters total).
-     *
-     * The full identity is still exchanged via the GATT Identity characteristic
-     * during connection handshake (Protocol v2.2).
-     */
-    const val IDENTITY_BYTES_IN_ADVERTISED_NAME = 3
-
     // Error Codes
     /**
      * GATT error code 133.

--- a/reticulum/src/main/java/com/lxmf/messenger/reticulum/ble/server/BleAdvertiser.kt
+++ b/reticulum/src/main/java/com/lxmf/messenger/reticulum/ble/server/BleAdvertiser.kt
@@ -69,10 +69,6 @@ class BleAdvertiser(
 
     private val bluetoothLeAdvertiser: BluetoothLeAdvertiser? = bluetoothAdapter.bluetoothLeAdvertiser
 
-    // Local transport identity (16 bytes, set by Python bridge)
-    @Volatile
-    private var transportIdentityHash: ByteArray? = null
-
     // State
     private val _isAdvertising = MutableStateFlow(false)
     val isAdvertising: StateFlow<Boolean> = _isAdvertising.asStateFlow()
@@ -137,21 +133,6 @@ class BleAdvertiser(
         }
 
     /**
-     * Set the local transport identity hash for Protocol v2.2 device naming.
-     * The device will advertise as "RNS-{32-hex-identity}" when identity is set.
-     *
-     * @param identityHash 16-byte Reticulum Transport identity hash
-     * @throws IllegalArgumentException if identityHash is not exactly 16 bytes
-     */
-    fun setTransportIdentity(identityHash: ByteArray) {
-        require(identityHash.size == 16) {
-            "Transport identity hash must be exactly 16 bytes, got ${identityHash.size}"
-        }
-        transportIdentityHash = identityHash
-        Log.d(TAG, "Transport identity set: ${identityHash.joinToString("") { "%02x".format(it) }}")
-    }
-
-    /**
      * Start BLE advertising with the Reticulum service UUID.
      * The device name is used only for internal logging; it is NOT
      * included in the scan response and the phone's Bluetooth name
@@ -203,21 +184,9 @@ class BleAdvertiser(
                     )
                 }
 
-                // Determine device name for logging / internal tracking only
-                // (not included in BLE advertisement payload)
-                val actualDeviceName =
-                    transportIdentityHash?.let { identity ->
-                        "RNS-${identity.take(BleConstants.IDENTITY_BYTES_IN_ADVERTISED_NAME).joinToString("") { "%02x".format(it) }}"
-                    } ?: deviceName
+                currentDeviceName = deviceName
 
-                currentDeviceName = actualDeviceName
-
-                Log.d(TAG, "Advertising with device name: $actualDeviceName")
-                if (transportIdentityHash != null) {
-                    Log.d(TAG, "  (Protocol v2.2 identity-based naming)")
-                } else {
-                    Log.w(TAG, "  (Protocol v1 fallback - identity not set)")
-                }
+                Log.d(TAG, "Advertising with device name: $deviceName")
 
                 // Build advertise settings
                 val settings =
@@ -257,7 +226,7 @@ class BleAdvertiser(
                     advertiseCallback,
                 )
 
-                Log.d(TAG, "Starting advertising as '$actualDeviceName'...")
+                Log.d(TAG, "Starting advertising as '$deviceName'...")
 
                 Result.success(Unit)
             } catch (e: Exception) {

--- a/reticulum/src/main/java/com/lxmf/messenger/reticulum/ble/service/BleConnectionManager.kt
+++ b/reticulum/src/main/java/com/lxmf/messenger/reticulum/ble/service/BleConnectionManager.kt
@@ -317,12 +317,12 @@ class BleConnectionManager(
         Log.i(TAG, "Setting transport identity on all BLE components")
         Log.i(TAG, "  Identity: ${identityHash.joinToString("") { "%02x".format(it) }}")
 
-        // Set on all components for Protocol v2.2 compliance
+        // Set on GATT components for Protocol v2.2 compliance
+        // (Advertiser no longer needs identity — device name is not advertised)
         gattClient.setTransportIdentity(identityHash)
         gattServer.setTransportIdentity(identityHash)
-        advertiser.setTransportIdentity(identityHash)
 
-        Log.d(TAG, "Transport identity set on client, server, and advertiser")
+        Log.d(TAG, "Transport identity set on client and server")
     }
 
     /**
@@ -485,9 +485,7 @@ class BleConnectionManager(
     /**
      * Get discovered devices sorted by priority.
      */
-    suspend fun getDiscoveredDevices(): List<BleDevice> {
-        return scanner.getDevicesSortedByPriority()
-    }
+    suspend fun getDiscoveredDevices(): List<BleDevice> = scanner.getDevicesSortedByPriority()
 
     /**
      * Get detailed information about all connected peers.
@@ -834,16 +832,12 @@ class BleConnectionManager(
      * Get the tracking key for a peer (identity if known, otherwise MAC).
      * Used for keying blacklists and connection tracking.
      */
-    private fun getPeerKey(address: String): String {
-        return macToIdentity[address] ?: address
-    }
+    private fun getPeerKey(address: String): String = macToIdentity[address] ?: address
 
     /**
      * Get the current MAC address for an identity (if known).
      */
-    private fun getIdentityMac(identityHash: String): String? {
-        return peers[identityHash]?.currentMac
-    }
+    private fun getIdentityMac(identityHash: String): String? = peers[identityHash]?.currentMac
 
     /**
      * Check if an address or identity is blacklisted.

--- a/reticulum/src/test/java/com/lxmf/messenger/reticulum/ble/bridge/KotlinBLEBridgeDeduplicationTest.kt
+++ b/reticulum/src/test/java/com/lxmf/messenger/reticulum/ble/bridge/KotlinBLEBridgeDeduplicationTest.kt
@@ -15,7 +15,6 @@ import io.mockk.coEvery
 import io.mockk.every
 import io.mockk.mockk
 import org.junit.After
-import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
 import org.junit.Before
@@ -23,12 +22,11 @@ import org.junit.Test
 import java.util.concurrent.ConcurrentHashMap
 
 /**
- * Unit tests for KotlinBLEBridge deduplication and cooldown functionality.
+ * Unit tests for KotlinBLEBridge deduplication tracking.
  *
- * Tests the following features from PR 59:
- * - shouldSkipDiscoveredDevice() - prevents reconnecting to recently deduplicated peers
+ * Tests the following live features:
  * - pendingCentralConnections - tracks in-progress central connections for race condition fix
- * - recentlyDeduplicatedIdentities - cooldown tracking for deduplication
+ * - onAddressChanged callback - notifies Python of MAC address changes
  */
 class KotlinBLEBridgeDeduplicationTest {
     private lateinit var mockContext: Context
@@ -60,143 +58,6 @@ class KotlinBLEBridgeDeduplicationTest {
     @After
     fun tearDown() {
         clearAllMocks()
-    }
-
-    // ========== shouldSkipDiscoveredDevice() Tests ==========
-
-    @Test
-    fun `shouldSkipDiscoveredDevice returns false for null device name`() {
-        val bridge = createBridgeWithMocks()
-
-        // Add an identity to the cooldown map
-        addToRecentlyDeduplicatedIdentities(bridge, "ab5609dfffb33b21a102e1ff81196be5", System.currentTimeMillis())
-
-        // When: null device name
-        val result = invokeShouldSkipDiscoveredDevice(bridge, null)
-
-        // Then: should return false
-        assertFalse("Should return false for null device name", result)
-    }
-
-    @Test
-    fun `shouldSkipDiscoveredDevice returns false when no recent deduplication`() {
-        val bridge = createBridgeWithMocks()
-
-        // No entries in recentlyDeduplicatedIdentities
-
-        // When: valid RNS device name
-        val result = invokeShouldSkipDiscoveredDevice(bridge, "RNS-ab5609")
-
-        // Then: should return false since map is empty
-        assertFalse("Should return false when no recent deduplication", result)
-    }
-
-    @Test
-    fun `shouldSkipDiscoveredDevice returns true for RNS prefix matching recently deduplicated identity`() {
-        val bridge = createBridgeWithMocks()
-
-        // Identity starts with "ab5609"
-        val fullIdentity = "ab5609dfffb33b21a102e1ff81196be5"
-        addToRecentlyDeduplicatedIdentities(bridge, fullIdentity, System.currentTimeMillis())
-
-        // When: device name with matching prefix (lowercase match)
-        val result = invokeShouldSkipDiscoveredDevice(bridge, "RNS-ab5609")
-
-        // Then: should return true
-        assertTrue("Should skip device matching recently deduplicated identity", result)
-    }
-
-    @Test
-    fun `shouldSkipDiscoveredDevice returns true for Reticulum prefix matching recently deduplicated identity`() {
-        val bridge = createBridgeWithMocks()
-
-        val fullIdentity = "272b4c8f1a3d5e9b0c2f7a4d6e8b1c3a"
-        addToRecentlyDeduplicatedIdentities(bridge, fullIdentity, System.currentTimeMillis())
-
-        // When: Reticulum-prefixed device name with matching identity
-        val result = invokeShouldSkipDiscoveredDevice(bridge, "Reticulum-272b4c")
-
-        // Then: should return true
-        assertTrue("Should skip Reticulum-prefixed device matching deduplicated identity", result)
-    }
-
-    @Test
-    fun `shouldSkipDiscoveredDevice returns false for unrelated device name`() {
-        val bridge = createBridgeWithMocks()
-
-        val fullIdentity = "ab5609dfffb33b21a102e1ff81196be5"
-        addToRecentlyDeduplicatedIdentities(bridge, fullIdentity, System.currentTimeMillis())
-
-        // When: device name with non-matching prefix
-        val result = invokeShouldSkipDiscoveredDevice(bridge, "RNS-ffffff")
-
-        // Then: should return false
-        assertFalse("Should not skip device with non-matching identity prefix", result)
-    }
-
-    @Test
-    fun `shouldSkipDiscoveredDevice returns false for non-RNS-Reticulum device name`() {
-        val bridge = createBridgeWithMocks()
-
-        val fullIdentity = "ab5609dfffb33b21a102e1ff81196be5"
-        addToRecentlyDeduplicatedIdentities(bridge, fullIdentity, System.currentTimeMillis())
-
-        // When: device name without RNS- or Reticulum- prefix
-        val result = invokeShouldSkipDiscoveredDevice(bridge, "SomeOtherDevice-ab5609")
-
-        // Then: should return false
-        assertFalse("Should not skip device without RNS/Reticulum prefix", result)
-    }
-
-    @Test
-    fun `shouldSkipDiscoveredDevice returns false after cooldown expires`() {
-        val bridge = createBridgeWithMocks()
-
-        // Add identity with timestamp 61 seconds in the past (cooldown is 60s)
-        val expiredTimestamp = System.currentTimeMillis() - 61_000L
-        addToRecentlyDeduplicatedIdentities(bridge, "ab5609dfffb33b21a102e1ff81196be5", expiredTimestamp)
-
-        // When: device name with matching prefix
-        val result = invokeShouldSkipDiscoveredDevice(bridge, "RNS-ab5609")
-
-        // Then: should return false since cooldown expired
-        assertFalse("Should not skip device after cooldown expires", result)
-    }
-
-    @Test
-    fun `shouldSkipDiscoveredDevice cleans up expired entries`() {
-        val bridge = createBridgeWithMocks()
-
-        // Add one expired entry and one fresh entry
-        val expiredTimestamp = System.currentTimeMillis() - 61_000L
-        val freshTimestamp = System.currentTimeMillis()
-
-        addToRecentlyDeduplicatedIdentities(bridge, "expired1dfffb33b21a102e1ff81196be5", expiredTimestamp)
-        addToRecentlyDeduplicatedIdentities(bridge, "fresh12dfffb33b21a102e1ff81196be5", freshTimestamp)
-
-        // When: invoke the method (it cleans up expired entries)
-        invokeShouldSkipDiscoveredDevice(bridge, "RNS-unrelated")
-
-        // Then: expired entry should be removed, fresh entry should remain
-        val map = getRecentlyDeduplicatedIdentities(bridge)
-        assertEquals("Should have only 1 entry after cleanup", 1, map.size)
-        assertTrue("Fresh entry should remain", map.containsKey("fresh12dfffb33b21a102e1ff81196be5"))
-        assertFalse("Expired entry should be removed", map.containsKey("expired1dfffb33b21a102e1ff81196be5"))
-    }
-
-    @Test
-    fun `shouldSkipDiscoveredDevice is case insensitive for identity prefix`() {
-        val bridge = createBridgeWithMocks()
-
-        // Identity stored in lowercase
-        val fullIdentity = "ab5609dfffb33b21a102e1ff81196be5"
-        addToRecentlyDeduplicatedIdentities(bridge, fullIdentity, System.currentTimeMillis())
-
-        // When: device name with uppercase prefix (should be lowercased internally)
-        val result = invokeShouldSkipDiscoveredDevice(bridge, "RNS-AB5609")
-
-        // Then: should return true (case insensitive match)
-        assertTrue("Should match identity case-insensitively", result)
     }
 
     // ========== pendingCentralConnections Tests ==========
@@ -252,60 +113,28 @@ class KotlinBLEBridgeDeduplicationTest {
         assertTrue("Pending connection should be detected as active", pending.contains(oldMac))
     }
 
-    // ========== recentlyDeduplicatedIdentities Tests ==========
+    // ========== onAddressChanged Callback Tests ==========
 
     @Test
-    fun `recentlyDeduplicatedIdentities stores identity with timestamp`() {
+    fun `onAddressChanged callback can be set`() {
         val bridge = createBridgeWithMocks()
-        val identityHash = "ab5609dfffb33b21a102e1ff81196be5"
-        val timestamp = System.currentTimeMillis()
+        val mockCallback = mockk<PyObject>(relaxed = true)
 
-        // When: add identity to cooldown
-        addToRecentlyDeduplicatedIdentities(bridge, identityHash, timestamp)
+        // When: set the callback
+        setOnAddressChanged(bridge, mockCallback)
 
-        // Then: should be stored with timestamp
-        val map = getRecentlyDeduplicatedIdentities(bridge)
-        assertEquals("Should store timestamp", timestamp, map[identityHash])
+        // Then: callback should be stored (use assertSame to avoid native PyObject.equals())
+        val storedCallback = getOnAddressChanged(bridge)
+        org.junit.Assert.assertSame("Callback should be stored", mockCallback, storedCallback)
     }
 
     @Test
-    fun `recentlyDeduplicatedIdentities can be cleared`() {
+    fun `onAddressChanged callback is initially null`() {
         val bridge = createBridgeWithMocks()
 
-        // Given: some entries
-        addToRecentlyDeduplicatedIdentities(bridge, "identity1aaaaaaaaaaaaaaaaaaaaaaaa", System.currentTimeMillis())
-        addToRecentlyDeduplicatedIdentities(bridge, "identity2bbbbbbbbbbbbbbbbbbbbbbbb", System.currentTimeMillis())
-
-        // When: clear all
-        clearRecentlyDeduplicatedIdentities(bridge)
-
-        // Then: should be empty
-        val map = getRecentlyDeduplicatedIdentities(bridge)
-        assertTrue("Map should be empty after clear", map.isEmpty())
-    }
-
-    @Test
-    fun `identity removed from cooldown allows reconnection`() {
-        val bridge = createBridgeWithMocks()
-        val identityHash = "ab5609dfffb33b21a102e1ff81196be5"
-
-        // Given: identity in cooldown
-        addToRecentlyDeduplicatedIdentities(bridge, identityHash, System.currentTimeMillis())
-
-        // Verify it blocks
-        assertTrue(
-            "Should skip initially",
-            invokeShouldSkipDiscoveredDevice(bridge, "RNS-ab5609"),
-        )
-
-        // When: remove from cooldown
-        removeFromRecentlyDeduplicatedIdentities(bridge, identityHash)
-
-        // Then: should no longer skip
-        assertFalse(
-            "Should not skip after removal",
-            invokeShouldSkipDiscoveredDevice(bridge, "RNS-ab5609"),
-        )
+        // Verify callback starts as null
+        val callback = getOnAddressChanged(bridge)
+        org.junit.Assert.assertNull("Callback should be null initially", callback)
     }
 
     // ========== Helper Methods ==========
@@ -326,38 +155,6 @@ class KotlinBLEBridgeDeduplicationTest {
         gattServerField.set(bridge, mockGattServer)
 
         return bridge
-    }
-
-    private fun addToRecentlyDeduplicatedIdentities(
-        bridge: KotlinBLEBridge,
-        identity: String,
-        timestamp: Long,
-    ) {
-        val field = KotlinBLEBridge::class.java.getDeclaredField("recentlyDeduplicatedIdentities")
-        field.isAccessible = true
-        @Suppress("UNCHECKED_CAST")
-        val map = field.get(bridge) as ConcurrentHashMap<String, Long>
-        map[identity] = timestamp
-    }
-
-    private fun getRecentlyDeduplicatedIdentities(bridge: KotlinBLEBridge): ConcurrentHashMap<String, Long> {
-        val field = KotlinBLEBridge::class.java.getDeclaredField("recentlyDeduplicatedIdentities")
-        field.isAccessible = true
-        @Suppress("UNCHECKED_CAST")
-        return field.get(bridge) as ConcurrentHashMap<String, Long>
-    }
-
-    private fun removeFromRecentlyDeduplicatedIdentities(
-        bridge: KotlinBLEBridge,
-        identity: String,
-    ) {
-        val map = getRecentlyDeduplicatedIdentities(bridge)
-        map.remove(identity)
-    }
-
-    private fun clearRecentlyDeduplicatedIdentities(bridge: KotlinBLEBridge) {
-        val map = getRecentlyDeduplicatedIdentities(bridge)
-        map.clear()
     }
 
     private fun getPendingCentralConnections(bridge: KotlinBLEBridge): MutableSet<String> {
@@ -406,95 +203,6 @@ class KotlinBLEBridgeDeduplicationTest {
         val map = field.get(bridge) as ConcurrentHashMap<String, String>
         map[identity] = address
     }
-
-    private fun invokeShouldSkipDiscoveredDevice(
-        bridge: KotlinBLEBridge,
-        deviceName: String?,
-    ): Boolean {
-        val method =
-            KotlinBLEBridge::class.java.getDeclaredMethod(
-                "shouldSkipDiscoveredDevice",
-                String::class.java,
-            )
-        method.isAccessible = true
-        return method.invoke(bridge, deviceName) as Boolean
-    }
-
-    private fun setTransportIdentityHash(
-        bridge: KotlinBLEBridge,
-        identityBytes: ByteArray?,
-    ) {
-        val field = KotlinBLEBridge::class.java.getDeclaredField("transportIdentityHash")
-        field.isAccessible = true
-        field.set(bridge, identityBytes)
-    }
-
-    // ========== Cooldown Asymmetry Tests ==========
-
-    @Test
-    fun `deduplication sets cooldown when keeping peripheral connection`() {
-        // This test verifies existing behavior (cooldown IS set when keeping peripheral)
-        val bridge = createBridgeWithMocks()
-        val identity = "ab5609dfffb33b21a102e1ff81196be5"
-
-        // Setup: local identity is HIGHER, so we keep peripheral (!weKeepCentral)
-        // Higher local identity means: localIdentityHex >= identityHash, so weKeepCentral = false
-        val localIdentity = ByteArray(16) { 0xFF.toByte() }
-        setTransportIdentityHash(bridge, localIdentity)
-
-        // When deduplication happens with keeping peripheral, cooldown should be set
-        // We can't easily trigger handleIdentityReceived, but we can verify the cooldown map behavior
-
-        // For now, just verify the mechanism works - add to cooldown and check shouldSkipDiscoveredDevice
-        addToRecentlyDeduplicatedIdentities(bridge, identity, System.currentTimeMillis())
-
-        // Should skip this device
-        val result = invokeShouldSkipDiscoveredDevice(bridge, "RNS-ab5609")
-        assertTrue("Should skip device with matching identity prefix", result)
-    }
-
-    @Test
-    fun `deduplication cooldown map is accessible for testing`() {
-        val bridge = createBridgeWithMocks()
-        val identity = "ab5609dfffb33b21a102e1ff81196be5"
-
-        // Initially empty
-        val cooldownBefore = getRecentlyDeduplicatedIdentities(bridge)
-        assertFalse("Cooldown should not contain identity initially", cooldownBefore.containsKey(identity))
-
-        // Add to cooldown
-        addToRecentlyDeduplicatedIdentities(bridge, identity, System.currentTimeMillis())
-
-        // Should now contain identity
-        val cooldownAfter = getRecentlyDeduplicatedIdentities(bridge)
-        assertTrue("Cooldown should contain identity after adding", cooldownAfter.containsKey(identity))
-    }
-
-    // ========== onAddressChanged Callback Tests ==========
-
-    @Test
-    fun `onAddressChanged callback can be set`() {
-        val bridge = createBridgeWithMocks()
-        val mockCallback = mockk<PyObject>(relaxed = true)
-
-        // When: set the callback
-        setOnAddressChanged(bridge, mockCallback)
-
-        // Then: callback should be stored (use assertSame to avoid native PyObject.equals())
-        val storedCallback = getOnAddressChanged(bridge)
-        org.junit.Assert.assertSame("Callback should be stored", mockCallback, storedCallback)
-    }
-
-    @Test
-    fun `onAddressChanged callback is initially null`() {
-        val bridge = createBridgeWithMocks()
-
-        // Verify callback starts as null
-        val callback = getOnAddressChanged(bridge)
-        org.junit.Assert.assertNull("Callback should be null initially", callback)
-    }
-
-    // ========== Additional Helper Methods for onAddressChanged Tests ==========
 
     private fun setOnAddressChanged(
         bridge: KotlinBLEBridge,


### PR DESCRIPTION
## Summary

- Removes `shouldSkipDiscoveredDevice()` and all supporting infrastructure (`recentlyDeduplicatedIdentities`, `deduplicationCooldownMs`, `IDENTITY_BYTES_IN_ADVERTISED_NAME`) — dead since PR #630 stopped advertising device names
- Removes `BleAdvertiser.setTransportIdentity()` and its callers in `KotlinBLEBridge` and `BleConnectionManager` — advertiser no longer needs identity for name computation
- Simplifies scanner callback to invoke Python directly without the always-false skip check
- Removes 15 dead tests and 6 dead test helpers; keeps 5 live tests (3 `pendingCentralConnections` + 2 `onAddressChanged`)
- Updates `docs/ble-architecture.md` and detekt baseline

**No behavioral change** — the GATT-layer identity dedup in `handleIdentityReceived()` remains fully intact and handles all deduplication correctly.

## Test plan

- [x] `:reticulum:compileDebugKotlin` passes
- [x] `:reticulum:testDebugUnitTest --tests "*.KotlinBLEBridgeDeduplicationTest"` — 5 remaining tests pass
- [x] `:app:compileNoSentryDebugKotlin` passes
- [x] `grep` for all removed symbols returns zero matches

🤖 Generated with [Claude Code](https://claude.com/claude-code)