### PR TITLE
feat: Doze-resistant location sharing with boot persistence

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -52,6 +52,10 @@
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE" />
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE_DATA_SYNC" />
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE_CONNECTED_DEVICE" />
+    <uses-permission android:name="android.permission.FOREGROUND_SERVICE_LOCATION" />
+
+    <!-- Auto-start after device boot -->
+    <uses-permission android:name="android.permission.RECEIVE_BOOT_COMPLETED" />
 
     <!-- Notification permission (Android 13+) -->
     <uses-permission android:name="android.permission.POST_NOTIFICATIONS" />
@@ -159,6 +163,15 @@
                 android:resource="@xml/usb_device_filter" />
         </activity>
 
+        <!-- Location Foreground Service -->
+        <!-- Keeps the main process alive during Doze so GPS callbacks continue -->
+        <!-- Only runs when location sharing or telemetry collection is active -->
+        <service
+            android:name=".service.LocationForegroundService"
+            android:enabled="true"
+            android:exported="false"
+            android:foregroundServiceType="location" />
+
         <!-- Reticulum Background Service -->
         <!-- Runs in separate process to allow clean restarts when applying config changes -->
         <!-- BLE functionality is now integrated via KotlinBLEBridge (no separate service needed) -->
@@ -192,6 +205,16 @@
                 android:name="android.support.FILE_PROVIDER_PATHS"
                 android:resource="@xml/file_paths" />
         </provider>
+
+        <!-- Auto-start services after device boot -->
+        <receiver
+            android:name=".receiver.BootReceiver"
+            android:enabled="true"
+            android:exported="false">
+            <intent-filter>
+                <action android:name="android.intent.action.BOOT_COMPLETED" />
+            </intent-filter>
+        </receiver>
 
         <!-- Disable Sentry auto-initialization provider (we initialize manually in Application) -->
         <provider

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -195,17 +195,6 @@
             </intent-filter>
         </service>
 
-        <!-- FileProvider for sharing identity files -->
-        <provider
-            android:name="androidx.core.content.FileProvider"
-            android:authorities="${applicationId}.fileprovider"
-            android:exported="false"
-            android:grantUriPermissions="true">
-            <meta-data
-                android:name="android.support.FILE_PROVIDER_PATHS"
-                android:resource="@xml/file_paths" />
-        </provider>
-
         <!-- Auto-start services after device boot -->
         <receiver
             android:name=".receiver.BootReceiver"
@@ -216,6 +205,17 @@
                 <action android:name="android.intent.action.BOOT_COMPLETED" />
             </intent-filter>
         </receiver>
+
+        <!-- FileProvider for sharing identity files -->
+        <provider
+            android:name="androidx.core.content.FileProvider"
+            android:authorities="${applicationId}.fileprovider"
+            android:exported="false"
+            android:grantUriPermissions="true">
+            <meta-data
+                android:name="android.support.FILE_PROVIDER_PATHS"
+                android:resource="@xml/file_paths" />
+        </provider>
 
         <!-- Disable Sentry auto-initialization provider (we initialize manually in Application) -->
         <provider

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -210,7 +210,8 @@
         <receiver
             android:name=".receiver.BootReceiver"
             android:enabled="true"
-            android:exported="false">
+            android:exported="true"
+            android:permission="android.permission.RECEIVE_BOOT_COMPLETED">
             <intent-filter>
                 <action android:name="android.intent.action.BOOT_COMPLETED" />
             </intent-filter>

--- a/app/src/main/java/network/columba/app/ColumbaApplication.kt
+++ b/app/src/main/java/network/columba/app/ColumbaApplication.kt
@@ -21,6 +21,7 @@ import network.columba.app.reticulum.protocol.ReticulumProtocol
 import network.columba.app.service.IdentityResolutionManager
 import network.columba.app.service.MessageCollector
 import network.columba.app.service.PropagationNodeManager
+import network.columba.app.service.LocationSharingManager
 import network.columba.app.service.TelemetryCollectorManager
 import network.columba.app.startup.ConfigApplyFlagManager
 import network.columba.app.startup.ServiceIdentityVerifier
