### PR TITLE
feat: add true color (24-bit RGB) support to MicronColor via FT/BT commands

### DIFF
--- a/micron/src/main/java/com/lxmf/messenger/micron/MicronColor.kt
+++ b/micron/src/main/java/com/lxmf/messenger/micron/MicronColor.kt
@@ -3,8 +3,9 @@ package com.lxmf.messenger.micron
 /**
  * Represents a color in Micron markup.
  *
- * Micron supports three color formats:
+ * Micron supports four color formats:
  * - 3-char hex: each digit is doubled (e.g., "ddd" → 0xDD, 0xDD, 0xDD)
+ * - 6-char true color hex: full 24-bit RGB (e.g., "ff8800" → 0xFF, 0x88, 0x00)
  * - Grayscale: "gNN" where NN is 0-99 (0 = black, 99 = white)
  * - Default: inherit from theme
  */
@@ -40,6 +41,7 @@ sealed class MicronColor {
         private const val HEX_RADIX = 16
         private const val HEX_DOUBLER = 0x11
         private const val MAX_GRAYSCALE = 99
+        private const val TRUE_COLOR_LEN = 6
 
         /**
          * Parse a Micron color string (3 chars after F/B command).
@@ -62,6 +64,28 @@ sealed class MicronColor {
             val b = colorStr[2].digitToIntOrNull(HEX_RADIX) ?: return null
 
             return Hex(r * HEX_DOUBLER, g * HEX_DOUBLER, b * HEX_DOUBLER)
+        }
+
+        /**
+         * Parse a 6-char true color hex string (after FT/BT command).
+         * - "ff8800" → Hex(0xFF, 0x88, 0x00)
+         */
+        @Suppress("ReturnCount")
+        fun parseTrueColor(colorStr: String): MicronColor? {
+            if (colorStr.length < TRUE_COLOR_LEN) return null
+
+            val rHi = colorStr[0].digitToIntOrNull(HEX_RADIX) ?: return null
+            val rLo = colorStr[1].digitToIntOrNull(HEX_RADIX) ?: return null
+            val gHi = colorStr[2].digitToIntOrNull(HEX_RADIX) ?: return null
+            val gLo = colorStr[3].digitToIntOrNull(HEX_RADIX) ?: return null
+            val bHi = colorStr[4].digitToIntOrNull(HEX_RADIX) ?: return null
+            val bLo = colorStr[5].digitToIntOrNull(HEX_RADIX) ?: return null
+
+            return Hex(
+                (rHi shl 4) or rLo,
+                (gHi shl 4) or gLo,
+                (bHi shl 4) or bLo,
+            )
         }
     }
 }

