### PR TITLE
Update compileSdk and targetSdk from 35 to 36

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -78,12 +78,12 @@ val (versionCodeValue, versionNameValue) = getVersionFromTag()
 
 android {
     namespace = "com.lxmf.messenger"
-    compileSdk = 35
+    compileSdk = 36
 
     defaultConfig {
         applicationId = "com.lxmf.messenger"
         minSdk = 24
-        targetSdk = 35
+        targetSdk = 36
         versionCode = versionCodeValue
         versionName = versionNameValue
 

--- a/data/build.gradle.kts
+++ b/data/build.gradle.kts
@@ -7,7 +7,7 @@ plugins {
 
 android {
     namespace = "tech.torlando.columba.data"
-    compileSdk = 35
+    compileSdk = 36
 
     defaultConfig {
         minSdk = 24

--- a/reticulum/build.gradle.kts
+++ b/reticulum/build.gradle.kts
@@ -10,7 +10,7 @@ plugins {
 
 android {
     namespace = "tech.torlando.columba.reticulum"
-    compileSdk = 35
+    compileSdk = 36
 
     defaultConfig {
         minSdk = 24

--- a/screenshot-tests/build.gradle.kts
+++ b/screenshot-tests/build.gradle.kts
@@ -7,7 +7,7 @@ plugins {
 
 android {
     namespace = "com.lxmf.messenger.screenshot"
-    compileSdk = 35
+    compileSdk = 36
 
     defaultConfig {
         minSdk = 24


### PR DESCRIPTION
## Summary
- Update `compileSdk` from 35 to 36 across all modules (`app`, `data`, `reticulum`, `screenshot-tests`)
- Update `targetSdk` from 35 to 36 in the `app` module
- Enables Android 16 features for compatible devices while keeping `minSdk` at 24 (Android 7.0)

Closes #615

## Test plan
- [x] Build compiles successfully with SDK 36
- [ ] Verify app installs and runs on Android 16 device/emulator
- [ ] Verify app still works on older Android versions (API 24+)

🤖 Generated with [Claude Code](https://claude.com/claude-code)