### PR TITLE
backport: deduplicate path requests with hasPath guard (#735)

### DIFF
--- a/app/src/main/java/com/lxmf/messenger/service/IdentityResolutionManager.kt
+++ b/app/src/main/java/com/lxmf/messenger/service/IdentityResolutionManager.kt
@@ -3,6 +3,7 @@ package com.lxmf.messenger.service
 import android.util.Log
 import com.lxmf.messenger.data.db.entity.ContactStatus
 import com.lxmf.messenger.data.repository.ContactRepository
+import com.lxmf.messenger.data.repository.ConversationRepository
 import com.lxmf.messenger.reticulum.protocol.ReticulumProtocol
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
@@ -16,25 +17,26 @@ import javax.inject.Singleton
 /**
  * Manages background identity resolution for pending contacts.
  *
- * This manager periodically:
- * 1. Checks pending contacts against Reticulum's identity cache
- * 2. Requests paths for contacts that need resolution
- * 3. Marks contacts as UNRESOLVED after 24 hours
- * 4. Persists transport data (paths) for crash resilience
- * 5. Requests paths for all contacts at startup as a safety net
+ * This manager:
+ * 1. Requests paths for the 3 most recent conversations at startup
+ * 2. Periodically checks pending contacts (every 3h, gives up after 24h)
+ * 3. Persists transport data for crash resilience
+ *
+ * All path requests go through [requestPathIfNeeded] which checks hasPath first.
  */
 @Singleton
 class IdentityResolutionManager
     @Inject
     constructor(
         private val contactRepository: ContactRepository,
+        private val conversationRepository: ConversationRepository,
         private val reticulumProtocol: ReticulumProtocol,
     ) {
         companion object {
             private const val TAG = "IdentityResolutionMgr"
 
-            // Check interval: 15 minutes
-            private const val CHECK_INTERVAL_MS = 15 * 60 * 1000L
+            // Check interval: 3 hours
+            private const val CHECK_INTERVAL_MS = 3 * 60 * 60 * 1000L
 
             // Resolution timeout: 24 hours
             private const val RESOLUTION_TIMEOUT_MS = 24 * 60 * 60 * 1000L
@@ -44,6 +46,9 @@ class IdentityResolutionManager
 
             // Delay before startup sweep to let Reticulum initialize
             private const val STARTUP_SWEEP_DELAY_MS = 5_000L
+
+            // Number of recent conversations to request paths for at startup
+            private const val STARTUP_SWEEP_LIMIT = 3
         }
 
         private var resolutionJob: Job? = null
@@ -73,11 +78,11 @@ class IdentityResolutionManager
                     }
                 }
 
-            // One-shot startup sweep: request paths for all contacts as a safety net
+            // One-shot startup sweep: request paths for 3 most recent conversations
             startupSweepJob =
                 scope.launch(Dispatchers.IO) {
                     delay(STARTUP_SWEEP_DELAY_MS)
-                    requestPathsForAllContacts()
+                    requestPathsForRecentConversations()
                 }
         }
 
@@ -136,9 +141,8 @@ class IdentityResolutionManager
                                 publicKey = identity.publicKey,
                             )
                         } else {
-                            // Not in cache, request path to trigger network search
-                            Log.d(TAG, "Requesting path for ${contact.destinationHash.take(8)}...")
-                            reticulumProtocol.requestPath(destHashBytes)
+                            // Not in cache, request path (guarded) to trigger network search
+                            requestPathIfNeeded(destHashBytes, contact.destinationHash)
                         }
                     } catch (e: Exception) {
                         Log.e(TAG, "Error processing contact ${contact.destinationHash.take(8)}...", e)
@@ -166,53 +170,38 @@ class IdentityResolutionManager
                         .map { it.toInt(16).toByte() }
                         .toByteArray()
 
-                if (reticulumProtocol.hasPath(destHashBytes)) {
-                    Log.d(TAG, "Path already exists for ${destinationHash.take(8)}..., skipping request")
-                    return
-                }
-
-                Log.d(TAG, "Requesting path for ${destinationHash.take(8)}...")
-                reticulumProtocol.requestPath(destHashBytes)
+                requestPathIfNeeded(destHashBytes, destinationHash)
             } catch (e: Exception) {
                 Log.e(TAG, "Error requesting path for ${destinationHash.take(8)}...", e)
             }
         }
 
         /**
-         * Request paths for all active and pending contacts.
-         * Called once at startup as a safety net to repopulate the path table.
+         * Request paths for the N most recent conversations.
+         * Called once at startup to ensure the most relevant peers are reachable.
          */
