### PR TITLE
fix: catch SecurityException when location permission revoked while backgrounded

### DIFF
--- a/app/src/main/java/com/lxmf/messenger/ui/screens/MapScreen.kt
+++ b/app/src/main/java/com/lxmf/messenger/ui/screens/MapScreen.kt
@@ -254,6 +254,7 @@ fun MapScreen(
                 // Permission was revoked between our check and MapLibre's
                 // internal LocationManager call (COLUMBA-5R)
                 Log.w("MapScreen", "Location permission revoked, disabling location component", e)
+                viewModel.onPermissionResult(false)
             }
         }
 
@@ -497,15 +498,25 @@ fun MapScreen(
                 when (event) {
                     Lifecycle.Event.ON_START -> view.onStart()
                     Lifecycle.Event.ON_RESUME -> {
-                        view.onResume()
-                        viewModel.refreshDefaultRegion()
-                        // Re-check actual Android permission on resume in case user
-                        // revoked it from Settings while the app was backgrounded.
-                        // This syncs ViewModel state with reality (fixes COLUMBA-5R).
+                        // Re-check actual Android permission BEFORE view.onResume(),
+                        // which may internally resume the location engine and throw
+                        // SecurityException if permission was revoked (COLUMBA-5R).
                         val stillHasPermission = LocationPermissionManager.hasPermission(context)
                         if (state.hasLocationPermission && !stillHasPermission) {
+                            // Disable location component before MapLibre resumes it
+                            mapLibreMap?.locationComponent?.let { lc ->
+                                if (lc.isLocationComponentActivated) {
+                                    lc.isLocationComponentEnabled = false
+                                }
+                            }
                             viewModel.onPermissionResult(false)
+                            platformLocationListener?.let {
+                                LocationCompat.removeLocationUpdates(context, it)
+                            }
+                            platformLocationListener = null
                         }
+                        view.onResume()
+                        viewModel.refreshDefaultRegion()
                     }
                     Lifecycle.Event.ON_PAUSE -> view.onPause()
                     Lifecycle.Event.ON_STOP -> view.onStop()


### PR DESCRIPTION
## Summary
Fixes COLUMBA-5R — fatal `SecurityException` crash on the Map screen.

- **Root cause**: User grants location permission → backgrounds app → revokes permission in Android Settings → returns to app. ViewModel still has `hasLocationPermission=true` (stale), but MapLibre calls `LocationManager.getLastKnownLocation()` which throws `SecurityException`.
- **ON_RESUME re-check**: Syncs ViewModel permission state with the actual Android permission when the app resumes from background
- **try-catch safety net**: Both `onMapStyleLoaded` and the `LaunchedEffect` location component activation paths now catch `SecurityException` as a TOCTOU guard

Observed on Realme 8s 5G / Android 13 — some OEMs don't kill the app process on permission revocation.

## Test plan
- [x] `MapViewModelTest` passes (permission state management)
- [ ] Manual: grant location → background → revoke in Settings → return to map → no crash, blue dot disappears

🤖 Generated with [Claude Code](https://claude.com/claude-code)