### PR TITLE
ci: add Codecov test analytics to all CI test jobs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -248,6 +248,7 @@ jobs:
       - name: Run Python unit tests with coverage
         run: |
           cd python && python -m pytest -v -n auto --dist loadfile \
+            --junitxml=junit.xml \
             --cov=. \
             --cov-report=term-missing \
             --cov-report=xml:coverage-python.xml
@@ -261,6 +262,14 @@ jobs:
           name: codecov-python
           fail_ci_if_error: false
           verbose: true
+
+      - name: Upload test results to Codecov
+        if: ${{ !cancelled() }}
+        uses: codecov/test-results-action@v1
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          files: ./python/junit.xml
+          flags: python
 
       - name: Upload Python coverage report
         if: always()
@@ -386,6 +395,14 @@ jobs:
           fail_ci_if_error: false
           verbose: true
 
+      - name: Upload test results to Codecov
+        if: ${{ !cancelled() }}
+        uses: codecov/test-results-action@v1
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          files: ./**/build/test-results/test*/*.xml
+          flags: kotlin-shard-${{ matrix.shard }}
+
       - name: Upload Kotlin coverage reports
         if: always()
         uses: actions/upload-artifact@v7
@@ -499,6 +516,14 @@ jobs:
             **/build/outputs/androidTest-results/**/*.xml
             **/build/outputs/androidTest-results/**/*.html
           retention-days: 7
+
+      - name: Upload test results to Codecov
+        if: ${{ !cancelled() }}
+        uses: codecov/test-results-action@v1
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          files: ./**/build/outputs/androidTest-results/**/*.xml
+          flags: instrumented
 
       - name: Upload instrumented test reports
         if: failure()


### PR DESCRIPTION
## Summary
- Add `codecov/test-results-action@v1` to Python, Kotlin (sharded), and instrumented test jobs for Codecov test analytics
- Add `--junitxml=junit.xml` to pytest command so Python generates JUnit XML reports
- Each job uploads with appropriate flags (`python`, `kotlin-shard-N`, `instrumented`)

## Test plan
- [ ] Verify CI passes with the new steps
- [ ] Confirm test results appear in Codecov test analytics dashboard

🤖 Generated with [Claude Code](https://claude.com/claude-code)