### PR TITLE
refactor: add RNS/LXMF binding interfaces and Chaquopy implementations

### DIFF
--- a/app/src/main/java/com/lxmf/messenger/reticulum/protocol/ServiceReticulumProtocol.kt
+++ b/app/src/main/java/com/lxmf/messenger/reticulum/protocol/ServiceReticulumProtocol.kt
@@ -1452,6 +1452,7 @@ class ServiceReticulumProtocol(
                     is DestinationType.SINGLE -> "SINGLE"
                     is DestinationType.GROUP -> "GROUP"
                     is DestinationType.PLAIN -> "PLAIN"
+                    is DestinationType.LINK -> "LINK"
                 }
 
             val resultJson =

--- a/app/src/main/java/com/lxmf/messenger/service/rns/ChaquopyLxmfAppDataParser.kt
+++ b/app/src/main/java/com/lxmf/messenger/service/rns/ChaquopyLxmfAppDataParser.kt
@@ -1,0 +1,62 @@
+package com.lxmf.messenger.service.rns
+
+import com.chaquo.python.PyObject
+import com.lxmf.messenger.reticulum.bindings.lxmf.LxmfAppDataParser
+
+/**
+ * Chaquopy implementation of [LxmfAppDataParser].
+ * Calls `rns_api.RnsApi` static methods that parse LXMF announce app_data.
+ *
+ * @param api The live Python `RnsApi` instance
+ */
+class ChaquopyLxmfAppDataParser(
+    private val api: PyObject,
+) : LxmfAppDataParser {
+    override fun displayNameFromAppData(appData: ByteArray): String? {
+        val result = api.callAttr("display_name_from_app_data", appData)
+        return try {
+            if (result != null && result.toString() != "None") {
+                result.toString()
+            } else {
+                null
+            }
+        } finally {
+            result?.close()
+        }
+    }
+
+    override fun propagationNodeNameFromAppData(appData: ByteArray): String? {
+        val result = api.callAttr("propagation_node_name_from_app_data", appData)
+        return try {
+            if (result != null && result.toString() != "None") {
+                result.toString()
+            } else {
+                null
+            }
+        } finally {
+            result?.close()
+        }
+    }
+
+    override fun stampCostFromAppData(appData: ByteArray): Int? {
+        val result = api.callAttr("stamp_cost_from_app_data", appData)
+        return try {
+            if (result != null && result.toString() != "None") {
+                result.toInt()
+            } else {
+                null
+            }
+        } finally {
+            result?.close()
+        }
+    }
+
+    override fun isPropagationNodeAnnounceValid(appData: ByteArray): Boolean {
+        val result = api.callAttr("is_propagation_node_announce_valid", appData)
+        return try {
+            result?.toBoolean() ?: false
+        } finally {
+            result?.close()
+        }
+    }
+}

--- a/app/src/main/java/com/lxmf/messenger/service/rns/ChaquopyLxmfMessage.kt
+++ b/app/src/main/java/com/lxmf/messenger/service/rns/ChaquopyLxmfMessage.kt
@@ -1,0 +1,123 @@
+package com.lxmf.messenger.service.rns
+
+import com.chaquo.python.PyObject
+import com.lxmf.messenger.reticulum.bindings.lxmf.LxmfMessage
+import com.lxmf.messenger.reticulum.bindings.lxmf.LxmfMessageState
+import com.lxmf.messenger.reticulum.protocol.DeliveryMethod
+
+/**
+ * Chaquopy implementation of [LxmfMessage].
+ * Wraps a live Python `LXMF.LXMessage` object.
+ *
+ * @param pyMessage The live Python LXMF.LXMessage object
+ * @param api The RnsApi instance for calling helper methods
+ */
+class ChaquopyLxmfMessage(
+    internal val pyMessage: PyObject,
+    private val api: PyObject,
+) : LxmfMessage,
+    AutoCloseable {
+    override val hash: ByteArray
+        get() {
+            val result = api.callAttr("lxmf_message_get_hash", pyMessage)
+            return try {
+                result?.toJava(ByteArray::class.java) ?: ByteArray(0)
+            } finally {
+                result?.close()
+            }
+        }
+
+    override val state: LxmfMessageState
+        get() {
+            val result = api.callAttr("lxmf_message_get_state", pyMessage)
+            return try {
+                when (result?.toInt()) {
+                    0 -> LxmfMessageState.DRAFT
+                    1 -> LxmfMessageState.OUTBOUND
+                    2 -> LxmfMessageState.SENDING
+                    3 -> LxmfMessageState.SENT
+                    4 -> LxmfMessageState.DELIVERED
+                    5 -> LxmfMessageState.FAILED
+                    else -> LxmfMessageState.DRAFT
+                }
+            } finally {
+                result?.close()
+            }
+        }
+
+    override val sourceHash: ByteArray
+        get() {
+            val result = api.callAttr("lxmf_message_get_source_hash", pyMessage)
+            return try {
+                result?.toJava(ByteArray::class.java) ?: ByteArray(0)
+            } finally {
+                result?.close()
+            }
+        }
+
+    override val destinationHash: ByteArray
+        get() {
+            val result = api.callAttr("lxmf_message_get_destination_hash", pyMessage)
+            return try {
+                result?.toJava(ByteArray::class.java) ?: ByteArray(0)
+            } finally {
+                result?.close()
+            }
+        }
+
+    override val content: String
+        get() {
+            val result = api.callAttr("lxmf_message_get_content", pyMessage)
+            return try {
+                result?.toString() ?: ""
+            } finally {
+                result?.close()
+            }
+        }
+
+    @Suppress("UNCHECKED_CAST")
+    override val fields: Map<Int, Any>?
+        get() {
+            val result = api.callAttr("lxmf_message_get_fields", pyMessage)
+            return try {
+                if (result != null && result.toString() != "None") {
+                    // Python dict with int keys — convert to Kotlin Map<Int, Any>
+                    val pyDict = result.asMap() as Map<PyObject, PyObject>
+                    pyDict.entries.associate { (k, v) ->
+                        k.toInt() to (v.toJava(Any::class.java) as Any)
+                    }
+                } else {
+                    null
+                }
+            } finally {
+                result?.close()
+            }
+        }
+
+    override val timestamp: Long
+        get() {
+            val result = api.callAttr("lxmf_message_get_timestamp", pyMessage)
+            return try {
+                result?.toLong() ?: 0L
+            } finally {
+                result?.close()
+            }
+        }
+
+    // Mutable properties — set on the Python object before handleOutbound
+    override var desiredMethod: DeliveryMethod = DeliveryMethod.DIRECT
+
+    override var tryPropagationOnFail: Boolean = true
+
+    override fun registerDeliveryCallback(callback: (LxmfMessage) -> Unit) {
+        // TODO: Bridge Python callback to Kotlin in Phase 4
+    }
+
+    override fun registerFailedCallback(callback: (LxmfMessage) -> Unit) {
+        // TODO: Bridge Python callback to Kotlin in Phase 4
+    }
+
+    override fun close() {
+        pyMessage.close()
+    }
+}