-        private suspend fun requestPathsForAllContacts() {
+        private suspend fun requestPathsForRecentConversations() {
             try {
-                val contacts =
-                    contactRepository.getContactsByStatus(
-                        listOf(ContactStatus.ACTIVE, ContactStatus.PENDING_IDENTITY),
-                    )
+                val recentPeerHashes = conversationRepository.getRecentPeerHashes(STARTUP_SWEEP_LIMIT)
 
-                if (contacts.isEmpty()) {
-                    Log.d(TAG, "Startup sweep: no contacts to request paths for")
+                if (recentPeerHashes.isEmpty()) {
+                    Log.d(TAG, "Startup sweep: no recent conversations")
                     return
                 }
 
-                Log.d(TAG, "Startup sweep: requesting paths for ${contacts.size} contact(s)")
+                Log.d(TAG, "Startup sweep: requesting paths for ${recentPeerHashes.size} recent conversation(s)")
 
-                for (contact in contacts) {
+                for (peerHash in recentPeerHashes) {
                     try {
                         val destHashBytes =
-                            contact.destinationHash
+                            peerHash
                                 .chunked(2)
                                 .map { it.toInt(16).toByte() }
                                 .toByteArray()
 
-                        if (reticulumProtocol.hasPath(destHashBytes)) {
-                            Log.d(TAG, "Startup sweep: path exists for ${contact.destinationHash.take(8)}..., skipping")
-                            continue
-                        }
-
-                        Log.d(TAG, "Startup sweep: requesting path for ${contact.destinationHash.take(8)}...")
-                        reticulumProtocol.requestPath(destHashBytes)
+                        requestPathIfNeeded(destHashBytes, peerHash)
                     } catch (e: Exception) {
-                        Log.e(TAG, "Startup sweep: error for ${contact.destinationHash.take(8)}...", e)
+                        Log.e(TAG, "Startup sweep: error for ${peerHash.take(8)}...", e)
                     }
                     delay(PATH_REQUEST_STAGGER_MS)
                 }
@@ -233,13 +222,29 @@ class IdentityResolutionManager
         suspend fun retryResolution(destinationHash: String) {
             Log.d(TAG, "Retry resolution for ${destinationHash.take(8)}...")
 
-            // Request path on network
             val destHashBytes =
                 destinationHash
                     .chunked(2)
                     .map { it.toInt(16).toByte() }
                     .toByteArray()
 
+            requestPathIfNeeded(destHashBytes, destinationHash)
+        }
+
+        /**
+         * Central path request method — checks hasPath before requesting.
+         * All path requests in this class must go through here.
+         */
+        private suspend fun requestPathIfNeeded(
+            destHashBytes: ByteArray,
+            displayHash: String,
+        ) {
+            if (reticulumProtocol.hasPath(destHashBytes)) {
+                Log.d(TAG, "Path exists for ${displayHash.take(8)}..., skipping request")
+                return
+            }
+
+            Log.d(TAG, "Requesting path for ${displayHash.take(8)}...")
             reticulumProtocol.requestPath(destHashBytes)
         }
     }

--- a/app/src/main/java/com/lxmf/messenger/service/IdentityResolutionManager.kt
+++ b/app/src/main/java/com/lxmf/messenger/service/IdentityResolutionManager.kt
@@ -222,13 +222,17 @@ class IdentityResolutionManager
         suspend fun retryResolution(destinationHash: String) {
             Log.d(TAG, "Retry resolution for ${destinationHash.take(8)}...")
 
-            val destHashBytes =
-                destinationHash
-                    .chunked(2)
-                    .map { it.toInt(16).toByte() }
-                    .toByteArray()
+            try {
+                val destHashBytes =
+                    destinationHash
+                        .chunked(2)
+                        .map { it.toInt(16).toByte() }
+                        .toByteArray()
 
-            requestPathIfNeeded(destHashBytes, destinationHash)
+                requestPathIfNeeded(destHashBytes, destinationHash)
+            } catch (e: Exception) {
+                Log.e(TAG, "Error in retryResolution for ${destinationHash.take(8)}...", e)
+            }
         }
 
         /**

--- a/data/src/main/java/com/lxmf/messenger/data/db/dao/ConversationDao.kt
+++ b/data/src/main/java/com/lxmf/messenger/data/db/dao/ConversationDao.kt
@@ -156,6 +156,19 @@ interface ConversationDao {
     @Query("SELECT * FROM conversations WHERE identityHash = :identityHash")
     suspend fun getAllConversationsList(identityHash: String): List<ConversationEntity>
 
+    @Query(
+        """
+        SELECT peerHash FROM conversations
+        WHERE identityHash = :identityHash
+        ORDER BY lastMessageTimestamp DESC
+        LIMIT :limit
+        """,
+    )
+    suspend fun getRecentPeerHashes(
+        identityHash: String,
+        limit: Int,
+    ): List<String>
+
     /**
      * Bulk insert conversations (for import).
      */

--- a/data/src/main/java/com/lxmf/messenger/data/repository/ConversationRepository.kt
+++ b/data/src/main/java/com/lxmf/messenger/data/repository/ConversationRepository.kt
@@ -142,6 +142,14 @@ class ConversationRepository
         }
 
         /**
+         * Get the peer hashes of the N most recent conversations (by last message time).
+         */
+        suspend fun getRecentPeerHashes(limit: Int): List<String> {
+            val activeIdentity = localIdentityDao.getActiveIdentitySync() ?: return emptyList()
+            return conversationDao.getRecentPeerHashes(activeIdentity.identityHash, limit)
+        }
+
+        /**
          * Get all messages for a specific conversation for the active identity.
          * Automatically switches when identity changes.
          */

--- a/python/lxst_modules/call_manager.py
+++ b/python/lxst_modules/call_manager.py
@@ -330,23 +330,14 @@ class CallManager:
             identity = RNS.Identity.recall(identity_hash)
             RNS.log(f"Identity.recall() returned: {identity is not None}", RNS.LOG_DEBUG)
 
-            # If identity not known locally, query the network (same pattern as LXMF messaging)
+            # If identity not known locally, request path (guarded) and fail immediately
             if identity is None:
-                RNS.log(f"Identity not found, requesting path to {destination_hash_hex[:16]}...", RNS.LOG_DEBUG)
-                try:
-                    RNS.Transport.request_path(identity_hash)
-                except Exception as e:
-                    RNS.log(f"Error requesting path: {e}", RNS.LOG_WARNING)
-
-                # Wait up to 5 seconds for path response to resolve identity
-                for attempt in range(10):
-                    if self._cancel_event.is_set():
-                        return {"success": False, "error": "Call cancelled"}
-                    time.sleep(0.5)
-                    identity = RNS.Identity.recall(identity_hash)
-                    if identity:
-                        RNS.log(f"Identity resolved after path request (attempt {attempt + 1})", RNS.LOG_DEBUG)
-                        break
+                RNS.log(f"Identity not found for {destination_hash_hex[:16]}, requesting path...", RNS.LOG_DEBUG)
+                if not RNS.Transport.has_path(identity_hash):
+                    try:
+                        RNS.Transport.request_path(identity_hash)
+                    except Exception as e:
+                        RNS.log(f"Error requesting path: {e}", RNS.LOG_WARNING)
 
             if identity is None:
                 RNS.log(f"Unknown identity: {destination_hash_hex[:16]}...", RNS.LOG_WARNING)

--- a/python/reticulum_wrapper.py
+++ b/python/reticulum_wrapper.py
@@ -3868,10 +3868,9 @@ class ReticulumWrapper:
                          f"Identity not found for {dest_hash.hex()[:16]}, requesting path...")
                 self._request_path_if_needed(dest_hash)
 
-                if not recipient_identity:
-                    error_msg = f"Recipient identity {dest_hash.hex()[:16]} not known. Path requested but no response received."
-                    log_error("ReticulumWrapper", "send_location_telemetry", f"❌ {error_msg}")
-                    return {"success": False, "error": error_msg}
+                error_msg = f"Recipient identity {dest_hash.hex()[:16]} not known — path requested, retry shortly"
+                log_error("ReticulumWrapper", "send_location_telemetry", f"❌ {error_msg}")
+                return {"success": False, "error": error_msg}
 
             # Create outgoing LXMF destination
             recipient_lxmf_destination = RNS.Destination(
@@ -4031,10 +4030,9 @@ class ReticulumWrapper:
                          f"Identity not found for {dest_hash.hex()[:16]}, requesting path...")
                 self._request_path_if_needed(dest_hash)
 
-                if not recipient_identity:
-                    error_msg = f"Collector identity {dest_hash.hex()[:16]} not known. Path requested but no response received."
-                    log_error("ReticulumWrapper", "send_telemetry_request", f"❌ {error_msg}")
-                    return {"success": False, "error": error_msg}
+                error_msg = f"Collector identity {dest_hash.hex()[:16]} not known — path requested, retry shortly"
+                log_error("ReticulumWrapper", "send_telemetry_request", f"❌ {error_msg}")
+                return {"success": False, "error": error_msg}
 
             # Create outgoing LXMF destination
             recipient_lxmf_destination = RNS.Destination(
@@ -4409,8 +4407,7 @@ class ReticulumWrapper:
                          f"Identity not found for {dest_hash.hex()[:16]}, requesting path...")
                 self._request_path_if_needed(dest_hash)
 
-                if not recipient_identity:
-                    return {"success": False, "error": f"Recipient identity {dest_hash.hex()[:16]} not known. Path requested but no response received.", "delivery_method": None}
+                return {"success": False, "error": f"Recipient identity {dest_hash.hex()[:16]} not known — path requested, retry shortly", "delivery_method": None}
 
             # Create destination
             recipient_lxmf_destination = RNS.Destination(
@@ -6198,8 +6195,8 @@ class ReticulumWrapper:
     def _request_path_if_needed(self, dest_hash: bytes) -> bool:
         """Request a path only if one doesn't already exist.
 
-        Returns True if a path exists (either already cached or just requested).
-        Returns False if the request could not be made (mock mode returns True).
+        Returns True  — path already present, or running in mock mode (no request fired).
+        Returns False — a path request was fired (or attempted); path not yet available.
         Callers that need to wait for the path should poll has_path() themselves.
         """
         if not RETICULUM_AVAILABLE or not self.reticulum:
@@ -6216,15 +6213,17 @@ class ReticulumWrapper:
         return False
 
     def request_path(self, dest_hash: bytes) -> Dict:
-        """Request a path to a destination (public API, used by Kotlin)."""
-        try:
-            if not RETICULUM_AVAILABLE:
-                return {"success": True}
+        """Request a path to a destination (public API, used by Kotlin).
 
-            self._request_path_if_needed(dest_hash)
+        Always returns success=True — transport-level exceptions are caught
+        and logged by _request_path_if_needed, so callers cannot distinguish
+        a successful fire from a failed one.
+        """
+        if not RETICULUM_AVAILABLE:
             return {"success": True}
-        except Exception as e:
-            return {"success": False, "error": str(e)}
+
+        self._request_path_if_needed(dest_hash)
+        return {"success": True}
 
     def persist_transport_data(self) -> Dict:
         """Persist Reticulum's transport data (path table, destinations) to disk."""

--- a/python/reticulum_wrapper.py
+++ b/python/reticulum_wrapper.py
@@ -3033,28 +3033,12 @@ class ReticulumWrapper:
                                             requester_identity = RNS.Identity.recall(lxmf_message.source_hash)
 
                                             if requester_identity is None:
-                                                # Identity not cached - request path from network (Sideband pattern)
+                                                # Identity not cached — request path (if needed) but don't block delivery
                                                 log_info("ReticulumWrapper", "_on_lxmf_delivery",
                                                         f"Identity for {lxmf_message.source_hash.hex()[:16]} not recalled, requesting path...")
-                                                RNS.Transport.request_path(lxmf_message.source_hash)
-                                                # Queue for retry after path resolution
-                                                def retry_send():
-                                                    import time
-                                                    time.sleep(2)  # Wait for path resolution
-                                                    retry_identity = RNS.Identity.recall(lxmf_message.source_hash)
-                                                    if retry_identity:
-                                                        log_info("ReticulumWrapper", "_on_lxmf_delivery",
-                                                                f"Identity recalled on retry, sending telemetry stream")
-                                                        self._send_telemetry_stream_response(
-                                                            lxmf_message.source_hash,
-                                                            retry_identity,
-                                                            timebase
-                                                        )
-                                                    else:
-                                                        log_warning("ReticulumWrapper", "_on_lxmf_delivery",
-                                                                   f"Still cannot recall identity for {lxmf_message.source_hash.hex()[:16]} after retry")
-                                                import threading
-                                                threading.Thread(target=retry_send, daemon=True).start()
+                                                self._request_path_if_needed(lxmf_message.source_hash)
+                                                log_warning("ReticulumWrapper", "_on_lxmf_delivery",
+                                                           f"Cannot send telemetry stream — identity for {lxmf_message.source_hash.hex()[:16]} not available")
                                             else:
                                                 self._send_telemetry_stream_response(
                                                     lxmf_message.source_hash,
@@ -3586,29 +3570,14 @@ class ReticulumWrapper:
                 log_info("ReticulumWrapper", "send_lxmf_message", f"✅ Retrieved identity from local cache")
 
             if not recipient_identity:
-                # Request path from network (triggers announces from peers who know destination)
+                # Fire-and-forget path request (guarded by has_path check)
                 log_info("ReticulumWrapper", "send_lxmf_message",
-                         f"Identity not found, requesting path to {dest_hash.hex()[:16]}...")
-                try:
-                    RNS.Transport.request_path(dest_hash)
-                except Exception as e:
-                    log_warning("ReticulumWrapper", "send_lxmf_message", f"Error requesting path: {e}")
+                         f"Identity not found for {dest_hash.hex()[:16]}, requesting path...")
+                self._request_path_if_needed(dest_hash)
 
-                # Wait up to 5 seconds for path response
-                for attempt in range(10):
-                    time.sleep(0.5)
-                    recipient_identity = RNS.Identity.recall(dest_hash)
-                    if not recipient_identity:
-                        recipient_identity = RNS.Identity.recall(dest_hash, from_identity_hash=True)
-                    if recipient_identity:
-                        log_info("ReticulumWrapper", "send_lxmf_message",
-                                 f"✅ Identity resolved after path request (attempt {attempt + 1})")
-                        break
-
-                if not recipient_identity:
-                    error_msg = f"Cannot send message: Recipient identity {dest_hash.hex()[:16]} not known. Path requested but no response received."
-                    log_error("ReticulumWrapper", "send_lxmf_message", f"❌ {error_msg}")
-                    return {"success": False, "error": error_msg}
+                error_msg = f"Recipient identity {dest_hash.hex()[:16]} not known — path requested, retry shortly"
+                log_warning("ReticulumWrapper", "send_lxmf_message", error_msg)
+                return {"success": False, "error": error_msg}
 
             # Create outgoing LXMF destination object from the recalled identity
             # The router.handle_outbound() REQUIRES a destination object, not just a hash!
@@ -3894,24 +3863,10 @@ class ReticulumWrapper:
                 recipient_identity = self.identities[dest_hash_hex]
 
             if not recipient_identity:
-                # Request path from network (triggers announces from peers who know destination)
+                # Fire-and-forget path request (guarded by has_path check)
                 log_info("ReticulumWrapper", "send_location_telemetry",
-                         f"Identity not found, requesting path to {dest_hash.hex()[:16]}...")
-                try:
-                    RNS.Transport.request_path(dest_hash)
-                except Exception as e:
-                    log_warning("ReticulumWrapper", "send_location_telemetry", f"Error requesting path: {e}")
-
-                # Wait up to 5 seconds for path response
-                for attempt in range(10):
-                    time.sleep(0.5)
-                    recipient_identity = RNS.Identity.recall(dest_hash)
-                    if not recipient_identity:
-                        recipient_identity = RNS.Identity.recall(dest_hash, from_identity_hash=True)
-                    if recipient_identity:
-                        log_info("ReticulumWrapper", "send_location_telemetry",
-                                 f"✅ Identity resolved after path request (attempt {attempt + 1})")
-                        break
+                         f"Identity not found for {dest_hash.hex()[:16]}, requesting path...")
+                self._request_path_if_needed(dest_hash)
 
                 if not recipient_identity:
                     error_msg = f"Recipient identity {dest_hash.hex()[:16]} not known. Path requested but no response received."
@@ -4071,24 +4026,10 @@ class ReticulumWrapper:
                 recipient_identity = self.identities[dest_hash_hex]
 
             if not recipient_identity:
-                # Request path from network (triggers announces from peers who know destination)
+                # Fire-and-forget path request (guarded by has_path check)
                 log_info("ReticulumWrapper", "send_telemetry_request",
-                         f"Identity not found, requesting path to {dest_hash.hex()[:16]}...")
-                try:
-                    RNS.Transport.request_path(dest_hash)
-                except Exception as e:
-                    log_warning("ReticulumWrapper", "send_telemetry_request", f"Error requesting path: {e}")
-
-                # Wait up to 5 seconds for path response
-                for attempt in range(10):
-                    time.sleep(0.5)
-                    recipient_identity = RNS.Identity.recall(dest_hash)
-                    if not recipient_identity:
-                        recipient_identity = RNS.Identity.recall(dest_hash, from_identity_hash=True)
-                    if recipient_identity:
-                        log_info("ReticulumWrapper", "send_telemetry_request",
-                                 f"✅ Identity resolved after path request (attempt {attempt + 1})")
-                        break
+                         f"Identity not found for {dest_hash.hex()[:16]}, requesting path...")
+                self._request_path_if_needed(dest_hash)
 
                 if not recipient_identity:
                     error_msg = f"Collector identity {dest_hash.hex()[:16]} not known. Path requested but no response received."
@@ -4463,24 +4404,10 @@ class ReticulumWrapper:
                 recipient_identity = self.identities[dest_hash.hex()]
 
             if not recipient_identity:
-                # Request path from network (triggers announces from peers who know destination)
+                # Fire-and-forget path request (guarded by has_path check)
                 log_info("ReticulumWrapper", "send_lxmf_message_with_method",
-                         f"Identity not found, requesting path to {dest_hash.hex()[:16]}...")
-                try:
-                    RNS.Transport.request_path(dest_hash)
-                except Exception as e:
-                    log_warning("ReticulumWrapper", "send_lxmf_message_with_method", f"Error requesting path: {e}")
-
-                # Wait up to 5 seconds for path response
-                for attempt in range(10):
-                    time.sleep(0.5)
-                    recipient_identity = RNS.Identity.recall(dest_hash)
-                    if not recipient_identity:
-                        recipient_identity = RNS.Identity.recall(dest_hash, from_identity_hash=True)
-                    if recipient_identity:
-                        log_info("ReticulumWrapper", "send_lxmf_message_with_method",
-                                 f"✅ Identity resolved after path request (attempt {attempt + 1})")
-                        break
+                         f"Identity not found for {dest_hash.hex()[:16]}, requesting path...")
+                self._request_path_if_needed(dest_hash)
 
                 if not recipient_identity:
                     return {"success": False, "error": f"Recipient identity {dest_hash.hex()[:16]} not known. Path requested but no response received.", "delivery_method": None}
