### PR TITLE
fix: prevent announce list scroll jumps when new announces arrive

### DIFF
--- a/app/src/main/java/com/lxmf/messenger/ui/screens/AnnounceStreamScreen.kt
+++ b/app/src/main/java/com/lxmf/messenger/ui/screens/AnnounceStreamScreen.kt
@@ -1034,19 +1034,21 @@ fun ClearAllAnnouncesDialog(
 /**
  * Stable key function for announce paging lists.
  *
- * Uses [AnnounceEntity.destinationHash] as the primary key so Compose can track
+ * Uses [com.lxmf.messenger.data.repository.Announce.destinationHash] as the primary key so Compose can track
  * items across list re-sorts (e.g., when new announces insert at the top).
  * Falls back to appending a disambiguator only for transient Paging3 duplicates
  * (issue #542) to avoid a duplicate-key crash.
  */
 private fun LazyPagingItems<com.lxmf.messenger.data.repository.Announce>.stableKey(): (index: Int) -> Any {
     val seen = mutableSetOf<String>()
-    return { index ->
-        val hash = peek(index)?.destinationHash
-        if (hash != null) {
-            if (seen.add(hash)) hash else "${hash}_dup$index"
-        } else {
-            "placeholder_$index"
+    val keys =
+        Array<Any>(itemCount) { index ->
+            val hash = peek(index)?.destinationHash
+            if (hash != null) {
+                if (seen.add(hash)) hash else "${hash}_dup$index"
+            } else {
+                "placeholder_$index"
+            }
         }
-    }
+    return { index -> keys[index] }
 }


### PR DESCRIPTION
## Summary
The announce list on the Network tab jumps around when new announces arrive, making it hard to select a specific node.

## Root cause
The `LazyColumn` key was `"${hash}_$index"`. When a new announce inserts at position 0 (sorted by timestamp), every existing item's index shifts by 1, generating entirely new keys. Compose can't match old items to new items, so it rebuilds the entire list and loses scroll position.

## Fix
Use `destinationHash` alone as the stable key via a `stableKey()` extension function. For the transient Paging3 duplicate edge case (#542), only actual duplicates get a disambiguated key (`hash_dupN`) instead of every item.

## Test plan
- [x] Build passes
- [x] detekt passes
- [x] `AnnounceStreamScreenTest` passes
- [ ] Scroll to middle of announce list, wait for new announces to arrive — list should not jump

🤖 Generated with [Claude Code](https://claude.com/claude-code)