### PR TITLE
fix: handle inline field=value variables in Micron links

### DIFF
--- a/app/src/main/java/com/lxmf/messenger/viewmodel/NomadNetBrowserViewModel.kt
+++ b/app/src/main/java/com/lxmf/messenger/viewmodel/NomadNetBrowserViewModel.kt
@@ -226,14 +226,36 @@ class NomadNetBrowserViewModel
 
             partialManager?.clear()
 
-            // Collect form field values for submission
+            // Collect form field values for submission.
+            // NomadNet link fields can be:
+            //   - "fieldname" → look up value from form fields
+            //   - "key=value" → inline variable (sent as "var_key")
+            //   - "*" → submit all form fields
             val isFormSubmission = fieldNames.isNotEmpty()
             val formDataJson =
                 if (isFormSubmission) {
                     val data = JSONObject()
-                    for (fieldName in fieldNames) {
-                        val value = _formFields.value[fieldName] ?: ""
-                        data.put(fieldName, value)
+                    val submitAll = "*" in fieldNames
+                    for (fieldEntry in fieldNames) {
+                        if (fieldEntry == "*") continue
+                        if ("=" in fieldEntry) {
+                            // Inline variable: "key=value" → sent as "var_key"
+                            val eqIdx = fieldEntry.indexOf('=')
+                            val key = fieldEntry.substring(0, eqIdx)
+                            val value = fieldEntry.substring(eqIdx + 1)
+                            data.put("var_$key", value)
+                        } else {
+                            // Form field reference: look up value from form state
+                            val value = _formFields.value[fieldEntry] ?: ""
+                            data.put(fieldEntry, value)
+                        }
+                    }
+                    if (submitAll) {
+                        for ((key, value) in _formFields.value) {
+                            if (!data.has(key)) {
+                                data.put(key, value)
+                            }
+                        }
                     }
                     data.toString()
                 } else {


### PR DESCRIPTION
## Summary
- NomadNet Micron links can embed variables as `key=value` pairs in the link field list
- Previously Columba treated `key=value` as a form field name to look up, so the value was never sent
- Now splits on `=` and sends as `var_key` matching NomadNet Browser.py behavior
- Also adds `*` wildcard support for submitting all form fields

## Root cause
Links like `[Download`:/page/download.mu`file=app.apk]` include `file=app.apk` as an inline variable. NomadNet's Browser.py (line 198) splits this: `request_data["var_file"] = "app.apk"`. Columba was sending `{"field_file=app.apk": ""}` instead.

## Test plan
- [x] All existing `NomadNetBrowserViewModelTest` tests pass
- [x] detekt passes
- [ ] Click a NomadNet link with inline variables → server receives correct var_ data

🤖 Generated with [Claude Code](https://claude.com/claude-code)