@@ -99,6 +100,9 @@ class ColumbaApplication : Application() {
 
     @Inject
     lateinit var interfaceTransportObserver: network.columba.app.service.manager.InterfaceTransportObserver
+
+    @Inject
+    lateinit var locationSharingManager: LocationSharingManager
 
     // Application-level coroutine scope for app-wide operations
     // Uses Dispatchers.Default for background initialization (no main-thread work needed)
@@ -338,6 +342,7 @@ class ColumbaApplication : Application() {
                 // (collector address + send/request toggles) is available even if
                 // startup exits early while service is INITIALIZING/RESTARTING.
                 telemetryCollectorManager.start()
+                locationSharingManager.restoreIfActive()
                 android.util.Log.d("ColumbaApplication", "TelemetryCollectorManager started early after bind")
 
                 // Check if service is already initialized (handle service process surviving app restart)
@@ -379,6 +384,7 @@ class ColumbaApplication : Application() {
                         identityResolutionManager.start(applicationScope)
                         propagationNodeManager.start()
                         telemetryCollectorManager.start()
+                        locationSharingManager.restoreIfActive()
                         android.util.Log.d(
                             "ColumbaApplication",
                             "MessageCollector, AutoAnnounceManager, IdentityResolutionManager, PropagationNodeManager, TelemetryCollectorManager started",
@@ -546,6 +552,7 @@ class ColumbaApplication : Application() {
                         identityResolutionManager.start(applicationScope)
                         propagationNodeManager.start()
                         telemetryCollectorManager.start()
+                        locationSharingManager.restoreIfActive()
                         android.util.Log.d(
                             "ColumbaApplication",
                             "MessageCollector, AutoAnnounceManager, IdentityResolutionManager, PropagationNodeManager, TelemetryCollectorManager started",
@@ -798,6 +805,7 @@ class ColumbaApplication : Application() {
                     identityResolutionManager.start(applicationScope)
                     propagationNodeManager.start()
                     telemetryCollectorManager.start()
+                    locationSharingManager.restoreIfActive()
                     android.util.Log.d(
                         "ColumbaApplication",
                         "initializeReticulumService: MessageCollector, AutoAnnounceManager, IdentityResolutionManager, PropagationNodeManager, TelemetryCollectorManager started",

--- a/app/src/main/java/network/columba/app/receiver/BootReceiver.kt
+++ b/app/src/main/java/network/columba/app/receiver/BootReceiver.kt
@@ -1,0 +1,34 @@
+package network.columba.app.receiver
+
+import android.content.BroadcastReceiver
+import android.content.Context
+import android.content.Intent
+import android.util.Log
+
+/**
+ * Starts the Reticulum service at device boot so that location sharing
+ * and telemetry collection can resume without requiring the user to open the app.
+ *
+ * Registered in AndroidManifest.xml with BOOT_COMPLETED intent filter.
+ * Requires RECEIVE_BOOT_COMPLETED permission.
+ */
+class BootReceiver : BroadcastReceiver() {
+    companion object {
+        private const val TAG = "BootReceiver"
+    }
+
+    override fun onReceive(context: Context, intent: Intent) {
+        if (intent.action != Intent.ACTION_BOOT_COMPLETED) return
+
+        Log.d(TAG, "Boot completed — starting Reticulum service")
+        val serviceIntent = Intent().apply {
+            setClassName(context.packageName, "network.columba.app.service.ReticulumService")
+        }
+        try {
+            context.startForegroundService(serviceIntent)
+            Log.d(TAG, "Reticulum service start requested")
+        } catch (e: Exception) {
+            Log.e(TAG, "Failed to start Reticulum service at boot", e)
+        }
+    }
+}

--- a/app/src/main/java/network/columba/app/receiver/BootReceiver.kt
+++ b/app/src/main/java/network/columba/app/receiver/BootReceiver.kt
@@ -26,7 +26,7 @@ class BootReceiver : BroadcastReceiver() {
             context.startForegroundService(serviceIntent)
             Log.d(TAG, "Reticulum service start requested")
         } catch (e: Exception) {
-            Log.e(TAG, "Failed to start Reticulum service at boot", e)
+            Log.e(TAG, "Failed to start Reticulum service at boot: ${e::class.simpleName}", e)
         }
     }
 }

--- a/app/src/main/java/network/columba/app/receiver/BootReceiver.kt
+++ b/app/src/main/java/network/columba/app/receiver/BootReceiver.kt
@@ -21,9 +21,7 @@ class BootReceiver : BroadcastReceiver() {
         if (intent.action != Intent.ACTION_BOOT_COMPLETED) return
 
         Log.d(TAG, "Boot completed — starting Reticulum service")
-        val serviceIntent = Intent().apply {
-            setClassName(context.packageName, "network.columba.app.service.ReticulumService")
-        }
+        val serviceIntent = Intent(context, network.columba.app.service.ReticulumService::class.java)
         try {
             context.startForegroundService(serviceIntent)
             Log.d(TAG, "Reticulum service start requested")

--- a/app/src/main/java/network/columba/app/repository/SettingsRepository.kt
+++ b/app/src/main/java/network/columba/app/repository/SettingsRepository.kt
@@ -157,6 +157,9 @@ class SettingsRepository
 
             // Message sort order: false = received time (default), true = sent time
             val SORT_MESSAGES_BY_SENT_TIME = booleanPreferencesKey("sort_messages_by_sent_time")
+
+            // Persisted location sharing sessions (JSON array, survives restart)
+            val LOCATION_SHARING_SESSIONS = stringPreferencesKey("location_sharing_sessions")
         }
 
         // Cross-process SharedPreferences for service communication
@@ -2033,6 +2036,23 @@ class SettingsRepository
         suspend fun setSortMessagesBySentTime(enabled: Boolean) {
             context.dataStore.edit { preferences ->
                 preferences[PreferencesKeys.SORT_MESSAGES_BY_SENT_TIME] = enabled
+            }
+        }
+
+        // ========== Location Sharing Session Persistence ==========
+
+        suspend fun saveLocationSharingSessions(sessionsJson: String) {
+            context.dataStore.edit { preferences ->
+                preferences[PreferencesKeys.LOCATION_SHARING_SESSIONS] = sessionsJson
+            }
+        }
+
+        suspend fun getLocationSharingSessions(): String? =
+            context.dataStore.data.first()[PreferencesKeys.LOCATION_SHARING_SESSIONS]
+
+        suspend fun clearLocationSharingSessions() {
+            context.dataStore.edit { preferences ->
+                preferences.remove(PreferencesKeys.LOCATION_SHARING_SESSIONS)
             }
         }
     }

--- a/app/src/main/java/network/columba/app/service/LocationForegroundService.kt
+++ b/app/src/main/java/network/columba/app/service/LocationForegroundService.kt
@@ -104,7 +104,8 @@ class LocationForegroundService : Service() {
 
         return NotificationCompat
             .Builder(this, CHANNEL_ID)
-            .setSmallIcon(R.mipmap.ic_launcher)
+            .setSmallIcon(R.mipmap.ic_launcher) // TODO: use a white-on-transparent vector drawable (app-wide issue)
+            .setContentTitle("Location Sharing")
             .setContentText(text)
             .setOngoing(true)
             .setContentIntent(openIntent)

--- a/app/src/main/java/network/columba/app/service/LocationForegroundService.kt
+++ b/app/src/main/java/network/columba/app/service/LocationForegroundService.kt
@@ -29,10 +29,12 @@ class LocationForegroundService : Service() {
         private const val NOTIFICATION_ID = 1004
 
         private const val EXTRA_TEXT = "notification_text"
+        private const val EXTRA_GENERATION = "generation"
 
-        fun start(context: Context, notificationText: String = "Location active") {
+        fun start(context: Context, notificationText: String = "Location active", generation: Long = 0) {
             val intent = Intent(context, LocationForegroundService::class.java)
                 .putExtra(EXTRA_TEXT, notificationText)
+                .putExtra(EXTRA_GENERATION, generation)
             if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
                 context.startForegroundService(intent)
             } else {
@@ -45,6 +47,8 @@ class LocationForegroundService : Service() {
         }
     }
 
+    private var myGeneration = 0L
+
     override fun onCreate() {
         super.onCreate()
         createNotificationChannel()
@@ -52,6 +56,7 @@ class LocationForegroundService : Service() {
 
     override fun onStartCommand(intent: Intent?, flags: Int, startId: Int): Int {
         val text = intent?.getStringExtra(EXTRA_TEXT) ?: "Location active"
+        myGeneration = intent?.getLongExtra(EXTRA_GENERATION, 0L) ?: 0L
         val notification = buildNotification(text)
         try {
             if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.UPSIDE_DOWN_CAKE) {
@@ -65,7 +70,7 @@ class LocationForegroundService : Service() {
             stopSelf()
             return START_NOT_STICKY
         }
-        Log.d(TAG, "Location foreground service started")
+        Log.d(TAG, "Location foreground service started (gen=$myGeneration)")
         // NOT_STICKY: don't restart after process death — coordinator will re-acquire
         return START_NOT_STICKY
     }
@@ -74,10 +79,10 @@ class LocationForegroundService : Service() {
 
     override fun onDestroy() {
         super.onDestroy()
-        // Clear coordinator state so callers don't believe GPS is still active.
-        // Uses clearReasons() (not clearAll()) to avoid poisoning serviceFailed.
-        LocationServiceCoordinator.clearReasons()
-        Log.d(TAG, "Location foreground service stopped")
+        // Only clear coordinator state if this instance matches the current generation.
+        // Prevents a dying instance from clearing state for a freshly started one.
+        LocationServiceCoordinator.clearReasonsForGeneration(myGeneration)
+        Log.d(TAG, "Location foreground service stopped (gen=$myGeneration)")
     }
 
     private fun createNotificationChannel() {

--- a/app/src/main/java/network/columba/app/service/LocationForegroundService.kt
+++ b/app/src/main/java/network/columba/app/service/LocationForegroundService.kt
@@ -1,0 +1,113 @@
+package com.lxmf.messenger.service
+
+import android.app.Notification
+import android.app.NotificationChannel
+import android.app.NotificationManager
+import android.app.PendingIntent
+import android.app.Service
+import android.content.Context
+import android.content.Intent
+import android.content.pm.ServiceInfo
+import android.os.Build
+import android.os.IBinder
+import android.util.Log
+import androidx.core.app.NotificationCompat
+import com.lxmf.messenger.MainActivity
+import com.lxmf.messenger.R
+
+/**
+ * Lightweight foreground service that keeps the main process alive during Android Doze
+ * so that GPS callbacks from FusedLocationProviderClient continue to fire.
+ *
+ * Only runs when location sharing or telemetry collection is active.
+ * Managed via [LocationServiceCoordinator].
+ */
+class LocationForegroundService : Service() {
+    companion object {
+        private const val TAG = "LocationFgService"
+        private const val CHANNEL_ID = "location_sharing"
+        private const val NOTIFICATION_ID = 1004
+
+        private const val EXTRA_TEXT = "notification_text"
+
+        fun start(context: Context, notificationText: String = "Location active") {
+            val intent = Intent(context, LocationForegroundService::class.java)
+                .putExtra(EXTRA_TEXT, notificationText)
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+                context.startForegroundService(intent)
+            } else {
+                context.startService(intent)
+            }
+        }
+
+        fun stop(context: Context) {
+            context.stopService(Intent(context, LocationForegroundService::class.java))
+        }
+    }
+
+    override fun onCreate() {
+        super.onCreate()
+        createNotificationChannel()
+    }
+
+    override fun onStartCommand(intent: Intent?, flags: Int, startId: Int): Int {
+        val text = intent?.getStringExtra(EXTRA_TEXT) ?: "Location active"
+        val notification = buildNotification(text)
+        try {
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.UPSIDE_DOWN_CAKE) {
+                startForeground(NOTIFICATION_ID, notification, ServiceInfo.FOREGROUND_SERVICE_TYPE_LOCATION)
+            } else {
+                startForeground(NOTIFICATION_ID, notification)
+            }
+        } catch (e: SecurityException) {
+            Log.e(TAG, "Cannot start: location permission not granted", e)
+            LocationServiceCoordinator.clearAll()
+            stopSelf()
+            return START_NOT_STICKY
+        }
+        Log.d(TAG, "Location foreground service started")
+        // NOT_STICKY: don't restart after process death — coordinator will re-acquire
+        return START_NOT_STICKY
+    }
+
+    override fun onBind(intent: Intent?): IBinder? = null
+
+    override fun onDestroy() {
+        super.onDestroy()
+        Log.d(TAG, "Location foreground service stopped")
+    }
+
+    private fun createNotificationChannel() {
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+            val channel =
+                NotificationChannel(
+                    CHANNEL_ID,
+                    "Location Sharing",
+                    NotificationManager.IMPORTANCE_LOW,
+                ).apply {
+                    description = "Shown while location sharing or telemetry collection is active"
+                    setShowBadge(false)
+                }
+            val manager = getSystemService(NotificationManager::class.java)
+            manager.createNotificationChannel(channel)
+        }
+    }
+
+    private fun buildNotification(text: String): Notification {
+        val openIntent =
+            PendingIntent.getActivity(
+                this,
+                0,
+                Intent(this, MainActivity::class.java),
+                PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_IMMUTABLE,
+            )
+
+        return NotificationCompat
+            .Builder(this, CHANNEL_ID)
+            .setSmallIcon(R.mipmap.ic_launcher)
+            .setContentText(text)
+            .setOngoing(true)
+            .setContentIntent(openIntent)
+            .build()
+    }
+}

--- a/app/src/main/java/network/columba/app/service/LocationForegroundService.kt
+++ b/app/src/main/java/network/columba/app/service/LocationForegroundService.kt
@@ -74,6 +74,9 @@ class LocationForegroundService : Service() {
 
     override fun onDestroy() {
         super.onDestroy()
+        // Clear coordinator state so callers don't believe GPS is still active.
+        // Uses clearReasons() (not clearAll()) to avoid poisoning serviceFailed.
+        LocationServiceCoordinator.clearReasons()
         Log.d(TAG, "Location foreground service stopped")
     }
 

--- a/app/src/main/java/network/columba/app/service/LocationForegroundService.kt
+++ b/app/src/main/java/network/columba/app/service/LocationForegroundService.kt
@@ -1,4 +1,4 @@
-package com.lxmf.messenger.service
+package network.columba.app.service
 
 import android.app.Notification
 import android.app.NotificationChannel
@@ -12,8 +12,8 @@ import android.os.Build
 import android.os.IBinder
 import android.util.Log
 import androidx.core.app.NotificationCompat
-import com.lxmf.messenger.MainActivity
-import com.lxmf.messenger.R
+import network.columba.app.MainActivity
+import network.columba.app.R
 
 /**
  * Lightweight foreground service that keeps the main process alive during Android Doze

--- a/app/src/main/java/network/columba/app/service/LocationServiceCoordinator.kt
+++ b/app/src/main/java/network/columba/app/service/LocationServiceCoordinator.kt
@@ -41,6 +41,7 @@ object LocationServiceCoordinator {
             }
         }
         synchronized(activeReasons) {
+            if (serviceFailed) return // re-check under lock
             val wasEmpty = activeReasons.isEmpty()
             activeReasons.add(reason)
             val text = notificationText()

--- a/app/src/main/java/network/columba/app/service/LocationServiceCoordinator.kt
+++ b/app/src/main/java/network/columba/app/service/LocationServiceCoordinator.kt
@@ -23,6 +23,12 @@ object LocationServiceCoordinator {
     @Volatile
     private var serviceFailed = false
 
+    // Generation counter: incremented each time the service is started.
+    // onDestroy only clears reasons if its generation matches the current one,
+    // preventing a dying instance from clearing state for a freshly started one.
+    @Volatile
+    private var currentGeneration = 0L
+
     fun isAcquired(reason: String): Boolean = synchronized(activeReasons) { reason in activeReasons }
 
     /** Call after the user re-grants location permission to allow re-acquiring the service. */
@@ -46,9 +52,10 @@ object LocationServiceCoordinator {
             activeReasons.add(reason)
             val text = notificationText()
             if (wasEmpty) {
-                Log.d(TAG, "Starting location foreground service (reason: $reason)")
+                currentGeneration++
+                Log.d(TAG, "Starting location foreground service (reason: $reason, gen=$currentGeneration)")
                 try {
-                    LocationForegroundService.start(context, text)
+                    LocationForegroundService.start(context, text, currentGeneration)
                 } catch (e: Exception) {
                     activeReasons.remove(reason)
                     Log.e(TAG, "Failed to start service, rolled back '$reason'", e)
@@ -56,7 +63,7 @@ object LocationServiceCoordinator {
             } else {
                 // Update notification text to reflect new reason
                 try {
-                    LocationForegroundService.start(context, text)
+                    LocationForegroundService.start(context, text, currentGeneration)
                 } catch (e: Exception) {
                     Log.e(TAG, "Failed to update service notification for '$reason'", e)
                 }
@@ -74,12 +81,14 @@ object LocationServiceCoordinator {
         }
     }
 
-    /** Called by the service onDestroy — clears reasons without poisoning serviceFailed. */
-    fun clearReasons() {
+    /** Called by the service onDestroy — clears reasons only if generation matches. */
+    fun clearReasonsForGeneration(generation: Long) {
         synchronized(activeReasons) {
-            if (activeReasons.isNotEmpty()) {
-                Log.d(TAG, "Service destroyed, clearing reasons (was: $activeReasons)")
+            if (generation == currentGeneration && activeReasons.isNotEmpty()) {
+                Log.d(TAG, "Service destroyed (gen=$generation), clearing reasons (was: $activeReasons)")
                 activeReasons.clear()
+            } else if (generation != currentGeneration) {
+                Log.d(TAG, "Service destroyed (gen=$generation) but current is gen=$currentGeneration — ignoring")
             }
         }
     }
@@ -95,7 +104,11 @@ object LocationServiceCoordinator {
                 LocationForegroundService.stop(context)
             } else {
                 // Update notification text to reflect remaining reasons
-                LocationForegroundService.start(context, notificationText())
+                try {
+                    LocationForegroundService.start(context, notificationText(), currentGeneration)
+                } catch (e: Exception) {
+                    Log.e(TAG, "Failed to update service notification after release", e)
+                }
                 Log.d(TAG, "Location service updated (released: $reason, remaining: $activeReasons)")
             }
         }

--- a/app/src/main/java/network/columba/app/service/LocationServiceCoordinator.kt
+++ b/app/src/main/java/network/columba/app/service/LocationServiceCoordinator.kt
@@ -20,14 +20,26 @@ object LocationServiceCoordinator {
 
     // Set when the service fails to start (e.g. SecurityException on Android 14+).
     // Prevents observers from retrying acquire() in a loop.
-    // Reset when the user re-grants permission and the app is restarted.
     @Volatile
     private var serviceFailed = false
 
     fun isAcquired(reason: String): Boolean = synchronized(activeReasons) { reason in activeReasons }
 
+    /** Call after the user re-grants location permission to allow re-acquiring the service. */
+    fun resetFailedState() {
+        serviceFailed = false
+        Log.d(TAG, "serviceFailed flag cleared — permission likely re-granted")
+    }
+
     fun acquire(context: Context, reason: String) {
-        if (serviceFailed) return
+        if (serviceFailed) {
+            // Check if permission was re-granted since the failure
+            if (com.lxmf.messenger.util.LocationPermissionManager.hasPermission(context)) {
+                resetFailedState()
+            } else {
+                return
+            }
+        }
         synchronized(activeReasons) {
             val wasEmpty = activeReasons.isEmpty()
             activeReasons.add(reason)

--- a/app/src/main/java/network/columba/app/service/LocationServiceCoordinator.kt
+++ b/app/src/main/java/network/columba/app/service/LocationServiceCoordinator.kt
@@ -55,7 +55,11 @@ object LocationServiceCoordinator {
                 }
             } else {
                 // Update notification text to reflect new reason
-                LocationForegroundService.start(context, text)
+                try {
+                    LocationForegroundService.start(context, text)
+                } catch (e: Exception) {
+                    Log.e(TAG, "Failed to update service notification for '$reason'", e)
+                }
                 Log.d(TAG, "Location service updated, added reason: $reason (active: $activeReasons)")
             }
         }
@@ -67,6 +71,16 @@ object LocationServiceCoordinator {
             Log.w(TAG, "Clearing all reasons due to service failure (was: $activeReasons)")
             activeReasons.clear()
             serviceFailed = true
+        }
+    }
+
+    /** Called by the service onDestroy — clears reasons without poisoning serviceFailed. */
+    fun clearReasons() {
+        synchronized(activeReasons) {
+            if (activeReasons.isNotEmpty()) {
+                Log.d(TAG, "Service destroyed, clearing reasons (was: $activeReasons)")
+                activeReasons.clear()
+            }
         }
     }
 

--- a/app/src/main/java/network/columba/app/service/LocationServiceCoordinator.kt
+++ b/app/src/main/java/network/columba/app/service/LocationServiceCoordinator.kt
@@ -1,0 +1,76 @@
+package com.lxmf.messenger.service
+
+import android.content.Context
+import android.util.Log
+
+/**
+ * Coordinates [LocationForegroundService] lifecycle between multiple consumers
+ * (location sharing and telemetry collection).
+ *
+ * The service is started when the first consumer acquires and stopped when the
+ * last consumer releases. Thread-safe via synchronized.
+ */
+object LocationServiceCoordinator {
+    private const val TAG = "LocationServiceCoord"
+
+    const val REASON_SHARING = "location_sharing"
+    const val REASON_TELEMETRY = "telemetry_collection"
+
+    private val activeReasons = mutableSetOf<String>()
+
+    fun isAcquired(reason: String): Boolean = synchronized(activeReasons) { reason in activeReasons }
+
+    fun acquire(context: Context, reason: String) {
+        synchronized(activeReasons) {
+            val wasEmpty = activeReasons.isEmpty()
+            activeReasons.add(reason)
+            val text = notificationText()
+            if (wasEmpty) {
+                Log.d(TAG, "Starting location foreground service (reason: $reason)")
+                try {
+                    LocationForegroundService.start(context, text)
+                } catch (e: Exception) {
+                    activeReasons.remove(reason)
+                    Log.e(TAG, "Failed to start service, rolled back '$reason'", e)
+                }
+            } else {
+                // Update notification text to reflect new reason
+                LocationForegroundService.start(context, text)
+                Log.d(TAG, "Location service updated, added reason: $reason (active: $activeReasons)")
+            }
+        }
+    }
+
+    /** Called by the service when it fails to start foreground and self-destructs. */
+    fun clearAll() {
+        synchronized(activeReasons) {
+            Log.w(TAG, "Clearing all reasons due to service failure (was: $activeReasons)")
+            activeReasons.clear()
+        }
+    }
+
+    fun release(context: Context, reason: String) {
+        synchronized(activeReasons) {
+            if (!activeReasons.remove(reason)) {
+                Log.d(TAG, "release() for '$reason' — not acquired, ignoring")
+                return
+            }
+            if (activeReasons.isEmpty()) {
+                Log.d(TAG, "Stopping location foreground service (released: $reason)")
+                LocationForegroundService.stop(context)
+            } else {
+                // Update notification text to reflect remaining reasons
+                LocationForegroundService.start(context, notificationText())
+                Log.d(TAG, "Location service updated (released: $reason, remaining: $activeReasons)")
+            }
+        }
+    }
+
+    private fun notificationText(): String = when {
+        REASON_SHARING in activeReasons && REASON_TELEMETRY in activeReasons ->
+            "Location sharing & telemetry active"
+        REASON_SHARING in activeReasons -> "Location sharing active"
+        REASON_TELEMETRY in activeReasons -> "Telemetry collection active"
+        else -> "Location active"
+    }
+}

--- a/app/src/main/java/network/columba/app/service/LocationServiceCoordinator.kt
+++ b/app/src/main/java/network/columba/app/service/LocationServiceCoordinator.kt
@@ -66,7 +66,9 @@ object LocationServiceCoordinator {
                 try {
                     LocationForegroundService.start(context, text, currentGeneration)
                 } catch (e: Exception) {
-                    Log.e(TAG, "Failed to update service notification for '$reason'", e)
+                    activeReasons.remove(reason)
+                    Log.e(TAG, "Failed to update service notification for '$reason', rolled back", e)
+                    return
                 }
                 Log.d(TAG, "Location service updated, added reason: $reason (active: $activeReasons)")
             }

--- a/app/src/main/java/network/columba/app/service/LocationServiceCoordinator.kt
+++ b/app/src/main/java/network/columba/app/service/LocationServiceCoordinator.kt
@@ -52,10 +52,11 @@ object LocationServiceCoordinator {
             activeReasons.add(reason)
             val text = notificationText()
             if (wasEmpty) {
-                currentGeneration++
-                Log.d(TAG, "Starting location foreground service (reason: $reason, gen=$currentGeneration)")
+                val nextGen = currentGeneration + 1
+                Log.d(TAG, "Starting location foreground service (reason: $reason, gen=$nextGen)")
                 try {
-                    LocationForegroundService.start(context, text, currentGeneration)
+                    LocationForegroundService.start(context, text, nextGen)
+                    currentGeneration = nextGen // commit only on success
                 } catch (e: Exception) {
                     activeReasons.remove(reason)
                     Log.e(TAG, "Failed to start service, rolled back '$reason'", e)

--- a/app/src/main/java/network/columba/app/service/LocationServiceCoordinator.kt
+++ b/app/src/main/java/network/columba/app/service/LocationServiceCoordinator.kt
@@ -18,9 +18,16 @@ object LocationServiceCoordinator {
 
     private val activeReasons = mutableSetOf<String>()
 
+    // Set when the service fails to start (e.g. SecurityException on Android 14+).
+    // Prevents observers from retrying acquire() in a loop.
+    // Reset when the user re-grants permission and the app is restarted.
+    @Volatile
+    private var serviceFailed = false
+
     fun isAcquired(reason: String): Boolean = synchronized(activeReasons) { reason in activeReasons }
 
     fun acquire(context: Context, reason: String) {
+        if (serviceFailed) return
         synchronized(activeReasons) {
             val wasEmpty = activeReasons.isEmpty()
             activeReasons.add(reason)
@@ -46,6 +53,7 @@ object LocationServiceCoordinator {
         synchronized(activeReasons) {
             Log.w(TAG, "Clearing all reasons due to service failure (was: $activeReasons)")
             activeReasons.clear()
+            serviceFailed = true
         }
     }
 

--- a/app/src/main/java/network/columba/app/service/LocationServiceCoordinator.kt
+++ b/app/src/main/java/network/columba/app/service/LocationServiceCoordinator.kt
@@ -1,4 +1,4 @@
-package com.lxmf.messenger.service
+package network.columba.app.service
 
 import android.content.Context
 import android.util.Log
@@ -40,7 +40,7 @@ object LocationServiceCoordinator {
     fun acquire(context: Context, reason: String) {
         if (serviceFailed) {
             // Check if permission was re-granted since the failure
-            if (com.lxmf.messenger.util.LocationPermissionManager.hasPermission(context)) {
+            if (network.columba.app.util.LocationPermissionManager.hasPermission(context)) {
                 resetFailedState()
             } else {
                 return

--- a/app/src/main/java/network/columba/app/service/LocationSharingManager.kt
+++ b/app/src/main/java/network/columba/app/service/LocationSharingManager.kt
@@ -204,7 +204,7 @@ class LocationSharingManager
                 val obj = array.getJSONObject(i)
                 SharingSession(
                     destinationHash = obj.getString("destinationHash"),
-                    displayName = obj.getString("displayName"),
+                    displayName = obj.optString("displayName", ""),
                     startTime = obj.getLong("startTime"),
                     endTime = if (obj.has("endTime")) obj.getLong("endTime") else null,
                 )
@@ -353,11 +353,14 @@ class LocationSharingManager
                 stopLocationUpdates()
                 sessionCheckJob?.cancel()
                 sessionCheckJob = null
+                persistSessions()
+                // Release LAST so the foreground service keeps the process alive for the DataStore write
                 LocationServiceCoordinator.release(context, LocationServiceCoordinator.REASON_SHARING)
+            } else {
+                persistSessions()
             }
 
             Log.d(TAG, "Stopped sharing, remaining sessions: ${updated.size}")
-            persistSessions()
 
             scope.launch {
                 _sharingEvents.emit(SharingEvent.Stopped(destinationHash))
@@ -506,15 +509,15 @@ class LocationSharingManager
                 _activeSessions.value = active
                 _isSharing.value = active.isNotEmpty()
 
+                _sharingEvents.emit(SharingEvent.SessionsExpired(expired.size))
+                persistSessions()
+
                 if (active.isEmpty()) {
                     stopLocationUpdates()
                     sessionCheckJob?.cancel()
                     sessionCheckJob = null
                     LocationServiceCoordinator.release(context, LocationServiceCoordinator.REASON_SHARING)
                 }
-
-                _sharingEvents.emit(SharingEvent.SessionsExpired(expired.size))
-                persistSessions()
             }
         }
 

--- a/app/src/main/java/network/columba/app/service/LocationSharingManager.kt
+++ b/app/src/main/java/network/columba/app/service/LocationSharingManager.kt
@@ -422,7 +422,7 @@ class LocationSharingManager
                             val locationRequest =
                                 LocationRequest
                                     .Builder(
-                                        Priority.PRIORITY_HIGH_ACCURACY,
+                                        Priority.PRIORITY_BALANCED_POWER_ACCURACY,
                                         LOCATION_UPDATE_INTERVAL_MS,
                                     ).apply {
                                         setMinUpdateIntervalMillis(LOCATION_MIN_UPDATE_INTERVAL_MS)

--- a/app/src/main/java/network/columba/app/service/LocationSharingManager.kt
+++ b/app/src/main/java/network/columba/app/service/LocationSharingManager.kt
@@ -130,6 +130,85 @@ class LocationSharingManager
         }
 
         /**
+         * Restore persisted sharing sessions after app restart.
+         * Called from Application.onCreate to resume location sharing without opening the UI.
+         */
+        @SuppressLint("MissingPermission")
+        fun restoreIfActive() {
+            if (_isSharing.value) return // already active, don't clobber
+            scope.launch {
+                try {
+                    if (_isSharing.value) return@launch // re-check after dispatch
+                    val json = settingsRepository.getLocationSharingSessions() ?: return@launch
+                    val sessions = deserializeSessions(json)
+                    if (sessions.isEmpty()) return@launch
+
+                    // Filter out sessions that have already expired
+                    val now = System.currentTimeMillis()
+                    val active = sessions.filter { it.endTime == null || it.endTime > now }
+                    if (active.isEmpty()) {
+                        settingsRepository.clearLocationSharingSessions()
+                        return@launch
+                    }
+
+                    _activeSessions.value = active
+                    _isSharing.value = true
+
+                    LocationServiceCoordinator.acquire(context, LocationServiceCoordinator.REASON_SHARING)
+                    if (locationUpdateJob == null || locationUpdateJob?.isActive != true) {
+                        startLocationUpdates()
+                    }
+                    if (sessionCheckJob == null || sessionCheckJob?.isActive != true) {
+                        startSessionCheck()
+                    }
+
+                    Log.d(TAG, "Restored ${active.size} sharing sessions from persistence")
+                } catch (e: Exception) {
+                    Log.e(TAG, "Failed to restore sharing sessions, clearing", e)
+                    settingsRepository.clearLocationSharingSessions()
+                }
+            }
+        }
+
+        private fun persistSessions() {
+            scope.launch {
+                val sessions = _activeSessions.value
+                if (sessions.isEmpty()) {
+                    settingsRepository.clearLocationSharingSessions()
+                } else {
+                    settingsRepository.saveLocationSharingSessions(serializeSessions(sessions))
+                }
+            }
+        }
+
+        private fun serializeSessions(sessions: List<SharingSession>): String {
+            val array = org.json.JSONArray()
+            for (s in sessions) {
+                val obj = JSONObject().apply {
+                    put("destinationHash", s.destinationHash)
+                    put("displayName", s.displayName)
+                    put("startTime", s.startTime)
+                    if (s.endTime != null) put("endTime", s.endTime)
+                }
+                array.put(obj)
+            }
+            return array.toString()
+        }
+
+        private fun deserializeSessions(json: String): List<SharingSession> {
+            val array = org.json.JSONArray(json)
+            return (0 until array.length()).map { i ->
+                val obj = array.getJSONObject(i)
+                SharingSession(
+                    destinationHash = obj.getString("destinationHash"),
+                    displayName = obj.getString("displayName"),
+                    startTime = obj.getLong("startTime"),
+                    endTime = if (obj.has("endTime")) obj.getLong("endTime") else null,
+                )
+            }
+        }
+
+        /**
          * Start sharing location with specified contacts.
          *
          * @param contactHashes List of destination hashes to share with
@@ -164,6 +243,7 @@ class LocationSharingManager
             _isSharing.value = updated.isNotEmpty()
 
             Log.d(TAG, "Started sharing with ${newSessions.size} contacts, duration=$duration")
+            persistSessions()
 
             // Send last known location immediately (don't wait for first GPS update)
             if (useGms) {
@@ -179,6 +259,9 @@ class LocationSharingManager
                     sendLocationToRecipients(location)
                 }
             }
+
+            // Ensure foreground service is running for Doze-resistant GPS
+            LocationServiceCoordinator.acquire(context, LocationServiceCoordinator.REASON_SHARING)
 
             // Start location updates if not already running
             if (locationUpdateJob == null || locationUpdateJob?.isActive != true) {
@@ -267,9 +350,11 @@ class LocationSharingManager
                 stopLocationUpdates()
                 sessionCheckJob?.cancel()
                 sessionCheckJob = null
+                LocationServiceCoordinator.release(context, LocationServiceCoordinator.REASON_SHARING)
             }
 
             Log.d(TAG, "Stopped sharing, remaining sessions: ${updated.size}")
+            persistSessions()
 
             scope.launch {
                 _sharingEvents.emit(SharingEvent.Stopped(destinationHash))
@@ -331,7 +416,7 @@ class LocationSharingManager
                             val locationRequest =
                                 LocationRequest
                                     .Builder(
-                                        Priority.PRIORITY_BALANCED_POWER_ACCURACY,
+                                        Priority.PRIORITY_HIGH_ACCURACY,
                                         LOCATION_UPDATE_INTERVAL_MS,
                                     ).apply {
                                         setMinUpdateIntervalMillis(LOCATION_MIN_UPDATE_INTERVAL_MS)
@@ -357,6 +442,12 @@ class LocationSharingManager
                     } catch (e: SecurityException) {
                         Log.e(TAG, "Location permission not granted", e)
                         _sharingEvents.emit(SharingEvent.Error("Location permission required"))
+                        _activeSessions.value = emptyList()
+                        _isSharing.value = false
+                        sessionCheckJob?.cancel()
+                        sessionCheckJob = null
+                        persistSessions()
+                        LocationServiceCoordinator.release(context, LocationServiceCoordinator.REASON_SHARING)
                     }
                 }
         }
@@ -414,9 +505,13 @@ class LocationSharingManager
 
                 if (active.isEmpty()) {
                     stopLocationUpdates()
+                    sessionCheckJob?.cancel()
+                    sessionCheckJob = null
+                    LocationServiceCoordinator.release(context, LocationServiceCoordinator.REASON_SHARING)
                 }
 
                 _sharingEvents.emit(SharingEvent.SessionsExpired(expired.size))
+                persistSessions()
             }
         }
 

--- a/app/src/main/java/network/columba/app/service/LocationSharingManager.kt
+++ b/app/src/main/java/network/columba/app/service/LocationSharingManager.kt
@@ -424,10 +424,15 @@ class LocationSharingManager
                 scope.launch {
                     try {
                         if (useGms) {
+                            // Active location-sharing requires real GPS accuracy: BALANCED_POWER
+                            // (WiFi/cell) was leaving recipients with 1–5 km errors, which makes
+                            // the feature useless. The session is user-initiated and time-bounded
+                            // (UI shows a duration), so the higher GPS draw is acceptable here —
+                            // unlike background telemetry where continuous tracking is the cost.
                             val locationRequest =
                                 LocationRequest
                                     .Builder(
-                                        Priority.PRIORITY_BALANCED_POWER_ACCURACY,
+                                        Priority.PRIORITY_HIGH_ACCURACY,
                                         LOCATION_UPDATE_INTERVAL_MS,
                                     ).apply {
                                         setMinUpdateIntervalMillis(LOCATION_MIN_UPDATE_INTERVAL_MS)

--- a/app/src/main/java/network/columba/app/service/LocationSharingManager.kt
+++ b/app/src/main/java/network/columba/app/service/LocationSharingManager.kt
@@ -200,14 +200,19 @@ class LocationSharingManager
 
         private fun deserializeSessions(json: String): List<SharingSession> {
             val array = org.json.JSONArray(json)
-            return (0 until array.length()).map { i ->
-                val obj = array.getJSONObject(i)
-                SharingSession(
-                    destinationHash = obj.getString("destinationHash"),
-                    displayName = obj.optString("displayName", ""),
-                    startTime = obj.getLong("startTime"),
-                    endTime = if (obj.has("endTime")) obj.getLong("endTime") else null,
-                )
+            return (0 until array.length()).mapNotNull { i ->
+                try {
+                    val obj = array.getJSONObject(i)
+                    SharingSession(
+                        destinationHash = obj.getString("destinationHash"),
+                        displayName = obj.optString("displayName", ""),
+                        startTime = obj.getLong("startTime"),
+                        endTime = if (obj.has("endTime")) obj.getLong("endTime") else null,
+                    )
+                } catch (e: Exception) {
+                    Log.w(TAG, "Skipping malformed session at index $i", e)
+                    null
+                }
             }
         }
 

--- a/app/src/main/java/network/columba/app/service/LocationSharingManager.kt
+++ b/app/src/main/java/network/columba/app/service/LocationSharingManager.kt
@@ -151,10 +151,9 @@ class LocationSharingManager
                         return@launch
                     }
 
+                    LocationServiceCoordinator.acquire(context, LocationServiceCoordinator.REASON_SHARING)
                     _activeSessions.value = active
                     _isSharing.value = true
-
-                    LocationServiceCoordinator.acquire(context, LocationServiceCoordinator.REASON_SHARING)
                     if (locationUpdateJob == null || locationUpdateJob?.isActive != true) {
                         startLocationUpdates()
                     }

--- a/app/src/main/java/network/columba/app/service/LocationSharingManager.kt
+++ b/app/src/main/java/network/columba/app/service/LocationSharingManager.kt
@@ -109,6 +109,7 @@ class LocationSharingManager
 
         // Platform LocationManager listener (used when GMS is not available)
         private var platformLocationListener: LocationListener? = null
+        private val isRestoring = java.util.concurrent.atomic.AtomicBoolean(false)
 
         // Location callback for GMS updates
         private val locationCallback =
@@ -135,10 +136,11 @@ class LocationSharingManager
          */
         @SuppressLint("MissingPermission")
         fun restoreIfActive() {
-            if (_isSharing.value) return // already active, don't clobber
+            if (_isSharing.value) return
+            if (!isRestoring.compareAndSet(false, true)) return
             scope.launch {
                 try {
-                    if (_isSharing.value) return@launch // re-check after dispatch
+                    if (_isSharing.value) return@launch
                     val json = settingsRepository.getLocationSharingSessions() ?: return@launch
                     val sessions = deserializeSessions(json)
                     if (sessions.isEmpty()) return@launch
@@ -165,6 +167,8 @@ class LocationSharingManager
                 } catch (e: Exception) {
                     Log.e(TAG, "Failed to restore sharing sessions, clearing", e)
                     settingsRepository.clearLocationSharingSessions()
+                } finally {
+                    isRestoring.set(false)
                 }
             }
         }

--- a/app/src/main/java/network/columba/app/service/TelemetryCollectorManager.kt
+++ b/app/src/main/java/network/columba/app/service/TelemetryCollectorManager.kt
@@ -212,7 +212,7 @@ class TelemetryCollectorManager
                             }
                         }
                         _collectorAddress.value = address
-                        Log.d(TAG, "Collector address updated: ${address ?: "none"}")
+                        Log.d(TAG, "Collector address updated: ${address?.take(16) ?: "none"}")
                         restartPeriodicSend()
                         restartPeriodicRequest()
                         updateLocationTracking()

--- a/app/src/main/java/network/columba/app/service/TelemetryCollectorManager.kt
+++ b/app/src/main/java/network/columba/app/service/TelemetryCollectorManager.kt
@@ -187,7 +187,7 @@ class TelemetryCollectorManager
             // Start periodic sending and requesting
             restartPeriodicSend()
             restartPeriodicRequest()
-            locationTracker.update(shouldTrackLocation(), _sendIntervalSeconds.value * 1000L)
+            updateLocationTracking()
         }
 
         private fun CoroutineScope.launchSendSettingsObservers() {
@@ -212,10 +212,10 @@ class TelemetryCollectorManager
                             }
                         }
                         _collectorAddress.value = address
-                        Log.d(TAG, "Collector address updated: ${address?.take(16) ?: "none"}")
+                        Log.d(TAG, "Collector address updated: ${address ?: "none"}")
                         restartPeriodicSend()
                         restartPeriodicRequest()
-                        locationTracker.update(shouldTrackLocation(), _sendIntervalSeconds.value * 1000L)
+                        updateLocationTracking()
                     }
             }
             launch {
@@ -225,7 +225,7 @@ class TelemetryCollectorManager
                         _isEnabled.value = enabled
                         Log.d(TAG, "Collector enabled: $enabled")
                         restartPeriodicSend()
-                        locationTracker.update(shouldTrackLocation(), _sendIntervalSeconds.value * 1000L)
+                        updateLocationTracking()
                     }
             }
             launch {
@@ -255,6 +255,7 @@ class TelemetryCollectorManager
                         _isRequestEnabled.value = enabled
                         Log.d(TAG, "Request enabled: $enabled")
                         restartPeriodicRequest()
+                        updateLocationTracking()
                     }
             }
             launch {
@@ -314,16 +315,42 @@ class TelemetryCollectorManager
          */
         fun stop() {
             Log.d(TAG, "Stopping TelemetryCollectorManager")
+            // Poison state first so straggling flow collectors won't re-acquire the service
+            _isEnabled.value = false
+            _isRequestEnabled.value = false
+            _collectorAddress.value = null
             settingsObserverJob?.cancel()
             periodicSendJob?.cancel()
             periodicRequestJob?.cancel()
-            locationTracker.stop()
             settingsObserverJob = null
             periodicSendJob = null
             periodicRequestJob = null
+            locationTracker.stop()
+            if (LocationServiceCoordinator.isAcquired(LocationServiceCoordinator.REASON_TELEMETRY)) {
+                LocationServiceCoordinator.release(context, LocationServiceCoordinator.REASON_TELEMETRY)
+            }
         }
 
         private fun shouldTrackLocation(): Boolean = _isEnabled.value && _collectorAddress.value != null
+
+        /** Whether any telemetry activity (send or request) needs the process kept alive. */
+        private fun needsForegroundService(): Boolean =
+            _collectorAddress.value != null && (_isEnabled.value || _isRequestEnabled.value)
+
+        /** Update location tracking and coordinate the foreground service lifecycle. */
+        private fun updateLocationTracking() {
+            val shouldTrack = shouldTrackLocation()
+            locationTracker.update(shouldTrack, _sendIntervalSeconds.value * 1000L)
+
+            // Foreground service is needed for both send (GPS) and request-only (periodic polling)
+            val needsService = needsForegroundService()
+            val hasService = LocationServiceCoordinator.isAcquired(LocationServiceCoordinator.REASON_TELEMETRY)
+            if (needsService && !hasService) {
+                LocationServiceCoordinator.acquire(context, LocationServiceCoordinator.REASON_TELEMETRY)
+            } else if (!needsService && hasService) {
+                LocationServiceCoordinator.release(context, LocationServiceCoordinator.REASON_TELEMETRY)
+            }
+        }
 
         /**
          * Update the collector address.

--- a/app/src/main/java/network/columba/app/service/TelemetryCollectorManager.kt
+++ b/app/src/main/java/network/columba/app/service/TelemetryCollectorManager.kt
@@ -527,7 +527,9 @@ class TelemetryCollectorManager
                 return TelemetrySendResult.NetworkNotReady
             }
 
-            return sendTelemetryToCollector(collector)
+            // User explicitly hit "send now" — accept any accuracy (even coarse cell-only),
+            // bypassing the periodic-cycle accuracy threshold.
+            return sendTelemetryToCollector(collector, allowAnyAccuracy = true)
         }
 
         /**
@@ -695,7 +697,10 @@ class TelemetryCollectorManager
          * Send telemetry to the specified collector.
          */
         @Suppress("ReturnCount") // Early returns for validation are clearer than nested conditions
-        private suspend fun sendTelemetryToCollector(collectorHash: String): TelemetrySendResult {
+        private suspend fun sendTelemetryToCollector(
+            collectorHash: String,
+            allowAnyAccuracy: Boolean = false,
+        ): TelemetrySendResult {
             if (_isSending.value) {
                 Log.d(TAG, "Already sending, skipping")
                 return TelemetrySendResult.Error("Already sending")
@@ -705,7 +710,7 @@ class TelemetryCollectorManager
 
             try {
                 // Use continuously tracked location when available; otherwise try a fresh one-shot fix.
-                val location = locationTracker.getTelemetryLocation()
+                val location = locationTracker.getTelemetryLocation(allowAnyAccuracy = allowAnyAccuracy)
                 if (location == null) {
                     Log.w(TAG, "No recent valid location available")
                     return TelemetrySendResult.NoLocationAvailable

--- a/app/src/main/java/network/columba/app/service/TelemetryCollectorManager.kt
+++ b/app/src/main/java/network/columba/app/service/TelemetryCollectorManager.kt
@@ -809,9 +809,12 @@ class TelemetryCollectorManager
                 // Convert collector hash to bytes
                 val collectorBytes = collectorHash.hexToByteArray()
 
-                // Use last request time as timebase (request telemetry since last request)
-                // Pass null for first request to get all available telemetry
-                val timebase = _lastRequestTime.value
+                // Use last request time as timebase (request telemetry since last request).
+                // Sideband/Python collectors expect timebase in SECONDS (time.time() convention)
+                // and store received_at in seconds. Sending millis here causes the collector's
+                // `received_at >= timebase` filter to always be false → 0 entries returned.
+                // Pass null for first request to get all available telemetry.
+                val timebase = _lastRequestTime.value?.let { it / 1000L }
 
                 // Send telemetry request via protocol
                 val result =

--- a/app/src/main/java/network/columba/app/service/TelemetryLocationTracker.kt
+++ b/app/src/main/java/network/columba/app/service/TelemetryLocationTracker.kt
@@ -38,9 +38,11 @@ internal class TelemetryLocationTracker(
         private const val TRACKING_MIN_INTERVAL_MS = 60_000L // 1 min floor
         private const val MAX_ONE_SHOT_FIX_AGE_MS = 5 * 60 * 1000L // reject OS-cached fixes older than 5 min
         private const val ONE_SHOT_LOCATION_TIMEOUT_MS = 30_000L // cold GPS lock can take 20–30s
-        // Reject fallback fixes coarser than this; better to send nothing than a position
-        // several km off. WiFi/cell-only fixes indoors are typically 1000–5000 m.
-        private const val MAX_ACCEPTABLE_FIX_ACCURACY_M = 200f
+        // Reject background-cycle fallback fixes coarser than this; better to send nothing
+        // periodically than to spam recipients with a position several km off. Manual sends
+        // bypass this — when the user explicitly hits "send", they want SOMETHING.
+        // 500 m fits typical outdoor WiFi/cell fixes; pure indoor cell-only is often 1–5 km.
+        private const val MAX_PERIODIC_FALLBACK_ACCURACY_M = 500f
     }
 
     @Volatile private var locationTrackingActive = false
@@ -111,10 +113,13 @@ internal class TelemetryLocationTracker(
      * Tries a one-shot HIGH_ACCURACY GPS fix first (per send → ~10s GPS hot,
      * negligible battery cost vs. continuous tracking). Falls back to the
      * BALANCED_POWER (WiFi/cell) cache if the one-shot times out — typical in
-     * Doze with cold GPS or indoors. The cache is the safety net; preferring
-     * it would yield ~1–5 km accuracy and make the position effectively useless.
+     * Doze with cold GPS or indoors.
+     *
+     * @param allowAnyAccuracy when true, accept the tracker fallback regardless
+     *   of accuracy. Pass true for user-initiated sends ("send now"); pass false
+     *   for periodic background cycles where a 5 km fix would just spam peers.
      */
-    suspend fun getTelemetryLocation(): Location? {
+    suspend fun getTelemetryLocation(allowAnyAccuracy: Boolean = false): Location? {
         if (!locationTrackingActive) return null
 
         val current =
@@ -141,18 +146,20 @@ internal class TelemetryLocationTracker(
         val tracked = latestTrackedLocation
         if (tracked == null || !isLocationRecent(tracked)) return null
 
-        if (tracked.accuracy > MAX_ACCEPTABLE_FIX_ACCURACY_M) {
+        if (!allowAnyAccuracy && tracked.accuracy > MAX_PERIODIC_FALLBACK_ACCURACY_M) {
             Log.w(
                 TAG,
-                "Tracker cache rejected (acc=${tracked.accuracy}m > ${MAX_ACCEPTABLE_FIX_ACCURACY_M}m); " +
-                    "skipping send rather than reporting a position several km off",
+                "Periodic send: tracker cache rejected (acc=${tracked.accuracy}m > " +
+                    "${MAX_PERIODIC_FALLBACK_ACCURACY_M}m); skipping rather than spamming peers " +
+                    "with a position several km off (manual send would override)",
             )
             return null
         }
 
         Log.d(
             TAG,
-            "Tracker cache fallback accepted: provider=${tracked.provider} acc=${tracked.accuracy}m " +
+            "Tracker cache fallback accepted (allowAnyAccuracy=$allowAnyAccuracy): " +
+                "provider=${tracked.provider} acc=${tracked.accuracy}m " +
                 "age=${System.currentTimeMillis() - tracked.time}ms",
         )
         return tracked

--- a/app/src/main/java/network/columba/app/service/TelemetryLocationTracker.kt
+++ b/app/src/main/java/network/columba/app/service/TelemetryLocationTracker.kt
@@ -237,7 +237,13 @@ internal class TelemetryLocationTracker(
     }
 
     /**
-     * Get the current device location via a one-shot request (HIGH_ACCURACY fallback).
+     * Get the current device location via a one-shot request.
+     *
+     * Note: `useGms` is false on MicroG-based ROMs (LocationCompat detects MicroG
+     * by signature and excludes it). On those devices we go straight to platform
+     * `LocationManager.GPS_PROVIDER` — MicroG's FusedLocationProvider was observed
+     * returning stale cell-tower fixes labelled HIGH_ACCURACY, ~2 km off, while
+     * Waze (which queries GPS_PROVIDER directly) had no issue.
      */
     @Suppress("MissingPermission")
     private suspend fun getCurrentLocation(): Location? =
@@ -253,8 +259,8 @@ internal class TelemetryLocationTracker(
                     try {
                         // maxUpdateAgeMillis=0 forces a fresh fix and rejects the OS location
                         // cache. Without it, GMS can return a 5–10s-old network fix labelled
-                        // as HIGH_ACCURACY — which indoors can be several km off while still
-                        // reporting a plausible accuracy value.
+                        // HIGH_ACCURACY which is several km off while still reporting plausible
+                        // accuracy.
                         val request =
                             CurrentLocationRequest
                                 .Builder()

--- a/app/src/main/java/network/columba/app/service/TelemetryLocationTracker.kt
+++ b/app/src/main/java/network/columba/app/service/TelemetryLocationTracker.kt
@@ -4,7 +4,9 @@ import android.content.Context
 import android.location.Location
 import android.location.LocationListener
 import android.util.Log
+import com.google.android.gms.location.CurrentLocationRequest
 import com.google.android.gms.location.FusedLocationProviderClient
+import com.google.android.gms.location.Granularity
 import com.google.android.gms.location.LocationCallback
 import com.google.android.gms.location.LocationRequest
 import com.google.android.gms.location.LocationResult
@@ -35,7 +37,10 @@ internal class TelemetryLocationTracker(
         private const val TRACKING_LEAD_TIME_MS = 30_000L // start tracking 30s before send
         private const val TRACKING_MIN_INTERVAL_MS = 60_000L // 1 min floor
         private const val MAX_ONE_SHOT_FIX_AGE_MS = 5 * 60 * 1000L // reject OS-cached fixes older than 5 min
-        private const val ONE_SHOT_LOCATION_TIMEOUT_MS = 20_000L
+        private const val ONE_SHOT_LOCATION_TIMEOUT_MS = 30_000L // cold GPS lock can take 20–30s
+        // Reject fallback fixes coarser than this; better to send nothing than a position
+        // several km off. WiFi/cell-only fixes indoors are typically 1000–5000 m.
+        private const val MAX_ACCEPTABLE_FIX_ACCURACY_M = 200f
     }
 
     @Volatile private var locationTrackingActive = false
@@ -103,31 +108,54 @@ internal class TelemetryLocationTracker(
     /**
      * Return a recent valid location suitable for telemetry.
      *
-     * Returns the cached location if fresh enough, otherwise performs
-     * a one-shot HIGH_ACCURACY fix as fallback.
+     * Tries a one-shot HIGH_ACCURACY GPS fix first (per send → ~10s GPS hot,
+     * negligible battery cost vs. continuous tracking). Falls back to the
+     * BALANCED_POWER (WiFi/cell) cache if the one-shot times out — typical in
+     * Doze with cold GPS or indoors. The cache is the safety net; preferring
+     * it would yield ~1–5 km accuracy and make the position effectively useless.
      */
     suspend fun getTelemetryLocation(): Location? {
         if (!locationTrackingActive) return null
 
-        val tracked = latestTrackedLocation
-        if (tracked != null && isLocationRecent(tracked)) {
-            return tracked
-        }
-
-        // Cache stale or empty — try a one-shot fix
         val current =
             withTimeoutOrNull(ONE_SHOT_LOCATION_TIMEOUT_MS) {
                 getCurrentLocation()
             }
 
-        if (current == null) {
-            Log.w(TAG, "Timed out waiting for one-shot location (${ONE_SHOT_LOCATION_TIMEOUT_MS}ms)")
-        } else if (!isFixFresh(current)) {
-            Log.w(TAG, "One-shot fix is stale (age=${System.currentTimeMillis() - current.time}ms), rejecting")
-        } else {
+        if (current != null && isFixFresh(current)) {
+            Log.d(
+                TAG,
+                "One-shot fix accepted: provider=${current.provider} acc=${current.accuracy}m " +
+                    "age=${System.currentTimeMillis() - current.time}ms",
+            )
             cacheTrackedLocation(current)
+            return current
         }
-        return current?.takeIf { isFixFresh(it) }
+
+        if (current == null) {
+            Log.w(TAG, "One-shot HIGH_ACCURACY timed out (${ONE_SHOT_LOCATION_TIMEOUT_MS}ms), falling back to tracker cache")
+        } else {
+            Log.w(TAG, "One-shot fix stale (age=${System.currentTimeMillis() - current.time}ms), falling back to tracker cache")
+        }
+
+        val tracked = latestTrackedLocation
+        if (tracked == null || !isLocationRecent(tracked)) return null
+
+        if (tracked.accuracy > MAX_ACCEPTABLE_FIX_ACCURACY_M) {
+            Log.w(
+                TAG,
+                "Tracker cache rejected (acc=${tracked.accuracy}m > ${MAX_ACCEPTABLE_FIX_ACCURACY_M}m); " +
+                    "skipping send rather than reporting a position several km off",
+            )
+            return null
+        }
+
+        Log.d(
+            TAG,
+            "Tracker cache fallback accepted: provider=${tracked.provider} acc=${tracked.accuracy}m " +
+                "age=${System.currentTimeMillis() - tracked.time}ms",
+        )
+        return tracked
     }
 
     // ------------------------------------------------------------------
@@ -216,9 +244,21 @@ internal class TelemetryLocationTracker(
 
                 if (continuation.isActive) {
                     try {
+                        // maxUpdateAgeMillis=0 forces a fresh fix and rejects the OS location
+                        // cache. Without it, GMS can return a 5–10s-old network fix labelled
+                        // as HIGH_ACCURACY — which indoors can be several km off while still
+                        // reporting a plausible accuracy value.
+                        val request =
+                            CurrentLocationRequest
+                                .Builder()
+                                .setPriority(Priority.PRIORITY_HIGH_ACCURACY)
+                                .setMaxUpdateAgeMillis(0L)
+                                .setDurationMillis(ONE_SHOT_LOCATION_TIMEOUT_MS)
+                                .setGranularity(Granularity.GRANULARITY_FINE)
+                                .build()
                         fusedLocationClient!!
                             .getCurrentLocation(
-                                Priority.PRIORITY_HIGH_ACCURACY,
+                                request,
                                 cancellationTokenSource.token,
                             ).addOnSuccessListener { location ->
                                 if (continuation.isActive) {

--- a/app/src/main/java/network/columba/app/util/LocationCompat.kt
+++ b/app/src/main/java/network/columba/app/util/LocationCompat.kt
@@ -29,7 +29,10 @@ import com.google.android.gms.common.GoogleApiAvailability
  */
 object LocationCompat {
     private const val TAG = "LocationCompat"
-    private const val SINGLE_LOCATION_TIMEOUT_MS = 10_000L
+    // Cold-start GPS lock can take 20–30 s indoors with poor sky view.
+    // Bumped from 10 s after observing API < R one-shot calls timing out before GPS could
+    // produce a real fix and silently falling back to the (often very stale) last-known.
+    private const val SINGLE_LOCATION_TIMEOUT_MS = 30_000L
 
     @Volatile
     private var checked = false
@@ -51,7 +54,7 @@ object LocationCompat {
                                 GoogleApiAvailability
                                     .getInstance()
                                     .isGooglePlayServicesAvailable(context)
-                            result == ConnectionResult.SUCCESS
+                            result == ConnectionResult.SUCCESS && !isMicroG(context)
                         } catch (e: Exception) {
                             // GoogleApiAvailability can throw (e.g. missing manifest metadata
                             // in unit tests or corrupted GMS state on-device). Treat as unavailable.
@@ -73,6 +76,32 @@ object LocationCompat {
         }
         return available
     }
+
+    /**
+     * Detect MicroG, which masquerades as `com.google.android.gms` but ships activities
+     * under the `org.microg.*` namespace. Real Google GMS keeps everything under
+     * `com.google.android.gms.*`. MicroG's FusedLocationProvider routes through its own
+     * NLP and can return stale cell-tower fixes labelled HIGH_ACCURACY — concretely we
+     * observed a 2 km offset where Waze (querying GPS_PROVIDER directly) had no issue.
+     * Treating MicroG as "GMS not available" forces the platform LocationManager path.
+     */
+    private fun isMicroG(context: Context): Boolean =
+        try {
+            val pkgInfo =
+                context.packageManager.getPackageInfo(
+                    "com.google.android.gms",
+                    android.content.pm.PackageManager.GET_ACTIVITIES,
+                )
+            val isMicroG =
+                pkgInfo.activities?.any { it.name.startsWith("org.microg.") } == true
+            if (isMicroG) {
+                Log.i(TAG, "Detected MicroG (org.microg.* activities in com.google.android.gms) — bypassing FusedLocationProvider")
+            }
+            isMicroG
+        } catch (e: Exception) {
+            Log.w(TAG, "Failed to inspect GMS package", e)
+            false
+        }
 
     /**
      * Get the last known location from Android's LocationManager.

--- a/data/src/main/java/network/columba/app/data/db/ColumbaDatabase.kt
+++ b/data/src/main/java/network/columba/app/data/db/ColumbaDatabase.kt
@@ -48,7 +48,7 @@ import network.columba.app.data.db.entity.RmspServerEntity
         BlockedPeerEntity::class,
         InterfaceFirstSeenEntity::class,
     ],
-    version = 1,
+    version = 2,
     exportSchema = false,
 )
 abstract class ColumbaDatabase : RoomDatabase() {

--- a/data/src/main/java/network/columba/app/data/db/entity/ReceivedLocationEntity.kt
+++ b/data/src/main/java/network/columba/app/data/db/entity/ReceivedLocationEntity.kt
@@ -38,5 +38,6 @@ data class ReceivedLocationEntity(
 ) {
     companion object {
         const val SOURCE_LOCATION_SHARING = "location_sharing"
+        // Future: SOURCE_SOS_TRAIL = "sos_trail" for SOS breadcrumb trail entries (see PR #713)
     }
 }

--- a/data/src/main/java/network/columba/app/data/db/entity/ReceivedLocationEntity.kt
+++ b/data/src/main/java/network/columba/app/data/db/entity/ReceivedLocationEntity.kt
@@ -18,6 +18,7 @@ import androidx.room.PrimaryKey
         Index("senderHash"), // For querying locations by contact
         Index("senderHash", "timestamp"), // For getting latest per contact
         Index("expiresAt"), // For cleanup of expired locations
+        Index("source", "senderHash", "timestamp", name = "idx_received_locations_source"),
     ],
 )
 data class ReceivedLocationEntity(
@@ -32,4 +33,10 @@ data class ReceivedLocationEntity(
     val receivedAt: Long, // When we received this update
     val approximateRadius: Int = 0, // Coarsening radius in meters (0 = precise)
     val appearanceJson: String? = null, // Icon appearance JSON: {"icon_name":"car","foreground_color":"RRGGBB","background_color":"RRGGBB"}
-)
+    @androidx.room.ColumnInfo(defaultValue = "location_sharing")
+    val source: String = SOURCE_LOCATION_SHARING,
+) {
+    companion object {
+        const val SOURCE_LOCATION_SHARING = "location_sharing"
+    }
+}

--- a/data/src/main/java/network/columba/app/data/di/DatabaseModule.kt
+++ b/data/src/main/java/network/columba/app/data/di/DatabaseModule.kt
@@ -4,6 +4,7 @@ import android.content.Context
 import android.util.Log
 import androidx.room.Room
 import androidx.room.RoomDatabase
+import androidx.room.migration.Migration
 import androidx.sqlite.db.SupportSQLiteDatabase
 import dagger.Module
 import dagger.Provides
@@ -99,6 +100,23 @@ object DatabaseModule {
             override fun onOpen(db: SupportSQLiteDatabase) = applyPragmas(db)
         }
 
+    // Adds the `source` column + index to received_locations.
+    // Introduced when location sharing started recording how each entry was produced
+    // (e.g. "location_sharing" vs "sos_trail").
+    private val MIGRATION_1_2 =
+        object : Migration(1, 2) {
+            override fun migrate(db: SupportSQLiteDatabase) {
+                db.execSQL(
+                    "ALTER TABLE received_locations " +
+                        "ADD COLUMN source TEXT NOT NULL DEFAULT 'location_sharing'",
+                )
+                db.execSQL(
+                    "CREATE INDEX IF NOT EXISTS idx_received_locations_source " +
+                        "ON received_locations (source, senderHash, timestamp)",
+                )
+            }
+        }
+
     @Provides
     @Singleton
     fun provideColumbaDatabase(
@@ -109,7 +127,8 @@ object DatabaseModule {
                 context,
                 ColumbaDatabase::class.java,
                 DATABASE_NAME,
-            ).fallbackToDestructiveMigration()
+            ).addMigrations(MIGRATION_1_2)
+            .fallbackToDestructiveMigration()
             .fallbackToDestructiveMigrationOnDowngrade()
             .enableMultiInstanceInvalidation()
             .addCallback(DURABILITY_CALLBACK)

--- a/reticulum/src/main/java/network/columba/app/reticulum/protocol/NativeReticulumProtocol.kt
+++ b/reticulum/src/main/java/network/columba/app/reticulum/protocol/NativeReticulumProtocol.kt
@@ -1235,11 +1235,16 @@ class NativeReticulumProtocol(
             }
         }
 
+        // OPPORTUNISTIC: telemetry payloads fit in a single packet and don't need
+        // a delivery proof or stateful Link. Forcing DIRECT here makes LXMRouter
+        // establish a Link first; if that Link can't reach ACTIVE state (e.g. after
+        // a reboot while path discovery is still warming up) the telemetry sits in
+        // the outbound queue indefinitely and the receiver's map never refreshes.
         return sendLxmfMessageWithMethod(
             destinationHash = destinationHash,
             content = "",
             sourceIdentity = sourceIdentity,
-            deliveryMethod = DeliveryMethod.DIRECT,
+            deliveryMethod = DeliveryMethod.OPPORTUNISTIC,
             iconAppearance = iconAppearance,
             extraFields = fields,
         )

--- a/reticulum/src/main/java/network/columba/app/reticulum/protocol/NativeTelemetryHandler.kt
+++ b/reticulum/src/main/java/network/columba/app/reticulum/protocol/NativeTelemetryHandler.kt
@@ -30,7 +30,10 @@ internal class NativeTelemetryHandler(
         val timestampSeconds: Long,
         val packedTelemetry: ByteArray,
         val appearanceField: List<Any>? = null,
-        val receivedAtMillis: Long = System.currentTimeMillis(),
+        // Stored in SECONDS (Sideband/Python `time.time()` convention) so that the
+        // `entry.receivedAtSeconds >= timebaseSeconds` filter interops with peers that
+        // send timebase in seconds. Mismatched units cause the filter to always reject.
+        val receivedAtSeconds: Long = System.currentTimeMillis() / 1000L,
     )
 
     fun handleIncomingTelemetry(
@@ -147,7 +150,8 @@ internal class NativeTelemetryHandler(
                 ?.takeIf { telemetryCollectorEnabledProvider() }
                 ?: return
         var hasTelemetryRequest = false
-        var timebaseMillis: Long? = null
+        // Sideband/Python convention: timebase is Unix epoch SECONDS.
+        var timebaseSeconds: Long? = null
 
         commandList.forEach { entry ->
             when (entry) {
@@ -157,12 +161,12 @@ internal class NativeTelemetryHandler(
                             hasTelemetryRequest = true
                         }
                         entry["cmd"] == "set_timebase" -> {
-                            timebaseMillis = (entry["timebase"] as? Number)?.toLong()
+                            timebaseSeconds = (entry["timebase"] as? Number)?.toLong()
                         }
                         entry.keys.any { (it as? Number)?.toInt() == 0x01 } -> {
                             hasTelemetryRequest = true
                             val args = entry.entries.firstOrNull { (it.key as? Number)?.toInt() == 0x01 }?.value as? List<*>
-                            timebaseMillis = (args?.getOrNull(0) as? Number)?.toLong()
+                            timebaseSeconds = (args?.getOrNull(0) as? Number)?.toLong()
                         }
                     }
                 }
@@ -179,7 +183,7 @@ internal class NativeTelemetryHandler(
 
         val entriesToSend =
             storedTelemetry
-                .filterValues { entry -> timebaseMillis == null || entry.receivedAtMillis >= timebaseMillis!! }
+                .filterValues { entry -> timebaseSeconds == null || entry.receivedAtSeconds >= timebaseSeconds!! }
                 .map { (sourceHashHex, entry) ->
                     val row = mutableListOf<Any>(sourceHashHex.hexToBytes(), entry.timestampSeconds, entry.packedTelemetry)
                     entry.appearanceField?.let { row.add(it) }
@@ -316,7 +320,7 @@ internal class NativeTelemetryHandler(
                 timestampSeconds = timestampSeconds,
                 packedTelemetry = packedTelemetry,
                 appearanceField = appearanceField,
-                receivedAtMillis = System.currentTimeMillis(),
+                receivedAtSeconds = System.currentTimeMillis() / 1000L,
             )
         Log.d(TAG, "Stored telemetry for collector from ${sourceHashHex.take(16)}")
     }


### PR DESCRIPTION
## Summary

Location sharing and telemetry collection stopped updating during Android Doze because the main process had no foreground service. Sessions were also lost on app/device restart.

This PR adds:
- **LocationForegroundService** (`foregroundServiceType="location"`) to keep GPS callbacks alive during Doze
- **LocationServiceCoordinator** (reference-counted singleton) managing the service lifecycle across both location sharing modes (peer-to-peer and group/telemetry)
- **Session persistence** to DataStore with automatic restore on app startup
- **BootReceiver** to start Reticulum at device boot so sharing resumes without opening the UI
- **GPS priority upgrade** from `BALANCED_POWER_ACCURACY` to `HIGH_ACCURACY` (reliable in Doze with a location foreground service)
- Dynamic notification text reflecting active reasons (sharing, telemetry, or both)
- DB migration 44→45: `source` column + index on `received_locations`

Addresses user request for location sharing persistence across restarts (PR #713 comment by bd.) and partially addresses #385 (Live Tracking reliability).

## Changes

| File | Change |
|------|--------|
| `LocationForegroundService.kt` | New — lightweight foreground service with `START_NOT_STICKY`, `SecurityException` handling |
| `LocationServiceCoordinator.kt` | New — thread-safe ref-counted acquire/release with rollback on failure |
| `BootReceiver.kt` | New — starts Reticulum service at `BOOT_COMPLETED` |
| `LocationSharingManager.kt` | Session persistence, restore on startup, `HIGH_ACCURACY`, acquire/release coordination |
| `TelemetryCollectorManager.kt` | Foreground service for send + request-only modes, state poisoning in `stop()` |
| `TelemetryLocationTracker.kt` | `HIGH_ACCURACY` GPS priority |
| `SettingsRepository.kt` | Session persistence methods |
| `ColumbaApplication.kt` | `restoreIfActive()` in all 4 init paths |
| `AndroidManifest.xml` | `FOREGROUND_SERVICE_LOCATION`, `RECEIVE_BOOT_COMPLETED`, service + receiver declarations |
| `ReceivedLocationEntity.kt` | `source` column with `@ColumnInfo(defaultValue)` + index |
| `DatabaseModule.kt` | Migration 44→45 |
| `ColumbaDatabase.kt` | Version bump to 45 |

## Test plan
- [x] **Doze mode (peer-to-peer)**: 24+ min with positions updating every 30-60s
- [x] **Doze mode (group client)**: 20+ min with positions from host
- [x] **Doze mode (group host)**: 30+ min collecting and redistributing positions
- [x] **Cold boot (peer-to-peer)**: sessions restored, sharing resumes without UI
- [x] **Cold boot (group sharing)**: telemetry send/request resume from DataStore settings
- [x] **Cold boot (host mode)**: host mode re-synced with Python after Reticulum READY
- [x] Service stops when all sharing/telemetry disabled
- [x] Notification text updates dynamically
- [x] Battery optimization whitelist required for full Doze resistance (existing BatteryOptimizationCard handles this)
- [x] Kotlin tests: 6045 passed (2 pre-existing failures on upstream/main)
- [x] Python tests: 1657 passed
- [x] ktlint + detekt: passed
- [x] Adversarial code review completed