### PR TITLE
test: add regression tests for identity recovery edge cases

### DIFF
--- a/app/src/test/java/com/lxmf/messenger/data/repository/IdentityRepositoryDatabaseTest.kt
+++ b/app/src/test/java/com/lxmf/messenger/data/repository/IdentityRepositoryDatabaseTest.kt
@@ -619,9 +619,7 @@ class IdentityRepositoryDatabaseTest : DatabaseTest() {
             defaultIdentityFile.writeBytes(keyData)
 
             val placeholder =
-                createTestIdentity(identityHash = "migration_placeholder").copy(
-                    isActive = false,
-                )
+                createTestIdentity(identityHash = "migration_placeholder", isActive = false)
             localIdentityDao.insert(placeholder)
 
             // Make encryption throw — this is the scenario that caused the original bug
@@ -660,9 +658,7 @@ class IdentityRepositoryDatabaseTest : DatabaseTest() {
             defaultIdentityFile.writeBytes(ByteArray(32)) // Wrong size!
 
             val placeholder =
-                createTestIdentity(identityHash = "migration_placeholder").copy(
-                    isActive = false,
-                )
+                createTestIdentity(identityHash = "migration_placeholder", isActive = false)
             localIdentityDao.insert(placeholder)
 
             // When


### PR DESCRIPTION
> [!NOTE]
> Stacked on #717 — merge that first.

## Summary

Adds 3 regression tests covering the critical paths identified in the code review of #717:

- **`migrateDefaultIdentityIfNeeded aborts when encryption fails`** — Verifies that when `encryptWithDeviceKey` throws (e.g. Keystore unavailable), no identity is inserted with null keys. This was the root cause of the original identity loss bug.
- **`migrateDefaultIdentityIfNeeded removes placeholder when file content is invalid`** — Verifies that when the `default_identity` file exists but has wrong size, the migration placeholder is cleaned up to prevent an infinite failed-migration loop on every cold start.
- **`ensureIdentityFileExists recovers from encryptedKeyData when no file or legacy keyData`** — Verifies the last-resort decryption fallback path: when no identity file exists on disk and no legacy plaintext `keyData` is available, the method successfully decrypts `encryptedKeyData` and recovers the file.

## Test plan

- [x] All 26 `IdentityRepositoryDatabaseTest` tests pass
- [x] detekt passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)