### PR TITLE
Interface discovery: search + filter + IFAC handling

### DIFF
--- a/app/src/main/java/com/lxmf/messenger/ColumbaApplication.kt
+++ b/app/src/main/java/com/lxmf/messenger/ColumbaApplication.kt
@@ -355,6 +355,7 @@ class ColumbaApplication : Application() {
                         enableTransport = transportNodeEnabled,
                         discoverInterfaces = discoverInterfaces,
                         autoconnectDiscoveredInterfaces = autoconnectDiscoveredCount,
+                        autoconnectIfacOnly = startupConfig.autoconnectIfacOnly,
                     )
 
                 reticulumProtocol
@@ -620,6 +621,7 @@ class ColumbaApplication : Application() {
                     enableTransport = transportNodeEnabled,
                     discoverInterfaces = discoverInterfaces,
                     autoconnectDiscoveredInterfaces = autoconnectDiscoveredCount,
+                    autoconnectIfacOnly = startupConfig.autoconnectIfacOnly,
                 )
 
             protocol

--- a/app/src/main/java/com/lxmf/messenger/MainActivity.kt
+++ b/app/src/main/java/com/lxmf/messenger/MainActivity.kt
@@ -1574,10 +1574,17 @@ fun ColumbaNavigation(
                         composable("discovered_interfaces") {
                             DiscoveredInterfacesScreen(
                                 onNavigateBack = { navController.popBackStack() },
-                                onNavigateToTcpClientWizard = { host, port, name ->
+                                onNavigateToTcpClientWizard = { host, port, name, ifacNet, ifacKey ->
                                     val encodedHost = Uri.encode(host)
                                     val encodedName = Uri.encode(name)
-                                    navController.navigate("tcp_client_wizard?host=$encodedHost&port=$port&name=$encodedName")
+                                    val ifacNetParam =
+                                        if (!ifacNet.isNullOrEmpty()) "&ifacNetname=${Uri.encode(ifacNet)}" else ""
+                                    val ifacKeyParam =
+                                        if (!ifacKey.isNullOrEmpty()) "&ifacNetkey=${Uri.encode(ifacKey)}" else ""
+                                    navController.navigate(
+                                        "tcp_client_wizard?host=$encodedHost&port=$port&name=$encodedName" +
+                                            ifacNetParam + ifacKeyParam,
+                                    )
                                 },
                                 onNavigateToMapWithInterface = { details ->
                                     val encodedLabel = Uri.encode(details.name)
@@ -1608,7 +1615,9 @@ fun ColumbaNavigation(
                         }
 
                         composable(
-                            route = "tcp_client_wizard?interfaceId={interfaceId}&host={host}&port={port}&name={name}",
+                            route =
+                                "tcp_client_wizard?interfaceId={interfaceId}&host={host}&port={port}&name={name}" +
+                                    "&ifacNetname={ifacNetname}&ifacNetkey={ifacNetkey}",
                             arguments =
                                 listOf(
                                     navArgument("interfaceId") {
@@ -1627,12 +1636,22 @@ fun ColumbaNavigation(
                                         type = NavType.StringType
                                         defaultValue = ""
                                     },
+                                    navArgument("ifacNetname") {
+                                        type = NavType.StringType
+                                        defaultValue = ""
+                                    },
+                                    navArgument("ifacNetkey") {
+                                        type = NavType.StringType
+                                        defaultValue = ""
+                                    },
                                 ),
                         ) { backStackEntry ->
                             val interfaceId = backStackEntry.arguments?.getLong("interfaceId") ?: -1L
                             val host = backStackEntry.arguments?.getString("host") ?: ""
                             val port = backStackEntry.arguments?.getInt("port") ?: 0
                             val name = backStackEntry.arguments?.getString("name") ?: ""
+                            val ifacNetname = backStackEntry.arguments?.getString("ifacNetname") ?: ""
+                            val ifacNetkey = backStackEntry.arguments?.getString("ifacNetkey") ?: ""
                             TcpClientWizardScreen(
                                 onNavigateBack = { navController.popBackStack() },
                                 onComplete = {
@@ -1644,6 +1663,8 @@ fun ColumbaNavigation(
                                 initialHost = host.ifEmpty { null },
                                 initialPort = if (port > 0) port else null,
                                 initialName = name.ifEmpty { null },
+                                initialIfacNetname = ifacNetname.ifEmpty { null },
+                                initialIfacNetkey = ifacNetkey.ifEmpty { null },
                             )
                         }
 

--- a/app/src/main/java/com/lxmf/messenger/repository/SettingsRepository.kt
+++ b/app/src/main/java/com/lxmf/messenger/repository/SettingsRepository.kt
@@ -110,6 +110,7 @@ class SettingsRepository
             // RNS 1.1.x Interface Discovery preferences
             val DISCOVER_INTERFACES_ENABLED = booleanPreferencesKey("discover_interfaces_enabled")
             val AUTOCONNECT_DISCOVERED_COUNT = intPreferencesKey("autoconnect_discovered_count")
+            val AUTOCONNECT_IFAC_ONLY = booleanPreferencesKey("autoconnect_ifac_only")
 
             // Location sharing preferences
             val LOCATION_SHARING_ENABLED = booleanPreferencesKey("location_sharing_enabled")
@@ -1115,6 +1116,30 @@ class SettingsRepository
         suspend fun saveAutoconnectDiscoveredCount(count: Int) {
             context.dataStore.edit { preferences ->
                 preferences[PreferencesKeys.AUTOCONNECT_DISCOVERED_COUNT] = count
+            }
+        }
+
+        /**
+         * Flow of the "auto-connect to IFAC-protected interfaces only" setting.
+         * When true, auto-connect skips discovered interfaces that did not
+         * publish an IFAC network name. Useful on mixed-trust networks where
+         * the user only wants to auto-join known private networks.
+         */
+        val autoconnectIfacOnlyFlow: Flow<Boolean> =
+            context.dataStore.data
+                .map { preferences ->
+                    preferences[PreferencesKeys.AUTOCONNECT_IFAC_ONLY] ?: false
+                }.distinctUntilChanged()
+
+        suspend fun getAutoconnectIfacOnly(): Boolean =
+            context.dataStore.data
+                .map { preferences ->
+                    preferences[PreferencesKeys.AUTOCONNECT_IFAC_ONLY] ?: false
+                }.first()
+
+        suspend fun saveAutoconnectIfacOnly(enabled: Boolean) {
+            context.dataStore.edit { preferences ->
+                preferences[PreferencesKeys.AUTOCONNECT_IFAC_ONLY] = enabled
             }
         }
 

--- a/app/src/main/java/com/lxmf/messenger/service/InterfaceConfigManager.kt
+++ b/app/src/main/java/com/lxmf/messenger/service/InterfaceConfigManager.kt
@@ -248,11 +248,13 @@ class InterfaceConfigManager
                     // Load discovery settings
                     val discoverInterfaces = settingsRepository.getDiscoverInterfacesEnabled()
                     val savedAutoconnect = settingsRepository.getAutoconnectDiscoveredCount()
-                    // Coerce -1 (never configured sentinel) to 0 for Python layer
+                    // Coerce -1 (never configured sentinel) to 0
                     val autoconnectDiscoveredCount = if (savedAutoconnect >= 0) savedAutoconnect else 0
+                    val autoconnectIfacOnly = settingsRepository.getAutoconnectIfacOnly()
                     Log.d(
                         TAG,
-                        "Discovery settings: discover=$discoverInterfaces, autoconnect=$autoconnectDiscoveredCount (saved=$savedAutoconnect)",
+                        "Discovery settings: discover=$discoverInterfaces, autoconnect=$autoconnectDiscoveredCount " +
+                            "(saved=$savedAutoconnect), ifacOnly=$autoconnectIfacOnly",
                     )
 
                     val config =
@@ -269,6 +271,7 @@ class InterfaceConfigManager
                             enableTransport = transportNodeEnabled,
                             discoverInterfaces = discoverInterfaces,
                             autoconnectDiscoveredInterfaces = autoconnectDiscoveredCount,
+                            autoconnectIfacOnly = autoconnectIfacOnly,
                         )
 
                     reticulumProtocol

--- a/app/src/main/java/com/lxmf/messenger/startup/StartupConfigLoader.kt
+++ b/app/src/main/java/com/lxmf/messenger/startup/StartupConfigLoader.kt
@@ -36,6 +36,7 @@ class StartupConfigLoader
             val batteryProfile: BatteryProfile,
             val discoverInterfaces: Boolean,
             val autoconnectDiscoveredCount: Int,
+            val autoconnectIfacOnly: Boolean,
         )
 
         /**
@@ -54,6 +55,7 @@ class StartupConfigLoader
                 val batteryProfileDeferred = async { settingsRepository.getBatteryProfile() }
                 val discoverInterfacesDeferred = async { settingsRepository.getDiscoverInterfacesEnabled() }
                 val autoconnectCountDeferred = async { settingsRepository.getAutoconnectDiscoveredCount() }
+                val autoconnectIfacOnlyDeferred = async { settingsRepository.getAutoconnectIfacOnly() }
 
                 val savedAutoconnect = autoconnectCountDeferred.await()
                 StartupConfig(
@@ -64,8 +66,9 @@ class StartupConfigLoader
                     transport = transportDeferred.await(),
                     batteryProfile = batteryProfileDeferred.await(),
                     discoverInterfaces = discoverInterfacesDeferred.await(),
-                    // Coerce -1 (never configured sentinel) to 0 for Python layer
+                    // Coerce -1 (never configured sentinel) to 0 for the native stack
                     autoconnectDiscoveredCount = if (savedAutoconnect >= 0) savedAutoconnect else 0,
+                    autoconnectIfacOnly = autoconnectIfacOnlyDeferred.await(),
                 )
             }
     }

--- a/app/src/main/java/com/lxmf/messenger/ui/screens/DiscoveredInterfacesScreen.kt
+++ b/app/src/main/java/com/lxmf/messenger/ui/screens/DiscoveredInterfacesScreen.kt
@@ -262,8 +262,10 @@ fun DiscoveredInterfacesScreen(
                             items(
                                 state.interfaces,
                                 key = { iface ->
-                                    // networkId + endpoint + lastHeard timestamp for stable uniqueness across sorts
-                                    "${iface.networkId}:${iface.reachableOn ?: ""}:${iface.port ?: ""}:${iface.lastHeard}"
+                                    // discoveryHash (hex SHA256 of transportId + name) is stable across re-announces;
+                                    // fall back to an endpoint-based composite for announces that don't carry one.
+                                    iface.discoveryHash
+                                        ?: "${iface.networkId}:${iface.reachableOn ?: ""}:${iface.port ?: ""}"
                                 },
                             ) { iface ->
                                 val reachableHost = iface.reachableOn

--- a/app/src/main/java/com/lxmf/messenger/ui/screens/DiscoveredInterfacesScreen.kt
+++ b/app/src/main/java/com/lxmf/messenger/ui/screens/DiscoveredInterfacesScreen.kt
@@ -5,6 +5,8 @@ import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.ExperimentalLayoutApi
+import androidx.compose.foundation.layout.FlowRow
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
@@ -20,11 +22,13 @@ import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
 import androidx.compose.material.icons.filled.Add
+import androidx.compose.material.icons.filled.Close
 import androidx.compose.material.icons.filled.ContentCopy
 import androidx.compose.material.icons.filled.Info
 import androidx.compose.material.icons.filled.LocationOn
 import androidx.compose.material.icons.filled.Public
 import androidx.compose.material.icons.filled.Refresh
+import androidx.compose.material.icons.filled.Search
 import androidx.compose.material.icons.filled.Settings
 import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.Button
@@ -33,11 +37,13 @@ import androidx.compose.material3.Card
 import androidx.compose.material3.CardDefaults
 import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.FilterChip
 import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.OutlinedButton
+import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Slider
 import androidx.compose.material3.Surface
@@ -98,7 +104,7 @@ private val MdiFont = FontFamily(Font(R.font.materialdesignicons))
 @Composable
 fun DiscoveredInterfacesScreen(
     onNavigateBack: () -> Unit,
-    onNavigateToTcpClientWizard: (host: String, port: Int, name: String) -> Unit = { _, _, _ -> },
+    onNavigateToTcpClientWizard: (host: String, port: Int, name: String, ifacNetname: String?, ifacNetkey: String?) -> Unit = { _, _, _, _, _ -> },
     onNavigateToMapWithInterface: (details: FocusInterfaceDetails) -> Unit = { _ -> },
     onNavigateToRNodeWizardWithParams: (
         frequency: Long?,
@@ -201,11 +207,11 @@ fun DiscoveredInterfacesScreen(
                             )
                         }
 
-                        // Status summary (only if we have interfaces)
-                        if (state.interfaces.isNotEmpty()) {
+                        // Status summary (counts reflect ALL discovered interfaces, not filtered)
+                        if (state.originalInterfaces.isNotEmpty()) {
                             item {
                                 DiscoveryStatusSummary(
-                                    totalCount = state.interfaces.size,
+                                    totalCount = state.originalInterfaces.size,
                                     availableCount = state.availableCount,
                                     unknownCount = state.unknownCount,
                                     staleCount = state.staleCount,
@@ -220,12 +226,29 @@ fun DiscoveredInterfacesScreen(
                                     onModeSelected = { viewModel.setSortMode(it) },
                                 )
                             }
+
+                            // Search + type filters
+                            item {
+                                DiscoveredInterfaceSearchAndFilter(
+                                    searchQuery = state.searchQuery,
+                                    onSearchQueryChange = { viewModel.setSearchQuery(it) },
+                                    typeFilters = state.typeFilters,
+                                    onToggleTypeFilter = { viewModel.toggleTypeFilter(it) },
+                                    onClearFilters = { viewModel.clearFilters() },
+                                    filteredCount = state.interfaces.size,
+                                    totalCount = state.originalInterfaces.size,
+                                )
+                            }
                         }
 
                         // Show empty state or interfaces
                         if (state.interfaces.isEmpty()) {
                             item {
-                                EmptyDiscoveredCard()
+                                if (state.originalInterfaces.isEmpty()) {
+                                    EmptyDiscoveredCard()
+                                } else {
+                                    NoFilterMatchesCard(onClearFilters = { viewModel.clearFilters() })
+                                }
                             }
                         } else {
                             items(
@@ -246,6 +269,8 @@ fun DiscoveredInterfacesScreen(
                                                 reachableHost,
                                                 iface.port ?: 4242,
                                                 iface.name,
+                                                iface.ifacNetname,
+                                                iface.ifacNetkey,
                                             )
                                         } else {
                                             Toast
@@ -554,6 +579,135 @@ internal fun DiscoverySettingsCard(
 /**
  * Card shown when no interfaces are discovered.
  */
+@Composable
+internal fun NoFilterMatchesCard(onClearFilters: () -> Unit) {
+    Card(
+        modifier = Modifier.fillMaxWidth(),
+        colors =
+            CardDefaults.cardColors(
+                containerColor = MaterialTheme.colorScheme.surface,
+            ),
+    ) {
+        Column(
+            modifier =
+                Modifier
+                    .fillMaxWidth()
+                    .padding(24.dp),
+            horizontalAlignment = Alignment.CenterHorizontally,
+        ) {
+            Icon(
+                imageVector = Icons.Default.Search,
+                contentDescription = null,
+                modifier = Modifier.size(48.dp),
+                tint = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
+            Spacer(modifier = Modifier.height(16.dp))
+            Text(
+                text = "No matches",
+                style = MaterialTheme.typography.titleMedium,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
+            Spacer(modifier = Modifier.height(8.dp))
+            Text(
+                text = "No discovered interfaces match the current search or filters.",
+                style = MaterialTheme.typography.bodyMedium,
+                color = MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.7f),
+            )
+            Spacer(modifier = Modifier.height(12.dp))
+            TextButton(onClick = onClearFilters) {
+                Text("Clear filters")
+            }
+        }
+    }
+}
+
+/**
+ * Search field + type-filter chip row for the discovered interfaces list.
+ */
+@OptIn(ExperimentalMaterial3Api::class, ExperimentalLayoutApi::class)
+@Composable
+internal fun DiscoveredInterfaceSearchAndFilter(
+    searchQuery: String,
+    onSearchQueryChange: (String) -> Unit,
+    typeFilters: Set<com.lxmf.messenger.viewmodel.DiscoveredInterfaceTypeFilter>,
+    onToggleTypeFilter: (com.lxmf.messenger.viewmodel.DiscoveredInterfaceTypeFilter) -> Unit,
+    onClearFilters: () -> Unit,
+    filteredCount: Int,
+    totalCount: Int,
+) {
+    Card(
+        modifier = Modifier.fillMaxWidth(),
+        colors =
+            CardDefaults.cardColors(
+                containerColor = MaterialTheme.colorScheme.surface,
+            ),
+    ) {
+        Column(
+            modifier =
+                Modifier
+                    .fillMaxWidth()
+                    .padding(horizontal = 12.dp, vertical = 8.dp),
+            verticalArrangement = Arrangement.spacedBy(8.dp),
+        ) {
+            OutlinedTextField(
+                value = searchQuery,
+                onValueChange = onSearchQueryChange,
+                modifier = Modifier.fillMaxWidth(),
+                singleLine = true,
+                placeholder = { Text("Search by name, type, host, or IFAC network") },
+                leadingIcon = {
+                    Icon(
+                        imageVector = Icons.Default.Search,
+                        contentDescription = null,
+                    )
+                },
+                trailingIcon = {
+                    if (searchQuery.isNotEmpty()) {
+                        IconButton(onClick = { onSearchQueryChange("") }) {
+                            Icon(
+                                imageVector = Icons.Default.Close,
+                                contentDescription = "Clear search",
+                            )
+                        }
+                    }
+                },
+            )
+
+            FlowRow(
+                modifier = Modifier.fillMaxWidth(),
+                horizontalArrangement = Arrangement.spacedBy(8.dp),
+                verticalArrangement = Arrangement.spacedBy(4.dp),
+            ) {
+                com.lxmf.messenger.viewmodel.DiscoveredInterfaceTypeFilter.entries.forEach { filter ->
+                    FilterChip(
+                        selected = filter in typeFilters,
+                        onClick = { onToggleTypeFilter(filter) },
+                        label = { Text(filter.label) },
+                    )
+                }
+            }
+
+            val hasActiveFilters = searchQuery.isNotBlank() || typeFilters.isNotEmpty()
+            if (hasActiveFilters) {
+                Row(
+                    modifier = Modifier.fillMaxWidth(),
+                    horizontalArrangement = Arrangement.SpaceBetween,
+                    verticalAlignment = Alignment.CenterVertically,
+                ) {
+                    Text(
+                        text = "$filteredCount of $totalCount",
+                        style = MaterialTheme.typography.bodySmall,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    )
+                    TextButton(onClick = onClearFilters) {
+                        Text("Clear")
+                    }
+                }
+            }
+        }
+    }
+}
+
 @Composable
 internal fun EmptyDiscoveredCard() {
     Card(
@@ -874,6 +1028,33 @@ internal fun DiscoveredInterfaceCard(
                 }
                 iface.isRadioInterface -> {
                     RadioInterfaceDetails(iface)
+                }
+            }
+
+            // IFAC indicator — the remote is publishing its IFAC network identity,
+            // so connecting to it requires the matching network_name / passphrase
+            // (which will be auto-filled into the Add flow).
+            iface.ifacNetname?.takeIf { it.isNotBlank() }?.let { ifacNet ->
+                Spacer(modifier = Modifier.height(6.dp))
+                Row(verticalAlignment = Alignment.CenterVertically) {
+                    Text(
+                        text = "IFAC: ",
+                        style = MaterialTheme.typography.bodySmall,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    )
+                    Text(
+                        text = ifacNet,
+                        style = MaterialTheme.typography.bodySmall,
+                        fontFamily = FontFamily.Monospace,
+                        color = MaterialTheme.colorScheme.primary,
+                    )
+                    if (!iface.ifacNetkey.isNullOrBlank()) {
+                        Spacer(modifier = Modifier.width(6.dp))
+                        Text(
+                            text = "🔑",
+                            style = MaterialTheme.typography.bodySmall,
+                        )
+                    }
                 }
             }
 

--- a/app/src/main/java/com/lxmf/messenger/ui/screens/DiscoveredInterfacesScreen.kt
+++ b/app/src/main/java/com/lxmf/messenger/ui/screens/DiscoveredInterfacesScreen.kt
@@ -90,6 +90,7 @@ import com.lxmf.messenger.ui.components.ServiceRestartBanner
 import com.lxmf.messenger.ui.components.SortModeSelector
 import com.lxmf.messenger.ui.theme.MaterialDesignIcons
 import com.lxmf.messenger.util.LocationCompat
+import com.lxmf.messenger.viewmodel.DiscoveredInterfaceTypeFilter
 import com.lxmf.messenger.viewmodel.DiscoveredInterfacesViewModel
 import java.text.SimpleDateFormat
 import java.util.Date
@@ -675,8 +676,8 @@ internal fun NoFilterMatchesCard(onClearFilters: () -> Unit) {
 internal fun DiscoveredInterfaceSearchAndFilter(
     searchQuery: String,
     onSearchQueryChange: (String) -> Unit,
-    typeFilters: Set<com.lxmf.messenger.viewmodel.DiscoveredInterfaceTypeFilter>,
-    onToggleTypeFilter: (com.lxmf.messenger.viewmodel.DiscoveredInterfaceTypeFilter) -> Unit,
+    typeFilters: Set<DiscoveredInterfaceTypeFilter>,
+    onToggleTypeFilter: (DiscoveredInterfaceTypeFilter) -> Unit,
     ifacOnly: Boolean,
     onToggleIfacOnly: () -> Unit,
     onClearFilters: () -> Unit,
@@ -726,7 +727,7 @@ internal fun DiscoveredInterfaceSearchAndFilter(
                 horizontalArrangement = Arrangement.spacedBy(8.dp),
                 verticalArrangement = Arrangement.spacedBy(4.dp),
             ) {
-                com.lxmf.messenger.viewmodel.DiscoveredInterfaceTypeFilter.entries.forEach { filter ->
+                DiscoveredInterfaceTypeFilter.entries.forEach { filter ->
                     FilterChip(
                         selected = filter in typeFilters,
                         onClick = { onToggleTypeFilter(filter) },

--- a/app/src/main/java/com/lxmf/messenger/ui/screens/DiscoveredInterfacesScreen.kt
+++ b/app/src/main/java/com/lxmf/messenger/ui/screens/DiscoveredInterfacesScreen.kt
@@ -25,7 +25,10 @@ import androidx.compose.material.icons.filled.Add
 import androidx.compose.material.icons.filled.Close
 import androidx.compose.material.icons.filled.ContentCopy
 import androidx.compose.material.icons.filled.Info
+import androidx.compose.material.icons.filled.KeyboardArrowDown
+import androidx.compose.material.icons.filled.KeyboardArrowUp
 import androidx.compose.material.icons.filled.LocationOn
+import androidx.compose.material.icons.filled.Lock
 import androidx.compose.material.icons.filled.Public
 import androidx.compose.material.icons.filled.Refresh
 import androidx.compose.material.icons.filled.Search
@@ -200,10 +203,12 @@ fun DiscoveredInterfacesScreen(
                                 isRuntimeEnabled = state.isDiscoveryEnabled,
                                 isSettingEnabled = state.discoverInterfacesEnabled,
                                 autoconnectCount = state.autoconnectCount,
+                                autoconnectIfacOnly = state.autoconnectIfacOnly,
                                 bootstrapInterfaceNames = state.bootstrapInterfaceNames,
                                 isRestarting = state.isRestarting,
                                 onToggleDiscovery = { viewModel.toggleDiscovery() },
                                 onAutoconnectCountChange = { viewModel.setAutoconnectCount(it) },
+                                onToggleAutoconnectIfacOnly = { viewModel.toggleAutoconnectIfacOnly() },
                             )
                         }
 
@@ -234,6 +239,8 @@ fun DiscoveredInterfacesScreen(
                                     onSearchQueryChange = { viewModel.setSearchQuery(it) },
                                     typeFilters = state.typeFilters,
                                     onToggleTypeFilter = { viewModel.toggleTypeFilter(it) },
+                                    ifacOnly = state.ifacOnly,
+                                    onToggleIfacOnly = { viewModel.toggleIfacOnlyFilter() },
                                     onClearFilters = { viewModel.clearFilters() },
                                     filteredCount = state.interfaces.size,
                                     totalCount = state.originalInterfaces.size,
@@ -341,10 +348,12 @@ internal fun DiscoverySettingsCard(
     isRuntimeEnabled: Boolean,
     isSettingEnabled: Boolean,
     autoconnectCount: Int = 0,
+    autoconnectIfacOnly: Boolean = false,
     bootstrapInterfaceNames: List<String> = emptyList(),
     isRestarting: Boolean = false,
     onToggleDiscovery: () -> Unit = {},
     onAutoconnectCountChange: (Int) -> Unit = {},
+    onToggleAutoconnectIfacOnly: () -> Unit = {},
 ) {
     val isEnabled = isRuntimeEnabled || isSettingEnabled
 
@@ -514,6 +523,43 @@ internal fun DiscoverySettingsCard(
                         modifier = Modifier.fillMaxWidth(),
                         enabled = !isRestarting,
                     )
+
+                    // IFAC-only sub-toggle. Only relevant when auto-connect is on.
+                    if (autoconnectCount > 0) {
+                        Spacer(modifier = Modifier.height(8.dp))
+                        Row(
+                            modifier = Modifier.fillMaxWidth(),
+                            verticalAlignment = Alignment.CenterVertically,
+                        ) {
+                            Column(modifier = Modifier.weight(1f)) {
+                                Row(verticalAlignment = Alignment.CenterVertically) {
+                                    Icon(
+                                        imageVector = Icons.Default.Lock,
+                                        contentDescription = null,
+                                        modifier = Modifier.size(14.dp),
+                                        tint = MaterialTheme.colorScheme.onPrimaryContainer,
+                                    )
+                                    Spacer(modifier = Modifier.width(4.dp))
+                                    Text(
+                                        text = "IFAC-protected interfaces only",
+                                        style = MaterialTheme.typography.labelMedium,
+                                        fontWeight = FontWeight.SemiBold,
+                                        color = MaterialTheme.colorScheme.onPrimaryContainer,
+                                    )
+                                }
+                                Text(
+                                    text = "Skip auto-connect for public interfaces; only join networks that announced IFAC credentials.",
+                                    style = MaterialTheme.typography.bodySmall,
+                                    color = MaterialTheme.colorScheme.onPrimaryContainer.copy(alpha = 0.7f),
+                                )
+                            }
+                            Switch(
+                                checked = autoconnectIfacOnly,
+                                onCheckedChange = { onToggleAutoconnectIfacOnly() },
+                                enabled = !isRestarting,
+                            )
+                        }
+                    }
                 }
             }
 
@@ -631,6 +677,8 @@ internal fun DiscoveredInterfaceSearchAndFilter(
     onSearchQueryChange: (String) -> Unit,
     typeFilters: Set<com.lxmf.messenger.viewmodel.DiscoveredInterfaceTypeFilter>,
     onToggleTypeFilter: (com.lxmf.messenger.viewmodel.DiscoveredInterfaceTypeFilter) -> Unit,
+    ifacOnly: Boolean,
+    onToggleIfacOnly: () -> Unit,
     onClearFilters: () -> Unit,
     filteredCount: Int,
     totalCount: Int,
@@ -685,9 +733,21 @@ internal fun DiscoveredInterfaceSearchAndFilter(
                         label = { Text(filter.label) },
                     )
                 }
+                FilterChip(
+                    selected = ifacOnly,
+                    onClick = onToggleIfacOnly,
+                    label = { Text("IFAC only") },
+                    leadingIcon = {
+                        Icon(
+                            imageVector = Icons.Default.Lock,
+                            contentDescription = null,
+                            modifier = Modifier.size(16.dp),
+                        )
+                    },
+                )
             }
 
-            val hasActiveFilters = searchQuery.isNotBlank() || typeFilters.isNotEmpty()
+            val hasActiveFilters = searchQuery.isNotBlank() || typeFilters.isNotEmpty() || ifacOnly
             if (hasActiveFilters) {
                 Row(
                     modifier = Modifier.fillMaxWidth(),
@@ -1091,6 +1151,10 @@ internal fun DiscoveredInterfaceCard(
                 }
             }
 
+            // Expandable "all announced fields" section
+            Spacer(modifier = Modifier.height(8.dp))
+            DiscoveredInterfaceAllFieldsSection(iface = iface)
+
             // Add to Config button (only for TCP interfaces with host info)
             if (iface.isTcpInterface && iface.reachableOn != null) {
                 Spacer(modifier = Modifier.height(12.dp))
@@ -1153,6 +1217,112 @@ internal fun DiscoveredInterfaceCard(
             }
         }
     }
+}
+
+/**
+ * Collapsible "all announced fields" section. Shows every field the remote
+ * published in its discovery announce as a key/value list — useful for
+ * diagnosing unexpected interfaces and confirming radio parameters.
+ */
+@Composable
+internal fun DiscoveredInterfaceAllFieldsSection(iface: DiscoveredInterface) {
+    var expanded by remember { mutableStateOf(false) }
+    Column(modifier = Modifier.fillMaxWidth()) {
+        Row(
+            modifier =
+                Modifier
+                    .fillMaxWidth()
+                    .clickable { expanded = !expanded }
+                    .padding(vertical = 4.dp),
+            verticalAlignment = Alignment.CenterVertically,
+        ) {
+            Icon(
+                imageVector =
+                    if (expanded) {
+                        Icons.Default.KeyboardArrowUp
+                    } else {
+                        Icons.Default.KeyboardArrowDown
+                    },
+                contentDescription = if (expanded) "Collapse details" else "Expand details",
+                tint = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
+            Spacer(modifier = Modifier.width(4.dp))
+            Text(
+                text = if (expanded) "Hide announced fields" else "Show all announced fields",
+                style = MaterialTheme.typography.bodySmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
+        }
+
+        if (expanded) {
+            Surface(
+                modifier = Modifier.fillMaxWidth(),
+                color = MaterialTheme.colorScheme.surfaceVariant.copy(alpha = 0.4f),
+                shape = RoundedCornerShape(6.dp),
+            ) {
+                Column(
+                    modifier = Modifier.padding(horizontal = 12.dp, vertical = 10.dp),
+                    verticalArrangement = Arrangement.spacedBy(4.dp),
+                ) {
+                    val rows =
+                        buildList<Pair<String, String?>> {
+                            add("name" to iface.name)
+                            add("type" to iface.type)
+                            add("status" to iface.status)
+                            add("transport node" to if (iface.transport) "yes" else "no")
+                            add("hops" to iface.hops.toString())
+                            add("heard count" to iface.heardCount.toString())
+                            add("stamp value" to iface.stampValue.toString())
+                            add("network id" to iface.networkId)
+                            add("transport id" to iface.transportId)
+                            add("discovery hash" to iface.discoveryHash)
+                            add("reachable on" to iface.reachableOn)
+                            add("port" to iface.port?.toString())
+                            add("frequency" to iface.frequency?.let { "$it Hz" })
+                            add("bandwidth" to iface.bandwidth?.let { "$it Hz" })
+                            add("spreading factor" to iface.spreadingFactor?.toString())
+                            add("coding rate" to iface.codingRate?.toString())
+                            add("modulation" to iface.modulation)
+                            add("channel" to iface.channel?.toString())
+                            add("latitude" to iface.latitude?.toString())
+                            add("longitude" to iface.longitude?.toString())
+                            add("height" to iface.height?.let { "$it m" })
+                            add("ifac network name" to iface.ifacNetname)
+                            // The passphrase was sent in the cleartext announce — anyone on
+                            // the discovery network already has it — so there's nothing to
+                            // obfuscate here and showing the value is useful for diagnostics.
+                            add("ifac passphrase" to iface.ifacNetkey?.takeIf { it.isNotBlank() })
+                            add("received at" to iface.receivedAt.takeIf { it > 0 }?.let { formatUnixSeconds(it) })
+                            add("discovered at" to iface.discoveredAt.takeIf { it > 0 }?.let { formatUnixSeconds(it) })
+                            add("last heard" to iface.lastHeard.takeIf { it > 0 }?.let { formatUnixSeconds(it) })
+                        }
+                    rows.forEach { (key, value) ->
+                        if (value.isNullOrBlank()) return@forEach
+                        Row(modifier = Modifier.fillMaxWidth()) {
+                            Text(
+                                text = key,
+                                style = MaterialTheme.typography.bodySmall,
+                                color = MaterialTheme.colorScheme.onSurfaceVariant,
+                                modifier = Modifier.width(120.dp),
+                            )
+                            Text(
+                                text = value,
+                                style = MaterialTheme.typography.bodySmall,
+                                fontFamily = FontFamily.Monospace,
+                                modifier = Modifier.weight(1f),
+                            )
+                        }
+                    }
+                }
+            }
+        }
+    }
+}
+
+private fun formatUnixSeconds(seconds: Long): String {
+    val date = Date(seconds * 1000L)
+    val fmt = SimpleDateFormat("yyyy-MM-dd HH:mm:ss", Locale.getDefault())
+    return fmt.format(date)
 }
 
 /**

--- a/app/src/main/java/com/lxmf/messenger/ui/screens/DiscoveredInterfacesScreen.kt
+++ b/app/src/main/java/com/lxmf/messenger/ui/screens/DiscoveredInterfacesScreen.kt
@@ -263,9 +263,10 @@ fun DiscoveredInterfacesScreen(
                                 state.interfaces,
                                 key = { iface ->
                                     // discoveryHash (hex SHA256 of transportId + name) is stable across re-announces;
-                                    // fall back to an endpoint-based composite for announces that don't carry one.
+                                    // fall back to a composite for announces that don't carry one. Including
+                                    // name keeps radio interfaces (no reachableOn/port) unique.
                                     iface.discoveryHash
-                                        ?: "${iface.networkId}:${iface.reachableOn ?: ""}:${iface.port ?: ""}"
+                                        ?: "${iface.networkId}:${iface.reachableOn ?: ""}:${iface.port ?: ""}:${iface.name}"
                                 },
                             ) { iface ->
                                 val reachableHost = iface.reachableOn

--- a/app/src/main/java/com/lxmf/messenger/ui/screens/tcpclient/ReviewConfigureStep.kt
+++ b/app/src/main/java/com/lxmf/messenger/ui/screens/tcpclient/ReviewConfigureStep.kt
@@ -15,9 +15,13 @@ import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Cloud
+import androidx.compose.material.icons.filled.Lock
+import androidx.compose.material.icons.filled.Visibility
+import androidx.compose.material.icons.filled.VisibilityOff
 import androidx.compose.material3.Card
 import androidx.compose.material3.CardDefaults
 import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.Switch
@@ -28,6 +32,8 @@ import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.text.input.KeyboardType
+import androidx.compose.ui.text.input.PasswordVisualTransformation
+import androidx.compose.ui.text.input.VisualTransformation
 import androidx.compose.ui.unit.dp
 import com.lxmf.messenger.viewmodel.TcpClientWizardViewModel
 
@@ -119,6 +125,68 @@ fun ReviewConfigureStep(viewModel: TcpClientWizardViewModel) {
         )
 
         Spacer(Modifier.height(24.dp))
+
+        // IFAC (network_name + passphrase). Auto-filled when reached from a
+        // discovered interface that published IFAC; otherwise optional user input.
+        Card(
+            colors =
+                CardDefaults.cardColors(
+                    containerColor = MaterialTheme.colorScheme.surfaceVariant,
+                ),
+            modifier = Modifier.fillMaxWidth(),
+        ) {
+            Column(modifier = Modifier.padding(16.dp)) {
+                Row(verticalAlignment = Alignment.CenterVertically) {
+                    Icon(
+                        Icons.Default.Lock,
+                        contentDescription = null,
+                        tint = MaterialTheme.colorScheme.onSurfaceVariant,
+                    )
+                    Spacer(Modifier.width(8.dp))
+                    Text(
+                        "IFAC (Network Access)",
+                        style = MaterialTheme.typography.titleSmall,
+                    )
+                }
+                Spacer(Modifier.height(4.dp))
+                Text(
+                    "Leave blank unless the remote interface requires an IFAC network " +
+                        "name and passphrase. Auto-filled when adding from a discovered interface.",
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                )
+                Spacer(Modifier.height(12.dp))
+                OutlinedTextField(
+                    value = state.networkName,
+                    onValueChange = { viewModel.setNetworkName(it) },
+                    label = { Text("Network Name") },
+                    modifier = Modifier.fillMaxWidth(),
+                    singleLine = true,
+                )
+                Spacer(Modifier.height(8.dp))
+                OutlinedTextField(
+                    value = state.passphrase,
+                    onValueChange = { viewModel.setPassphrase(it) },
+                    label = { Text("Passphrase") },
+                    modifier = Modifier.fillMaxWidth(),
+                    singleLine = true,
+                    visualTransformation =
+                        if (state.passphraseVisible) VisualTransformation.None else PasswordVisualTransformation(),
+                    trailingIcon = {
+                        IconButton(onClick = { viewModel.togglePassphraseVisibility() }) {
+                            Icon(
+                                imageVector =
+                                    if (state.passphraseVisible) Icons.Default.VisibilityOff else Icons.Default.Visibility,
+                                contentDescription =
+                                    if (state.passphraseVisible) "Hide passphrase" else "Show passphrase",
+                            )
+                        }
+                    },
+                )
+            }
+        }
+
+        Spacer(Modifier.height(16.dp))
 
         // Bootstrap interface toggle (RNS 1.1.x feature)
         Card(

--- a/app/src/main/java/com/lxmf/messenger/ui/screens/tcpclient/TcpClientWizardScreen.kt
+++ b/app/src/main/java/com/lxmf/messenger/ui/screens/tcpclient/TcpClientWizardScreen.kt
@@ -38,6 +38,10 @@ fun TcpClientWizardScreen(
     initialHost: String? = null,
     initialPort: Int? = null,
     initialName: String? = null,
+    // IFAC fields auto-filled when launched from a discovered interface that
+    // announced its IFAC network.
+    initialIfacNetname: String? = null,
+    initialIfacNetkey: String? = null,
     viewModel: TcpClientWizardViewModel = hiltViewModel(),
 ) {
     val state by viewModel.state.collectAsState()
@@ -51,6 +55,8 @@ fun TcpClientWizardScreen(
                 host = initialHost,
                 port = initialPort ?: 4242,
                 name = initialName ?: "TCP Connection",
+                ifacNetname = initialIfacNetname,
+                ifacNetkey = initialIfacNetkey,
             )
         }
     }

--- a/app/src/main/java/com/lxmf/messenger/viewmodel/DiscoveredInterfacesViewModel.kt
+++ b/app/src/main/java/com/lxmf/messenger/viewmodel/DiscoveredInterfacesViewModel.kt
@@ -314,11 +314,8 @@ class DiscoveredInterfacesViewModel
         fun toggleAutoconnectIfacOnly() {
             viewModelScope.launch(ioDispatcher) {
                 try {
-                    var newValue = false
-                    _state.update { currentState ->
-                        newValue = !currentState.autoconnectIfacOnly
-                        currentState.copy(autoconnectIfacOnly = newValue)
-                    }
+                    val newValue = !_state.value.autoconnectIfacOnly
+                    _state.update { it.copy(autoconnectIfacOnly = newValue) }
                     settingsRepository.saveAutoconnectIfacOnly(newValue)
                     reticulumProtocol.setAutoconnectIfacOnly(newValue)
                     Log.d(TAG, "Autoconnect IFAC-only: $newValue")

--- a/app/src/main/java/com/lxmf/messenger/viewmodel/DiscoveredInterfacesViewModel.kt
+++ b/app/src/main/java/com/lxmf/messenger/viewmodel/DiscoveredInterfacesViewModel.kt
@@ -75,6 +75,8 @@ data class DiscoveredInterfacesState(
     // Discovery settings (from DataStore - user preference)
     val discoverInterfacesEnabled: Boolean = false,
     val autoconnectCount: Int = 0,
+    /** When true, auto-connect only accepts interfaces that announced IFAC. */
+    val autoconnectIfacOnly: Boolean = false,
     // Runtime status (from RNS - current state)
     val isDiscoveryEnabled: Boolean = false,
     // Bootstrap interfaces that enable discovery
@@ -87,6 +89,8 @@ data class DiscoveredInterfacesState(
     val searchQuery: String = "",
     // Multi-select type filter. Empty set = no filtering (all types shown).
     val typeFilters: Set<DiscoveredInterfaceTypeFilter> = emptySet(),
+    // When true, only show interfaces that announced an IFAC network name.
+    val ifacOnly: Boolean = false,
 )
 
 /**
@@ -146,6 +150,7 @@ class DiscoveredInterfacesViewModel
                                 source = discovered,
                                 searchQuery = currentState.searchQuery,
                                 typeFilters = currentState.typeFilters,
+                                ifacOnly = currentState.ifacOnly,
                                 sortMode = effectiveSortMode,
                                 userLat = currentState.userLatitude,
                                 userLon = currentState.userLongitude,
@@ -183,22 +188,28 @@ class DiscoveredInterfacesViewModel
                 try {
                     val discoverEnabled = settingsRepository.getDiscoverInterfacesEnabled()
                     val savedAutoconnect = settingsRepository.getAutoconnectDiscoveredCount()
+                    val ifacOnly = settingsRepository.getAutoconnectIfacOnly()
                     val bootstrapNames = interfaceRepository.bootstrapInterfaceNames.first()
 
                     // Coerce -1 (never configured) to 0 for UI display
                     // The actual default of 3 is applied in toggleDiscovery() when enabling
                     val autoconnectCount = if (savedAutoconnect >= 0) savedAutoconnect else 0
 
+                    // Push persisted value into the native protocol so the
+                    // filter applies from the moment the service starts.
+                    reticulumProtocol.setAutoconnectIfacOnly(ifacOnly)
+
                     _state.update {
                         it.copy(
                             discoverInterfacesEnabled = discoverEnabled,
                             autoconnectCount = autoconnectCount,
+                            autoconnectIfacOnly = ifacOnly,
                             bootstrapInterfaceNames = bootstrapNames,
                         )
                     }
                     Log.d(
                         TAG,
-                        "Loaded discovery settings: enabled=$discoverEnabled, autoconnect=$autoconnectCount (saved=$savedAutoconnect), bootstrap=$bootstrapNames",
+                        "Loaded discovery settings: enabled=$discoverEnabled, autoconnect=$autoconnectCount (saved=$savedAutoconnect), ifacOnly=$ifacOnly, bootstrap=$bootstrapNames",
                     )
                 } catch (e: Exception) {
                     Log.e(TAG, "Failed to load discovery settings", e)
@@ -295,6 +306,29 @@ class DiscoveredInterfacesViewModel
         }
 
         /**
+         * Toggle the "auto-connect to IFAC-protected interfaces only" setting.
+         * Applies immediately — subsequent announces from non-IFAC interfaces
+         * will be skipped by the autoconnect factory. Already-connected
+         * non-IFAC interfaces are not affected retroactively.
+         */
+        fun toggleAutoconnectIfacOnly() {
+            viewModelScope.launch(ioDispatcher) {
+                try {
+                    val newValue = !_state.value.autoconnectIfacOnly
+                    _state.update { it.copy(autoconnectIfacOnly = newValue) }
+                    settingsRepository.saveAutoconnectIfacOnly(newValue)
+                    reticulumProtocol.setAutoconnectIfacOnly(newValue)
+                    Log.d(TAG, "Autoconnect IFAC-only: $newValue")
+                } catch (e: Exception) {
+                    Log.e(TAG, "Failed to toggle autoconnect IFAC-only", e)
+                    _state.update {
+                        it.copy(errorMessage = "Failed to update IFAC-only setting: ${e.message}")
+                    }
+                }
+            }
+        }
+
+        /**
          * Set user's location for distance calculation.
          * Re-sorts the interface list if currently in PROXIMITY sort mode.
          */
@@ -336,6 +370,7 @@ class DiscoveredInterfacesViewModel
                         source = currentState.originalInterfacesForFiltering(),
                         searchQuery = query,
                         typeFilters = currentState.typeFilters,
+                        ifacOnly = currentState.ifacOnly,
                         sortMode = currentState.sortMode,
                         userLat = currentState.userLatitude,
                         userLon = currentState.userLongitude,
@@ -360,6 +395,7 @@ class DiscoveredInterfacesViewModel
                         source = currentState.originalInterfacesForFiltering(),
                         searchQuery = currentState.searchQuery,
                         typeFilters = newFilters,
+                        ifacOnly = currentState.ifacOnly,
                         sortMode = currentState.sortMode,
                         userLat = currentState.userLatitude,
                         userLon = currentState.userLongitude,
@@ -368,7 +404,28 @@ class DiscoveredInterfacesViewModel
             }
         }
 
-        /** Clear search query and type filters. */
+        /**
+         * Toggle the IFAC-only filter. When enabled, only interfaces that
+         * announced an IFAC network name are shown.
+         */
+        fun toggleIfacOnlyFilter() {
+            _state.update { currentState ->
+                val newValue = !currentState.ifacOnly
+                val newInterfaces =
+                    applySearchAndFilter(
+                        source = currentState.originalInterfacesForFiltering(),
+                        searchQuery = currentState.searchQuery,
+                        typeFilters = currentState.typeFilters,
+                        ifacOnly = newValue,
+                        sortMode = currentState.sortMode,
+                        userLat = currentState.userLatitude,
+                        userLon = currentState.userLongitude,
+                    )
+                currentState.copy(ifacOnly = newValue, interfaces = newInterfaces)
+            }
+        }
+
+        /** Clear search query and all filters (type + IFAC). */
         fun clearFilters() {
             _state.update { currentState ->
                 val newInterfaces =
@@ -376,6 +433,7 @@ class DiscoveredInterfacesViewModel
                         source = currentState.originalInterfacesForFiltering(),
                         searchQuery = "",
                         typeFilters = emptySet(),
+                        ifacOnly = false,
                         sortMode = currentState.sortMode,
                         userLat = currentState.userLatitude,
                         userLon = currentState.userLongitude,
@@ -383,6 +441,7 @@ class DiscoveredInterfacesViewModel
                 currentState.copy(
                     searchQuery = "",
                     typeFilters = emptySet(),
+                    ifacOnly = false,
                     interfaces = newInterfaces,
                 )
             }
@@ -394,6 +453,7 @@ class DiscoveredInterfacesViewModel
             source: List<DiscoveredInterface>,
             searchQuery: String,
             typeFilters: Set<DiscoveredInterfaceTypeFilter>,
+            ifacOnly: Boolean,
             sortMode: DiscoveredInterfacesSortMode,
             userLat: Double?,
             userLon: Double?,
@@ -403,6 +463,8 @@ class DiscoveredInterfacesViewModel
                     .asSequence()
                     .filter { iface ->
                         typeFilters.isEmpty() || DiscoveredInterfaceTypeFilter.classify(iface) in typeFilters
+                    }.filter { iface ->
+                        !ifacOnly || !iface.ifacNetname.isNullOrBlank()
                     }.filter { iface ->
                         if (searchQuery.isBlank()) return@filter true
                         val q = searchQuery.trim()
@@ -431,6 +493,7 @@ class DiscoveredInterfacesViewModel
                         source = currentState.originalInterfacesForFiltering(),
                         searchQuery = currentState.searchQuery,
                         typeFilters = currentState.typeFilters,
+                        ifacOnly = currentState.ifacOnly,
                         sortMode = mode,
                         userLat = currentState.userLatitude,
                         userLon = currentState.userLongitude,

--- a/app/src/main/java/com/lxmf/messenger/viewmodel/DiscoveredInterfacesViewModel.kt
+++ b/app/src/main/java/com/lxmf/messenger/viewmodel/DiscoveredInterfacesViewModel.kt
@@ -29,6 +29,32 @@ enum class DiscoveredInterfacesSortMode {
 }
 
 /**
+ * Coarse-grained bucket for filtering discovered interfaces by type. Maps from
+ * the fine-grained type strings RNS reports (e.g. "TCPServerInterface",
+ * "BackboneInterface", "RNodeInterface") to UI-friendly buckets.
+ */
+enum class DiscoveredInterfaceTypeFilter(
+    val label: String,
+) {
+    TCP("TCP"),
+    RADIO("Radio"),
+    I2P("I2P"),
+    OTHER("Other"),
+    ;
+
+    companion object {
+        /** Classify a DiscoveredInterface into a filter bucket. */
+        fun classify(iface: DiscoveredInterface): DiscoveredInterfaceTypeFilter =
+            when {
+                iface.isTcpInterface -> TCP
+                iface.isRadioInterface -> RADIO
+                iface.type.contains("I2P", ignoreCase = true) -> I2P
+                else -> OTHER
+            }
+    }
+}
+
+/**
  * State for the discovered interfaces screen.
  */
 @androidx.compose.runtime.Immutable
@@ -57,6 +83,10 @@ data class DiscoveredInterfacesState(
     val isRestarting: Boolean = false,
     // Currently auto-connected interface endpoints (e.g., "host:port")
     val autoconnectedEndpoints: Set<String> = emptySet(),
+    // Free-form search filter, matched against interface name + reachableOn + type.
+    val searchQuery: String = "",
+    // Multi-select type filter. Empty set = no filtering (all types shown).
+    val typeFilters: Set<DiscoveredInterfaceTypeFilter> = emptySet(),
 )
 
 /**
@@ -111,16 +141,18 @@ class DiscoveredInterfacesViewModel
                                 currentState.sortMode
                             }
 
-                        val sortedInterfaces =
-                            sortInterfaces(
-                                discovered,
-                                effectiveSortMode,
-                                currentState.userLatitude,
-                                currentState.userLongitude,
+                        val visibleInterfaces =
+                            applySearchAndFilter(
+                                source = discovered,
+                                searchQuery = currentState.searchQuery,
+                                typeFilters = currentState.typeFilters,
+                                sortMode = effectiveSortMode,
+                                userLat = currentState.userLatitude,
+                                userLon = currentState.userLongitude,
                             )
                         currentState.copy(
-                            interfaces = sortedInterfaces,
-                            originalInterfaces = discovered, // Store original Python-sorted list
+                            interfaces = visibleInterfaces,
+                            originalInterfaces = discovered, // Store original list for re-filtering
                             sortMode = effectiveSortMode,
                             isLoading = false,
                             availableCount = availableCount,
@@ -294,6 +326,95 @@ class DiscoveredInterfacesViewModel
         }
 
         /**
+         * Update the free-form search query. Matches against interface name,
+         * reachableOn (host/IP), and raw type string, case-insensitive.
+         */
+        fun setSearchQuery(query: String) {
+            _state.update { currentState ->
+                val newInterfaces =
+                    applySearchAndFilter(
+                        source = currentState.originalInterfacesForFiltering(),
+                        searchQuery = query,
+                        typeFilters = currentState.typeFilters,
+                        sortMode = currentState.sortMode,
+                        userLat = currentState.userLatitude,
+                        userLon = currentState.userLongitude,
+                    )
+                currentState.copy(searchQuery = query, interfaces = newInterfaces)
+            }
+        }
+
+        /**
+         * Toggle a type filter chip. Empty filter set means no type filtering.
+         */
+        fun toggleTypeFilter(filter: DiscoveredInterfaceTypeFilter) {
+            _state.update { currentState ->
+                val newFilters =
+                    if (filter in currentState.typeFilters) {
+                        currentState.typeFilters - filter
+                    } else {
+                        currentState.typeFilters + filter
+                    }
+                val newInterfaces =
+                    applySearchAndFilter(
+                        source = currentState.originalInterfacesForFiltering(),
+                        searchQuery = currentState.searchQuery,
+                        typeFilters = newFilters,
+                        sortMode = currentState.sortMode,
+                        userLat = currentState.userLatitude,
+                        userLon = currentState.userLongitude,
+                    )
+                currentState.copy(typeFilters = newFilters, interfaces = newInterfaces)
+            }
+        }
+
+        /** Clear search query and type filters. */
+        fun clearFilters() {
+            _state.update { currentState ->
+                val newInterfaces =
+                    applySearchAndFilter(
+                        source = currentState.originalInterfacesForFiltering(),
+                        searchQuery = "",
+                        typeFilters = emptySet(),
+                        sortMode = currentState.sortMode,
+                        userLat = currentState.userLatitude,
+                        userLon = currentState.userLongitude,
+                    )
+                currentState.copy(
+                    searchQuery = "",
+                    typeFilters = emptySet(),
+                    interfaces = newInterfaces,
+                )
+            }
+        }
+
+        private fun DiscoveredInterfacesState.originalInterfacesForFiltering(): List<DiscoveredInterface> = originalInterfaces.ifEmpty { interfaces }
+
+        private fun applySearchAndFilter(
+            source: List<DiscoveredInterface>,
+            searchQuery: String,
+            typeFilters: Set<DiscoveredInterfaceTypeFilter>,
+            sortMode: DiscoveredInterfacesSortMode,
+            userLat: Double?,
+            userLon: Double?,
+        ): List<DiscoveredInterface> {
+            val filtered =
+                source
+                    .asSequence()
+                    .filter { iface ->
+                        typeFilters.isEmpty() || DiscoveredInterfaceTypeFilter.classify(iface) in typeFilters
+                    }.filter { iface ->
+                        if (searchQuery.isBlank()) return@filter true
+                        val q = searchQuery.trim()
+                        iface.name.contains(q, ignoreCase = true) ||
+                            iface.type.contains(q, ignoreCase = true) ||
+                            (iface.reachableOn?.contains(q, ignoreCase = true) ?: false) ||
+                            (iface.ifacNetname?.contains(q, ignoreCase = true) ?: false)
+                    }.toList()
+            return sortInterfaces(filtered, sortMode, userLat, userLon)
+        }
+
+        /**
          * Set the sort mode and re-sort the interfaces list.
          * PROXIMITY mode requires user location; if unavailable, the request is ignored.
          */
@@ -305,19 +426,14 @@ class DiscoveredInterfacesViewModel
                 ) {
                     return@update currentState
                 }
-                // Use originalInterfaces for QUALITY mode to restore Python's sort order
-                val sourceList =
-                    if (mode == DiscoveredInterfacesSortMode.AVAILABILITY_AND_QUALITY) {
-                        currentState.originalInterfaces
-                    } else {
-                        currentState.interfaces
-                    }
                 val sortedInterfaces =
-                    sortInterfaces(
-                        sourceList,
-                        mode,
-                        currentState.userLatitude,
-                        currentState.userLongitude,
+                    applySearchAndFilter(
+                        source = currentState.originalInterfacesForFiltering(),
+                        searchQuery = currentState.searchQuery,
+                        typeFilters = currentState.typeFilters,
+                        sortMode = mode,
+                        userLat = currentState.userLatitude,
+                        userLon = currentState.userLongitude,
                     )
                 currentState.copy(
                     sortMode = mode,

--- a/app/src/main/java/com/lxmf/messenger/viewmodel/DiscoveredInterfacesViewModel.kt
+++ b/app/src/main/java/com/lxmf/messenger/viewmodel/DiscoveredInterfacesViewModel.kt
@@ -314,8 +314,11 @@ class DiscoveredInterfacesViewModel
         fun toggleAutoconnectIfacOnly() {
             viewModelScope.launch(ioDispatcher) {
                 try {
-                    val newValue = !_state.value.autoconnectIfacOnly
-                    _state.update { it.copy(autoconnectIfacOnly = newValue) }
+                    var newValue = false
+                    _state.update { currentState ->
+                        newValue = !currentState.autoconnectIfacOnly
+                        currentState.copy(autoconnectIfacOnly = newValue)
+                    }
                     settingsRepository.saveAutoconnectIfacOnly(newValue)
                     reticulumProtocol.setAutoconnectIfacOnly(newValue)
                     Log.d(TAG, "Autoconnect IFAC-only: $newValue")

--- a/app/src/main/java/com/lxmf/messenger/viewmodel/TcpClientWizardViewModel.kt
+++ b/app/src/main/java/com/lxmf/messenger/viewmodel/TcpClientWizardViewModel.kt
@@ -43,6 +43,12 @@ data class TcpClientWizardState(
     val interfaceName: String = "",
     val targetHost: String = "",
     val targetPort: String = "",
+    // IFAC (network_name / passphrase). Auto-populated from interface discovery
+    // when the remote side publishes IFAC; remote will refuse packets unless the
+    // local interface matches. User-editable for manual entry.
+    val networkName: String = "",
+    val passphrase: String = "",
+    val passphraseVisible: Boolean = false,
     // RNS 1.1.x Bootstrap Interface option
     val bootstrapOnly: Boolean = false,
     // SOCKS5 proxy (Tor/Orbot) settings
@@ -102,6 +108,8 @@ class TcpClientWizardViewModel
                             interfaceName = config.name,
                             targetHost = config.targetHost,
                             targetPort = config.targetPort.toString(),
+                            networkName = config.networkName.orEmpty(),
+                            passphrase = config.passphrase.orEmpty(),
                             bootstrapOnly = config.bootstrapOnly,
                             socksProxyEnabled = config.socksProxyEnabled,
                             socksProxyHost = config.socksProxyHost,
@@ -118,11 +126,18 @@ class TcpClientWizardViewModel
 
         /**
          * Set initial values when creating from a discovered interface.
+         *
+         * @param ifacNetname IFAC network name from discovery announce, if the
+         *   remote interface published one. Required to pass the IFAC handshake
+         *   on the remote side.
+         * @param ifacNetkey IFAC passphrase from discovery announce.
          */
         fun setInitialValues(
             host: String,
             port: Int,
             name: String,
+            ifacNetname: String? = null,
+            ifacNetkey: String? = null,
         ) {
             // Check if this matches a community server
             val matchingServer =
@@ -138,6 +153,8 @@ class TcpClientWizardViewModel
                     interfaceName = name,
                     targetHost = host,
                     targetPort = port.toString(),
+                    networkName = ifacNetname.orEmpty(),
+                    passphrase = ifacNetkey.orEmpty(),
                     bootstrapOnly = matchingServer?.isBootstrap ?: false,
                     // Auto-enable SOCKS proxy for .onion addresses
                     socksProxyEnabled = isOnion,
@@ -145,7 +162,27 @@ class TcpClientWizardViewModel
                     currentStep = TcpClientWizardStep.REVIEW_CONFIGURE,
                 )
             }
-            Log.d(TAG, "Set initial values from discovered: $name @ $host:$port, matched server: ${matchingServer?.name}")
+            Log.d(
+                TAG,
+                "Set initial values from discovered: $name @ $host:$port, " +
+                    "matched server: ${matchingServer?.name}, " +
+                    "ifacNet=${ifacNetname?.take(8)}…",
+            )
+        }
+
+        /** Update IFAC network name field. */
+        fun setNetworkName(value: String) {
+            _state.update { it.copy(networkName = value) }
+        }
+
+        /** Update IFAC passphrase field. */
+        fun setPassphrase(value: String) {
+            _state.update { it.copy(passphrase = value) }
+        }
+
+        /** Toggle passphrase visibility. */
+        fun togglePassphraseVisibility() {
+            _state.update { it.copy(passphraseVisible = !it.passphraseVisible) }
         }
 
         /**
@@ -338,6 +375,8 @@ class TcpClientWizardViewModel
                             targetPort = currentState.targetPort.toIntOrNull() ?: 4242,
                             kissFraming = false,
                             mode = "full",
+                            networkName = currentState.networkName.trim().ifEmpty { null },
+                            passphrase = currentState.passphrase.trim().ifEmpty { null },
                             bootstrapOnly = currentState.bootstrapOnly,
                             socksProxyEnabled = currentState.socksProxyEnabled,
                             socksProxyHost = currentState.socksProxyHost.trim().ifEmpty { "127.0.0.1" },

--- a/app/src/test/java/com/lxmf/messenger/repository/SettingsRepositoryTest.kt
+++ b/app/src/test/java/com/lxmf/messenger/repository/SettingsRepositoryTest.kt
@@ -1531,4 +1531,34 @@ class SettingsRepositoryTest {
                 cancelAndConsumeRemainingEvents()
             }
         }
+
+    // ========== Autoconnect IFAC-only filter ==========
+
+    @Test
+    fun autoconnectIfacOnly_defaultsToFalse() =
+        runTest {
+            assertFalse(repository.getAutoconnectIfacOnly())
+        }
+
+    @Test
+    fun autoconnectIfacOnly_persistsValue() =
+        runTest {
+            repository.saveAutoconnectIfacOnly(true)
+            assertTrue(repository.getAutoconnectIfacOnly())
+            repository.saveAutoconnectIfacOnly(false)
+            assertFalse(repository.getAutoconnectIfacOnly())
+        }
+
+    @Test
+    fun autoconnectIfacOnlyFlow_emitsOnlyOnChange() =
+        runTest {
+            repository.autoconnectIfacOnlyFlow.test(timeout = 5.seconds) {
+                val initial = awaitItem()
+                repository.saveAutoconnectIfacOnly(initial)
+                expectNoEvents()
+                repository.saveAutoconnectIfacOnly(!initial)
+                assertEquals(!initial, awaitItem())
+                cancelAndIgnoreRemainingEvents()
+            }
+        }
 }

--- a/app/src/test/java/com/lxmf/messenger/startup/StartupConfigLoaderTest.kt
+++ b/app/src/test/java/com/lxmf/messenger/startup/StartupConfigLoaderTest.kt
@@ -71,6 +71,7 @@ class StartupConfigLoaderTest {
         coEvery { settingsRepository.getBatteryProfile() } returns BatteryProfile.BALANCED
         coEvery { settingsRepository.getDiscoverInterfacesEnabled() } returns false
         coEvery { settingsRepository.getAutoconnectDiscoveredCount() } returns 0
+        coEvery { settingsRepository.getAutoconnectIfacOnly() } returns false
 
         loader = StartupConfigLoader(interfaceRepository, identityRepository, settingsRepository)
     }
@@ -227,6 +228,21 @@ class StartupConfigLoaderTest {
         }
 
     @Test
+    fun `loadConfig surfaces autoconnect IFAC-only setting`() =
+        runTest {
+            coEvery { interfaceRepository.enabledInterfaces } returns flowOf(emptyList())
+            coEvery { identityRepository.getActiveIdentitySync() } returns null
+            coEvery { settingsRepository.preferOwnInstanceFlow } returns flowOf(false)
+            coEvery { settingsRepository.rpcKeyFlow } returns flowOf(null)
+            coEvery { settingsRepository.getTransportNodeEnabled() } returns false
+            coEvery { settingsRepository.getAutoconnectIfacOnly() } returns true
+
+            val config = loader.loadConfig()
+
+            assertTrue(config.autoconnectIfacOnly)
+        }
+
+    @Test
     fun `StartupConfig data class equals and hashCode work correctly`() {
         val config1 =
             StartupConfigLoader.StartupConfig(
@@ -238,6 +254,7 @@ class StartupConfigLoaderTest {
                 batteryProfile = BatteryProfile.BALANCED,
                 discoverInterfaces = false,
                 autoconnectDiscoveredCount = 0,
+                autoconnectIfacOnly = false,
             )
         val config2 =
             StartupConfigLoader.StartupConfig(
@@ -249,6 +266,7 @@ class StartupConfigLoaderTest {
                 batteryProfile = BatteryProfile.BALANCED,
                 discoverInterfaces = false,
                 autoconnectDiscoveredCount = 0,
+                autoconnectIfacOnly = false,
             )
         val config3 =
             StartupConfigLoader.StartupConfig(
@@ -260,6 +278,7 @@ class StartupConfigLoaderTest {
                 batteryProfile = BatteryProfile.PERFORMANCE,
                 discoverInterfaces = true,
                 autoconnectDiscoveredCount = 5,
+                autoconnectIfacOnly = true,
             )
 
         assertEquals(config1, config2)

--- a/app/src/test/java/com/lxmf/messenger/viewmodel/DiscoveredInterfacesViewModelTest.kt
+++ b/app/src/test/java/com/lxmf/messenger/viewmodel/DiscoveredInterfacesViewModelTest.kt
@@ -1165,6 +1165,104 @@ class DiscoveredInterfacesViewModelTest {
             assertEquals("NoLoc2", state.interfaces[1].name)
         }
 
+    // ========== Search + Filter Tests ==========
+
+    @Test
+    fun `setSearchQuery filters by name case-insensitively`() =
+        runTest {
+            val interfaces =
+                listOf(
+                    createTestDiscoveredInterface(name = "Columba Node Alpha", reachableOn = "10.0.0.1"),
+                    createTestDiscoveredInterface(name = "Some Other Interface", reachableOn = "10.0.0.2"),
+                )
+            coEvery { reticulumProtocol.getDiscoveredInterfaces() } returns interfaces
+            viewModel = createViewModel()
+            advanceUntilIdle()
+
+            viewModel.setSearchQuery("columba")
+
+            val state = viewModel.state.value
+            assertEquals("columba", state.searchQuery)
+            assertEquals(1, state.interfaces.size)
+            assertEquals("Columba Node Alpha", state.interfaces[0].name)
+        }
+
+    @Test
+    fun `setSearchQuery also matches host and ifac network name`() =
+        runTest {
+            val interfaces =
+                listOf(
+                    createTestDiscoveredInterface(name = "Node A", reachableOn = "mesh.example.com"),
+                    createTestDiscoveredInterface(name = "Node B", reachableOn = "10.0.0.2", ifacNetname = "community-mesh"),
+                    createTestDiscoveredInterface(name = "Node C", reachableOn = "10.0.0.3"),
+                )
+            coEvery { reticulumProtocol.getDiscoveredInterfaces() } returns interfaces
+            viewModel = createViewModel()
+            advanceUntilIdle()
+
+            viewModel.setSearchQuery("mesh")
+
+            val names =
+                viewModel.state.value.interfaces
+                    .map { it.name }
+                    .toSet()
+            assertEquals(setOf("Node A", "Node B"), names)
+        }
+
+    @Test
+    fun `toggleTypeFilter restricts to selected types`() =
+        runTest {
+            val interfaces =
+                listOf(
+                    createTestDiscoveredInterface(name = "TCP-1", type = "TCPServerInterface"),
+                    createTestDiscoveredInterface(name = "Radio-1", type = "RNodeInterface"),
+                    createTestDiscoveredInterface(name = "I2P-1", type = "I2PInterface"),
+                )
+            coEvery { reticulumProtocol.getDiscoveredInterfaces() } returns interfaces
+            viewModel = createViewModel()
+            advanceUntilIdle()
+
+            viewModel.toggleTypeFilter(DiscoveredInterfaceTypeFilter.TCP)
+
+            assertEquals(
+                listOf("TCP-1"),
+                viewModel.state.value.interfaces
+                    .map { it.name },
+            )
+
+            viewModel.toggleTypeFilter(DiscoveredInterfaceTypeFilter.RADIO)
+
+            val names =
+                viewModel.state.value.interfaces
+                    .map { it.name }
+                    .toSet()
+            assertEquals(setOf("TCP-1", "Radio-1"), names)
+        }
+
+    @Test
+    fun `clearFilters resets search and type filters`() =
+        runTest {
+            val interfaces =
+                listOf(
+                    createTestDiscoveredInterface(name = "TCP-1", type = "TCPServerInterface"),
+                    createTestDiscoveredInterface(name = "Radio-1", type = "RNodeInterface"),
+                )
+            coEvery { reticulumProtocol.getDiscoveredInterfaces() } returns interfaces
+            viewModel = createViewModel()
+            advanceUntilIdle()
+
+            viewModel.setSearchQuery("TCP")
+            viewModel.toggleTypeFilter(DiscoveredInterfaceTypeFilter.TCP)
+            assertEquals(1, viewModel.state.value.interfaces.size)
+
+            viewModel.clearFilters()
+
+            val state = viewModel.state.value
+            assertEquals("", state.searchQuery)
+            assertTrue(state.typeFilters.isEmpty())
+            assertEquals(2, state.interfaces.size)
+        }
+
     // ========== Helper Functions ==========
 
     private fun createTestDiscoveredInterface(
@@ -1175,6 +1273,8 @@ class DiscoveredInterfacesViewModelTest {
         port: Int? = 4242,
         latitude: Double? = null,
         longitude: Double? = null,
+        ifacNetname: String? = null,
+        ifacNetkey: String? = null,
     ): DiscoveredInterface =
         DiscoveredInterface(
             name = name,
@@ -1203,5 +1303,7 @@ class DiscoveredInterfacesViewModelTest {
             latitude = latitude,
             longitude = longitude,
             height = null,
+            ifacNetname = ifacNetname,
+            ifacNetkey = ifacNetkey,
         )
 }

--- a/app/src/test/java/com/lxmf/messenger/viewmodel/DiscoveredInterfacesViewModelTest.kt
+++ b/app/src/test/java/com/lxmf/messenger/viewmodel/DiscoveredInterfacesViewModelTest.kt
@@ -93,6 +93,9 @@ class DiscoveredInterfacesViewModelTest {
         coEvery { reticulumProtocol.setAutoconnectLimit(any()) } returns Unit
         coEvery { settingsRepository.getDiscoverInterfacesEnabled() } returns false
         coEvery { settingsRepository.getAutoconnectDiscoveredCount() } returns 0
+        coEvery { settingsRepository.getAutoconnectIfacOnly() } returns false
+        coEvery { settingsRepository.saveAutoconnectIfacOnly(any()) } returns Unit
+        coEvery { reticulumProtocol.setAutoconnectIfacOnly(any()) } returns Unit
         every { interfaceRepository.bootstrapInterfaceNames } returns bootstrapNamesFlow
     }
 
@@ -1261,6 +1264,43 @@ class DiscoveredInterfacesViewModelTest {
             assertEquals("", state.searchQuery)
             assertTrue(state.typeFilters.isEmpty())
             assertEquals(2, state.interfaces.size)
+        }
+
+    // ========== Autoconnect IFAC-only toggle ==========
+
+    @Test
+    fun `loadDiscoverySettings pushes persisted IFAC-only value to protocol`() =
+        runTest {
+            coEvery { settingsRepository.getAutoconnectIfacOnly() } returns true
+
+            viewModel = createViewModel()
+            advanceUntilIdle()
+
+            assertTrue(viewModel.state.value.autoconnectIfacOnly)
+            coVerify { reticulumProtocol.setAutoconnectIfacOnly(true) }
+        }
+
+    @Test
+    fun `toggleAutoconnectIfacOnly flips state, persists, and forwards to protocol`() =
+        runTest {
+            coEvery { settingsRepository.getAutoconnectIfacOnly() } returns false
+            viewModel = createViewModel()
+            advanceUntilIdle()
+            assertFalse(viewModel.state.value.autoconnectIfacOnly)
+
+            viewModel.toggleAutoconnectIfacOnly()
+            advanceUntilIdle()
+
+            assertTrue(viewModel.state.value.autoconnectIfacOnly)
+            coVerify { settingsRepository.saveAutoconnectIfacOnly(true) }
+            coVerify { reticulumProtocol.setAutoconnectIfacOnly(true) }
+
+            viewModel.toggleAutoconnectIfacOnly()
+            advanceUntilIdle()
+
+            assertFalse(viewModel.state.value.autoconnectIfacOnly)
+            coVerify { settingsRepository.saveAutoconnectIfacOnly(false) }
+            coVerify { reticulumProtocol.setAutoconnectIfacOnly(false) }
         }
 
     // ========== Helper Functions ==========

--- a/app/src/test/java/com/lxmf/messenger/viewmodel/TcpClientWizardViewModelTest.kt
+++ b/app/src/test/java/com/lxmf/messenger/viewmodel/TcpClientWizardViewModelTest.kt
@@ -1495,4 +1495,77 @@ class TcpClientWizardViewModelTest {
                 assertFalse(finalState.isSaving)
             }
         }
+
+    // ========== IFAC auto-population from discovery ==========
+
+    @Test
+    fun `setInitialValues populates networkName and passphrase when IFAC provided`() =
+        runTest {
+            viewModel.state.test {
+                awaitItem() // initial
+
+                viewModel.setInitialValues(
+                    host = "mesh.example.com",
+                    port = 4242,
+                    name = "From Discovery",
+                    ifacNetname = "private-net",
+                    ifacNetkey = "super-secret",
+                )
+                advanceUntilIdle()
+
+                val state = expectMostRecentItem()
+                assertEquals("private-net", state.networkName)
+                assertEquals("super-secret", state.passphrase)
+                assertEquals("From Discovery", state.interfaceName)
+                assertEquals("mesh.example.com", state.targetHost)
+            }
+        }
+
+    @Test
+    fun `setInitialValues leaves IFAC fields empty when omitted`() =
+        runTest {
+            viewModel.state.test {
+                awaitItem()
+
+                viewModel.setInitialValues(host = "10.0.0.1", port = 4242, name = "No IFAC")
+                advanceUntilIdle()
+
+                val state = expectMostRecentItem()
+                assertEquals("", state.networkName)
+                assertEquals("", state.passphrase)
+            }
+        }
+
+    @Test
+    fun `setNetworkName and setPassphrase update state`() =
+        runTest {
+            viewModel.state.test {
+                awaitItem()
+
+                viewModel.setNetworkName("manual-net")
+                advanceUntilIdle()
+                assertEquals("manual-net", awaitItem().networkName)
+
+                viewModel.setPassphrase("manual-pass")
+                advanceUntilIdle()
+                assertEquals("manual-pass", awaitItem().passphrase)
+            }
+        }
+
+    @Test
+    fun `togglePassphraseVisibility flips flag`() =
+        runTest {
+            viewModel.state.test {
+                awaitItem()
+                assertFalse(viewModel.state.value.passphraseVisible)
+
+                viewModel.togglePassphraseVisibility()
+                advanceUntilIdle()
+                assertTrue(awaitItem().passphraseVisible)
+
+                viewModel.togglePassphraseVisibility()
+                advanceUntilIdle()
+                assertFalse(awaitItem().passphraseVisible)
+            }
+        }
 }

--- a/reticulum/src/main/java/com/lxmf/messenger/reticulum/model/ReticulumConfig.kt
+++ b/reticulum/src/main/java/com/lxmf/messenger/reticulum/model/ReticulumConfig.kt
@@ -48,6 +48,12 @@ data class ReticulumConfig(
      */
     val autoconnectDiscoveredInterfaces: Int = 0,
     /**
+     * When true, the auto-connect factory only accepts discovered interfaces
+     * whose announce included an IFAC network name. Non-IFAC interfaces are
+     * skipped, freeing the autoconnect slot for an IFAC-advertised peer.
+     */
+    val autoconnectIfacOnly: Boolean = false,
+    /**
      * List of identity hashes (hex) of trusted discovery sources.
      * If null or empty, all discovered interfaces are considered.
      * If set, only interfaces from these sources will be auto-connected.

--- a/reticulum/src/main/java/com/lxmf/messenger/reticulum/protocol/NativeReticulumProtocol.kt
+++ b/reticulum/src/main/java/com/lxmf/messenger/reticulum/protocol/NativeReticulumProtocol.kt
@@ -1629,6 +1629,8 @@ class NativeReticulumProtocol(
                 latitude = info.latitude,
                 longitude = info.longitude,
                 height = info.height,
+                ifacNetname = info.ifacNetname,
+                ifacNetkey = info.ifacNetkey,
             )
         }
 

--- a/reticulum/src/main/java/com/lxmf/messenger/reticulum/protocol/NativeReticulumProtocol.kt
+++ b/reticulum/src/main/java/com/lxmf/messenger/reticulum/protocol/NativeReticulumProtocol.kt
@@ -175,6 +175,10 @@ class NativeReticulumProtocol(
 
     private var scope = CoroutineScope(SupervisorJob() + Dispatchers.Default)
 
+    // When true, auto-connect ignores discovered interfaces that did not
+    // advertise an IFAC network name. Set via setAutoconnectIfacOnly().
+    @Volatile private var autoconnectIfacOnly: Boolean = false
+
     // Native reticulum-kt / lxmf-kt instances
     private var reticulum: Reticulum? = null
     private var router: LXMRouter? = null
@@ -428,6 +432,13 @@ class NativeReticulumProtocol(
                 // Register announce handlers for all relevant aspects
                 registerAnnounceHandlers()
 
+                // Apply the IFAC-only autoconnect filter before starting the
+                // discovery listener so the filter is active from the first
+                // announce — otherwise a non-IFAC interface could race in and
+                // grab the slot before the user-facing screen has a chance to
+                // re-push the setting.
+                autoconnectIfacOnly = config.autoconnectIfacOnly
+
                 // Wire up interface discovery if configured
                 if (config.discoverInterfaces) {
                     startDiscovery(config)
@@ -577,13 +588,14 @@ class NativeReticulumProtocol(
                 ?.map { network.reticulum.common.ByteArrayKey(hexStringToByteArray(it)) }
                 ?.toSet()
 
-        // Auto-connect factory: creates a TCPClientInterface from discovered info
-        val autoConnectFactory: ((network.reticulum.discovery.DiscoveredInterface) -> network.reticulum.transport.InterfaceRef?)? =
-            if (config.autoconnectDiscoveredInterfaces > 0) {
-                { discovered -> createAutoconnectInterface(discovered) }
-            } else {
-                null
-            }
+        // Auto-connect factory: creates a TCPClientInterface from discovered
+        // info. Always register the factory, even when autoconnect count is 0
+        // at init time — InterfaceDiscovery.autoConnectFactory is immutable
+        // after construction, so if we pass null here the user can't later turn
+        // on autoconnect without restarting the service. `maxAutoConnected` is
+        // mutable and gates the factory's callers.
+        val autoConnectFactory: (network.reticulum.discovery.DiscoveredInterface) -> network.reticulum.transport.InterfaceRef? =
+            { discovered -> createAutoconnectInterface(discovered) }
 
         // Start the listener (receives others' discovery announces)
         Transport.discoverInterfaces(
@@ -603,6 +615,13 @@ class NativeReticulumProtocol(
     private fun createAutoconnectInterface(discovered: network.reticulum.discovery.DiscoveredInterface): network.reticulum.transport.InterfaceRef? {
         val host = discovered.reachableOn ?: return null
         val port = discovered.port ?: return null
+        if (autoconnectIfacOnly && discovered.ifacNetname.isNullOrBlank()) {
+            Log.i(
+                TAG,
+                "Skipping auto-connect for ${discovered.name} at $host:$port — IFAC-only mode and interface has no IFAC",
+            )
+            return null
+        }
         return try {
             val iface =
                 network.reticulum.interfaces.tcp.TCPClientInterface(
@@ -1583,6 +1602,11 @@ class NativeReticulumProtocol(
         Log.i(TAG, "Auto-connect limit updated to $count (no restart)")
     }
 
+    override suspend fun setAutoconnectIfacOnly(enabled: Boolean) {
+        autoconnectIfacOnly = enabled
+        Log.i(TAG, "Auto-connect IFAC-only filter ${if (enabled) "enabled" else "disabled"}")
+    }
+
     override suspend fun getFailedInterfaces(): List<FailedInterface> = emptyList()
 
     override suspend fun getInterfaceStats(interfaceName: String): Map<String, Any>? {
@@ -1631,6 +1655,10 @@ class NativeReticulumProtocol(
                 height = info.height,
                 ifacNetname = info.ifacNetname,
                 ifacNetkey = info.ifacNetkey,
+                transport = info.transport,
+                discoveryHash = info.discoveryHash.joinToString("") { "%02x".format(it) },
+                receivedAt = info.received,
+                discoveredAt = info.discovered,
             )
         }
 

--- a/reticulum/src/main/java/com/lxmf/messenger/reticulum/protocol/ReticulumProtocol.kt
+++ b/reticulum/src/main/java/com/lxmf/messenger/reticulum/protocol/ReticulumProtocol.kt
@@ -600,6 +600,13 @@ interface ReticulumProtocol {
     /** Update the auto-connect limit without restarting. Default no-op (ServiceReticulumProtocol needs restart). */
     suspend fun setAutoconnectLimit(count: Int) {}
 
+    /**
+     * When enabled, auto-connect only accepts discovered interfaces that
+     * published an IFAC network name. Useful on mixed-trust networks where
+     * the user only wants Columba to auto-join known private networks.
+     */
+    suspend fun setAutoconnectIfacOnly(enabled: Boolean) {}
+
     // ==================== NomadNet Page Browsing ====================
 
     /**
@@ -786,6 +793,15 @@ data class DiscoveredInterface(
     // passphrase or the IFAC handshake fails and no packets get through.
     val ifacNetname: String? = null,
     val ifacNetkey: String? = null,
+    // Additional raw announce fields exposed for the "all fields" card view.
+    /** Whether the remote interface is a transport (routing) node. */
+    val transport: Boolean = false,
+    /** Unique identifier for this announce (hex SHA256 of transportId + name). */
+    val discoveryHash: String? = null,
+    /** When the remote generated the announce (unix seconds). */
+    val receivedAt: Long = 0L,
+    /** When we first discovered this interface locally (unix seconds). */
+    val discoveredAt: Long = 0L,
 ) {
     /**
      * Returns true if this is a TCP-based interface.

--- a/reticulum/src/main/java/com/lxmf/messenger/reticulum/protocol/ReticulumProtocol.kt
+++ b/reticulum/src/main/java/com/lxmf/messenger/reticulum/protocol/ReticulumProtocol.kt
@@ -869,6 +869,11 @@ data class DiscoveredInterface(
                 // IFAC
                 ifacNetname = item.optString("ifac_netname", "").ifEmpty { null },
                 ifacNetkey = item.optString("ifac_netkey", "").ifEmpty { null },
+                // Additional raw announce fields
+                transport = item.optBoolean("transport", false),
+                discoveryHash = item.optString("discovery_hash", "").ifEmpty { null },
+                receivedAt = item.optLong("received", 0L),
+                discoveredAt = item.optLong("discovered", 0L),
             )
 
         // JSON extension helpers for nullable values

--- a/reticulum/src/main/java/com/lxmf/messenger/reticulum/protocol/ReticulumProtocol.kt
+++ b/reticulum/src/main/java/com/lxmf/messenger/reticulum/protocol/ReticulumProtocol.kt
@@ -781,6 +781,11 @@ data class DiscoveredInterface(
     val latitude: Double?,
     val longitude: Double?,
     val height: Double?, // Altitude in meters
+    // IFAC (Interface Access Code) — when the remote interface publishes its IFAC
+    // identity, peers adding this interface locally must match network_name and
+    // passphrase or the IFAC handshake fails and no packets get through.
+    val ifacNetname: String? = null,
+    val ifacNetkey: String? = null,
 ) {
     /**
      * Returns true if this is a TCP-based interface.
@@ -845,6 +850,9 @@ data class DiscoveredInterface(
                 latitude = item.optDoubleOrNull("latitude"),
                 longitude = item.optDoubleOrNull("longitude"),
                 height = item.optDoubleOrNull("height"),
+                // IFAC
+                ifacNetname = item.optString("ifac_netname", "").ifEmpty { null },
+                ifacNetkey = item.optString("ifac_netkey", "").ifEmpty { null },
             )
 
         // JSON extension helpers for nullable values


### PR DESCRIPTION
## Summary
- Add search-by-name and multi-select type-filter (TCP / Radio / I2P / Other) to the discovered-interfaces screen.
- Plumb IFAC (`network_name` + `passphrase`) through the discovery pipeline end-to-end. Previously Columba dropped these fields, so any discovered interface advertising an IFAC network was essentially unusable — you'd see the announce but adding it via the wizard would omit the access code and the remote would refuse packets.

## Fix details (IFAC)
- `DiscoveredInterface` wrapper gains `ifacNetname` / `ifacNetkey`, mapped from reticulum-kt's native type in `NativeReticulumProtocol.getDiscoveredInterfaces()`.
- Discovery card shows an `IFAC: <network-name> 🔑` line when the remote published access info so the user knows the interface is gated before tapping "Add".
- Nav route `tcp_client_wizard` now accepts `ifacNetname` / `ifacNetkey` params.
- `TcpClientWizardState` gains `networkName` + `passphrase` fields auto-populated from discovery. `ReviewConfigureStep` exposes them as user-editable inputs (password has show/hide toggle).
- Save path carries IFAC through into the persisted `InterfaceConfig.TCPClient`.

## Fix details (search + filter)
- New `DiscoveredInterfaceTypeFilter` enum with a `classify()` helper.
- VM exposes `searchQuery`, `typeFilters`, `setSearchQuery`, `toggleTypeFilter`, `clearFilters`. Filtering is in-memory over the same one-shot load used for sort.
- Screen adds a search `OutlinedTextField` with leading search icon + trailing clear icon, and a `FlowRow` of `FilterChip`s. Shows filtered count + "clear" action when any filter is active.
- Empty filtered state shows a distinct "No matches" card with a one-tap clear button; true empty state (no interfaces discovered) keeps its original messaging.

## Test plan
- [x] `:app:testNoSentryDebugUnitTest --tests "*DiscoveredInterfacesViewModelTest*"` — all existing + 4 new tests pass (search by name, search matches host/IFAC netname, multi-select type filter, clearFilters reset).
- [x] `:app:testNoSentryDebugUnitTest --tests "*TcpClientWizard*"` — still passes.
- [x] `:app:assembleNoSentryDebug` succeeds.
- [ ] Manual: discovered TCP interface on the network, open screen, confirm search + type filter behave as expected.
- [ ] Manual: announce an IFAC-protected interface and confirm it appears with the IFAC badge, the wizard auto-populates the network/passphrase fields, and the resulting config actually connects.

🤖 Generated with [Claude Code](https://claude.com/claude-code)