### PR TITLE
ci: trigger CI on release/* branches

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,9 +2,9 @@ name: CI
 
 on:
   push:
-    branches: [ main, 'v[0-9].[0-9]+.x' ]
+    branches: [ main, 'v[0-9].[0-9]+.x', 'release/**' ]
   pull_request:
-    branches: [ main, 'v[0-9].[0-9]+.x' ]
+    branches: [ main, 'v[0-9].[0-9]+.x', 'release/**' ]
 
 permissions:
   contents: read


### PR DESCRIPTION
## Summary
- CI workflow branch filters (`v[0-9].[0-9]+.x`) didn't match `release/v0.9.x` — the `release/` prefix was missing from the pattern
- PRs targeting release branches had no lint, compile, or test checks, allowing broken code to be merged (see v0.9.19-beta tagged release failure)
- Adds `'release/**'` to both `push` and `pull_request` triggers

## Test plan
- [ ] After merge, verify CI triggers on a PR targeting `release/v0.9.x`

🤖 Generated with [Claude Code](https://claude.com/claude-code)