### PR TITLE
Default transport node to disabled for new users

### DIFF
--- a/app/src/main/java/com/lxmf/messenger/repository/SettingsRepository.kt
+++ b/app/src/main/java/com/lxmf/messenger/repository/SettingsRepository.kt
@@ -994,9 +994,9 @@ class SettingsRepository
 
         /**
          * Flow of the transport node enabled setting.
-         * When enabled (default), this device forwards traffic for the mesh network.
-         * When disabled, only handles its own traffic.
-         * Defaults to true if not set.
+         * When enabled, this device forwards traffic for the mesh network.
+         * When disabled (default), only handles its own traffic.
+         * Defaults to false if not set.
          */
         val transportNodeEnabledFlow: Flow<Boolean> =
             context.dataStore.data

--- a/app/src/main/java/com/lxmf/messenger/repository/SettingsRepository.kt
+++ b/app/src/main/java/com/lxmf/messenger/repository/SettingsRepository.kt
@@ -1001,7 +1001,7 @@ class SettingsRepository
         val transportNodeEnabledFlow: Flow<Boolean> =
             context.dataStore.data
                 .map { preferences ->
-                    preferences[PreferencesKeys.TRANSPORT_NODE_ENABLED] ?: true
+                    preferences[PreferencesKeys.TRANSPORT_NODE_ENABLED] ?: false
                 }.distinctUntilChanged()
 
         /**
@@ -1010,7 +1010,7 @@ class SettingsRepository
         suspend fun getTransportNodeEnabled(): Boolean =
             context.dataStore.data
                 .map { preferences ->
-                    preferences[PreferencesKeys.TRANSPORT_NODE_ENABLED] ?: true
+                    preferences[PreferencesKeys.TRANSPORT_NODE_ENABLED] ?: false
                 }.first()
 
         /**

--- a/app/src/test/java/com/lxmf/messenger/viewmodel/SettingsViewModelTest.kt
+++ b/app/src/test/java/com/lxmf/messenger/viewmodel/SettingsViewModelTest.kt
@@ -2117,7 +2117,7 @@ class SettingsViewModelTest {
         }
 
     @Test
-    fun `initial transportNodeEnabled state is true by default`() =
+    fun `state reflects transportNodeEnabled when explicitly set to true`() =
         runTest {
             transportNodeEnabledFlow.value = true
             viewModel = createViewModel()
@@ -2129,7 +2129,7 @@ class SettingsViewModelTest {
                     state = awaitItem()
                 }
 
-                assertTrue("Transport node should be enabled by default", state.transportNodeEnabled)
+                assertTrue("Transport node should reflect the true value from the flow", state.transportNodeEnabled)
 
                 cancelAndConsumeRemainingEvents()
             }


### PR DESCRIPTION
## Summary

Changes the default value of \`TRANSPORT_NODE_ENABLED\` from \`true\` to \`false\`. Running as a transport node should be opt-in — most users install Columba as a client and don't need to relay traffic.

- Flips the fallback in both \`transportNodeEnabledFlow\` and \`getTransportNodeEnabled()\` from \`true\` to \`false\`.
- Existing users with an explicit saved preference are unaffected — DataStore's stored value still takes precedence over the fallback.

## Test plan

- [x] Fresh install: Transport node toggle starts off.
- [ ] Existing install with transport previously enabled: still enabled after upgrade.
- [ ] Existing install with transport explicitly disabled: still disabled after upgrade.

🤖 Generated with [Claude Code](https://claude.com/claude-code)