### PR TITLE
fix: prevent identity file loss and add opportunistic key backup

### DIFF
--- a/app/src/test/java/com/lxmf/messenger/data/repository/IdentityRepositoryDatabaseTest.kt
+++ b/app/src/test/java/com/lxmf/messenger/data/repository/IdentityRepositoryDatabaseTest.kt
@@ -528,6 +528,14 @@ class IdentityRepositoryDatabaseTest : DatabaseTest() {
             val canonicalFile = File(reticulumDir, "identity_$TEST_IDENTITY_HASH")
             assertTrue("Canonical file should be created", canonicalFile.exists())
             assertEquals(64L, canonicalFile.length())
+
+            // Verify opportunistic backup also ran
+            val updated = localIdentityDao.getIdentity(TEST_IDENTITY_HASH)
+            assertNotNull("encryptedKeyData should be backed up after file recovery", updated?.encryptedKeyData)
+            assertEquals(
+                IdentityKeyEncryptor.VERSION_DEVICE_ONLY.toInt(),
+                updated?.keyEncryptionVersion,
+            )
         }
 
     @Test

--- a/data/src/main/java/com/lxmf/messenger/data/repository/IdentityRepository.kt
+++ b/data/src/main/java/com/lxmf/messenger/data/repository/IdentityRepository.kt
@@ -421,7 +421,7 @@ class IdentityRepository
          * @param identityHash Optional identity hash to use (if not provided, migration will retry later)
          * @param destinationHash Optional destination hash to use (if not provided, migration will retry later)
          */
-        @Suppress("LongMethod") // Migration logic is complex but cohesive
+        @Suppress("LongMethod", "CyclomaticComplexMethod") // Migration logic is complex but cohesive
         suspend fun migrateDefaultIdentityIfNeeded(
             identityHash: String? = null,
             destinationHash: String? = null,
@@ -488,8 +488,15 @@ class IdentityRepository
                 if (keyData == null || keyData.size != 64) {
                     android.util.Log.e(
                         "IdentityRepository",
-                        "Cannot migrate identity: key data unavailable or invalid size (${keyData?.size}), will retry",
+                        "Cannot migrate identity: key data unavailable or invalid size (${keyData?.size})",
                     )
+                    // If the file exists but content is invalid, retry will never succeed —
+                    // remove the placeholder to avoid an infinite failed-migration loop.
+                    // If the file doesn't exist yet, keep placeholder so we retry when it appears.
+                    if (defaultIdentityFile.exists() && placeholder != null) {
+                        android.util.Log.w("IdentityRepository", "File exists but invalid — removing placeholder")
+                        identityDao.delete(placeholder.identityHash)
+                    }
                     return@withContext
                 }
 


### PR DESCRIPTION
## Summary

- **migrateDefaultIdentityIfNeeded** aborts if key encryption fails, instead of creating an identity record with null keys that becomes unrecoverable
- **ensureIdentityFileExists** now checks the stored `filePath` (e.g. `default_identity`) when the canonical path is missing, recovering the file before Python overwrites it
- **Opportunistic key backup**: when the identity file exists but `encryptedKeyData` is null in DB, encrypts and saves the key immediately

## Root cause

Identities could end up with both `keyData=null` and `encryptedKeyData=null` in the database if key encryption failed during `migrateDefaultIdentityIfNeeded`. Then on next startup, `ensureIdentityFileExists` only checked the canonical path (`identity_<hash>`), not the stored `filePath` (`default_identity`). Recovery failed, Python received `identityPath=null`, created a new identity overwriting the original file — permanently destroying the key.

## Test plan

- [ ] `ensureIdentityFileExists recovers from stored filePath when canonical missing`
- [ ] `ensureIdentityFileExists performs opportunistic key backup`
- [ ] `ensureIdentityFileExists does not overwrite existing encryptedKeyData`
- [ ] All existing identity tests still pass
- [ ] detekt passes