### PR TITLE
fix: scope MapViewModel announce query to location senders

### DIFF
--- a/app/src/main/java/com/lxmf/messenger/viewmodel/MapViewModel.kt
+++ b/app/src/main/java/com/lxmf/messenger/viewmodel/MapViewModel.kt
@@ -291,7 +291,7 @@ class MapViewModel
                 combine(
                     receivedLocationDao.getLatestLocationsPerSenderUnfiltered(),
                     contacts,
-                    announceDao.getEnrichedAnnounces(),
+                    announceDao.getAnnouncesForLocationSenders(),
                     _refreshTrigger,
                 ) { locations, contactList, announceList, _ ->
                     val currentTime = System.currentTimeMillis()
@@ -307,63 +307,64 @@ class MapViewModel
 
                     Log.d(TAG, "Processing ${locations.size} locations, ${contactList.size} contacts, ${announceList.size} announces")
 
-                    locations.mapNotNull { loc ->
-                        // Ignore self-echo telemetry entries from collector streams.
-                        val senderHash = loc.senderHash.lowercase()
-                        val isSelfEcho = localHashes.any { localHash -> senderHash == localHash }
-                        if (isSelfEcho) {
-                            return@mapNotNull null
-                        }
+                    locations
+                        .mapNotNull { loc ->
+                            // Ignore self-echo telemetry entries from collector streams.
+                            val senderHash = loc.senderHash.lowercase()
+                            val isSelfEcho = localHashes.any { localHash -> senderHash == localHash }
+                            if (isSelfEcho) {
+                                return@mapNotNull null
+                            }
 
-                        // Calculate marker state - returns null if marker should be hidden
-                        // Use sender emission timestamp for freshness/staleness semantics:
-                        // a coordinate emitted long ago should be treated as stale,
-                        // even if it was received only recently.
-                        val markerState =
-                            calculateMarkerState(
+                            // Calculate marker state - returns null if marker should be hidden
+                            // Use sender emission timestamp for freshness/staleness semantics:
+                            // a coordinate emitted long ago should be treated as stale,
+                            // even if it was received only recently.
+                            val markerState =
+                                calculateMarkerState(
+                                    timestamp = loc.timestamp,
+                                    expiresAt = loc.expiresAt,
+                                    currentTime = currentTime,
+                                ) ?: return@mapNotNull null
+
+                            // Look up announce for icon data and name fallback
+                            val announce =
+                                announceMap[loc.senderHash]
+                                    ?: announceMapLower[loc.senderHash.lowercase()]
+
+                            // Try contacts first (exact, then case-insensitive)
+                            // Then try announces (exact, then case-insensitive)
+                            val displayName =
+                                contactMap[loc.senderHash]?.displayName
+                                    ?: contactMapLower[loc.senderHash.lowercase()]?.displayName
+                                    ?: announce?.peerName
+                                    ?: loc.senderHash.take(8)
+
+                            if (displayName == loc.senderHash.take(8)) {
+                                Log.w(TAG, "No name found for senderHash: ${loc.senderHash}")
+                            }
+
+                            // Prefer appearance from telemetry message, fall back to announce
+                            val telemetryAppearance = parseAppearanceJson(loc.appearanceJson)
+
+                            ContactMarker(
+                                destinationHash = loc.senderHash,
+                                displayName = displayName,
+                                latitude = loc.latitude,
+                                longitude = loc.longitude,
+                                accuracy = loc.accuracy,
+                                // Display sender emission timestamp in UI (requested behavior).
+                                // Freshness/staleness is based on sender emission time (timestamp) per calculateMarkerState above.
                                 timestamp = loc.timestamp,
                                 expiresAt = loc.expiresAt,
-                                currentTime = currentTime,
-                            ) ?: return@mapNotNull null
-
-                        // Look up announce for icon data and name fallback
-                        val announce =
-                            announceMap[loc.senderHash]
-                                ?: announceMapLower[loc.senderHash.lowercase()]
-
-                        // Try contacts first (exact, then case-insensitive)
-                        // Then try announces (exact, then case-insensitive)
-                        val displayName =
-                            contactMap[loc.senderHash]?.displayName
-                                ?: contactMapLower[loc.senderHash.lowercase()]?.displayName
-                                ?: announce?.peerName
-                                ?: loc.senderHash.take(8)
-
-                        if (displayName == loc.senderHash.take(8)) {
-                            Log.w(TAG, "No name found for senderHash: ${loc.senderHash}")
-                        }
-
-                        // Prefer appearance from telemetry message, fall back to announce
-                        val telemetryAppearance = parseAppearanceJson(loc.appearanceJson)
-
-                        ContactMarker(
-                            destinationHash = loc.senderHash,
-                            displayName = displayName,
-                            latitude = loc.latitude,
-                            longitude = loc.longitude,
-                            accuracy = loc.accuracy,
-                            // Display sender emission timestamp in UI (requested behavior).
-                            // Freshness/staleness is based on sender emission time (timestamp) per calculateMarkerState above.
-                            timestamp = loc.timestamp,
-                            expiresAt = loc.expiresAt,
-                            state = markerState,
-                            approximateRadius = loc.approximateRadius,
-                            iconName = telemetryAppearance?.first ?: announce?.iconName,
-                            iconForegroundColor = telemetryAppearance?.second ?: announce?.iconForegroundColor,
-                            iconBackgroundColor = telemetryAppearance?.third ?: announce?.iconBackgroundColor,
-                            publicKey = announce?.publicKey,
-                        )
-                    }.let(::deduplicateContactMarkersByDestination)
+                                state = markerState,
+                                approximateRadius = loc.approximateRadius,
+                                iconName = telemetryAppearance?.first ?: announce?.iconName,
+                                iconForegroundColor = telemetryAppearance?.second ?: announce?.iconForegroundColor,
+                                iconBackgroundColor = telemetryAppearance?.third ?: announce?.iconBackgroundColor,
+                                publicKey = announce?.publicKey,
+                            )
+                        }.let(::deduplicateContactMarkersByDestination)
                 }.collect { markers ->
                     _state.update { currentState ->
                         currentState.copy(

--- a/app/src/test/java/com/lxmf/messenger/viewmodel/MapViewModelTest.kt
+++ b/app/src/test/java/com/lxmf/messenger/viewmodel/MapViewModelTest.kt
@@ -7,7 +7,7 @@ import app.cash.turbine.test
 import com.lxmf.messenger.data.db.dao.AnnounceDao
 import com.lxmf.messenger.data.db.dao.ReceivedLocationDao
 import com.lxmf.messenger.data.db.entity.ReceivedLocationEntity
-import com.lxmf.messenger.data.model.EnrichedAnnounce
+import com.lxmf.messenger.data.model.MapAnnounceLookup
 import com.lxmf.messenger.data.repository.ContactRepository
 import com.lxmf.messenger.data.repository.OfflineMapRegionRepository
 import com.lxmf.messenger.map.MapStyleResult
@@ -88,7 +88,7 @@ class MapViewModelTest {
 
         every { contactRepository.getEnrichedContacts() } returns flowOf(emptyList())
         every { receivedLocationDao.getLatestLocationsPerSenderUnfiltered() } returns flowOf(emptyList())
-        every { announceDao.getEnrichedAnnounces() } returns flowOf(emptyList())
+        every { announceDao.getAnnouncesForLocationSenders() } returns flowOf(emptyList())
         every { locationSharingManager.isSharing } returns MutableStateFlow(false)
         every { locationSharingManager.activeSessions } returns MutableStateFlow(emptyList())
         every { locationSharingManager.startSharing(any(), any(), any()) } just Runs
@@ -1292,26 +1292,10 @@ class MapViewModelTest {
         runTest {
             val announces =
                 listOf(
-                    EnrichedAnnounce(
+                    MapAnnounceLookup(
                         destinationHash = "hash1",
                         peerName = "Announce Name",
                         publicKey = ByteArray(64),
-                        appData = null,
-                        hops = 1,
-                        lastSeenTimestamp = System.currentTimeMillis(),
-                        nodeType = "peer",
-                        receivingInterface = null,
-                        receivingInterfaceType = null,
-                        aspect = "lxmf.delivery",
-                        isFavorite = false,
-                        favoritedTimestamp = null,
-                        stampCost = null,
-                        stampCostFlexibility = null,
-                        peeringCost = null,
-                        propagationTransferLimitKb = null,
-                        iconName = null,
-                        iconForegroundColor = null,
-                        iconBackgroundColor = null,
                     ),
                 )
             val receivedLocations =
@@ -1330,7 +1314,7 @@ class MapViewModelTest {
             // Empty contacts - no match
             every { contactRepository.getEnrichedContacts() } returns flowOf(emptyList())
             every { receivedLocationDao.getLatestLocationsPerSenderUnfiltered() } returns flowOf(receivedLocations)
-            every { announceDao.getEnrichedAnnounces() } returns flowOf(announces)
+            every { announceDao.getAnnouncesForLocationSenders() } returns flowOf(announces)
 
             viewModel =
                 MapViewModel(
@@ -1371,7 +1355,7 @@ class MapViewModelTest {
             // No contacts or announces
             every { contactRepository.getEnrichedContacts() } returns flowOf(emptyList())
             every { receivedLocationDao.getLatestLocationsPerSenderUnfiltered() } returns flowOf(receivedLocations)
-            every { announceDao.getEnrichedAnnounces() } returns flowOf(emptyList())
+            every { announceDao.getAnnouncesForLocationSenders() } returns flowOf(emptyList())
 
             viewModel =
                 MapViewModel(
@@ -1406,26 +1390,10 @@ class MapViewModelTest {
                 )
             val announces =
                 listOf(
-                    EnrichedAnnounce(
+                    MapAnnounceLookup(
                         destinationHash = "hash1",
                         peerName = "Announce Name",
                         publicKey = ByteArray(64),
-                        appData = null,
-                        hops = 1,
-                        lastSeenTimestamp = System.currentTimeMillis(),
-                        nodeType = "peer",
-                        receivingInterface = null,
-                        receivingInterfaceType = null,
-                        aspect = "lxmf.delivery",
-                        isFavorite = false,
-                        favoritedTimestamp = null,
-                        stampCost = null,
-                        stampCostFlexibility = null,
-                        peeringCost = null,
-                        propagationTransferLimitKb = null,
-                        iconName = null,
-                        iconForegroundColor = null,
-                        iconBackgroundColor = null,
                     ),
                 )
             val receivedLocations =
@@ -1443,7 +1411,7 @@ class MapViewModelTest {
                 )
             every { contactRepository.getEnrichedContacts() } returns flowOf(contacts)
             every { receivedLocationDao.getLatestLocationsPerSenderUnfiltered() } returns flowOf(receivedLocations)
-            every { announceDao.getEnrichedAnnounces() } returns flowOf(announces)
+            every { announceDao.getAnnouncesForLocationSenders() } returns flowOf(announces)
 
             viewModel =
                 MapViewModel(
@@ -1473,23 +1441,10 @@ class MapViewModelTest {
         runTest {
             val announces =
                 listOf(
-                    EnrichedAnnounce(
+                    MapAnnounceLookup(
                         destinationHash = "hash1",
                         peerName = "Test User",
                         publicKey = ByteArray(64) { it.toByte() },
-                        appData = null,
-                        hops = 1,
-                        lastSeenTimestamp = System.currentTimeMillis(),
-                        nodeType = "peer",
-                        receivingInterface = null,
-                        receivingInterfaceType = null,
-                        aspect = "lxmf.delivery",
-                        isFavorite = false,
-                        favoritedTimestamp = null,
-                        stampCost = null,
-                        stampCostFlexibility = null,
-                        peeringCost = null,
-                        propagationTransferLimitKb = null,
                         iconName = "account",
                         iconForegroundColor = "FFFFFF",
                         iconBackgroundColor = "1E88E5",
@@ -1510,7 +1465,7 @@ class MapViewModelTest {
                 )
             every { contactRepository.getEnrichedContacts() } returns flowOf(emptyList())
             every { receivedLocationDao.getLatestLocationsPerSenderUnfiltered() } returns flowOf(receivedLocations)
-            every { announceDao.getEnrichedAnnounces() } returns flowOf(announces)
+            every { announceDao.getAnnouncesForLocationSenders() } returns flowOf(announces)
 
             viewModel =
                 MapViewModel(
@@ -1541,27 +1496,11 @@ class MapViewModelTest {
         runTest {
             val announces =
                 listOf(
-                    EnrichedAnnounce(
+                    MapAnnounceLookup(
                         destinationHash = "hash1",
                         peerName = "Test User",
                         publicKey = ByteArray(64),
-                        appData = null,
-                        hops = 1,
-                        lastSeenTimestamp = System.currentTimeMillis(),
-                        nodeType = "peer",
-                        receivingInterface = null,
-                        receivingInterfaceType = null,
-                        aspect = "lxmf.delivery",
-                        isFavorite = false,
-                        favoritedTimestamp = null,
-                        stampCost = null,
-                        stampCostFlexibility = null,
-                        peeringCost = null,
-                        propagationTransferLimitKb = null,
                         // No icon set - peer_icons table has no entry for this peer
-                        iconName = null,
-                        iconForegroundColor = null,
-                        iconBackgroundColor = null,
                     ),
                 )
             val receivedLocations =
@@ -1579,7 +1518,7 @@ class MapViewModelTest {
                 )
             every { contactRepository.getEnrichedContacts() } returns flowOf(emptyList())
             every { receivedLocationDao.getLatestLocationsPerSenderUnfiltered() } returns flowOf(receivedLocations)
-            every { announceDao.getEnrichedAnnounces() } returns flowOf(announces)
+            every { announceDao.getAnnouncesForLocationSenders() } returns flowOf(announces)
 
             viewModel =
                 MapViewModel(
@@ -1630,7 +1569,7 @@ class MapViewModelTest {
             // Contact exists but no announce with icon (peer_icons table has no entry)
             every { contactRepository.getEnrichedContacts() } returns flowOf(contacts)
             every { receivedLocationDao.getLatestLocationsPerSenderUnfiltered() } returns flowOf(receivedLocations)
-            every { announceDao.getEnrichedAnnounces() } returns flowOf(emptyList())
+            every { announceDao.getAnnouncesForLocationSenders() } returns flowOf(emptyList())
 
             viewModel =
                 MapViewModel(

--- a/data/src/main/java/com/lxmf/messenger/data/db/dao/AnnounceDao.kt
+++ b/data/src/main/java/com/lxmf/messenger/data/db/dao/AnnounceDao.kt
@@ -7,6 +7,7 @@ import androidx.room.OnConflictStrategy
 import androidx.room.Query
 import com.lxmf.messenger.data.db.entity.AnnounceEntity
 import com.lxmf.messenger.data.model.EnrichedAnnounce
+import com.lxmf.messenger.data.model.MapAnnounceLookup
 import kotlinx.coroutines.flow.Flow
 
 @Dao
@@ -299,6 +300,29 @@ interface AnnounceDao {
         """,
     )
     fun getEnrichedAnnounces(): Flow<List<EnrichedAnnounce>>
+
+    /**
+     * Get lightweight announce data only for peers that have location entries.
+     *
+     * Used by MapViewModel to resolve display names and icons for map markers
+     * without loading the full announce table. Scoped via subquery on
+     * received_locations to avoid CursorWindow overflow on large databases.
+     */
+    @Query(
+        """
+        SELECT
+            a.destinationHash,
+            a.peerName,
+            a.publicKey,
+            pi.iconName as iconName,
+            pi.foregroundColor as iconForegroundColor,
+            pi.backgroundColor as iconBackgroundColor
+        FROM announces a
+        LEFT JOIN peer_icons pi ON a.destinationHash = pi.destinationHash
+        WHERE a.destinationHash IN (SELECT DISTINCT senderHash FROM received_locations)
+        """,
+    )
+    fun getAnnouncesForLocationSenders(): Flow<List<MapAnnounceLookup>>
 
     /**
      * Search announces with icon data by peer name or destination hash.

--- a/data/src/main/java/com/lxmf/messenger/data/db/dao/AnnounceDao.kt
+++ b/data/src/main/java/com/lxmf/messenger/data/db/dao/AnnounceDao.kt
@@ -319,7 +319,7 @@ interface AnnounceDao {
             pi.backgroundColor as iconBackgroundColor
         FROM announces a
         LEFT JOIN peer_icons pi ON a.destinationHash = pi.destinationHash
-        WHERE a.destinationHash IN (SELECT DISTINCT senderHash FROM received_locations)
+        WHERE lower(a.destinationHash) IN (SELECT DISTINCT lower(senderHash) FROM received_locations)
         """,
     )
     fun getAnnouncesForLocationSenders(): Flow<List<MapAnnounceLookup>>

--- a/data/src/main/java/com/lxmf/messenger/data/model/MapAnnounceLookup.kt
+++ b/data/src/main/java/com/lxmf/messenger/data/model/MapAnnounceLookup.kt
@@ -1,0 +1,45 @@
+package com.lxmf.messenger.data.model
+
+/**
+ * Lightweight announce lookup for map marker display.
+ *
+ * Contains only the fields needed by MapViewModel to resolve display names
+ * and icons for location markers. Avoids loading heavy fields like appData
+ * that can cause CursorWindow overflow on large announce tables.
+ *
+ * @see EnrichedAnnounce for the full announce projection used elsewhere.
+ */
+data class MapAnnounceLookup(
+    val destinationHash: String,
+    val peerName: String,
+    val publicKey: ByteArray,
+    val iconName: String? = null,
+    val iconForegroundColor: String? = null,
+    val iconBackgroundColor: String? = null,
+) {
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (javaClass != other?.javaClass) return false
+
+        other as MapAnnounceLookup
+
+        if (destinationHash != other.destinationHash) return false
+        if (peerName != other.peerName) return false
+        if (!publicKey.contentEquals(other.publicKey)) return false
+        if (iconName != other.iconName) return false
+        if (iconForegroundColor != other.iconForegroundColor) return false
+        if (iconBackgroundColor != other.iconBackgroundColor) return false
+
+        return true
+    }
+
+    override fun hashCode(): Int {
+        var result = destinationHash.hashCode()
+        result = 31 * result + peerName.hashCode()
+        result = 31 * result + publicKey.contentHashCode()
+        result = 31 * result + (iconName?.hashCode() ?: 0)
+        result = 31 * result + (iconForegroundColor?.hashCode() ?: 0)
+        result = 31 * result + (iconBackgroundColor?.hashCode() ?: 0)
+        return result
+    }
+}


### PR DESCRIPTION
## Summary

Fixes #734 — crash on startup for users with large announce databases (12,557+ rows).

- `MapViewModel` was loading **all announces** via `getEnrichedAnnounces()` at activity-level init (hoisted for "Locate on Map" feature), exhausting Android's 2MB `CursorWindow` at row ~1372
- Replaced with `getAnnouncesForLocationSenders()` — a scoped subquery that only loads announces matching `received_locations` senders, with a lightweight 6-column projection (`MapAnnounceLookup`)
- Result set drops from ~12,557 rows × 19 columns to ~17 rows × 6 columns

### Root cause analysis

1. `MainActivity.kt:606` instantiates `MapViewModel` at activity scope (needed for cross-tab "Locate on Map")
2. `MapViewModel.init` starts a `combine` flow including `announceDao.getEnrichedAnnounces()` — unbounded, all rows
3. With 12,557 announces × 19 columns (including `publicKey` ByteArray + `appData` ByteArray), the 2MB `CursorWindow` overflows at row ~1372
4. Process of elimination confirms this is the only query that can fail at row 1372 (next largest candidate — `PropagationNodeManager`'s filtered query — returns max ~1,193 rows)

## Test plan

- [x] All 19 `MapViewModelTest` tests pass
- [x] Full app compiles (`compileNoSentryDebugKotlin`)
- [x] Room KSP code generation succeeds
- [ ] Manual: verify map markers still show display names and icons correctly
- [ ] Manual: verify new location telemetry causes markers to appear reactively

🤖 Generated with [Claude Code](https://claude.com/claude-code)