@@ -4752,26 +4679,11 @@ class ReticulumWrapper:
                 recipient_identity = self.identities[dest_hash.hex()]
 
             if not recipient_identity:
-                # Request path from network
+                # Fire-and-forget path request (guarded by has_path check)
                 log_info("ReticulumWrapper", "send_reaction",
-                         f"Identity not found, requesting path to {dest_hash.hex()[:16]}...")
-                try:
-                    RNS.Transport.request_path(dest_hash)
-                except Exception as e:
-                    log_warning("ReticulumWrapper", "send_reaction", f"Error requesting path: {e}")
-
-                # Wait up to 5 seconds for path response
-                wait_start = time.time()
-                while time.time() - wait_start < 5:
-                    recipient_identity = RNS.Identity.recall(dest_hash)
-                    if not recipient_identity:
-                        recipient_identity = RNS.Identity.recall(dest_hash, from_identity_hash=True)
-                    if recipient_identity:
-                        break
-                    time.sleep(0.1)
-
-                if not recipient_identity:
-                    return {"success": False, "error": f"Recipient identity {dest_hash.hex()[:16]} not known"}
+                         f"Identity not found for {dest_hash.hex()[:16]}, requesting path...")
+                self._request_path_if_needed(dest_hash)
+                return {"success": False, "error": f"Recipient identity {dest_hash.hex()[:16]} not known — path requested, retry shortly"}
 
             # Create destination
             recipient_lxmf_destination = RNS.Destination(
@@ -6283,13 +6195,33 @@ class ReticulumWrapper:
 
         return RNS.Transport.has_path(dest_hash)
 
+    def _request_path_if_needed(self, dest_hash: bytes) -> bool:
+        """Request a path only if one doesn't already exist.
+
+        Returns True if a path exists (either already cached or just requested).
+        Returns False if the request could not be made (mock mode returns True).
+        Callers that need to wait for the path should poll has_path() themselves.
+        """
+        if not RETICULUM_AVAILABLE or not self.reticulum:
+            return True
+
+        if RNS.Transport.has_path(dest_hash):
+            return True
+
+        try:
+            RNS.Transport.request_path(dest_hash)
+        except Exception as e:
+            log_warning("ReticulumWrapper", "_request_path_if_needed",
+                       f"Error requesting path to {dest_hash.hex()[:16]}: {e}")
+        return False
+
     def request_path(self, dest_hash: bytes) -> Dict:
-        """Request a path to a destination"""
+        """Request a path to a destination (public API, used by Kotlin)."""
         try:
             if not RETICULUM_AVAILABLE:
                 return {"success": True}
 
-            RNS.Transport.request_path(dest_hash)
+            self._request_path_if_needed(dest_hash)
             return {"success": True}
         except Exception as e:
             return {"success": False, "error": str(e)}
@@ -6721,7 +6653,7 @@ class ReticulumWrapper:
             if not has_path:
                 log_debug("ReticulumWrapper", "establish_link",
                          f"Requesting path to {recipient_dest.hash.hex()[:16]}...")
-                RNS.Transport.request_path(recipient_dest.hash)
+                self._request_path_if_needed(recipient_dest.hash)
 
             # Wait for path if we don't have one
             if not has_path:

--- a/python/reticulum_wrapper.py
+++ b/python/reticulum_wrapper.py
@@ -3033,12 +3033,20 @@ class ReticulumWrapper:
                                             requester_identity = RNS.Identity.recall(lxmf_message.source_hash)
 
                                             if requester_identity is None:
-                                                # Identity not cached — request path (if needed) but don't block delivery
-                                                log_info("ReticulumWrapper", "_on_lxmf_delivery",
-                                                        f"Identity for {lxmf_message.source_hash.hex()[:16]} not recalled, requesting path...")
-                                                self._request_path_if_needed(lxmf_message.source_hash)
+                                                # Try identity hash lookup — the sender's path exists
+                                                # (the message arrived), but the identity may be keyed
+                                                # differently in the recall cache.
+                                                requester_identity = RNS.Identity.recall(
+                                                    lxmf_message.source_hash, from_identity_hash=True)
+
+                                            if requester_identity is None:
+                                                # Both lookups failed — silently drop the telemetry
+                                                # response. The sender's identity was never announced
+                                                # to us; a path request won't help since we already
+                                                # have the path (the message arrived over it).
                                                 log_warning("ReticulumWrapper", "_on_lxmf_delivery",
-                                                           f"Cannot send telemetry stream — identity for {lxmf_message.source_hash.hex()[:16]} not available")
+                                                           f"Cannot send telemetry stream — identity for "
+                                                           f"{lxmf_message.source_hash.hex()[:16]} not recalled")
                                             else:
                                                 self._send_telemetry_stream_response(
                                                     lxmf_message.source_hash,

--- a/python/test_path_request.py
+++ b/python/test_path_request.py
@@ -35,39 +35,46 @@ class TestPathRequestIntegration(unittest.TestCase):
     """Integration tests that verify the path request code is present and structured correctly."""
 
     def test_path_request_code_exists_in_send_lxmf_message(self):
-        """Verify that send_lxmf_message contains path request logic"""
+        """Verify that send_lxmf_message delegates path requests to _request_path_if_needed"""
         import inspect
         source = inspect.getsource(reticulum_wrapper.ReticulumWrapper.send_lxmf_message)
 
-        # Check for key patterns that indicate path request logic
-        self.assertIn('Transport.request_path', source,
-                      "send_lxmf_message should call Transport.request_path")
-        self.assertIn('Identity not found, requesting path', source,
-                      "send_lxmf_message should log path request")
-        self.assertIn('Identity resolved after path request', source,
-                      "send_lxmf_message should log successful resolution")
+        # Send methods now delegate to _request_path_if_needed instead of calling Transport directly
+        self.assertIn('_request_path_if_needed', source,
+                      "send_lxmf_message should call _request_path_if_needed")
+        self.assertIn('Identity not found', source,
+                      "send_lxmf_message should log when identity is not found")
 
     def test_path_request_code_exists_in_send_lxmf_message_with_method(self):
-        """Verify that send_lxmf_message_with_method contains path request logic"""
+        """Verify that send_lxmf_message_with_method delegates path requests to _request_path_if_needed"""
         import inspect
         source = inspect.getsource(reticulum_wrapper.ReticulumWrapper.send_lxmf_message_with_method)
 
-        # Check for key patterns
-        self.assertIn('Transport.request_path', source,
-                      "send_lxmf_message_with_method should call Transport.request_path")
-        self.assertIn('Identity not found, requesting path', source,
-                      "send_lxmf_message_with_method should log path request")
+        # Send methods now delegate to _request_path_if_needed instead of calling Transport directly
+        self.assertIn('_request_path_if_needed', source,
+                      "send_lxmf_message_with_method should call _request_path_if_needed")
+        self.assertIn('Identity not found', source,
+                      "send_lxmf_message_with_method should log when identity is not found")
 
-    def test_retry_loop_has_correct_timing(self):
-        """Verify the retry loop parameters (10 iterations, 0.5s sleep = 5s total)"""
+    def test_no_retry_loop_in_send_method(self):
+        """Verify send methods no longer contain blocking retry loops.
+
+        After the path-dedup refactor, send methods call _request_path_if_needed
+        and fail immediately if the identity isn't found, rather than polling
+        in a 5-second retry loop.
+        """
         import inspect
         source = inspect.getsource(reticulum_wrapper.ReticulumWrapper.send_lxmf_message_with_method)
 
-        # Check for the retry loop structure
-        self.assertIn('range(10)', source,
-                      "Retry loop should iterate 10 times")
-        self.assertIn('sleep(0.5)', source,
-                      "Should sleep 0.5 seconds between retries")
+        # The retry loop (range(10) + sleep(0.5)) should be gone
+        self.assertNotIn('range(10)', source,
+                         "send_lxmf_message_with_method should no longer have a retry loop")
+        self.assertNotIn('sleep(0.5)', source,
+                         "send_lxmf_message_with_method should no longer sleep between retries")
+
+        # Instead, it should delegate to _request_path_if_needed
+        self.assertIn('_request_path_if_needed', source,
+                      "send_lxmf_message_with_method should delegate to _request_path_if_needed")
 
 
 class TestPathRequestErrorMessages(unittest.TestCase):

--- a/python/test_path_request.py
+++ b/python/test_path_request.py
@@ -86,7 +86,7 @@ class TestPathRequestErrorMessages(unittest.TestCase):
         source = inspect.getsource(reticulum_wrapper.ReticulumWrapper.send_lxmf_message_with_method)
 
         # The error message should indicate that a path was requested
-        self.assertIn('Path requested but no response received', source,
+        self.assertIn('path requested, retry shortly', source,
                       "Error message should mention path was requested")
 
 

--- a/python/test_telemetry_host_mode.py
+++ b/python/test_telemetry_host_mode.py
@@ -1221,8 +1221,8 @@ class TestOnLxmfDeliveryFieldCommands(unittest.TestCase):
         # Verify _send_telemetry_stream_response was NOT called
         self.wrapper._send_telemetry_stream_response.assert_not_called()
 
-    def test_handles_field_commands_with_identity_retry(self):
-        """Should retry sending when identity is not immediately recalled."""
+    def test_skips_telemetry_response_when_identity_not_found(self):
+        """Should skip telemetry response when identity is not recalled (no retry thread)."""
         commands = [{reticulum_wrapper.COMMAND_TELEMETRY_REQUEST: [0, True]}]
         fields = {reticulum_wrapper.FIELD_COMMANDS: commands}
         mock_message = self._create_mock_lxmf_message(fields=fields)
@@ -1230,29 +1230,16 @@ class TestOnLxmfDeliveryFieldCommands(unittest.TestCase):
         # Add requester to allowed list (source_hash is "a" * 32)
         self.wrapper.telemetry_allowed_requesters = {"a" * 32}
 
-        # First recall returns None, then returns identity on retry
-        mock_identity = MagicMock()
-        reticulum_wrapper.RNS.Identity.recall.side_effect = [None, mock_identity]
+        # Identity recall returns None — path will be requested but response skipped
+        reticulum_wrapper.RNS.Identity.recall.return_value = None
 
         # Spy on _send_telemetry_stream_response
         self.wrapper._send_telemetry_stream_response = MagicMock()
 
-        # Patch threading and time.sleep to execute immediately
-        with unittest.mock.patch('threading.Thread') as mock_thread:
-            # Capture and execute the thread target immediately
-            def run_target(*args, **kwargs):
-                target = kwargs.get('target')
-                if target:
-                    # Patch time.sleep inside the target
-                    with unittest.mock.patch('time.sleep'):
-                        target()
-                return MagicMock()
-            mock_thread.side_effect = run_target
+        self.wrapper._on_lxmf_delivery(mock_message)
 
-            self.wrapper._on_lxmf_delivery(mock_message)
-
-        # Verify _send_telemetry_stream_response was called after retry
-        self.wrapper._send_telemetry_stream_response.assert_called()
+        # Verify _send_telemetry_stream_response was NOT called (identity unknown)
+        self.wrapper._send_telemetry_stream_response.assert_not_called()
 
     def test_ignores_non_collector_request(self):
         """Should ignore telemetry requests with is_collector_request=False."""

--- a/python/test_wrapper_messaging.py
+++ b/python/test_wrapper_messaging.py
@@ -174,9 +174,14 @@ class TestSendLXMFMessage(unittest.TestCase):
     @patch('reticulum_wrapper.RNS')
     @patch('reticulum_wrapper.LXMF')
     def test_send_message_identity_not_found(self, mock_lxmf, mock_rns):
-        """Test sending when recipient identity cannot be recalled"""
+        """Test sending when recipient identity cannot be recalled.
+
+        When identity is not found, send_lxmf_message calls _request_path_if_needed
+        which checks has_path before calling Transport.request_path.
+        """
         wrapper = reticulum_wrapper.ReticulumWrapper(self.temp_dir)
         wrapper.initialized = True
+        wrapper.reticulum = Mock()  # Must be truthy for _request_path_if_needed to proceed
         wrapper.router = MagicMock()
 
         mock_local_dest = MagicMock()
@@ -189,7 +194,10 @@ class TestSendLXMFMessage(unittest.TestCase):
         # Empty identities cache
         wrapper.identities = {}
 
-        # Should still request path and attempt send
+        # has_path returns False so _request_path_if_needed will fire Transport.request_path
+        mock_rns.Transport.has_path = Mock(return_value=False)
+        mock_rns.Transport.request_path = Mock()
+
         result = wrapper.send_lxmf_message(
             dest_hash=b'0123456789abcdef',
             content="Test message",
@@ -200,8 +208,8 @@ class TestSendLXMFMessage(unittest.TestCase):
         self.assertFalse(result['success'])
         self.assertIn('error', result)
 
-        # Verify path request was attempted
-        mock_rns.Transport.request_path.assert_called()
+        # Verify path request was attempted (through _request_path_if_needed)
+        mock_rns.Transport.request_path.assert_called_once_with(b'0123456789abcdef')
 
     @patch('reticulum_wrapper.RNS')
     @patch('reticulum_wrapper.LXMF')
@@ -2328,25 +2336,26 @@ class TestPathRequestRetryLogic(unittest.TestCase):
     @patch('reticulum_wrapper.RNS')
     @patch('reticulum_wrapper.LXMF')
     def test_requests_path_when_identity_not_found(self, mock_lxmf_module, mock_rns, mock_sleep):
-        """Test that path is requested when identity recall initially fails"""
+        """Test that _request_path_if_needed fires when identity recall fails.
+
+        After the path-dedup refactor, the send method no longer retries in a loop.
+        It calls _request_path_if_needed (which checks has_path before requesting)
+        and returns an error immediately.
+        """
         wrapper = reticulum_wrapper.ReticulumWrapper(self.temp_dir)
         wrapper.initialized = True
+        wrapper.reticulum = Mock()  # Must be truthy for _request_path_if_needed to proceed
         wrapper.router = MagicMock()
         wrapper.local_lxmf_destination = MagicMock()
         wrapper.display_name = "Test"
 
-        # Identity found on 3rd attempt (after path request)
-        mock_identity = MagicMock()
-        mock_identity.hash = b'0123456789abcdef'
-        # recall returns None twice, then identity on 3rd call
-        mock_rns.Identity.recall.side_effect = [None, None, None, mock_identity]
+        # Identity never found (no retry loop to eventually find it)
+        mock_rns.Identity.recall.return_value = None
+        wrapper.identities = {}
 
-        mock_dest = MagicMock()
-        mock_rns.Destination.return_value = mock_dest
-
-        mock_message = MagicMock()
-        mock_message.hash = b'msghash123456789'
-        mock_lxmf_module.LXMessage.return_value = mock_message
+        # has_path returns False so Transport.request_path fires
+        mock_rns.Transport.has_path = Mock(return_value=False)
+        mock_rns.Transport.request_path = Mock()
 
         result = wrapper.send_lxmf_message_with_method(
             dest_hash=b'0123456789abcdef',
@@ -2355,16 +2364,22 @@ class TestPathRequestRetryLogic(unittest.TestCase):
             delivery_method="direct"
         )
 
-        # Verify path was requested
-        mock_rns.Transport.request_path.assert_called()
-        # Verify sleep was called (retry loop)
-        self.assertTrue(mock_sleep.called)
+        # Verify path was requested through _request_path_if_needed
+        mock_rns.Transport.request_path.assert_called_once_with(b'0123456789abcdef')
+        # Should return error immediately (no retry loop, no sleep)
+        self.assertFalse(result['success'])
+        self.assertIn('error', result)
+        self.assertFalse(mock_sleep.called, "No retry loop means no sleep calls")
 
     @patch('reticulum_wrapper.time.sleep')
     @patch('reticulum_wrapper.RNS')
     @patch('reticulum_wrapper.LXMF')
     def test_path_request_timeout_returns_error(self, mock_lxmf_module, mock_rns, mock_sleep):
-        """Test error returned when path request times out after all retries"""
+        """Test error returned immediately when identity not found.
+
+        After the path-dedup refactor, there is no retry loop. The send method
+        calls _request_path_if_needed and returns an error immediately.
+        """
         wrapper = reticulum_wrapper.ReticulumWrapper(self.temp_dir)
         wrapper.initialized = True
         wrapper.router = MagicMock()
@@ -2373,6 +2388,11 @@ class TestPathRequestRetryLogic(unittest.TestCase):
 
         # Identity never found
         mock_rns.Identity.recall.return_value = None
+        wrapper.identities = {}
+
+        # has_path returns False so the path request fires
+        mock_rns.Transport.has_path = Mock(return_value=False)
+        mock_rns.Transport.request_path = Mock()
 
         result = wrapper.send_lxmf_message_with_method(
             dest_hash=b'0123456789abcdef',
@@ -2384,9 +2404,9 @@ class TestPathRequestRetryLogic(unittest.TestCase):
         # Should fail with "not known" error
         self.assertFalse(result['success'])
         self.assertIn('not known', result['error'].lower())
-        # Verify retry attempts ran (at least 10 sleep calls for the retry loop)
-        # Note: Use >= because background threads may also call time.sleep
-        self.assertGreaterEqual(mock_sleep.call_count, 10)
+        # No retry loop means no sleep calls
+        self.assertEqual(mock_sleep.call_count, 0,
+                         "No retry loop — should not sleep")
 
     @patch('reticulum_wrapper.time.sleep')
     @patch('reticulum_wrapper.RNS')

--- a/python/test_wrapper_path.py
+++ b/python/test_wrapper_path.py
@@ -122,34 +122,44 @@ class TestRequestPath(unittest.TestCase):
     @patch('reticulum_wrapper.RETICULUM_AVAILABLE', True)
     @patch('reticulum_wrapper.RNS')
     def test_request_path_calls_rns_transport(self, mock_rns):
-        """Test that request_path calls RNS.Transport.request_path"""
-        # Mock RNS.Transport.request_path
+        """Test that request_path calls RNS.Transport.request_path when no path exists"""
+        # _request_path_if_needed checks has_path first; return False so the request fires
+        mock_rns.Transport.has_path = Mock(return_value=False)
         mock_rns.Transport.request_path = Mock()
 
         wrapper = reticulum_wrapper.ReticulumWrapper(self.temp_dir)
+        wrapper.reticulum = Mock()  # Must be truthy for _request_path_if_needed to proceed
 
         test_dest_hash = b'test_destination_hash'
         result = wrapper.request_path(test_dest_hash)
 
-        # Verify RNS.Transport.request_path was called
+        # Verify RNS.Transport.request_path was called through _request_path_if_needed
         mock_rns.Transport.request_path.assert_called_once_with(test_dest_hash)
         self.assertTrue(result['success'], "request_path should return success")
 
     @patch('reticulum_wrapper.RETICULUM_AVAILABLE', True)
     @patch('reticulum_wrapper.RNS')
     def test_request_path_handles_exception(self, mock_rns):
-        """Test that request_path handles exceptions gracefully"""
-        # Mock RNS.Transport.request_path to raise an exception
+        """Test that request_path handles exceptions gracefully.
+
+        _request_path_if_needed catches Transport.request_path exceptions
+        internally (logging them), so request_path still returns success.
+        """
+        # has_path must return False so the Transport.request_path call fires
+        mock_rns.Transport.has_path = Mock(return_value=False)
         mock_rns.Transport.request_path = Mock(side_effect=Exception("Network error"))
 
         wrapper = reticulum_wrapper.ReticulumWrapper(self.temp_dir)
+        wrapper.reticulum = Mock()  # Must be truthy for _request_path_if_needed to proceed
 
         test_dest_hash = b'test_destination_hash'
         result = wrapper.request_path(test_dest_hash)
 
-        self.assertFalse(result['success'], "request_path should return failure on exception")
-        self.assertIn('error', result, "Should include error message")
-        self.assertEqual(result['error'], "Network error")
+        # The exception is caught inside _request_path_if_needed and logged,
+        # so request_path still returns success
+        self.assertTrue(result['success'],
+                        "request_path should return success (exception is caught internally)")
+        mock_rns.Transport.request_path.assert_called_once_with(test_dest_hash)
 
     @patch('reticulum_wrapper.RETICULUM_AVAILABLE', True)
     @patch('reticulum_wrapper.RNS')


### PR DESCRIPTION
## Summary

Backport of #735 to `release/v0.9.x`. Cherry-picked all 4 commits cleanly with no conflicts.

- Centralize path requests through `_request_path_if_needed()` with `has_path()` guard
- Remove 5-second blocking retry loops from all send methods
- Startup sweep: all contacts → 3 most recent conversations
- Periodic check interval: 15 min → 3 hours
- Add `hasPath()` guard to call_manager identity resolution
- Add `ConversationDao.getRecentPeerHashes()` for scoped startup sweep

## Test plan

- [ ] CI build passes
- [ ] Python tests pass (test_wrapper_path, test_path_request, test_wrapper_messaging)
- [ ] Kotlin tests pass for affected ViewModels

🤖 Generated with [Claude Code](https://claude.com/claude-code)