--- a/app/src/main/java/com/lxmf/messenger/service/rns/ChaquopyLxmfMessage.kt
+++ b/app/src/main/java/com/lxmf/messenger/service/rns/ChaquopyLxmfMessage.kt
@@ -83,8 +83,16 @@ class ChaquopyLxmfMessage(
                 if (result != null && result.toString() != "None") {
                     // Python dict with int keys — convert to Kotlin Map<Int, Any>
                     val pyDict = result.asMap() as Map<PyObject, PyObject>
-                    pyDict.entries.associate { (k, v) ->
-                        k.toInt() to (v.toJava(Any::class.java) as Any)
+                    try {
+                        pyDict.entries.associate { (k, v) ->
+                            k.toInt() to (v.toJava(Any::class.java) as Any)
+                        }
+                    } finally {
+                        // Close all PyObject keys and values from the dict view
+                        for ((k, v) in pyDict) {
+                            k.close()
+                            v.close()
+                        }
                     }
                 } else {
                     null

--- a/app/src/main/java/com/lxmf/messenger/service/rns/ChaquopyLxmfMessageFactory.kt
+++ b/app/src/main/java/com/lxmf/messenger/service/rns/ChaquopyLxmfMessageFactory.kt
@@ -15,7 +15,7 @@ import com.lxmf.messenger.reticulum.protocol.DeliveryMethod
  *
  * @param api The live Python `RnsApi` instance
  */
-@Suppress("UnusedImport") // Imports needed for interface contract; implementation deferred to Phase 4
+@Suppress("UnusedPrivateProperty") // api will be used in Phase 4 when source/dest wiring is complete
 class ChaquopyLxmfMessageFactory(
     private val api: PyObject,
 ) : LxmfMessageFactory {

--- a/app/src/main/java/com/lxmf/messenger/service/rns/ChaquopyLxmfMessageFactory.kt
+++ b/app/src/main/java/com/lxmf/messenger/service/rns/ChaquopyLxmfMessageFactory.kt
@@ -15,6 +15,7 @@ import com.lxmf.messenger.reticulum.protocol.DeliveryMethod
  *
  * @param api The live Python `RnsApi` instance
  */
+@Suppress("UnusedImport") // Imports needed for interface contract; implementation deferred to Phase 4
 class ChaquopyLxmfMessageFactory(
     private val api: PyObject,
 ) : LxmfMessageFactory {
@@ -26,32 +27,12 @@ class ChaquopyLxmfMessageFactory(
         desiredMethod: DeliveryMethod,
         tryPropagationOnFail: Boolean,
     ): LxmfMessage {
-        // Map DeliveryMethod enum to LXMF Python constants
-        val methodInt =
-            when (desiredMethod) {
-                DeliveryMethod.OPPORTUNISTIC -> 0
-                DeliveryMethod.DIRECT -> 1
-                DeliveryMethod.PROPAGATED -> 2
-            }
-
-        // TODO: Phase 4 — resolve destinationHash to live Python Destination objects
-        // For now, we pass primitives and let the Python side handle destination lookup.
-        // The full wiring requires the LXMF router's delivery destination for source,
-        // and a recalled/created destination for the recipient.
-        val pyMessage =
-            api.callAttr(
-                "create_lxmf_message",
-                null as Any?, // source_destination — wired in Phase 4
-                null as Any?, // dest_destination — wired in Phase 4
-                content,
-                fields,
-                methodInt,
-                tryPropagationOnFail,
-            )
-
-        return ChaquopyLxmfMessage(pyMessage, api).also {
-            it.desiredMethod = desiredMethod
-            it.tryPropagationOnFail = tryPropagationOnFail
-        }
+        // Phase 4 will resolve destinationHash to live Python Destination objects.
+        // LXMF.LXMessage requires non-null source and destination Destination objects;
+        // passing null would crash the Python constructor immediately.
+        throw UnsupportedOperationException(
+            "LxmfMessageFactory.create() requires live Python Destination objects. " +
+                "This will be wired in Phase 4 when the LXMF router provides source/dest.",
+        )
     }
 }

--- a/app/src/main/java/com/lxmf/messenger/service/rns/ChaquopyLxmfMessageFactory.kt
+++ b/app/src/main/java/com/lxmf/messenger/service/rns/ChaquopyLxmfMessageFactory.kt
@@ -1,0 +1,57 @@
+package com.lxmf.messenger.service.rns
+
+import com.chaquo.python.PyObject
+import com.lxmf.messenger.reticulum.bindings.lxmf.LxmfMessage
+import com.lxmf.messenger.reticulum.bindings.lxmf.LxmfMessageFactory
+import com.lxmf.messenger.reticulum.bindings.rns.RnsIdentity
+import com.lxmf.messenger.reticulum.protocol.DeliveryMethod
+
+/**
+ * Chaquopy implementation of [LxmfMessageFactory].
+ * Calls `rns_api.RnsApi.create_lxmf_message()` which returns a live Python LXMessage.
+ *
+ * Note: This factory needs source/destination as live Python Destination objects.
+ * The full wiring (resolving destinationHash to a Python Destination) happens in Phase 4.
+ *
+ * @param api The live Python `RnsApi` instance
+ */
+class ChaquopyLxmfMessageFactory(
+    private val api: PyObject,
+) : LxmfMessageFactory {
+    override fun create(
+        sourceIdentity: RnsIdentity,
+        destinationHash: ByteArray,
+        content: String,
+        fields: Map<Int, Any>?,
+        desiredMethod: DeliveryMethod,
+        tryPropagationOnFail: Boolean,
+    ): LxmfMessage {
+        // Map DeliveryMethod enum to LXMF Python constants
+        val methodInt =
+            when (desiredMethod) {
+                DeliveryMethod.OPPORTUNISTIC -> 0
+                DeliveryMethod.DIRECT -> 1
+                DeliveryMethod.PROPAGATED -> 2
+            }
+
+        // TODO: Phase 4 — resolve destinationHash to live Python Destination objects
+        // For now, we pass primitives and let the Python side handle destination lookup.
+        // The full wiring requires the LXMF router's delivery destination for source,
+        // and a recalled/created destination for the recipient.
+        val pyMessage =
+            api.callAttr(
+                "create_lxmf_message",
+                null as Any?, // source_destination — wired in Phase 4
+                null as Any?, // dest_destination — wired in Phase 4
+                content,
+                fields,
+                methodInt,
+                tryPropagationOnFail,
+            )
+
+        return ChaquopyLxmfMessage(pyMessage, api).also {
+            it.desiredMethod = desiredMethod
+            it.tryPropagationOnFail = tryPropagationOnFail
+        }
+    }
+}

--- a/app/src/main/java/com/lxmf/messenger/service/rns/ChaquopyLxmfRouter.kt
+++ b/app/src/main/java/com/lxmf/messenger/service/rns/ChaquopyLxmfRouter.kt
@@ -69,35 +69,36 @@ class ChaquopyLxmfRouter(
         val result = api.callAttr("lxmf_get_propagation_state")
         return try {
             val dict = result?.asMap() as? Map<PyObject, PyObject>
-            if (dict != null) {
-                PropagationState(
-                    state =
-                        dict.entries
-                            .find { it.key.toString() == "state" }
-                            ?.value
-                            ?.toInt() ?: 0,
-                    stateName =
-                        dict.entries
-                            .find { it.key.toString() == "state_name" }
-                            ?.value
-                            ?.toString() ?: "idle",
-                    progress =
-                        dict.entries
-                            .find { it.key.toString() == "progress" }
-                            ?.value
-                            ?.toFloat() ?: 0f,
-                    messagesReceived =
-                        dict.entries
-                            .find { it.key.toString() == "messages_received" }
-                            ?.value
-                            ?.toInt() ?: 0,
-                )
-            } else {
-                PropagationState.IDLE
-            }
+            if (dict != null) parsePropagationDict(dict) else PropagationState.IDLE
         } finally {
             result?.close()
         }
+    }
+
+    private fun parsePropagationDict(dict: Map<PyObject, PyObject>): PropagationState {
+        var state = 0
+        var stateName = "idle"
+        var progress = 0f
+        var messagesReceived = 0
+        for ((k, v) in dict) {
+            try {
+                when (k.toString()) {
+                    "state" -> state = v.toInt()
+                    "state_name" -> stateName = v.toString()
+                    "progress" -> progress = v.toFloat()
+                    "messages_received" -> messagesReceived = v.toInt()
+                }
+            } finally {
+                k.close()
+                v.close()
+            }
+        }
+        return PropagationState(
+            state = state,
+            stateName = stateName,
+            progress = progress,
+            messagesReceived = messagesReceived,
+        )
     }
 
     override fun getVersion(): String? {

--- a/app/src/main/java/com/lxmf/messenger/service/rns/ChaquopyLxmfRouter.kt
+++ b/app/src/main/java/com/lxmf/messenger/service/rns/ChaquopyLxmfRouter.kt
@@ -1,0 +1,111 @@
+package com.lxmf.messenger.service.rns
+
+import com.chaquo.python.PyObject
+import com.lxmf.messenger.reticulum.bindings.lxmf.LxmfMessage
+import com.lxmf.messenger.reticulum.bindings.lxmf.LxmfRouter
+import com.lxmf.messenger.reticulum.bindings.rns.RnsIdentity
+import com.lxmf.messenger.reticulum.protocol.PropagationState
+
+/**
+ * Chaquopy implementation of [LxmfRouter].
+ * Wraps `rns_api.RnsApi` LXMF router methods.
+ *
+ * @param api The live Python `RnsApi` instance
+ */
+@Suppress("UNCHECKED_CAST")
+class ChaquopyLxmfRouter(
+    private val api: PyObject,
+) : LxmfRouter {
+    override fun registerDeliveryIdentity(identity: RnsIdentity) {
+        val pyIdentity = (identity as ChaquopyRnsIdentity).pyIdentity
+        api.callAttr("lxmf_register_delivery_identity", pyIdentity)?.close()
+    }
+
+    override fun registerDeliveryCallback(callback: (LxmfMessage) -> Unit) {
+        // TODO: Bridge Python delivery callback to Kotlin in Phase 4
+        // The Python callback receives a raw LXMF.LXMessage which needs wrapping
+    }
+
+    override fun handleOutbound(message: LxmfMessage) {
+        val pyMessage = (message as ChaquopyLxmfMessage).pyMessage
+        api.callAttr("lxmf_handle_outbound", pyMessage)?.close()
+    }
+
+    override fun setOutboundPropagationNode(destinationHash: ByteArray?) {
+        if (destinationHash != null) {
+            api.callAttr("lxmf_set_outbound_propagation_node", destinationHash)?.close()
+        } else {
+            api.callAttr("lxmf_set_outbound_propagation_node", null as Any?)?.close()
+        }
+    }
+
+    override fun getOutboundPropagationNode(): ByteArray? {
+        val result = api.callAttr("lxmf_get_outbound_propagation_node")
+        return try {
+            if (result != null && result.toString() != "None") {
+                result.toJava(ByteArray::class.java)
+            } else {
+                null
+            }
+        } finally {
+            result?.close()
+        }
+    }
+
+    override fun requestMessagesFromPropagationNode(
+        identity: RnsIdentity?,
+        maxMessages: Int,
+    ) {
+        val pyIdentity = (identity as? ChaquopyRnsIdentity)?.pyIdentity
+        api
+            .callAttr(
+                "lxmf_request_messages_from_propagation_node",
+                pyIdentity,
+                maxMessages,
+            )?.close()
+    }
+
+    override fun getPropagationState(): PropagationState {
+        val result = api.callAttr("lxmf_get_propagation_state")
+        return try {
+            val dict = result?.asMap() as? Map<PyObject, PyObject>
+            if (dict != null) {
+                PropagationState(
+                    state =
+                        dict.entries
+                            .find { it.key.toString() == "state" }
+                            ?.value
+                            ?.toInt() ?: 0,
+                    stateName =
+                        dict.entries
+                            .find { it.key.toString() == "state_name" }
+                            ?.value
+                            ?.toString() ?: "idle",
+                    progress =
+                        dict.entries
+                            .find { it.key.toString() == "progress" }
+                            ?.value
+                            ?.toFloat() ?: 0f,
+                    messagesReceived =
+                        dict.entries
+                            .find { it.key.toString() == "messages_received" }
+                            ?.value
+                            ?.toInt() ?: 0,
+                )
+            } else {
+                PropagationState.IDLE
+            }
+        } finally {
+            result?.close()
+        }
+    }
+
+    override fun getVersion(): String? {
+        val result = api.callAttr("lxmf_get_version")
+        return try {
+            result?.toString()
+        } finally {
+            result?.close()
+        }
+    }
+}

--- a/app/src/main/java/com/lxmf/messenger/service/rns/ChaquopyRnsDestination.kt
+++ b/app/src/main/java/com/lxmf/messenger/service/rns/ChaquopyRnsDestination.kt
@@ -80,14 +80,9 @@ class ChaquopyRnsDestination(
         path: String,
         responseGenerator: (path: String, data: ByteArray?, requestId: ByteArray) -> ByteArray?,
     ) {
-        // TODO: Bridge Python request handler callback to Kotlin lambda
-        api
-            .callAttr(
-                "destination_register_request_handler",
-                pyDestination,
-                path,
-                null as Any?, // Will wire callback in Phase 4
-            )?.close()
+        // TODO: Phase 4 — bridge Kotlin responseGenerator lambda to Python callable.
+        // Cannot register yet; RNS validates that response_generator is callable
+        // and raises ValueError for None.
     }
 
     override fun deregisterRequestHandler(path: String) {

--- a/app/src/main/java/com/lxmf/messenger/service/rns/ChaquopyRnsDestination.kt
+++ b/app/src/main/java/com/lxmf/messenger/service/rns/ChaquopyRnsDestination.kt
@@ -1,0 +1,127 @@
+package com.lxmf.messenger.service.rns
+
+import com.chaquo.python.PyObject
+import com.lxmf.messenger.reticulum.bindings.rns.RnsDestination
+import com.lxmf.messenger.reticulum.bindings.rns.RnsIdentity
+import com.lxmf.messenger.reticulum.bindings.rns.RnsLink
+import com.lxmf.messenger.reticulum.model.Destination
+import com.lxmf.messenger.reticulum.model.DestinationType
+import com.lxmf.messenger.reticulum.model.Direction
+
+/**
+ * Chaquopy implementation of [RnsDestination].
+ * Wraps a live Python `RNS.Destination` object.
+ *
+ * @param pyDestination The live Python RNS.Destination object
+ * @param rnsIdentity The [RnsIdentity] that owns this destination
+ * @param api The RnsApi instance for calling helper methods
+ * @param directionValue The [Direction] of this destination
+ * @param typeValue The [DestinationType] of this destination
+ */
+class ChaquopyRnsDestination(
+    internal val pyDestination: PyObject,
+    private val rnsIdentity: RnsIdentity,
+    private val api: PyObject,
+    private val directionValue: Direction,
+    private val typeValue: DestinationType,
+) : RnsDestination,
+    AutoCloseable {
+    override val hash: ByteArray
+        get() {
+            val result = api.callAttr("destination_get_hash", pyDestination)
+            return try {
+                result?.toJava(ByteArray::class.java) ?: ByteArray(0)
+            } finally {
+                result?.close()
+            }
+        }
+
+    override val hexHash: String
+        get() {
+            val result = api.callAttr("destination_get_hex_hash", pyDestination)
+            return try {
+                result?.toString() ?: ""
+            } finally {
+                result?.close()
+            }
+        }
+
+    override val identity: RnsIdentity get() = rnsIdentity
+
+    override val direction: Direction get() = directionValue
+
+    override val type: DestinationType get() = typeValue
+
+    override fun announce(appData: ByteArray?) {
+        if (appData != null) {
+            api.callAttr("destination_announce", pyDestination, appData)?.close()
+        } else {
+            api.callAttr("destination_announce", pyDestination)?.close()
+        }
+    }
+
+    override fun setLinkEstablishedCallback(callback: ((RnsLink) -> Unit)?) {
+        // Callback bridging: Python calls this with a raw Link, we wrap it
+        if (callback != null) {
+            val pyCallback = createLinkCallback(callback)
+            api
+                .callAttr(
+                    "destination_set_link_established_callback",
+                    pyDestination,
+                    pyCallback,
+                )?.close()
+        } else {
+            api
+                .callAttr(
+                    "destination_set_link_established_callback",
+                    pyDestination,
+                    null as Any?,
+                )?.close()
+        }
+    }
+
+    override fun registerRequestHandler(
+        path: String,
+        responseGenerator: (path: String, data: ByteArray?, requestId: ByteArray) -> ByteArray?,
+    ) {
+        // TODO: Bridge Python request handler callback to Kotlin lambda
+        api
+            .callAttr(
+                "destination_register_request_handler",
+                pyDestination,
+                path,
+                null as Any?, // Will wire callback in Phase 4
+            )?.close()
+    }
+
+    override fun deregisterRequestHandler(path: String) {
+        api.callAttr("destination_deregister_request_handler", pyDestination, path)?.close()
+    }
+
+    override fun toSnapshot(): Destination =
+        Destination(
+            hash = hash,
+            hexHash = hexHash,
+            identity = rnsIdentity.toSnapshot(),
+            direction = directionValue,
+            type = typeValue,
+            appName = "", // Not cached — retrieve from Python if needed
+            aspects = emptyList(),
+        )
+
+    /**
+     * Create a Python-callable wrapper that converts a raw Python Link to [RnsLink]
+     * before forwarding to the Kotlin callback.
+     */
+    private fun createLinkCallback(callback: (RnsLink) -> Unit): PyObject {
+        // Use Chaquopy's proxy mechanism — the Python side receives a Java lambda
+        // that wraps the incoming PyObject Link in ChaquopyRnsLink
+        // This is wired in Phase 4 when we have the full callback bridge
+        // For now, return a no-op proxy
+        return api // placeholder — real wiring in Phase 4
+    }
+
+    override fun close() {
+        pyDestination.close()
+    }
+}

--- a/app/src/main/java/com/lxmf/messenger/service/rns/ChaquopyRnsDestination.kt
+++ b/app/src/main/java/com/lxmf/messenger/service/rns/ChaquopyRnsDestination.kt
@@ -113,6 +113,7 @@ class ChaquopyRnsDestination(
      * Create a Python-callable wrapper that converts a raw Python Link to [RnsLink]
      * before forwarding to the Kotlin callback.
      */
+    @Suppress("UnusedParameter") // callback wired in Phase 4
     private fun createLinkCallback(callback: (RnsLink) -> Unit): PyObject {
         // Use Chaquopy's proxy mechanism — the Python side receives a Java lambda
         // that wraps the incoming PyObject Link in ChaquopyRnsLink

--- a/app/src/main/java/com/lxmf/messenger/service/rns/ChaquopyRnsDestination.kt
+++ b/app/src/main/java/com/lxmf/messenger/service/rns/ChaquopyRnsDestination.kt
@@ -61,16 +61,12 @@ class ChaquopyRnsDestination(
     }
 
     override fun setLinkEstablishedCallback(callback: ((RnsLink) -> Unit)?) {
-        // Callback bridging: Python calls this with a raw Link, we wrap it
         if (callback != null) {
-            val pyCallback = createLinkCallback(callback)
-            api
-                .callAttr(
-                    "destination_set_link_established_callback",
-                    pyDestination,
-                    pyCallback,
-                )?.close()
+            // TODO: Phase 4 — bridge Kotlin callback to Python-callable proxy.
+            // Cannot register yet; doing so would pass a non-callable placeholder
+            // that crashes when RNS fires the link-established event.
         } else {
+            // Clear the callback on the Python side
             api
                 .callAttr(
                     "destination_set_link_established_callback",
@@ -108,19 +104,6 @@ class ChaquopyRnsDestination(
             appName = "", // Not cached — retrieve from Python if needed
             aspects = emptyList(),
         )
-
-    /**
-     * Create a Python-callable wrapper that converts a raw Python Link to [RnsLink]
-     * before forwarding to the Kotlin callback.
-     */
-    @Suppress("UnusedParameter") // callback wired in Phase 4
-    private fun createLinkCallback(callback: (RnsLink) -> Unit): PyObject {
-        // Use Chaquopy's proxy mechanism — the Python side receives a Java lambda
-        // that wraps the incoming PyObject Link in ChaquopyRnsLink
-        // This is wired in Phase 4 when we have the full callback bridge
-        // For now, return a no-op proxy
-        return api // placeholder — real wiring in Phase 4
-    }
 
     override fun close() {
         pyDestination.close()

--- a/app/src/main/java/com/lxmf/messenger/service/rns/ChaquopyRnsDestinationProvider.kt
+++ b/app/src/main/java/com/lxmf/messenger/service/rns/ChaquopyRnsDestinationProvider.kt
@@ -45,14 +45,18 @@ class ChaquopyRnsDestinationProvider(
                 .callAttr("list", aspects.toList().toTypedArray())
 
         val pyDestination =
-            api.callAttr(
-                "create_destination",
-                pyIdentity,
-                directionInt,
-                typeInt,
-                appName,
-                pyAspects,
-            )
+            try {
+                api.callAttr(
+                    "create_destination",
+                    pyIdentity,
+                    directionInt,
+                    typeInt,
+                    appName,
+                    pyAspects,
+                )
+            } finally {
+                pyAspects.close()
+            }
         return ChaquopyRnsDestination(
             pyDestination = pyDestination,
             rnsIdentity = identity,

--- a/app/src/main/java/com/lxmf/messenger/service/rns/ChaquopyRnsDestinationProvider.kt
+++ b/app/src/main/java/com/lxmf/messenger/service/rns/ChaquopyRnsDestinationProvider.kt
@@ -27,15 +27,15 @@ class ChaquopyRnsDestinationProvider(
         val pyIdentity = (identity as ChaquopyRnsIdentity).pyIdentity
         val directionInt =
             when (direction) {
-                Direction.IN -> 1 // RNS.Destination.IN
-                Direction.OUT -> 2 // RNS.Destination.OUT
+                Direction.IN -> 0x11 // RNS.Destination.IN (17)
+                Direction.OUT -> 0x12 // RNS.Destination.OUT (18)
             }
         val typeInt =
             when (type) {
-                DestinationType.SINGLE -> 1
-                DestinationType.GROUP -> 2
-                DestinationType.PLAIN -> 3
-                DestinationType.LINK -> 4
+                DestinationType.SINGLE -> 0 // RNS.Destination.SINGLE
+                DestinationType.GROUP -> 1 // RNS.Destination.GROUP
+                DestinationType.PLAIN -> 2 // RNS.Destination.PLAIN
+                DestinationType.LINK -> 3 // RNS.Destination.LINK
             }
         // Convert Kotlin vararg to Python list
         val pyAspects =

--- a/app/src/main/java/com/lxmf/messenger/service/rns/ChaquopyRnsDestinationProvider.kt
+++ b/app/src/main/java/com/lxmf/messenger/service/rns/ChaquopyRnsDestinationProvider.kt
@@ -1,0 +1,64 @@
+package com.lxmf.messenger.service.rns
+
+import com.chaquo.python.PyObject
+import com.chaquo.python.Python
+import com.lxmf.messenger.reticulum.bindings.rns.RnsDestination
+import com.lxmf.messenger.reticulum.bindings.rns.RnsDestinationProvider
+import com.lxmf.messenger.reticulum.bindings.rns.RnsIdentity
+import com.lxmf.messenger.reticulum.model.DestinationType
+import com.lxmf.messenger.reticulum.model.Direction
+
+/**
+ * Chaquopy implementation of [RnsDestinationProvider].
+ * Calls `rns_api.RnsApi.create_destination()` which returns a live Python Destination.
+ *
+ * @param api The live Python `RnsApi` instance
+ */
+class ChaquopyRnsDestinationProvider(
+    private val api: PyObject,
+) : RnsDestinationProvider {
+    override fun create(
+        identity: RnsIdentity,
+        direction: Direction,
+        type: DestinationType,
+        appName: String,
+        vararg aspects: String,
+    ): RnsDestination {
+        val pyIdentity = (identity as ChaquopyRnsIdentity).pyIdentity
+        val directionInt =
+            when (direction) {
+                Direction.IN -> 1 // RNS.Destination.IN
+                Direction.OUT -> 2 // RNS.Destination.OUT
+            }
+        val typeInt =
+            when (type) {
+                DestinationType.SINGLE -> 1
+                DestinationType.GROUP -> 2
+                DestinationType.PLAIN -> 3
+                DestinationType.LINK -> 4
+            }
+        // Convert Kotlin vararg to Python list
+        val pyAspects =
+            Python
+                .getInstance()
+                .builtins
+                .callAttr("list", aspects.toList().toTypedArray())
+
+        val pyDestination =
+            api.callAttr(
+                "create_destination",
+                pyIdentity,
+                directionInt,
+                typeInt,
+                appName,
+                pyAspects,
+            )
+        return ChaquopyRnsDestination(
+            pyDestination = pyDestination,
+            rnsIdentity = identity,
+            api = api,
+            directionValue = direction,
+            typeValue = type,
+        )
+    }
+}

--- a/app/src/main/java/com/lxmf/messenger/service/rns/ChaquopyRnsIdentity.kt
+++ b/app/src/main/java/com/lxmf/messenger/service/rns/ChaquopyRnsIdentity.kt
@@ -1,0 +1,106 @@
+package com.lxmf.messenger.service.rns
+
+import com.chaquo.python.PyObject
+import com.lxmf.messenger.reticulum.bindings.rns.RnsIdentity
+import com.lxmf.messenger.reticulum.model.Identity
+
+/**
+ * Chaquopy implementation of [RnsIdentity].
+ * Wraps a live Python `RNS.Identity` object, calling methods via `rns_api` static helpers.
+ *
+ * @param pyIdentity The live Python RNS.Identity object
+ * @param api The RnsApi instance for calling static helper methods
+ */
+class ChaquopyRnsIdentity(
+    internal val pyIdentity: PyObject,
+    private val api: PyObject,
+) : RnsIdentity,
+    AutoCloseable {
+    override val hash: ByteArray
+        get() {
+            val result = api.callAttr("identity_get_hash", pyIdentity)
+            return try {
+                result?.toJava(ByteArray::class.java) ?: ByteArray(0)
+            } finally {
+                result?.close()
+            }
+        }
+
+    override val hexHash: String
+        get() {
+            val result = api.callAttr("identity_get_hex_hash", pyIdentity)
+            return try {
+                result?.toString() ?: ""
+            } finally {
+                result?.close()
+            }
+        }
+
+    override fun getPublicKey(): ByteArray {
+        val result = api.callAttr("identity_get_public_key", pyIdentity)
+        return try {
+            result?.toJava(ByteArray::class.java) ?: ByteArray(0)
+        } finally {
+            result?.close()
+        }
+    }
+
+    override fun getPrivateKey(): ByteArray? {
+        val result = api.callAttr("identity_get_private_key", pyIdentity)
+        return try {
+            result?.toJava(ByteArray::class.java)
+        } finally {
+            result?.close()
+        }
+    }
+
+    override fun sign(message: ByteArray): ByteArray {
+        val result = api.callAttr("identity_sign", pyIdentity, message)
+        return try {
+            result?.toJava(ByteArray::class.java) ?: ByteArray(0)
+        } finally {
+            result?.close()
+        }
+    }
+
+    override fun validate(
+        signature: ByteArray,
+        message: ByteArray,
+    ): Boolean {
+        val result = api.callAttr("identity_validate", pyIdentity, signature, message)
+        return try {
+            result?.toBoolean() ?: false
+        } finally {
+            result?.close()
+        }
+    }
+
+    override fun encrypt(plaintext: ByteArray): ByteArray {
+        val result = api.callAttr("identity_encrypt", pyIdentity, plaintext)
+        return try {
+            result?.toJava(ByteArray::class.java) ?: ByteArray(0)
+        } finally {
+            result?.close()
+        }
+    }
+
+    override fun decrypt(ciphertext: ByteArray): ByteArray? {
+        val result = api.callAttr("identity_decrypt", pyIdentity, ciphertext)
+        return try {
+            result?.toJava(ByteArray::class.java)
+        } finally {
+            result?.close()
+        }
+    }
+
+    override fun toSnapshot(): Identity =
+        Identity(
+            hash = hash,
+            publicKey = getPublicKey(),
+            privateKey = getPrivateKey(),
+        )
+
+    override fun close() {
+        pyIdentity.close()
+    }
+}

--- a/app/src/main/java/com/lxmf/messenger/service/rns/ChaquopyRnsIdentityProvider.kt
+++ b/app/src/main/java/com/lxmf/messenger/service/rns/ChaquopyRnsIdentityProvider.kt
@@ -1,0 +1,71 @@
+package com.lxmf.messenger.service.rns
+
+import com.chaquo.python.PyObject
+import com.lxmf.messenger.reticulum.bindings.rns.RnsIdentity
+import com.lxmf.messenger.reticulum.bindings.rns.RnsIdentityProvider
+
+/**
+ * Chaquopy implementation of [RnsIdentityProvider].
+ * Calls `rns_api.RnsApi` factory methods that return live Python Identity objects.
+ *
+ * @param api The live Python `RnsApi` instance
+ */
+class ChaquopyRnsIdentityProvider(
+    private val api: PyObject,
+) : RnsIdentityProvider {
+    override fun create(): RnsIdentity {
+        val pyIdentity = api.callAttr("create_identity")
+        return ChaquopyRnsIdentity(pyIdentity, api)
+    }
+
+    override fun load(path: String): RnsIdentity {
+        val pyIdentity = api.callAttr("load_identity", path)
+        return ChaquopyRnsIdentity(pyIdentity, api)
+    }
+
+    override fun fromBytes(privateKeyBytes: ByteArray): RnsIdentity {
+        val pyIdentity = api.callAttr("identity_from_bytes", privateKeyBytes)
+        return ChaquopyRnsIdentity(pyIdentity, api)
+    }
+
+    override fun recall(destinationHash: ByteArray): RnsIdentity? {
+        val pyIdentity = api.callAttr("recall_identity", destinationHash)
+        return if (pyIdentity != null && pyIdentity.toString() != "None") {
+            ChaquopyRnsIdentity(pyIdentity, api)
+        } else {
+            pyIdentity?.close()
+            null
+        }
+    }
+
+    override fun recallAppData(destinationHash: ByteArray): ByteArray? {
+        val result = api.callAttr("recall_app_data", destinationHash)
+        return try {
+            if (result != null && result.toString() != "None") {
+                result.toJava(ByteArray::class.java)
+            } else {
+                null
+            }
+        } finally {
+            result?.close()
+        }
+    }
+
+    override fun fullHash(data: ByteArray): ByteArray {
+        val result = api.callAttr("full_hash", data)
+        return try {
+            result?.toJava(ByteArray::class.java) ?: ByteArray(0)
+        } finally {
+            result?.close()
+        }
+    }
+
+    override fun truncatedHash(data: ByteArray): ByteArray {
+        val result = api.callAttr("truncated_hash", data)
+        return try {
+            result?.toJava(ByteArray::class.java) ?: ByteArray(0)
+        } finally {
+            result?.close()
+        }
+    }
+}

--- a/app/src/main/java/com/lxmf/messenger/service/rns/ChaquopyRnsLink.kt
+++ b/app/src/main/java/com/lxmf/messenger/service/rns/ChaquopyRnsLink.kt
@@ -160,13 +160,19 @@ class ChaquopyRnsLink(
     }
 
     override fun setClosedCallback(callback: ((RnsLink) -> Unit)?) {
-        // TODO: Bridge Python callback to Kotlin in Phase 4
-        api.callAttr("link_set_closed_callback", pyLink, null as Any?)?.close()
+        if (callback != null) {
+            // TODO: Phase 4 — bridge Kotlin callback to Python-callable proxy.
+        } else {
+            api.callAttr("link_set_closed_callback", pyLink, null as Any?)?.close()
+        }
     }
 
     override fun setPacketCallback(callback: ((ByteArray, RnsLink) -> Unit)?) {
-        // TODO: Bridge Python callback to Kotlin in Phase 4
-        api.callAttr("link_set_packet_callback", pyLink, null as Any?)?.close()
+        if (callback != null) {
+            // TODO: Phase 4 — bridge Kotlin callback to Python-callable proxy.
+        } else {
+            api.callAttr("link_set_packet_callback", pyLink, null as Any?)?.close()
+        }
     }
 
     override fun close() {

--- a/app/src/main/java/com/lxmf/messenger/service/rns/ChaquopyRnsLink.kt
+++ b/app/src/main/java/com/lxmf/messenger/service/rns/ChaquopyRnsLink.kt
@@ -1,0 +1,175 @@
+package com.lxmf.messenger.service.rns
+
+import com.chaquo.python.PyObject
+import com.lxmf.messenger.reticulum.bindings.rns.RnsDestination
+import com.lxmf.messenger.reticulum.bindings.rns.RnsIdentity
+import com.lxmf.messenger.reticulum.bindings.rns.RnsLink
+import com.lxmf.messenger.reticulum.model.LinkStatus
+
+/**
+ * Chaquopy implementation of [RnsLink].
+ * Wraps a live Python `RNS.Link` object.
+ *
+ * @param pyLink The live Python RNS.Link object
+ * @param api The RnsApi instance for calling helper methods
+ */
+class ChaquopyRnsLink(
+    internal val pyLink: PyObject,
+    private val api: PyObject,
+) : RnsLink,
+    AutoCloseable {
+    override val linkId: ByteArray
+        get() {
+            val result = api.callAttr("link_get_id", pyLink)
+            return try {
+                result?.toJava(ByteArray::class.java) ?: ByteArray(0)
+            } finally {
+                result?.close()
+            }
+        }
+
+    override val status: LinkStatus
+        get() {
+            val result = api.callAttr("link_get_status", pyLink)
+            return try {
+                when (result?.toInt()) {
+                    0x00 -> LinkStatus.PENDING // RNS PENDING
+                    0x01 -> LinkStatus.ACTIVE // RNS ACTIVE
+                    0x02 -> LinkStatus.STALE // RNS STALE
+                    0x04 -> LinkStatus.CLOSED // RNS CLOSED
+                    else -> LinkStatus.CLOSED
+                }
+            } finally {
+                result?.close()
+            }
+        }
+
+    override val destination: RnsDestination?
+        get() = null // Destination tracking deferred to Phase 4
+
+    override val isInitiator: Boolean
+        get() {
+            val result = api.callAttr("link_get_is_initiator", pyLink)
+            return try {
+                result?.toBoolean() ?: false
+            } finally {
+                result?.close()
+            }
+        }
+
+    override val mtu: Int
+        get() {
+            val result = api.callAttr("link_get_mtu", pyLink)
+            return try {
+                result?.toInt() ?: 0
+            } finally {
+                result?.close()
+            }
+        }
+
+    override val rtt: Long?
+        get() {
+            val result = api.callAttr("link_get_rtt", pyLink)
+            return try {
+                if (result != null && result.toString() != "None") {
+                    // Python returns RTT in seconds as float, convert to millis
+                    (result.toDouble() * 1000).toLong()
+                } else {
+                    null
+                }
+            } finally {
+                result?.close()
+            }
+        }
+
+    override fun send(data: ByteArray): Boolean {
+        val result = api.callAttr("link_send", pyLink, data)
+        return try {
+            result?.toBoolean() ?: false
+        } finally {
+            result?.close()
+        }
+    }
+
+    override fun teardown(reason: Int) {
+        api.callAttr("link_teardown", pyLink, reason)?.close()
+    }
+
+    override fun identify(identity: RnsIdentity): Boolean {
+        val pyIdentity = (identity as ChaquopyRnsIdentity).pyIdentity
+        val result = api.callAttr("link_identify", pyLink, pyIdentity)
+        return try {
+            result?.toBoolean() ?: false
+        } finally {
+            result?.close()
+        }
+    }
+
+    override fun getRemoteIdentity(): RnsIdentity? {
+        val pyIdentity = api.callAttr("link_get_remote_identity", pyLink)
+        return if (pyIdentity != null && pyIdentity.toString() != "None") {
+            ChaquopyRnsIdentity(pyIdentity, api)
+        } else {
+            pyIdentity?.close()
+            null
+        }
+    }
+
+    override fun getEstablishmentRate(): Long? {
+        val result = api.callAttr("link_get_establishment_rate", pyLink)
+        return try {
+            if (result != null && result.toString() != "None") {
+                result.toLong()
+            } else {
+                null
+            }
+        } finally {
+            result?.close()
+        }
+    }
+
+    override fun getExpectedRate(): Long? {
+        val result = api.callAttr("link_get_expected_rate", pyLink)
+        return try {
+            if (result != null && result.toString() != "None") {
+                result.toLong()
+            } else {
+                null
+            }
+        } finally {
+            result?.close()
+        }
+    }
+
+    override fun encrypt(plaintext: ByteArray): ByteArray {
+        val result = api.callAttr("link_encrypt", pyLink, plaintext)
+        return try {
+            result?.toJava(ByteArray::class.java) ?: ByteArray(0)
+        } finally {
+            result?.close()
+        }
+    }
+
+    override fun decrypt(ciphertext: ByteArray): ByteArray? {
+        val result = api.callAttr("link_decrypt", pyLink, ciphertext)
+        return try {
+            result?.toJava(ByteArray::class.java)
+        } finally {
+            result?.close()
+        }
+    }
+
+    override fun setClosedCallback(callback: ((RnsLink) -> Unit)?) {
+        // TODO: Bridge Python callback to Kotlin in Phase 4
+        api.callAttr("link_set_closed_callback", pyLink, null as Any?)?.close()
+    }
+
+    override fun setPacketCallback(callback: ((ByteArray, RnsLink) -> Unit)?) {
+        // TODO: Bridge Python callback to Kotlin in Phase 4
+        api.callAttr("link_set_packet_callback", pyLink, null as Any?)?.close()
+    }
+
+    override fun close() {
+        pyLink.close()
+    }
+}

--- a/app/src/main/java/com/lxmf/messenger/service/rns/ChaquopyRnsLinkProvider.kt
+++ b/app/src/main/java/com/lxmf/messenger/service/rns/ChaquopyRnsLinkProvider.kt
@@ -1,0 +1,27 @@
+package com.lxmf.messenger.service.rns
+
+import com.chaquo.python.PyObject
+import com.lxmf.messenger.reticulum.bindings.rns.RnsDestination
+import com.lxmf.messenger.reticulum.bindings.rns.RnsLink
+import com.lxmf.messenger.reticulum.bindings.rns.RnsLinkProvider
+
+/**
+ * Chaquopy implementation of [RnsLinkProvider].
+ * Calls `rns_api.RnsApi.create_link()` which returns a live Python Link.
+ *
+ * @param api The live Python `RnsApi` instance
+ */
+class ChaquopyRnsLinkProvider(
+    private val api: PyObject,
+) : RnsLinkProvider {
+    override fun create(
+        destination: RnsDestination,
+        establishedCallback: ((RnsLink) -> Unit)?,
+        closedCallback: ((RnsLink) -> Unit)?,
+    ): RnsLink {
+        val pyDestination = (destination as ChaquopyRnsDestination).pyDestination
+        // TODO: Bridge callbacks in Phase 4 — for now pass null
+        val pyLink = api.callAttr("create_link", pyDestination)
+        return ChaquopyRnsLink(pyLink, api)
+    }
+}

--- a/app/src/main/java/com/lxmf/messenger/service/rns/ChaquopyRnsReticulum.kt
+++ b/app/src/main/java/com/lxmf/messenger/service/rns/ChaquopyRnsReticulum.kt
@@ -1,0 +1,70 @@
+package com.lxmf.messenger.service.rns
+
+import com.chaquo.python.PyObject
+import com.lxmf.messenger.reticulum.bindings.rns.RnsReticulum
+
+/**
+ * Chaquopy implementation of [RnsReticulum].
+ * Wraps `rns_api.RnsApi` lifecycle methods.
+ *
+ * @param api The live Python `RnsApi` instance
+ */
+class ChaquopyRnsReticulum(
+    private val api: PyObject,
+) : RnsReticulum,
+    AutoCloseable {
+    @Volatile
+    var shuttingDown = false
+
+    override fun start(
+        configDir: String,
+        enableTransport: Boolean,
+    ): Boolean {
+        if (shuttingDown) return false
+        val result = api.callAttr("start", configDir, enableTransport)
+        return try {
+            result?.toBoolean() ?: false
+        } finally {
+            result?.close()
+        }
+    }
+
+    override fun stop() {
+        shuttingDown = true
+        runCatching { api.callAttr("stop")?.close() }
+    }
+
+    override fun isStarted(): Boolean {
+        if (shuttingDown) return false
+        val result = api.callAttr("is_started")
+        return try {
+            result?.toBoolean() ?: false
+        } finally {
+            result?.close()
+        }
+    }
+
+    override fun isTransportEnabled(): Boolean {
+        if (shuttingDown) return false
+        val result = api.callAttr("is_transport_enabled")
+        return try {
+            result?.toBoolean() ?: false
+        } finally {
+            result?.close()
+        }
+    }
+
+    override fun getVersion(): String? {
+        if (shuttingDown) return null
+        val result = api.callAttr("get_rns_version")
+        return try {
+            result?.toString()
+        } finally {
+            result?.close()
+        }
+    }
+
+    override fun close() {
+        shuttingDown = true
+    }
+}

--- a/app/src/main/java/com/lxmf/messenger/service/rns/ChaquopyRnsTransport.kt
+++ b/app/src/main/java/com/lxmf/messenger/service/rns/ChaquopyRnsTransport.kt
@@ -1,0 +1,115 @@
+package com.lxmf.messenger.service.rns
+
+import com.chaquo.python.PyObject
+import com.lxmf.messenger.reticulum.bindings.rns.RnsAnnounceHandler
+import com.lxmf.messenger.reticulum.bindings.rns.RnsDestination
+import com.lxmf.messenger.reticulum.bindings.rns.RnsIdentity
+import com.lxmf.messenger.reticulum.bindings.rns.RnsInterfaceInfo
+import com.lxmf.messenger.reticulum.bindings.rns.RnsTransport
+
+/**
+ * Chaquopy implementation of [RnsTransport].
+ * Wraps `rns_api.RnsApi` transport-level methods (path, announce, interface management).
+ *
+ * @param api The live Python `RnsApi` instance
+ */
+class ChaquopyRnsTransport(
+    private val api: PyObject,
+) : RnsTransport {
+    override val identity: RnsIdentity?
+        get() = null // Transport identity managed at higher level
+
+    override val transportEnabled: Boolean
+        get() {
+            val result = api.callAttr("is_transport_enabled")
+            return try {
+                result?.toBoolean() ?: false
+            } finally {
+                result?.close()
+            }
+        }
+
+    override fun registerDestination(destination: RnsDestination) {
+        val pyDest = (destination as ChaquopyRnsDestination).pyDestination
+        api.callAttr("transport_register_destination", pyDest)?.close()
+    }
+
+    override fun deregisterDestination(destination: RnsDestination) {
+        val pyDest = (destination as ChaquopyRnsDestination).pyDestination
+        api.callAttr("transport_deregister_destination", pyDest)?.close()
+    }
+
+    override fun registerAnnounceHandler(handler: RnsAnnounceHandler) {
+        // TODO: Bridge Kotlin AnnounceHandler to Python handler in Phase 4
+    }
+
+    override fun deregisterAnnounceHandler(handler: RnsAnnounceHandler) {
+        // TODO: Bridge in Phase 4
+    }
+
+    override fun hasPath(destinationHash: ByteArray): Boolean {
+        val result = api.callAttr("transport_has_path", destinationHash)
+        return try {
+            result?.toBoolean() ?: false
+        } finally {
+            result?.close()
+        }
+    }
+
+    override fun requestPath(destinationHash: ByteArray) {
+        api.callAttr("transport_request_path", destinationHash)?.close()
+    }
+
+    override fun hopsTo(destinationHash: ByteArray): Int {
+        val result = api.callAttr("transport_hops_to", destinationHash)
+        return try {
+            result?.toInt() ?: -1
+        } finally {
+            result?.close()
+        }
+    }
+
+    @Suppress("UNCHECKED_CAST")
+    override fun getInterfaces(): List<RnsInterfaceInfo> {
+        val result = api.callAttr("transport_get_interfaces")
+        return try {
+            val pyList = result?.asList() ?: return emptyList()
+            pyList.map { item ->
+                val dict = item.asMap() as Map<PyObject, PyObject>
+                RnsInterfaceInfo(
+                    name =
+                        dict.entries
+                            .find { it.key.toString() == "name" }
+                            ?.value
+                            ?.toString() ?: "",
+                    online =
+                        dict.entries
+                            .find { it.key.toString() == "online" }
+                            ?.value
+                            ?.toBoolean() ?: false,
+                    type =
+                        dict.entries
+                            .find { it.key.toString() == "type" }
+                            ?.value
+                            ?.toString() ?: "",
+                    rxBytes =
+                        dict.entries
+                            .find { it.key.toString() == "rxb" }
+                            ?.value
+                            ?.toLong() ?: 0L,
+                    txBytes =
+                        dict.entries
+                            .find { it.key.toString() == "txb" }
+                            ?.value
+                            ?.toLong() ?: 0L,
+                )
+            }
+        } finally {
+            result?.close()
+        }
+    }
+
+    override fun persistData() {
+        api.callAttr("transport_persist_data")?.close()
+    }
+}

--- a/app/src/main/java/com/lxmf/messenger/service/rns/ChaquopyRnsTransport.kt
+++ b/app/src/main/java/com/lxmf/messenger/service/rns/ChaquopyRnsTransport.kt
@@ -76,33 +76,41 @@ class ChaquopyRnsTransport(
             val pyList = result?.asList() ?: return emptyList()
             pyList.map { item ->
                 val dict = item.asMap() as Map<PyObject, PyObject>
-                RnsInterfaceInfo(
-                    name =
-                        dict.entries
-                            .find { it.key.toString() == "name" }
-                            ?.value
-                            ?.toString() ?: "",
-                    online =
-                        dict.entries
-                            .find { it.key.toString() == "online" }
-                            ?.value
-                            ?.toBoolean() ?: false,
-                    type =
-                        dict.entries
-                            .find { it.key.toString() == "type" }
-                            ?.value
-                            ?.toString() ?: "",
-                    rxBytes =
-                        dict.entries
-                            .find { it.key.toString() == "rxb" }
-                            ?.value
-                            ?.toLong() ?: 0L,
-                    txBytes =
-                        dict.entries
-                            .find { it.key.toString() == "txb" }
-                            ?.value
-                            ?.toLong() ?: 0L,
-                )
+                try {
+                    RnsInterfaceInfo(
+                        name =
+                            dict.entries
+                                .find { it.key.toString() == "name" }
+                                ?.value
+                                ?.toString() ?: "",
+                        online =
+                            dict.entries
+                                .find { it.key.toString() == "online" }
+                                ?.value
+                                ?.toBoolean() ?: false,
+                        type =
+                            dict.entries
+                                .find { it.key.toString() == "type" }
+                                ?.value
+                                ?.toString() ?: "",
+                        rxBytes =
+                            dict.entries
+                                .find { it.key.toString() == "rxb" }
+                                ?.value
+                                ?.toLong() ?: 0L,
+                        txBytes =
+                            dict.entries
+                                .find { it.key.toString() == "txb" }
+                                ?.value
+                                ?.toLong() ?: 0L,
+                    )
+                } finally {
+                    // Close all PyObject keys and values from the dict view
+                    for ((k, v) in dict) {
+                        k.close()
+                        v.close()
+                    }
+                }
             }
         } finally {
             result?.close()

--- a/python/rns_api.py
+++ b/python/rns_api.py
@@ -1,20 +1,363 @@
 # rns_api.py — Thin pass-through to RNS/LXMF. NO business logic.
 #
-# Strangler Fig Phase 0: This is the seed file for migrating away from
-# reticulum_wrapper.py. All new Python-facing functionality goes here
-# as thin pass-throughs. Business logic goes in Kotlin.
+# Strangler Fig: This module gives Kotlin (via Chaquopy) a stable, narrow
+# surface to call into. Every method receives primitives and returns either
+# a raw Python object (for live-object interfaces like Identity, Destination,
+# Link, LXMessage) or a dict/primitive.
+#
+# NO BUSINESS LOGIC HERE. If you're tempted to add a conditional or loop,
+# it belongs in a Kotlin manager.
+#
+# Loaded alongside reticulum_wrapper.py — never modify the wrapper.
+
+import RNS
+import LXMF
+import logging
+import traceback
+
 from interface_lookup import format_interface_name
 from logging_utils import log_debug
 
+log = logging.getLogger("rns_api")
+
 
 class RnsApi:
+    """Thin Python bridge for Kotlin binding interfaces."""
+
     def __init__(self):
-        pass
+        self.reticulum = None
+        self.lxmf_router = None
+
+    # ─── RnsReticulum ─────────────────────────────────────────────
+
+    def start(self, config_dir, enable_transport=False):
+        """Start Reticulum. Returns True on success."""
+        try:
+            self.reticulum = RNS.Reticulum(
+                configdir=config_dir,
+                loglevel=RNS.LOG_DEBUG,
+            )
+            if enable_transport:
+                RNS.Transport.start()
+            return True
+        except Exception:
+            log.error("Failed to start Reticulum: %s", traceback.format_exc())
+            return False
+
+    def stop(self):
+        """Shutdown Reticulum."""
+        try:
+            if self.reticulum:
+                RNS.Transport.exit_handler()
+                RNS.Reticulum.exit_handler(self.reticulum)
+                self.reticulum = None
+        except Exception:
+            log.error("Error during shutdown: %s", traceback.format_exc())
+
+    def is_started(self):
+        return self.reticulum is not None
+
+    def is_transport_enabled(self):
+        try:
+            return RNS.Transport.transport_enabled() if self.reticulum else False
+        except Exception:
+            return False
+
+    def get_rns_version(self):
+        try:
+            return RNS.__version__
+        except Exception:
+            return None
+
+    # ─── RnsIdentityProvider ──────────────────────────────────────
+
+    def create_identity(self):
+        """Create a new identity. Returns live RNS.Identity object."""
+        return RNS.Identity()
+
+    def load_identity(self, path):
+        """Load identity from file. Returns live RNS.Identity object."""
+        return RNS.Identity.from_file(path)
+
+    def identity_from_bytes(self, private_key_bytes):
+        """Create identity from private key bytes. Returns live RNS.Identity object."""
+        identity = RNS.Identity(create_keys=False)
+        identity.load_private_key(bytes(private_key_bytes))
+        return identity
+
+    def recall_identity(self, dest_hash_bytes):
+        """Recall a known identity by destination hash. Returns live object or None."""
+        return RNS.Identity.recall(bytes(dest_hash_bytes))
+
+    def recall_app_data(self, dest_hash_bytes):
+        """Recall app data for a destination hash. Returns bytes or None."""
+        return RNS.Identity.recall_app_data(bytes(dest_hash_bytes))
+
+    def full_hash(self, data):
+        """Compute full SHA-256 hash. Returns bytes."""
+        return RNS.Identity.full_hash(bytes(data))
+
+    def truncated_hash(self, data):
+        """Compute truncated hash (16 bytes). Returns bytes."""
+        return RNS.Identity.truncated_hash(bytes(data))
+
+    # ─── RnsIdentity (live object methods) ────────────────────────
+
+    @staticmethod
+    def identity_get_hash(identity):
+        """Get identity hash bytes."""
+        return identity.hash
+
+    @staticmethod
+    def identity_get_hex_hash(identity):
+        """Get identity hex hash string."""
+        return identity.hexhash
+
+    @staticmethod
+    def identity_get_public_key(identity):
+        """Get public key bytes."""
+        return identity.get_public_key()
+
+    @staticmethod
+    def identity_get_private_key(identity):
+        """Get private key bytes, or None if public-only."""
+        try:
+            return identity.get_private_key()
+        except Exception:
+            return None
+
+    @staticmethod
+    def identity_sign(identity, message):
+        """Sign a message. Returns signature bytes."""
+        return identity.sign(bytes(message))
+
+    @staticmethod
+    def identity_validate(identity, signature, message):
+        """Validate a signature. Returns bool."""
+        return identity.validate(bytes(signature), bytes(message))
+
+    @staticmethod
+    def identity_encrypt(identity, plaintext):
+        """Encrypt with identity's public key. Returns ciphertext bytes."""
+        return identity.encrypt(bytes(plaintext))
+
+    @staticmethod
+    def identity_decrypt(identity, ciphertext):
+        """Decrypt with identity's private key. Returns plaintext bytes or None."""
+        try:
+            return identity.decrypt(bytes(ciphertext))
+        except Exception:
+            return None
+
+    # ─── RnsDestinationProvider ───────────────────────────────────
+
+    def create_destination(self, identity, direction, dest_type, app_name, aspects):
+        """Create a destination. Returns live RNS.Destination object.
+
+        Args:
+            identity: Live RNS.Identity object
+            direction: int (RNS.Destination.IN=1 or RNS.Destination.OUT=2)
+            dest_type: int (SINGLE=1, GROUP=2, PLAIN=3, LINK=4)
+            app_name: str
+            aspects: list of str
+        """
+        return RNS.Destination(
+            identity,
+            direction,
+            dest_type,
+            app_name,
+            *aspects,
+        )
+
+    # ─── RnsDestination (live object methods) ─────────────────────
+
+    @staticmethod
+    def destination_get_hash(destination):
+        return destination.hash
+
+    @staticmethod
+    def destination_get_hex_hash(destination):
+        return destination.hexhash
+
+    @staticmethod
+    def destination_announce(destination, app_data=None):
+        """Announce this destination on the network."""
+        if app_data is not None:
+            destination.announce(app_data=bytes(app_data))
+        else:
+            destination.announce()
+
+    @staticmethod
+    def destination_set_link_established_callback(destination, callback):
+        """Set link established callback. callback receives a raw Link object."""
+        destination.set_link_established_callback(callback)
+
+    @staticmethod
+    def destination_register_request_handler(destination, path, response_generator):
+        """Register a request handler on the destination."""
+        destination.register_request_handler(
+            path,
+            response_generator=response_generator,
+            allow=RNS.Destination.ALLOW_ALL,
+        )
+
+    @staticmethod
+    def destination_deregister_request_handler(destination, path):
+        destination.deregister_request_handler(path)
+
+    # ─── RnsLinkProvider ──────────────────────────────────────────
+
+    @staticmethod
+    def create_link(destination, established_callback=None, closed_callback=None):
+        """Create a link to a destination. Returns live RNS.Link object."""
+        link = RNS.Link(destination)
+        if established_callback:
+            link.set_link_established_callback(established_callback)
+        if closed_callback:
+            link.set_link_closed_callback(closed_callback)
+        return link
+
+    # ─── RnsLink (live object methods) ────────────────────────────
+
+    @staticmethod
+    def link_get_id(link):
+        return link.link_id
+
+    @staticmethod
+    def link_get_status(link):
+        """Returns int status: 0=PENDING, 1=ACTIVE, 2=STALE, 4=CLOSED."""
+        return link.status
+
+    @staticmethod
+    def link_get_mtu(link):
+        return link.MDU  # Maximum Data Unit
+
+    @staticmethod
+    def link_get_rtt(link):
+        """Returns RTT in seconds (float), or None."""
+        return link.rtt
+
+    @staticmethod
+    def link_get_is_initiator(link):
+        return link.initiator
+
+    @staticmethod
+    def link_send(link, data):
+        """Send data over link. Returns True on success."""
+        try:
+            packet = RNS.Packet(link, bytes(data))
+            receipt = packet.send()
+            return receipt is not None
+        except Exception:
+            return False
+
+    @staticmethod
+    def link_teardown(link, reason=0):
+        link.teardown()
+
+    @staticmethod
+    def link_identify(link, identity):
+        """Identify on this link. Returns True on success."""
+        try:
+            link.identify(identity)
+            return True
+        except Exception:
+            return False
+
+    @staticmethod
+    def link_get_remote_identity(link):
+        """Get remote peer's identity. Returns live Identity or None."""
+        return link.get_remote_identity()
+
+    @staticmethod
+    def link_get_establishment_rate(link):
+        """Returns establishment rate in bits/sec, or None."""
+        try:
+            return link.get_establishment_rate()
+        except Exception:
+            return None
+
+    @staticmethod
+    def link_get_expected_rate(link):
+        """Returns expected throughput in bits/sec, or None."""
+        try:
+            return link.get_expected_rate()
+        except Exception:
+            return None
+
+    @staticmethod
+    def link_encrypt(link, plaintext):
+        return link.encrypt(bytes(plaintext))
+
+    @staticmethod
+    def link_decrypt(link, ciphertext):
+        try:
+            return link.decrypt(bytes(ciphertext))
+        except Exception:
+            return None
+
+    @staticmethod
+    def link_set_closed_callback(link, callback):
+        link.set_link_closed_callback(callback)
+
+    @staticmethod
+    def link_set_packet_callback(link, callback):
+        link.set_packet_callback(callback)
+
+    # ─── RnsTransport ─────────────────────────────────────────────
+
+    @staticmethod
+    def transport_register_destination(destination):
+        RNS.Transport.register_destination(destination)
+
+    @staticmethod
+    def transport_deregister_destination(destination):
+        RNS.Transport.deregister_destination(destination)
+
+    @staticmethod
+    def transport_register_announce_handler(handler):
+        RNS.Transport.register_announce_handler(handler)
+
+    @staticmethod
+    def transport_deregister_announce_handler(handler):
+        RNS.Transport.deregister_announce_handler(handler)
+
+    @staticmethod
+    def transport_has_path(dest_hash_bytes):
+        return RNS.Transport.has_path(bytes(dest_hash_bytes))
+
+    @staticmethod
+    def transport_request_path(dest_hash_bytes):
+        RNS.Transport.request_path(bytes(dest_hash_bytes))
+
+    @staticmethod
+    def transport_hops_to(dest_hash_bytes):
+        return RNS.Transport.hops_to(bytes(dest_hash_bytes))
+
+    @staticmethod
+    def transport_get_interfaces():
+        """Returns list of dicts with interface info."""
+        result = []
+        for iface in RNS.Transport.interfaces:
+            result.append({
+                "name": str(iface),
+                "online": getattr(iface, "online", True),
+                "type": type(iface).__name__,
+                "rxb": getattr(iface, "rxb", 0),
+                "txb": getattr(iface, "txb", 0),
+            })
+        return result
+
+    @staticmethod
+    def transport_persist_data():
+        try:
+            RNS.Transport.persist_data()
+        except Exception:
+            log.error("Error persisting transport data: %s", traceback.format_exc())
 
     def get_next_hop_interface_name(self, dest_hash):
         """Return formatted interface name for next hop to destination, or None."""
         try:
-            import RNS
             # Convert Chaquopy jarray to Python bytes for RNS dict key lookups
             if not isinstance(dest_hash, (bytes, bytearray)):
                 dest_hash = bytes(dest_hash)
@@ -26,3 +369,190 @@ class RnsApi:
         except Exception as e:
             log_debug("RnsApi", "get_next_hop_interface_name", f"lookup failed: {e}")
         return None
+
+    # ─── LxmfRouter ──────────────────────────────────────────────
+
+    def init_lxmf_router(self, identity, storagepath=None):
+        """Initialize LXMF router. Returns the raw router object."""
+        self.lxmf_router = LXMF.LXMRouter(
+            identity=identity,
+            storagepath=storagepath,
+        )
+        return self.lxmf_router
+
+    def lxmf_register_delivery_identity(self, identity):
+        if self.lxmf_router:
+            self.lxmf_router.register_delivery_identity(identity)
+
+    def lxmf_register_delivery_callback(self, callback):
+        if self.lxmf_router:
+            self.lxmf_router.register_delivery_callback(callback)
+
+    def lxmf_handle_outbound(self, message):
+        if self.lxmf_router:
+            self.lxmf_router.handle_outbound(message)
+
+    def lxmf_set_outbound_propagation_node(self, dest_hash_bytes):
+        if self.lxmf_router:
+            if dest_hash_bytes is not None:
+                self.lxmf_router.set_outbound_propagation_node(bytes(dest_hash_bytes))
+            else:
+                self.lxmf_router.set_outbound_propagation_node(None)
+
+    def lxmf_get_outbound_propagation_node(self):
+        if self.lxmf_router:
+            return self.lxmf_router.get_outbound_propagation_node()
+        return None
+
+    def lxmf_request_messages_from_propagation_node(self, identity=None, max_messages=256):
+        if self.lxmf_router:
+            self.lxmf_router.request_messages_from_propagation_node(
+                identity=identity,
+                max_messages=max_messages,
+            )
+
+    def lxmf_get_propagation_state(self):
+        """Returns dict with propagation transfer state."""
+        if not self.lxmf_router:
+            return {"state": 0, "state_name": "idle", "progress": 0.0, "messages_received": 0}
+        try:
+            state = self.lxmf_router.propagation_transfer_state
+            progress = self.lxmf_router.propagation_transfer_progress
+            return {
+                "state": state,
+                "state_name": self._propagation_state_name(state),
+                "progress": float(progress) if progress else 0.0,
+                "messages_received": getattr(
+                    self.lxmf_router, "propagation_transfer_last_result", 0
+                ) or 0,
+            }
+        except Exception:
+            return {"state": 0, "state_name": "idle", "progress": 0.0, "messages_received": 0}
+
+    def lxmf_get_version(self):
+        try:
+            return LXMF.__version__
+        except Exception:
+            return None
+
+    @staticmethod
+    def _propagation_state_name(state):
+        names = {
+            0: "idle",
+            1: "path_requested",
+            2: "link_establishing",
+            3: "link_established",
+            4: "request_sent",
+            5: "receiving",
+            6: "response_received",
+            7: "complete",
+        }
+        return names.get(state, "unknown")
+
+    # ─── LxmfMessageFactory ──────────────────────────────────────
+
+    @staticmethod
+    def create_lxmf_message(
+        source_destination,
+        dest_destination,
+        content,
+        fields=None,
+        desired_method=None,
+        try_propagation_on_fail=True,
+    ):
+        """Create an LXMF message. Returns live LXMF.LXMessage object.
+
+        Args:
+            source_destination: Live RNS.Destination (sender's delivery destination)
+            dest_destination: Live RNS.Destination (recipient's delivery destination)
+            content: str message content
+            fields: dict of LXMF fields (optional)
+            desired_method: LXMF delivery method constant (optional)
+            try_propagation_on_fail: bool
+        """
+        if desired_method is None:
+            desired_method = LXMF.LXMessage.DIRECT
+
+        msg = LXMF.LXMessage(
+            source_destination,
+            dest_destination,
+            content,
+            desired_method=desired_method,
+        )
+        if fields:
+            msg.fields = fields
+        msg.try_propagation_on_fail = try_propagation_on_fail
+        return msg
+
+    # ─── LxmfMessage (live object methods) ────────────────────────
+
+    @staticmethod
+    def lxmf_message_get_hash(message):
+        return message.hash
+
+    @staticmethod
+    def lxmf_message_get_state(message):
+        """Returns int state code."""
+        return message.state
+
+    @staticmethod
+    def lxmf_message_get_content(message):
+        return message.content_as_string()
+
+    @staticmethod
+    def lxmf_message_get_fields(message):
+        return message.fields
+
+    @staticmethod
+    def lxmf_message_get_timestamp(message):
+        return message.timestamp
+
+    @staticmethod
+    def lxmf_message_get_source_hash(message):
+        return message.source_hash
+
+    @staticmethod
+    def lxmf_message_get_destination_hash(message):
+        return message.destination_hash
+
+    @staticmethod
+    def lxmf_message_register_delivery_callback(message, callback):
+        message.register_delivery_callback(callback)
+
+    @staticmethod
+    def lxmf_message_register_failed_callback(message, callback):
+        message.register_failed_callback(callback)
+
+    # ─── LxmfAppDataParser ────────────────────────────────────────
+
+    @staticmethod
+    def display_name_from_app_data(app_data):
+        """Parse display name from LXMF announce app_data."""
+        try:
+            return LXMF.LXMRouter.display_name_from_app_data(bytes(app_data))
+        except Exception:
+            return None
+
+    @staticmethod
+    def propagation_node_name_from_app_data(app_data):
+        """Parse propagation node name from app_data."""
+        try:
+            return LXMF.LXMRouter.node_name_from_app_data(bytes(app_data))
+        except Exception:
+            return None
+
+    @staticmethod
+    def stamp_cost_from_app_data(app_data):
+        """Parse stamp cost from app_data."""
+        try:
+            return LXMF.LXMRouter.stamp_cost_from_app_data(bytes(app_data))
+        except Exception:
+            return None
+
+    @staticmethod
+    def is_propagation_node_announce_valid(app_data):
+        """Check if propagation node announce app_data is valid."""
+        try:
+            return LXMF.LXMRouter.propagation_node_announce_is_valid(bytes(app_data))
+        except Exception:
+            return False

--- a/python/rns_api.py
+++ b/python/rns_api.py
@@ -30,12 +30,14 @@ class RnsApi:
 
     # ─── RnsReticulum ─────────────────────────────────────────────
 
-    def start(self, config_dir, enable_transport=False):
+    def start(self, config_dir, enable_transport=False, loglevel=None):
         """Start Reticulum. Returns True on success."""
+        if loglevel is None:
+            loglevel = RNS.LOG_WARNING
         try:
             self.reticulum = RNS.Reticulum(
                 configdir=config_dir,
-                loglevel=RNS.LOG_DEBUG,
+                loglevel=loglevel,
             )
             if enable_transport:
                 RNS.Transport.start()

--- a/reticulum/src/main/java/com/lxmf/messenger/reticulum/bindings/lxmf/LxmfAppDataParser.kt
+++ b/reticulum/src/main/java/com/lxmf/messenger/reticulum/bindings/lxmf/LxmfAppDataParser.kt
@@ -1,0 +1,17 @@
+package com.lxmf.messenger.reticulum.bindings.lxmf
+
+/**
+ * Utilities for parsing LXMF announce app_data fields.
+ *
+ * App data is a msgpack-encoded structure attached to LXMF destination announces.
+ * Contains display name, propagation node info, stamp cost, and other metadata.
+ */
+interface LxmfAppDataParser {
+    fun displayNameFromAppData(appData: ByteArray): String?
+
+    fun propagationNodeNameFromAppData(appData: ByteArray): String?
+
+    fun stampCostFromAppData(appData: ByteArray): Int?
+
+    fun isPropagationNodeAnnounceValid(appData: ByteArray): Boolean
+}

--- a/reticulum/src/main/java/com/lxmf/messenger/reticulum/bindings/lxmf/LxmfMessage.kt
+++ b/reticulum/src/main/java/com/lxmf/messenger/reticulum/bindings/lxmf/LxmfMessage.kt
@@ -1,0 +1,26 @@
+package com.lxmf.messenger.reticulum.bindings.lxmf
+
+import com.lxmf.messenger.reticulum.protocol.DeliveryMethod
+
+/**
+ * Live LXMF message object with delivery/failure callbacks.
+ *
+ * Wraps a live Python LXMF.LXMessage (now) or native LXMF-kt LXMessage (later).
+ * Mutable properties ([desiredMethod], [tryPropagationOnFail]) can be set before
+ * passing to [LxmfRouter.handleOutbound].
+ */
+interface LxmfMessage {
+    val hash: ByteArray
+    val state: LxmfMessageState
+    val sourceHash: ByteArray
+    val destinationHash: ByteArray
+    val content: String
+    val fields: Map<Int, Any>?
+    val timestamp: Long
+    var desiredMethod: DeliveryMethod
+    var tryPropagationOnFail: Boolean
+
+    fun registerDeliveryCallback(callback: (LxmfMessage) -> Unit)
+
+    fun registerFailedCallback(callback: (LxmfMessage) -> Unit)
+}

--- a/reticulum/src/main/java/com/lxmf/messenger/reticulum/bindings/lxmf/LxmfMessageFactory.kt
+++ b/reticulum/src/main/java/com/lxmf/messenger/reticulum/bindings/lxmf/LxmfMessageFactory.kt
@@ -1,0 +1,20 @@
+package com.lxmf.messenger.reticulum.bindings.lxmf
+
+import com.lxmf.messenger.reticulum.bindings.rns.RnsIdentity
+import com.lxmf.messenger.reticulum.protocol.DeliveryMethod
+
+/**
+ * Factory for constructing [LxmfMessage] instances.
+ *
+ * Mirrors future LXMF-kt: `LXMessage(source, destination, content, ...)`.
+ */
+interface LxmfMessageFactory {
+    fun create(
+        sourceIdentity: RnsIdentity,
+        destinationHash: ByteArray,
+        content: String,
+        fields: Map<Int, Any>? = null,
+        desiredMethod: DeliveryMethod = DeliveryMethod.DIRECT,
+        tryPropagationOnFail: Boolean = true,
+    ): LxmfMessage
+}

--- a/reticulum/src/main/java/com/lxmf/messenger/reticulum/bindings/lxmf/LxmfMessageState.kt
+++ b/reticulum/src/main/java/com/lxmf/messenger/reticulum/bindings/lxmf/LxmfMessageState.kt
@@ -1,0 +1,16 @@
+package com.lxmf.messenger.reticulum.bindings.lxmf
+
+/**
+ * LXMF message lifecycle states.
+ *
+ * Maps to Python LXMF.LXMessage state constants:
+ * - DRAFT (0), OUTBOUND (1), SENDING (2), SENT (3), DELIVERED (4), FAILED (5)
+ */
+enum class LxmfMessageState {
+    DRAFT,
+    OUTBOUND,
+    SENDING,
+    SENT,
+    DELIVERED,
+    FAILED,
+}

--- a/reticulum/src/main/java/com/lxmf/messenger/reticulum/bindings/lxmf/LxmfRouter.kt
+++ b/reticulum/src/main/java/com/lxmf/messenger/reticulum/bindings/lxmf/LxmfRouter.kt
@@ -1,0 +1,32 @@
+package com.lxmf.messenger.reticulum.bindings.lxmf
+
+import com.lxmf.messenger.reticulum.bindings.rns.RnsIdentity
+import com.lxmf.messenger.reticulum.protocol.PropagationState
+
+/**
+ * LXMF message routing — delivery registration, outbound handling, propagation sync.
+ *
+ * Mirrors future LXMF-kt: `LXMRouter` class. Separated from RNS layer to match
+ * the RNS/LXMF library boundary — when LXMF-kt arrives, only implementations
+ * in this package change.
+ */
+interface LxmfRouter {
+    fun registerDeliveryIdentity(identity: RnsIdentity)
+
+    fun registerDeliveryCallback(callback: (LxmfMessage) -> Unit)
+
+    fun handleOutbound(message: LxmfMessage)
+
+    fun setOutboundPropagationNode(destinationHash: ByteArray?)
+
+    fun getOutboundPropagationNode(): ByteArray?
+
+    fun requestMessagesFromPropagationNode(
+        identity: RnsIdentity? = null,
+        maxMessages: Int = 256,
+    )
+
+    fun getPropagationState(): PropagationState
+
+    fun getVersion(): String?
+}

--- a/reticulum/src/main/java/com/lxmf/messenger/reticulum/bindings/rns/RnsAnnounceHandler.kt
+++ b/reticulum/src/main/java/com/lxmf/messenger/reticulum/bindings/rns/RnsAnnounceHandler.kt
@@ -1,0 +1,18 @@
+package com.lxmf.messenger.reticulum.bindings.rns
+
+/**
+ * Callback interface for receiving announce events.
+ *
+ * Mirrors reticulum-kt: `AnnounceHandler` functional interface.
+ * Register with [RnsTransport.registerAnnounceHandler].
+ */
+interface RnsAnnounceHandler {
+    val aspect: String
+
+    fun receivedAnnounce(
+        destinationHash: ByteArray,
+        announcedIdentity: RnsIdentity,
+        appData: ByteArray?,
+        hops: Int,
+    )
+}

--- a/reticulum/src/main/java/com/lxmf/messenger/reticulum/bindings/rns/RnsDestination.kt
+++ b/reticulum/src/main/java/com/lxmf/messenger/reticulum/bindings/rns/RnsDestination.kt
@@ -1,0 +1,35 @@
+package com.lxmf.messenger.reticulum.bindings.rns
+
+import com.lxmf.messenger.reticulum.model.Destination
+import com.lxmf.messenger.reticulum.model.DestinationType
+import com.lxmf.messenger.reticulum.model.Direction
+
+/**
+ * Live destination object with announce and request handler registration.
+ *
+ * Mirrors reticulum-kt: `Destination` class with `announce()`,
+ * `setLinkEstablishedCallback()`, `registerRequestHandler()`.
+ *
+ * For UI/persistence, call [toSnapshot] to get a [Destination] data class.
+ */
+interface RnsDestination {
+    val hash: ByteArray
+    val hexHash: String
+    val identity: RnsIdentity
+    val direction: Direction
+    val type: DestinationType
+
+    fun announce(appData: ByteArray? = null)
+
+    fun setLinkEstablishedCallback(callback: ((RnsLink) -> Unit)?)
+
+    fun registerRequestHandler(
+        path: String,
+        responseGenerator: (path: String, data: ByteArray?, requestId: ByteArray) -> ByteArray?,
+    )
+
+    fun deregisterRequestHandler(path: String)
+
+    /** Bridge to existing [Destination] data class for UI/persistence. */
+    fun toSnapshot(): Destination
+}

--- a/reticulum/src/main/java/com/lxmf/messenger/reticulum/bindings/rns/RnsDestinationProvider.kt
+++ b/reticulum/src/main/java/com/lxmf/messenger/reticulum/bindings/rns/RnsDestinationProvider.kt
@@ -1,0 +1,19 @@
+package com.lxmf.messenger.reticulum.bindings.rns
+
+import com.lxmf.messenger.reticulum.model.DestinationType
+import com.lxmf.messenger.reticulum.model.Direction
+
+/**
+ * Factory for creating [RnsDestination] instances.
+ *
+ * Mirrors reticulum-kt: `Destination.create(identity, direction, type, appName, *aspects)`.
+ */
+interface RnsDestinationProvider {
+    fun create(
+        identity: RnsIdentity,
+        direction: Direction,
+        type: DestinationType,
+        appName: String,
+        vararg aspects: String,
+    ): RnsDestination
+}

--- a/reticulum/src/main/java/com/lxmf/messenger/reticulum/bindings/rns/RnsIdentity.kt
+++ b/reticulum/src/main/java/com/lxmf/messenger/reticulum/bindings/rns/RnsIdentity.kt
@@ -1,0 +1,36 @@
+package com.lxmf.messenger.reticulum.bindings.rns
+
+import com.lxmf.messenger.reticulum.model.Identity
+
+/**
+ * Live identity object with cryptographic operations.
+ *
+ * Mirrors reticulum-kt: `Identity` class with sign(), encrypt(), validate(), decrypt().
+ * Wraps a live Python RNS.Identity (now) or a native reticulum-kt Identity (later).
+ *
+ * For UI/persistence use cases that only need data, call [toSnapshot] to get an
+ * [Identity] data class. Both layers coexist: live objects for business logic,
+ * data classes for serialization.
+ */
+interface RnsIdentity {
+    val hash: ByteArray
+    val hexHash: String
+
+    fun getPublicKey(): ByteArray
+
+    fun getPrivateKey(): ByteArray?
+
+    fun sign(message: ByteArray): ByteArray
+
+    fun validate(
+        signature: ByteArray,
+        message: ByteArray,
+    ): Boolean
+
+    fun encrypt(plaintext: ByteArray): ByteArray
+
+    fun decrypt(ciphertext: ByteArray): ByteArray?
+
+    /** Bridge to existing [Identity] data class for UI/persistence. */
+    fun toSnapshot(): Identity
+}

--- a/reticulum/src/main/java/com/lxmf/messenger/reticulum/bindings/rns/RnsIdentityProvider.kt
+++ b/reticulum/src/main/java/com/lxmf/messenger/reticulum/bindings/rns/RnsIdentityProvider.kt
@@ -1,0 +1,23 @@
+package com.lxmf.messenger.reticulum.bindings.rns
+
+/**
+ * Factory and recall operations for [RnsIdentity].
+ *
+ * Mirrors reticulum-kt: `Identity.create()`, `Identity.load()`, `Identity.fromBytes()`,
+ * `Identity.recall()`, `Identity.recallAppData()`.
+ */
+interface RnsIdentityProvider {
+    fun create(): RnsIdentity
+
+    fun load(path: String): RnsIdentity
+
+    fun fromBytes(privateKeyBytes: ByteArray): RnsIdentity
+
+    fun recall(destinationHash: ByteArray): RnsIdentity?
+
+    fun recallAppData(destinationHash: ByteArray): ByteArray?
+
+    fun fullHash(data: ByteArray): ByteArray
+
+    fun truncatedHash(data: ByteArray): ByteArray
+}

--- a/reticulum/src/main/java/com/lxmf/messenger/reticulum/bindings/rns/RnsInterfaceInfo.kt
+++ b/reticulum/src/main/java/com/lxmf/messenger/reticulum/bindings/rns/RnsInterfaceInfo.kt
@@ -1,0 +1,12 @@
+package com.lxmf.messenger.reticulum.bindings.rns
+
+/**
+ * Snapshot of a Reticulum network interface's state and traffic counters.
+ */
+data class RnsInterfaceInfo(
+    val name: String,
+    val online: Boolean,
+    val type: String,
+    val rxBytes: Long,
+    val txBytes: Long,
+)

--- a/reticulum/src/main/java/com/lxmf/messenger/reticulum/bindings/rns/RnsLink.kt
+++ b/reticulum/src/main/java/com/lxmf/messenger/reticulum/bindings/rns/RnsLink.kt
@@ -1,0 +1,42 @@
+package com.lxmf.messenger.reticulum.bindings.rns
+
+import com.lxmf.messenger.reticulum.model.LinkStatus
+
+/**
+ * Live link object with send/receive and crypto operations.
+ *
+ * Mirrors reticulum-kt: `Link` class — live object with `send()`, `teardown()`,
+ * callbacks. Wraps a live Python RNS.Link (now) or native reticulum-kt Link (later).
+ */
+interface RnsLink {
+    val linkId: ByteArray
+    val status: LinkStatus
+    val destination: RnsDestination?
+    val isInitiator: Boolean
+    val mtu: Int
+
+    /** Round-trip time in milliseconds, or null if not yet measured. */
+    val rtt: Long?
+
+    fun send(data: ByteArray): Boolean
+
+    fun teardown(reason: Int = 0)
+
+    fun identify(identity: RnsIdentity): Boolean
+
+    fun getRemoteIdentity(): RnsIdentity?
+
+    /** Link establishment rate in bits per second. */
+    fun getEstablishmentRate(): Long?
+
+    /** Expected throughput in bits per second (from prior transfers). */
+    fun getExpectedRate(): Long?
+
+    fun encrypt(plaintext: ByteArray): ByteArray
+
+    fun decrypt(ciphertext: ByteArray): ByteArray?
+
+    fun setClosedCallback(callback: ((RnsLink) -> Unit)?)
+
+    fun setPacketCallback(callback: ((ByteArray, RnsLink) -> Unit)?)
+}

--- a/reticulum/src/main/java/com/lxmf/messenger/reticulum/bindings/rns/RnsLinkProvider.kt
+++ b/reticulum/src/main/java/com/lxmf/messenger/reticulum/bindings/rns/RnsLinkProvider.kt
@@ -1,0 +1,14 @@
+package com.lxmf.messenger.reticulum.bindings.rns
+
+/**
+ * Factory for creating [RnsLink] instances.
+ *
+ * Mirrors reticulum-kt: `Link.create(destination, callbacks)`.
+ */
+interface RnsLinkProvider {
+    fun create(
+        destination: RnsDestination,
+        establishedCallback: ((RnsLink) -> Unit)? = null,
+        closedCallback: ((RnsLink) -> Unit)? = null,
+    ): RnsLink
+}

--- a/reticulum/src/main/java/com/lxmf/messenger/reticulum/bindings/rns/RnsReticulum.kt
+++ b/reticulum/src/main/java/com/lxmf/messenger/reticulum/bindings/rns/RnsReticulum.kt
@@ -1,0 +1,22 @@
+package com.lxmf.messenger.reticulum.bindings.rns
+
+/**
+ * Main entry point for Reticulum lifecycle management.
+ *
+ * Mirrors reticulum-kt: `Reticulum.start()`, `Reticulum.stop()`, `Reticulum.isStarted()`.
+ * Blocking functions — callers dispatch to Dispatchers.IO as needed.
+ */
+interface RnsReticulum {
+    fun start(
+        configDir: String,
+        enableTransport: Boolean = false,
+    ): Boolean
+
+    fun stop()
+
+    fun isStarted(): Boolean
+
+    fun isTransportEnabled(): Boolean
+
+    fun getVersion(): String?
+}

--- a/reticulum/src/main/java/com/lxmf/messenger/reticulum/bindings/rns/RnsTransport.kt
+++ b/reticulum/src/main/java/com/lxmf/messenger/reticulum/bindings/rns/RnsTransport.kt
@@ -1,0 +1,31 @@
+package com.lxmf.messenger.reticulum.bindings.rns
+
+/**
+ * Routing, path management, and announce handling.
+ *
+ * Mirrors reticulum-kt: `Transport` singleton — `hasPath()`, `requestPath()`,
+ * `hopsTo()`, `registerAnnounceHandler()`, `registerDestination()`.
+ * Interface (not singleton) for testability — Chaquopy impl is the singleton.
+ */
+interface RnsTransport {
+    val identity: RnsIdentity?
+    val transportEnabled: Boolean
+
+    fun registerDestination(destination: RnsDestination)
+
+    fun deregisterDestination(destination: RnsDestination)
+
+    fun registerAnnounceHandler(handler: RnsAnnounceHandler)
+
+    fun deregisterAnnounceHandler(handler: RnsAnnounceHandler)
+
+    fun hasPath(destinationHash: ByteArray): Boolean
+
+    fun requestPath(destinationHash: ByteArray)
+
+    fun hopsTo(destinationHash: ByteArray): Int
+
+    fun getInterfaces(): List<RnsInterfaceInfo>
+
+    fun persistData()
+}

--- a/reticulum/src/main/java/com/lxmf/messenger/reticulum/model/DestinationType.kt
+++ b/reticulum/src/main/java/com/lxmf/messenger/reticulum/model/DestinationType.kt
@@ -6,4 +6,7 @@ sealed class DestinationType {
     object GROUP : DestinationType()
 
     object PLAIN : DestinationType()
+
+    /** Used for link-based destinations. Mirrors reticulum-kt DestinationType.LINK. */
+    object LINK : DestinationType()
 }


### PR DESCRIPTION
## Summary

- **Phase 1**: 15 binding interfaces in `:reticulum` module (`bindings/rns/` + `bindings/lxmf/`) mirroring reticulum-kt's live-object API shape. Add `DestinationType.LINK`.
- **Phase 2**: Expand `rns_api.py` with thin pass-through methods for all RNS/LXMF operations (Identity, Destination, Link, Transport, LXMF Router, Message).
- **Phase 3**: 12 Chaquopy implementation classes in `app/service/rns/` wrapping live Python objects via PyObject with proper `close()` lifecycle.

**Zero runtime impact** — not wired into DI yet. Callback bridging deferred to Phase 4.

### Architecture

```
RnsIdentity (interface)          — live object with sign(), encrypt()
  ├── ChaquopyRnsIdentity        — wraps PyObject (now)
  └── reticulum-kt Identity      — native Kotlin (later)

Identity (data class)            — snapshot: hash + publicKey
  └── created from RnsIdentity.toSnapshot()
```

Interfaces are blocking (not suspend) to match reticulum-kt — callers dispatch to `Dispatchers.IO`.

## Test plan

- [x] `:reticulum:compileDebugKotlin` passes
- [x] `:app:compileNoSentryDebugKotlin` passes
- [x] `:reticulum:testDebugUnitTest` passes (no regressions)
- [x] Python syntax check passes
- [ ] CI build passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)