### PR TITLE
Update ci.yml - update JDK to 25 and setup-java to @5

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -176,11 +176,11 @@ jobs:
           persist-credentials: false
           token: ${{ secrets.SUBMODULES_TOKEN || github.token }}
 
-      - name: Set up JDK 21
-        uses: actions/setup-java@v4
+      - name: Set up JDK 25
+        uses: actions/setup-java@v5
         with:
           distribution: temurin
-          java-version: 21
+          java-version: 25
 
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@v6
@@ -292,11 +292,11 @@ jobs:
           persist-credentials: false
           token: ${{ secrets.SUBMODULES_TOKEN || github.token }}
 
-      - name: Set up JDK 21
-        uses: actions/setup-java@v4
+      - name: Set up JDK 25
+        uses: actions/setup-java@v5
         with:
           distribution: temurin
-          java-version: 21
+          java-version: 25
 
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@v6
@@ -377,11 +377,11 @@ jobs:
           persist-credentials: false
           token: ${{ secrets.SUBMODULES_TOKEN || github.token }}
 
-      - name: Set up JDK 21
-        uses: actions/setup-java@v4
+      - name: Set up JDK 25
+        uses: actions/setup-java@v5
         with:
           distribution: temurin
-          java-version: 21
+          java-version: 25
 
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@v6


### PR DESCRIPTION
This is important to prevent ci from probably stopping to work in about 6 weeks. Node20 got EOL this month (april 2026). The current versions are outdated and create at every ci build annotations like: Node.js 20 actions are deprecated. The following actions are running on Node.js 20 and may not work as expected: actions/setup-java@v4.

This PR is upgrading to the recent default settings: https://github.com/actions/setup-java?tab=readme-ov-file#eclipse-temurin

More background information: https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/