### PR TITLE
fix: prevent crash on corrupted interface in edit dialog

### DIFF
--- a/app/src/main/java/com/lxmf/messenger/viewmodel/InterfaceManagementViewModel.kt
+++ b/app/src/main/java/com/lxmf/messenger/viewmodel/InterfaceManagementViewModel.kt
@@ -406,12 +406,17 @@ class InterfaceManagementViewModel
          * Show the edit interface dialog.
          */
         fun showEditDialog(interfaceEntity: InterfaceEntity) {
-            _configState.value = entityToConfigState(interfaceEntity)
-            _state.value =
-                _state.value.copy(
-                    showAddDialog = true,
-                    editingInterface = interfaceEntity,
-                )
+            try {
+                _configState.value = entityToConfigState(interfaceEntity)
+                _state.value =
+                    _state.value.copy(
+                        showAddDialog = true,
+                        editingInterface = interfaceEntity,
+                    )
+            } catch (e: Exception) {
+                Log.e(TAG, "Failed to load interface config for '${interfaceEntity.name}': ${e.message}", e)
+                showError("Failed to load interface: ${e.message}")
+            }
         }
 
         /**


### PR DESCRIPTION
## Summary
- Fixes #693 — `showEditDialog()` was the only `entityToConfig()` caller without a try-catch
- A corrupted `type` field in the Room database (e.g. invisible unicode characters) caused `IllegalArgumentException` to crash the app when the user tapped an interface to edit it
- Now catches the exception and shows a user-visible error message instead of crashing

## Test plan
- [x] All existing `InterfaceManagementViewModel` tests pass (121 tasks, BUILD SUCCESSFUL)
- [ ] Manual: corrupt an interface entity's `type` field and verify tapping it shows an error toast instead of crashing


🤖 Generated with [Claude Code](https://claude.com/claude-code)