### PR TITLE
Keep foreground notification in sync after :reticulum process restart

### DIFF
--- a/app/src/main/java/com/lxmf/messenger/ColumbaApplication.kt
+++ b/app/src/main/java/com/lxmf/messenger/ColumbaApplication.kt
@@ -208,7 +208,13 @@ class ColumbaApplication : Application() {
         applicationScope.launch {
             reticulumProtocol.networkStatus.collect { status ->
                 val serviceStatus = networkStatusToServiceString(status)
-                serviceSettingsAccessor.saveLastNetworkStatus(serviceStatus)
+                // applicationScope runs on Dispatchers.Default; commit() is a synchronous
+                // disk write, so move the persistence hop to IO to keep StrictMode quiet
+                // in debug builds. updateServiceNotification itself just dispatches an
+                // Intent and can stay on the collector's context.
+                kotlinx.coroutines.withContext(Dispatchers.IO) {
+                    serviceSettingsAccessor.saveLastNetworkStatus(serviceStatus)
+                }
                 updateServiceNotification(serviceStatus)
             }
         }
@@ -506,10 +512,13 @@ class ColumbaApplication : Application() {
                 }
             // startForegroundService also spins up the :reticulum process if it isn't running.
             // ReticulumService.onStartCommand guards on ::managers.isInitialized and returns
-            // START_STICKY if onCreate hasn't finished, so an ACTION_UPDATE_NOTIFICATION delivered
-            // during that brief window is dropped. In practice we only call this after
-            // initialize() has resolved, by which point the service process has been alive for
-            // seconds, so the window never opens for real notification updates.
+            // START_STICKY if onCreate hasn't finished, so an ACTION_UPDATE_NOTIFICATION
+            // delivered during that brief window is dropped. Because this function now fires
+            // for every networkStatus transition (including early SHUTDOWN / INITIALIZING /
+            // CONNECTING emissions during startup), the drop window can be hit — but
+            // ReticulumService.onCreate reads saveLastNetworkStatus back from cross-process
+            // prefs before it calls startForeground, so the initial notification still
+            // reflects the most recent status even when an early intent was dropped.
             androidx.core.content.ContextCompat
                 .startForegroundService(this, intent)
         } catch (e: Exception) {

--- a/app/src/main/java/com/lxmf/messenger/ColumbaApplication.kt
+++ b/app/src/main/java/com/lxmf/messenger/ColumbaApplication.kt
@@ -44,6 +44,14 @@ class ColumbaApplication : Application() {
     @Inject
     lateinit var reticulumProtocol: ReticulumProtocol
 
+    // Cross-process SharedPreferences wrapper shared with the :reticulum process.
+    // Constructed lazily rather than via Hilt because it only needs a Context and has
+    // no other dependencies — this avoids adding a module binding for a single call site.
+    private val serviceSettingsAccessor by lazy {
+        com.lxmf.messenger.service.persistence
+            .ServiceSettingsAccessor(this)
+    }
+
     @Inject
     lateinit var startupConfigLoader: StartupConfigLoader
 
@@ -188,6 +196,21 @@ class ColumbaApplication : Application() {
         reticulumProtocol.onServiceNeedsInitialization = {
             android.util.Log.i("ColumbaApplication", "Service needs reinitialization after rebind - starting initialization")
             initializeReticulumService(reticulumProtocol)
+        }
+
+        // Mirror the protocol's networkStatus into the :reticulum service process so the
+        // foreground notification stays in sync. On the native stack the protocol lives in
+        // the app process — the service is just the notification/wake-lock host. When its
+        // state changes (INITIALIZING → READY, or later ERROR) we push it; we also persist
+        // the value via cross-process prefs so that if Android kills and restarts :reticulum
+        // on its own, onCreate() can restore the correct initial text instead of defaulting
+        // to SHUTDOWN / "Disconnected".
+        applicationScope.launch {
+            reticulumProtocol.networkStatus.collect { status ->
+                val serviceStatus = networkStatusToServiceString(status)
+                serviceSettingsAccessor.saveLastNetworkStatus(serviceStatus)
+                updateServiceNotification(serviceStatus)
+            }
         }
 
         applicationScope.launch {
@@ -455,6 +478,19 @@ class ColumbaApplication : Application() {
             reticulumProtocol.unbindService()
         }
     }
+
+    /**
+     * Map the protocol's sealed NetworkStatus to the string vocabulary that
+     * ServiceNotificationManager.getStatusTexts already branches on.
+     */
+    private fun networkStatusToServiceString(status: com.lxmf.messenger.reticulum.model.NetworkStatus): String =
+        when (status) {
+            is com.lxmf.messenger.reticulum.model.NetworkStatus.READY -> "READY"
+            is com.lxmf.messenger.reticulum.model.NetworkStatus.INITIALIZING -> "INITIALIZING"
+            is com.lxmf.messenger.reticulum.model.NetworkStatus.CONNECTING -> "CONNECTING"
+            is com.lxmf.messenger.reticulum.model.NetworkStatus.SHUTDOWN -> "SHUTDOWN"
+            is com.lxmf.messenger.reticulum.model.NetworkStatus.ERROR -> "ERROR:${status.message}"
+        }
 
     /**
      * Send a network status update to the service process to refresh

--- a/app/src/main/java/com/lxmf/messenger/ColumbaApplication.kt
+++ b/app/src/main/java/com/lxmf/messenger/ColumbaApplication.kt
@@ -386,8 +386,9 @@ class ColumbaApplication : Application() {
                     .onSuccess {
                         android.util.Log.i("ColumbaApplication", "Reticulum initialized successfully")
 
-                        // Update the service notification to reflect the native stack is ready
-                        updateServiceNotification("READY")
+                        // networkStatus.collect (set up earlier) already pushes
+                        // ACTION_UPDATE_NOTIFICATION when status transitions to READY, so no
+                        // explicit call is needed here.
 
                         // Battery optimization exemption is now handled in OnboardingPagerScreen
                         // for new users, and via Settings for existing users
@@ -669,10 +670,8 @@ class ColumbaApplication : Application() {
                 .onSuccess {
                     android.util.Log.i("ColumbaApplication", "initializeReticulumService: Reticulum initialized successfully")
 
-                    // Match the cold-start path so the foreground notification reflects the new
-                    // state — otherwise a post-rebind reinit leaves the notification stuck on
-                    // whatever status was showing when the service was last killed.
-                    updateServiceNotification("READY")
+                    // networkStatus.collect (set up in onCreate) handles the READY
+                    // notification push.
 
                     restorePeerIdentities(protocol)
 

--- a/app/src/main/java/com/lxmf/messenger/service/ReticulumService.kt
+++ b/app/src/main/java/com/lxmf/messenger/service/ReticulumService.kt
@@ -101,6 +101,14 @@ class ReticulumService : Service() {
         // Create notification channel
         managers.notificationManager.createNotificationChannel()
 
+        // Restore the last persisted network status written by the app process. If Android
+        // restarted the :reticulum process on its own (START_STICKY), the native stack in
+        // the app process is still READY, and without this restore the first notification
+        // would flash "Disconnected" with no one around to push a fresh update.
+        managers.settingsAccessor.getLastNetworkStatus()?.let { status ->
+            managers.state.networkStatus.set(status)
+        }
+
         // CRITICAL: Start foreground immediately in onCreate to prevent being killed
         // before onStartCommand or onBind are called. This is the earliest safe point.
         managers.notificationManager.startForeground(this)

--- a/app/src/main/java/com/lxmf/messenger/service/persistence/ServiceSettingsAccessor.kt
+++ b/app/src/main/java/com/lxmf/messenger/service/persistence/ServiceSettingsAccessor.kt
@@ -23,6 +23,7 @@ class ServiceSettingsAccessor(
         const val KEY_BLOCK_UNKNOWN_SENDERS = "block_unknown_senders"
         const val KEY_NETWORK_CHANGE_ANNOUNCE_TIME = "network_change_announce_time"
         const val KEY_LAST_AUTO_ANNOUNCE_TIME = "last_auto_announce_time"
+        const val KEY_LAST_NETWORK_STATUS = "last_network_status"
     }
 
     // Get fresh SharedPreferences each time to avoid caching issues across processes
@@ -36,7 +37,8 @@ class ServiceSettingsAccessor(
      * @param timestamp The timestamp in epoch milliseconds
      */
     fun saveNetworkChangeAnnounceTime(timestamp: Long) {
-        getCrossProcessPrefs().edit()
+        getCrossProcessPrefs()
+            .edit()
             .putLong(KEY_NETWORK_CHANGE_ANNOUNCE_TIME, timestamp)
             .apply()
     }
@@ -48,7 +50,8 @@ class ServiceSettingsAccessor(
      * @param timestamp The timestamp in epoch milliseconds
      */
     fun saveLastAutoAnnounceTime(timestamp: Long) {
-        getCrossProcessPrefs().edit()
+        getCrossProcessPrefs()
+            .edit()
             .putLong(KEY_LAST_AUTO_ANNOUNCE_TIME, timestamp)
             .apply()
     }
@@ -63,4 +66,28 @@ class ServiceSettingsAccessor(
      * @return true if unknown senders should be blocked, false otherwise (default)
      */
     fun getBlockUnknownSenders(): Boolean = getCrossProcessPrefs().getBoolean(KEY_BLOCK_UNKNOWN_SENDERS, false)
+
+    /**
+     * Persist the app process's current network-status string so the service process can
+     * restore the correct initial notification across Android-driven restarts of the
+     * `:reticulum` process. Without this the service comes back with the default "SHUTDOWN"
+     * and the foreground notification flashes (or sticks on) "Disconnected" even though
+     * the native stack in the app process is still READY.
+     *
+     * Values follow the same vocabulary the notification already expects: "SHUTDOWN",
+     * "INITIALIZING", "CONNECTING", "READY", or "ERROR:message".
+     */
+    fun saveLastNetworkStatus(status: String) {
+        getCrossProcessPrefs()
+            .edit()
+            .putString(KEY_LAST_NETWORK_STATUS, status)
+            .apply()
+    }
+
+    /**
+     * Read the last network status written by the app process. Returns null when nothing
+     * has been persisted yet (first install, or before the app process has run) so the
+     * caller can fall back to its own default.
+     */
+    fun getLastNetworkStatus(): String? = getCrossProcessPrefs().getString(KEY_LAST_NETWORK_STATUS, null)
 }

--- a/app/src/main/java/com/lxmf/messenger/service/persistence/ServiceSettingsAccessor.kt
+++ b/app/src/main/java/com/lxmf/messenger/service/persistence/ServiceSettingsAccessor.kt
@@ -78,10 +78,15 @@ class ServiceSettingsAccessor(
      * "INITIALIZING", "CONNECTING", "READY", or "ERROR:message".
      */
     fun saveLastNetworkStatus(status: String) {
+        // commit() rather than apply(): the service process reads this in the very first
+        // thing onCreate() does when Android restarts :reticulum, so an async-queued write
+        // that hasn't flushed can lose the transition and leave the notification stale.
+        // The disk sync is ~1ms and happens on the networkStatus collector coroutine, not
+        // the main thread.
         getCrossProcessPrefs()
             .edit()
             .putString(KEY_LAST_NETWORK_STATUS, status)
-            .apply()
+            .commit()
     }
 
     /**


### PR DESCRIPTION
## Summary

Fixes a stale-notification bug on the native migration: if Android kills the `:reticulum` service process and restarts it via START_STICKY, the foreground notification flashes or sticks on **Disconnected** even though the native stack (which lives in the app process) is still READY and the mesh is working.

## Root cause

`ServiceState.networkStatus` defaults to `"SHUTDOWN"` on every service-process start. The app process only pushes an `ACTION_UPDATE_NOTIFICATION` intent once, inside `initialize().onSuccess`. When Android restarts only the service process, `initialize()` never runs again so nothing ever corrects the status.

## Fix

- New cross-process setting `KEY_LAST_NETWORK_STATUS` on `ServiceSettingsAccessor` (the existing `MODE_MULTI_PROCESS` channel we already use for announce timestamps).
- `ColumbaApplication` now collects `reticulumProtocol.networkStatus`, writes each value through `ServiceSettingsAccessor.saveLastNetworkStatus`, and pushes `ACTION_UPDATE_NOTIFICATION` to the service. Replaces the two ad-hoc `updateServiceNotification(\"READY\")` calls with a single reactive source of truth.
- `ReticulumService.onCreate` reads the persisted status and seeds `ServiceState.networkStatus` **before** `startForeground`, so the very first notification built on a solo service-process restart reflects the real state.

## Test plan

- [x] Cold start: notification transitions SHUTDOWN → INITIALIZING → "Connected - Mesh network active".
- [x] Kill `:reticulum` process while the app process stays alive; Android restarts the service; notification stays on "Connected - Mesh network active" (verified via `dumpsys notification`).
- [ ] Force-error state (e.g. bad config): notification surfaces the error text and stays persisted across service restart.

🤖 Generated with [Claude Code](https://claude.com/claude-code)