--- a/micron/src/main/java/com/lxmf/messenger/micron/MicronColor.kt
+++ b/micron/src/main/java/com/lxmf/messenger/micron/MicronColor.kt
@@ -41,7 +41,7 @@ sealed class MicronColor {
         private const val HEX_RADIX = 16
         private const val HEX_DOUBLER = 0x11
         private const val MAX_GRAYSCALE = 99
-        private const val TRUE_COLOR_LEN = 6
+        internal const val TRUE_COLOR_LEN = 6
 
         /**
          * Parse a Micron color string (3 chars after F/B command).

--- a/micron/src/main/java/com/lxmf/messenger/micron/MicronParser.kt
+++ b/micron/src/main/java/com/lxmf/messenger/micron/MicronParser.kt
@@ -347,34 +347,14 @@ object MicronParser {
             // Reset background color
             'b' -> FormatResult(style.copy(background = MicronColor.Default), alignment, afterCmd)
 
-            // Foreground color: Fxxx (3 chars)
+            // Foreground color: Fxxx (3 chars) or FTxxxxxx (true color, 6 chars)
             'F' -> {
-                if (afterCmd + 3 <= line.length) {
-                    val colorStr = line.substring(afterCmd, afterCmd + 3)
-                    val color = MicronColor.parse(colorStr)
-                    if (color != null) {
-                        FormatResult(style.copy(foreground = color), alignment, afterCmd + 3)
-                    } else {
-                        null
-                    }
-                } else {
-                    null
-                }
+                parseForegroundOrBackground(line, afterCmd, style, alignment, isForeground = true)
             }
 
-            // Background color: Bxxx (3 chars)
+            // Background color: Bxxx (3 chars) or BTxxxxxx (true color, 6 chars)
             'B' -> {
-                if (afterCmd + 3 <= line.length) {
-                    val colorStr = line.substring(afterCmd, afterCmd + 3)
-                    val color = MicronColor.parse(colorStr)
-                    if (color != null) {
-                        FormatResult(style.copy(background = color), alignment, afterCmd + 3)
-                    } else {
-                        null
-                    }
-                } else {
-                    null
-                }
+                parseForegroundOrBackground(line, afterCmd, style, alignment, isForeground = false)
             }
 
             // Alignment
@@ -388,6 +368,49 @@ object MicronParser {
 
             else -> null
         }
+    }
+
+    private const val TRUE_COLOR_LEN = 6
+    private const val SHORT_COLOR_LEN = 3
+
+    /**
+     * Parse a foreground or background color command.
+     * Supports both 3-char shorthand (`Fxxx` / `Bxxx`) and true color (`FTxxxxxx` / `BTxxxxxx`).
+     */
+    @Suppress("ReturnCount")
+    private fun parseForegroundOrBackground(
+        line: String,
+        afterCmd: Int,
+        currentStyle: MicronStyle,
+        alignment: MicronAlignment,
+        isForeground: Boolean,
+    ): FormatResult? {
+        // True color: next char is 'T' followed by 6 hex chars
+        if (afterCmd < line.length && line[afterCmd] == 'T') {
+            val colorStart = afterCmd + 1
+            if (colorStart + TRUE_COLOR_LEN <= line.length) {
+                val colorStr = line.substring(colorStart, colorStart + TRUE_COLOR_LEN)
+                val color = MicronColor.parseTrueColor(colorStr)
+                if (color != null) {
+                    val newStyle =
+                        if (isForeground) currentStyle.copy(foreground = color) else currentStyle.copy(background = color)
+                    return FormatResult(newStyle, alignment, colorStart + TRUE_COLOR_LEN)
+                }
+            }
+        }
+
+        // Standard 3-char color
+        if (afterCmd + SHORT_COLOR_LEN <= line.length) {
+            val colorStr = line.substring(afterCmd, afterCmd + SHORT_COLOR_LEN)
+            val color = MicronColor.parse(colorStr)
+            if (color != null) {
+                val newStyle =
+                    if (isForeground) currentStyle.copy(foreground = color) else currentStyle.copy(background = color)
+                return FormatResult(newStyle, alignment, afterCmd + SHORT_COLOR_LEN)
+            }
+        }
+
+        return null
     }
 
     /**

--- a/micron/src/main/java/com/lxmf/messenger/micron/MicronParser.kt
+++ b/micron/src/main/java/com/lxmf/messenger/micron/MicronParser.kt
@@ -370,7 +370,6 @@ object MicronParser {
         }
     }
 
-    private const val TRUE_COLOR_LEN = 6
     private const val SHORT_COLOR_LEN = 3
 
     /**
@@ -388,15 +387,19 @@ object MicronParser {
         // True color: next char is 'T' followed by 6 hex chars
         if (afterCmd < line.length && line[afterCmd] == 'T') {
             val colorStart = afterCmd + 1
-            if (colorStart + TRUE_COLOR_LEN <= line.length) {
-                val colorStr = line.substring(colorStart, colorStart + TRUE_COLOR_LEN)
+            if (colorStart + MicronColor.TRUE_COLOR_LEN <= line.length) {
+                val colorStr = line.substring(colorStart, colorStart + MicronColor.TRUE_COLOR_LEN)
                 val color = MicronColor.parseTrueColor(colorStr)
                 if (color != null) {
                     val newStyle =
                         if (isForeground) currentStyle.copy(foreground = color) else currentStyle.copy(background = color)
-                    return FormatResult(newStyle, alignment, colorStart + TRUE_COLOR_LEN)
+                    return FormatResult(newStyle, alignment, colorStart + MicronColor.TRUE_COLOR_LEN)
                 }
             }
+            // 'T' was committed as a true-color marker; skip the 3-char fallback
+            // to avoid a pointless attempt to parse "T..." as a 3-char color
+            // (T is never a valid hex digit, so the fallback always fails).
+            return null
         }
 
         // Standard 3-char color

--- a/micron/src/test/java/com/lxmf/messenger/micron/MicronParserTest.kt
+++ b/micron/src/test/java/com/lxmf/messenger/micron/MicronParserTest.kt
@@ -281,6 +281,125 @@ class MicronParserTest {
         assertEquals(MicronColor.Hex(0xDD, 0xDD, 0xDD), color)
     }
 
+    // ==================== True Color ====================
+
+    @Test
+    fun `foreground true color FT with 6 hex chars`() {
+        val doc = MicronParser.parse("`FTff8800Orange text")
+        val text =
+            doc.lines[0]
+                .elements
+                .filterIsInstance<MicronElement.Text>()
+                .first { it.content == "Orange text" }
+        assertEquals(MicronColor.Hex(0xFF, 0x88, 0x00), text.style.foreground)
+    }
+
+    @Test
+    fun `background true color BT with 6 hex chars`() {
+        val doc = MicronParser.parse("`BT1a2b3cColored bg")
+        val text =
+            doc.lines[0]
+                .elements
+                .filterIsInstance<MicronElement.Text>()
+                .first { it.content == "Colored bg" }
+        assertEquals(MicronColor.Hex(0x1A, 0x2B, 0x3C), text.style.background)
+    }
+
+    @Test
+    fun `true color FT 000000 is black`() {
+        val doc = MicronParser.parse("`FT000000Black")
+        val text =
+            doc.lines[0]
+                .elements
+                .filterIsInstance<MicronElement.Text>()
+                .first { it.content == "Black" }
+        assertEquals(MicronColor.Hex(0x00, 0x00, 0x00), text.style.foreground)
+    }
+
+    @Test
+    fun `true color FT ffffff is white`() {
+        val doc = MicronParser.parse("`FTffffffWhite")
+        val text =
+            doc.lines[0]
+                .elements
+                .filterIsInstance<MicronElement.Text>()
+                .first { it.content == "White" }
+        assertEquals(MicronColor.Hex(0xFF, 0xFF, 0xFF), text.style.foreground)
+    }
+
+    @Test
+    fun `true color persists across lines`() {
+        val doc = MicronParser.parse("`FTff8800orange\nstill orange")
+        val line2 = doc.lines[1].elements[0] as MicronElement.Text
+        assertEquals(MicronColor.Hex(0xFF, 0x88, 0x00), line2.style.foreground)
+    }
+
+    @Test
+    fun `true color reset with lowercase f`() {
+        val doc = MicronParser.parse("`FTff8800Orange`fDefault")
+        val defaultText =
+            doc.lines[0]
+                .elements
+                .filterIsInstance<MicronElement.Text>()
+                .first { it.content == "Default" }
+        assertEquals(MicronColor.Default, defaultText.style.foreground)
+    }
+
+    @Test
+    fun `true color BT reset with lowercase b`() {
+        val doc = MicronParser.parse("`BT1a2b3cColored`bDefault")
+        val defaultText =
+            doc.lines[0]
+                .elements
+                .filterIsInstance<MicronElement.Text>()
+                .first { it.content == "Default" }
+        assertEquals(MicronColor.Default, defaultText.style.background)
+    }
+
+    @Test
+    fun `true color mixed with 3-char color`() {
+        val doc = MicronParser.parse("`FTff8800Orange`Ff00Red")
+        val texts = doc.lines[0].elements.filterIsInstance<MicronElement.Text>()
+        val orange = texts.first { it.content == "Orange" }
+        assertEquals(MicronColor.Hex(0xFF, 0x88, 0x00), orange.style.foreground)
+        val red = texts.first { it.content == "Red" }
+        assertEquals(MicronColor.Hex(0xFF, 0x00, 0x00), red.style.foreground)
+    }
+
+    @Test
+    fun `3-char color still works after adding true color support`() {
+        val doc = MicronParser.parse("`Ff00Red text")
+        val text =
+            doc.lines[0]
+                .elements
+                .filterIsInstance<MicronElement.Text>()
+                .first { it.content == "Red text" }
+        assertEquals(MicronColor.Hex(0xFF, 0x00, 0x00), text.style.foreground)
+    }
+
+    @Test
+    fun `parseTrueColor with valid 6 hex chars`() {
+        val color = MicronColor.parseTrueColor("aabbcc")
+        assertEquals(MicronColor.Hex(0xAA, 0xBB, 0xCC), color)
+    }
+
+    @Test
+    fun `parseTrueColor with invalid chars returns null`() {
+        assertNull(MicronColor.parseTrueColor("gghhii"))
+    }
+
+    @Test
+    fun `parseTrueColor too short returns null`() {
+        assertNull(MicronColor.parseTrueColor("aabb"))
+    }
+
+    @Test
+    fun `page directive bg with true color not supported stays 3-char`() {
+        // Page directives still use 3-char format via MicronColor.parse
+        val doc = MicronParser.parse("#!bg=f00\ntext")
+        assertEquals(MicronColor.Hex(0xFF, 0x00, 0x00), doc.pageBackground)
+    }
+
     // ==================== Alignment ====================
 
     @Test


### PR DESCRIPTION
Extend Micron markup to support full 24-bit true color alongside the
existing 3-char (12-bit) hex and grayscale formats. The new syntax uses
`FTrrggbb` for foreground and `BTrrggbb` for background, keeping full
backward compatibility with existing `Fxxx`/`Bxxx` shorthand.

https://claude.ai/code/session_015rjJisX2XNt331xgXdFbB9