### PR TITLE
ci: split module tests into separate job to prevent shard 0 timeouts

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -402,6 +402,30 @@ jobs:
       - name: Grant execute permission for gradlew
         run: chmod +x gradlew
 
+      - name: Clean AIDL generated code
+        run: |
+          # Clean AIDL generated code to avoid stale cache issues
+          # This MUST happen before Gradle cache restore to prevent cached stale AIDL files
+          rm -rf app/build/generated/aidl_source_output_dir
+          rm -rf */build/generated/aidl_source_output_dir
+
+      - name: Clean JaCoCo execution data
+        run: |
+          # Clean stale JaCoCo execution data to avoid "exceeds max age" errors in Codecov
+          rm -rf build/jacoco
+          rm -rf */build/jacoco
+          rm -rf build/reports/jacoco
+          rm -rf */build/reports/jacoco
+
+      - name: Cache Robolectric Android SDKs
+        uses: actions/cache@v5
+        with:
+          path: ~/.m2/repository/org/robolectric
+          key: robolectric-4.16-${{ runner.os }}
+          restore-keys: |
+            robolectric-4.16-
+            robolectric-
+
       - name: Run reticulum and data module tests
         run: ./gradlew :reticulum:testDebugUnitTest :data:testDebugUnitTest --stacktrace --max-workers=4
 


### PR DESCRIPTION
## Summary
- Moves `:reticulum` and `:data` module tests out of Kotlin test shard 0 into a new `module-tests` job
- Shard 0 was overloaded (~12min vs ~9-10min for other shards), causing intermittent 15min timeout failures on slow CI runners
- New job runs in parallel with existing app test shards, wired into `ci-passed` gate

## Test plan
- [ ] All 4 app test shards pass
- [ ] New `Module Tests (reticulum + data)` job passes
- [ ] `ci-passed` gate correctly depends on the new job

🤖 Generated with [Claude Code](https://claude.com/claude-code)