### PR TITLE
Wire delivery + transport identities through memory, scrub on-disk copies

### DIFF
--- a/app/src/main/java/network/columba/app/ColumbaApplication.kt
+++ b/app/src/main/java/network/columba/app/ColumbaApplication.kt
@@ -664,35 +664,8 @@ class ColumbaApplication : Application() {
                 "initializeReticulumService: Discover interfaces: $discoverInterfaces, autoconnect: $autoconnectDiscoveredCount",
             )
 
-            // Decrypt the active identity's private key into memory so we can hand
-            // it to the native stack without ever writing plaintext to disk.
-            var deliveryKey: ByteArray? = null
             val displayName = activeIdentity?.displayName
-            if (activeIdentity != null) {
-                android.util.Log.d(
-                    "ColumbaApplication",
-                    "initializeReticulumService: Active identity: ${activeIdentity.displayName} " +
-                        "(${activeIdentity.identityHash.take(8)}...)",
-                )
-                val keyResult = identityKeyProvider.getDecryptedKeyData(activeIdentity.identityHash)
-                if (keyResult.isSuccess) {
-                    deliveryKey = keyResult.getOrNull()
-                    android.util.Log.d(
-                        "ColumbaApplication",
-                        "initializeReticulumService: Decrypted delivery identity key into memory (${deliveryKey?.size ?: 0} bytes)",
-                    )
-                } else {
-                    android.util.Log.e(
-                        "ColumbaApplication",
-                        "initializeReticulumService: Could not decrypt identity key: ${keyResult.exceptionOrNull()}",
-                    )
-                }
-            } else {
-                android.util.Log.d(
-                    "ColumbaApplication",
-                    "initializeReticulumService: No active identity found, native stack will create default",
-                )
-            }
+            val deliveryKey = decryptDeliveryKey(activeIdentity)
 
             // Initialize Reticulum with config from database
             android.util.Log.d("ColumbaApplication", "initializeReticulumService: Initializing Reticulum...")
@@ -738,6 +711,44 @@ class ColumbaApplication : Application() {
         } catch (e: Exception) {
             android.util.Log.e("ColumbaApplication", "initializeReticulumService: Error during initialization", e)
         }
+    }
+
+    /**
+     * Decrypt the active identity's private key into memory so it can be handed
+     * to the native stack without ever writing plaintext to disk. Returns null
+     * when no active identity exists (native stack will create a fresh one) or
+     * when decryption fails (caller falls back to the same path).
+     */
+    private suspend fun decryptDeliveryKey(activeIdentity: network.columba.app.data.db.entity.LocalIdentityEntity?): ByteArray? {
+        if (activeIdentity == null) {
+            android.util.Log.d(
+                "ColumbaApplication",
+                "initializeReticulumService: No active identity found, native stack will create default",
+            )
+            return null
+        }
+        android.util.Log.d(
+            "ColumbaApplication",
+            "initializeReticulumService: Active identity: ${activeIdentity.displayName} " +
+                "(${activeIdentity.identityHash.take(8)}...)",
+        )
+        val keyResult = identityKeyProvider.getDecryptedKeyData(activeIdentity.identityHash)
+        return keyResult.fold(
+            onSuccess = { key ->
+                android.util.Log.d(
+                    "ColumbaApplication",
+                    "initializeReticulumService: Decrypted delivery identity key into memory (${key.size} bytes)",
+                )
+                key
+            },
+            onFailure = { error ->
+                android.util.Log.e(
+                    "ColumbaApplication",
+                    "initializeReticulumService: Could not decrypt identity key: $error",
+                )
+                null
+            },
+        )
     }
 
     /** Helper to restore peer identities in background after Reticulum initialization. */

--- a/app/src/main/java/network/columba/app/ColumbaApplication.kt
+++ b/app/src/main/java/network/columba/app/ColumbaApplication.kt
@@ -393,13 +393,19 @@ class ColumbaApplication : Application() {
                 // usable as a future unlock-flow input rather than silently booting
                 // a fresh ephemeral identity that severs contact with the user's
                 // peers. TODO: wire an unlock screen that resumes this init path.
+                // Fail safe on a DB/Keystore error: a thrown requiresPassword would
+                // otherwise escape to the outer catch and get logged as "Failed to bind
+                // to ReticulumService" — the real failure is a DB query, and we want to
+                // skip init in that case rather than power on with the wrong identity.
                 if (activeIdentity != null &&
-                    identityRepository.requiresPassword(activeIdentity.identityHash)
+                    runCatching {
+                        identityRepository.requiresPassword(activeIdentity.identityHash)
+                    }.getOrDefault(true)
                 ) {
                     android.util.Log.w(
                         "ColumbaApplication",
-                        "Active identity ${activeIdentity.identityHash.take(8)}... is password-protected - " +
-                            "skipping auto-init until an unlock flow provides the password",
+                        "Active identity ${activeIdentity.identityHash.take(8)}... is password-protected " +
+                            "(or password status unreadable) - skipping auto-init until unlock",
                     )
                     return@launch
                 }
@@ -672,12 +678,14 @@ class ColumbaApplication : Application() {
             val activeIdentity = startupConfig.identity
 
             if (activeIdentity != null &&
-                identityRepository.requiresPassword(activeIdentity.identityHash)
+                runCatching {
+                    identityRepository.requiresPassword(activeIdentity.identityHash)
+                }.getOrDefault(true)
             ) {
                 android.util.Log.w(
                     "ColumbaApplication",
                     "initializeReticulumService: Active identity ${activeIdentity.identityHash.take(8)}... " +
-                        "is password-protected - skipping init until an unlock flow provides the password",
+                        "is password-protected (or password status unreadable) - skipping init until unlock",
                 )
                 return
             }

--- a/app/src/main/java/network/columba/app/ColumbaApplication.kt
+++ b/app/src/main/java/network/columba/app/ColumbaApplication.kt
@@ -165,22 +165,22 @@ class ColumbaApplication : Application() {
                 .cleanupAllTempFiles(this@ColumbaApplication)
         }
 
-        // Migrate unencrypted identity keys to encrypted storage (one-time, idempotent)
+        // Migrate unencrypted identity keys to encrypted storage (one-time, idempotent),
+        // then scrub any stale plaintext identity_<hash> files. The migration reads those
+        // same files for upgraders whose keys were only on disk, so the scrub MUST run
+        // after the migration completes — otherwise a lost race deletes the only copy of
+        // the private key and the identity is permanently gone.
+        //
+        // The scrub itself removes forensic liability: the native stack now gets the key
+        // in memory via ReticulumConfig.deliveryIdentityKey; the disk copies are dead
+        // weight. Best-effort zero-overwrite + delete — true secure erase isn't achievable
+        // on wear-levelled / journalled storage, but we remove the dangling-reference risk.
         applicationScope.launch(Dispatchers.IO) {
             try {
                 identityRepository.runEncryptionMigration()
             } catch (e: Exception) {
                 android.util.Log.e("ColumbaApplication", "Identity key encryption migration failed", e)
             }
-        }
-
-        // Scrub any stale plaintext identity_<hash> files left on disk from the previous
-        // file-backed flow. The native stack now gets the key in memory via
-        // ReticulumConfig.deliveryIdentityKey; the disk copies are dead weight and a
-        // forensic liability. Best-effort zero-overwrite + delete — true secure erase
-        // isn't achievable on wear-levelled / journalled storage, but we remove the
-        // dangling-reference risk.
-        applicationScope.launch(Dispatchers.IO) {
             try {
                 val reticulumDir = java.io.File(filesDir, "reticulum")
                 val staleIdentityFiles =

--- a/app/src/main/java/network/columba/app/ColumbaApplication.kt
+++ b/app/src/main/java/network/columba/app/ColumbaApplication.kt
@@ -360,6 +360,22 @@ class ColumbaApplication : Application() {
                 val startupConfig = startupConfigLoader.loadConfig()
                 val enabledInterfaces = startupConfig.interfaces
                 val activeIdentity = startupConfig.identity
+
+                // Fresh install: no identity AND onboarding not yet completed.
+                // Defer Reticulum init so the native stack doesn't auto-create an
+                // "Anonymous Peer" identity that then masks the onboarding flow
+                // (OnboardingViewModel treats any pre-existing identity as an upgrade).
+                // Onboarding completion calls InterfaceConfigManager.applyInterfaceChanges(),
+                // which will start the service with the user's chosen settings.
+                if (activeIdentity == null &&
+                    !settingsRepository.hasCompletedOnboardingFlow.first()
+                ) {
+                    android.util.Log.d(
+                        "ColumbaApplication",
+                        "Fresh install - deferring Reticulum init until onboarding completes",
+                    )
+                    return@launch
+                }
                 val preferOwnInstance = startupConfig.preferOwn
                 val rpcKey = startupConfig.rpcKey
                 val transportNodeEnabled = startupConfig.transport

--- a/app/src/main/java/network/columba/app/ColumbaApplication.kt
+++ b/app/src/main/java/network/columba/app/ColumbaApplication.kt
@@ -749,12 +749,17 @@ class ColumbaApplication : Application() {
      * the user onto a fresh ephemeral identity.
      */
     private suspend fun anyActiveIdentityRequiresPassword(): Boolean {
+        // Fail safe: if we can't read the active identity or its password status, assume
+        // yes. The caller uses this to decide whether to delete on-disk key files; a
+        // transient DB/Keystore error shouldn't let the scrub proceed and potentially
+        // destroy the only copy of a password-protected identity.
         val active =
-            runCatching { identityRepository.getActiveIdentitySync() }.getOrNull()
+            runCatching { identityRepository.getActiveIdentitySync() }
+                .getOrElse { return true }
                 ?: return false
         return runCatching {
             identityRepository.requiresPassword(active.identityHash)
-        }.getOrDefault(false)
+        }.getOrDefault(true)
     }
 
     /**

--- a/app/src/main/java/network/columba/app/ColumbaApplication.kt
+++ b/app/src/main/java/network/columba/app/ColumbaApplication.kt
@@ -2,6 +2,14 @@ package network.columba.app
 
 import android.app.Application
 import android.os.StrictMode
+import dagger.hilt.android.HiltAndroidApp
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.withTimeoutOrNull
 import network.columba.app.data.repository.ContactRepository
 import network.columba.app.data.repository.ConversationRepository
 import network.columba.app.data.repository.IdentityRepository
@@ -19,14 +27,6 @@ import network.columba.app.startup.ServiceIdentityVerifier
 import network.columba.app.startup.StartupConfigLoader
 import network.columba.app.util.CrashReportManager
 import network.columba.app.util.HexUtils.hexStringToByteArray
-import dagger.hilt.android.HiltAndroidApp
-import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.SupervisorJob
-import kotlinx.coroutines.delay
-import kotlinx.coroutines.flow.first
-import kotlinx.coroutines.launch
-import kotlinx.coroutines.withTimeoutOrNull
 import javax.inject.Inject
 
 /**
@@ -78,6 +78,9 @@ class ColumbaApplication : Application() {
 
     @Inject
     lateinit var identityRepository: IdentityRepository
+
+    @Inject
+    lateinit var identityKeyProvider: network.columba.app.data.crypto.IdentityKeyProvider
 
     @Inject
     lateinit var settingsRepository: SettingsRepository
@@ -168,6 +171,29 @@ class ColumbaApplication : Application() {
                 identityRepository.runEncryptionMigration()
             } catch (e: Exception) {
                 android.util.Log.e("ColumbaApplication", "Identity key encryption migration failed", e)
+            }
+        }
+
+        // Scrub any stale plaintext identity_<hash> files left on disk from the previous
+        // file-backed flow. The native stack now gets the key in memory via
+        // ReticulumConfig.deliveryIdentityKey; the disk copies are dead weight and a
+        // forensic liability. Best-effort zero-overwrite + delete — true secure erase
+        // isn't achievable on wear-levelled / journalled storage, but we remove the
+        // dangling-reference risk.
+        applicationScope.launch(Dispatchers.IO) {
+            try {
+                val reticulumDir = java.io.File(filesDir, "reticulum")
+                val staleIdentityFiles =
+                    reticulumDir.listFiles { f -> f.isFile && f.name.startsWith("identity_") }
+                        ?: return@launch
+                staleIdentityFiles.forEach { f ->
+                    runCatching { f.writeBytes(ByteArray(f.length().toInt())) }
+                    if (f.delete()) {
+                        android.util.Log.i("ColumbaApplication", "Removed stale identity file: ${f.name}")
+                    }
+                }
+            } catch (e: Exception) {
+                android.util.Log.w("ColumbaApplication", "Stale identity file cleanup failed: ${e.message}")
             }
         }
 
@@ -344,8 +370,11 @@ class ColumbaApplication : Application() {
                 android.util.Log.d("ColumbaApplication", "Transport node enabled: $transportNodeEnabled")
                 android.util.Log.d("ColumbaApplication", "Discover interfaces: $discoverInterfaces, autoconnect: $autoconnectDiscoveredCount")
 
-                // Ensure identity file exists (recover from keyData if missing)
-                var identityPath: String? = null
+                // Decrypt the active identity's private key into memory so we can hand
+                // it to the native stack without ever writing plaintext to disk.
+                // Failure to decrypt falls through to `deliveryIdentityKey = null`,
+                // in which case the native stack creates a fresh identity.
+                var deliveryKey: ByteArray? = null
                 val displayName = activeIdentity?.displayName
                 if (activeIdentity != null) {
                     android.util.Log.d(
@@ -353,16 +382,18 @@ class ColumbaApplication : Application() {
                         "Active identity: ${activeIdentity.displayName} " +
                             "(${activeIdentity.identityHash.take(8)}...)",
                     )
-                    val fileResult = identityRepository.ensureIdentityFileExists(activeIdentity)
-                    if (fileResult.isSuccess) {
-                        identityPath = fileResult.getOrNull()
-                        android.util.Log.d("ColumbaApplication", "Identity file verified/recovered: $identityPath")
+                    val keyResult = identityKeyProvider.getDecryptedKeyData(activeIdentity.identityHash)
+                    if (keyResult.isSuccess) {
+                        deliveryKey = keyResult.getOrNull()
+                        android.util.Log.d(
+                            "ColumbaApplication",
+                            "Decrypted delivery identity key into memory (${deliveryKey?.size ?: 0} bytes)",
+                        )
                     } else {
                         android.util.Log.e(
                             "ColumbaApplication",
-                            "Could not ensure identity file exists: ${fileResult.exceptionOrNull()}",
+                            "Could not decrypt identity key: ${keyResult.exceptionOrNull()}",
                         )
-                        // identityPath remains null — native stack will use its in-memory identity
                     }
                     android.util.Log.d("ColumbaApplication", "Display name: $displayName")
                 } else {
@@ -375,7 +406,7 @@ class ColumbaApplication : Application() {
                     ReticulumConfig(
                         storagePath = filesDir.absolutePath + "/reticulum",
                         enabledInterfaces = enabledInterfaces,
-                        identityFilePath = identityPath,
+                        deliveryIdentityKey = deliveryKey,
                         displayName = displayName,
                         logLevel = LogLevel.DEBUG,
                         allowAnonymous = false,
@@ -633,8 +664,9 @@ class ColumbaApplication : Application() {
                 "initializeReticulumService: Discover interfaces: $discoverInterfaces, autoconnect: $autoconnectDiscoveredCount",
             )
 
-            // Ensure identity file exists (recover from keyData if missing)
-            var identityPath: String? = null
+            // Decrypt the active identity's private key into memory so we can hand
+            // it to the native stack without ever writing plaintext to disk.
+            var deliveryKey: ByteArray? = null
             val displayName = activeIdentity?.displayName
             if (activeIdentity != null) {
                 android.util.Log.d(
@@ -642,18 +674,24 @@ class ColumbaApplication : Application() {
                     "initializeReticulumService: Active identity: ${activeIdentity.displayName} " +
                         "(${activeIdentity.identityHash.take(8)}...)",
                 )
-                val fileResult = identityRepository.ensureIdentityFileExists(activeIdentity)
-                if (fileResult.isSuccess) {
-                    identityPath = fileResult.getOrNull()
-                    android.util.Log.d("ColumbaApplication", "initializeReticulumService: Identity file verified/recovered: $identityPath")
+                val keyResult = identityKeyProvider.getDecryptedKeyData(activeIdentity.identityHash)
+                if (keyResult.isSuccess) {
+                    deliveryKey = keyResult.getOrNull()
+                    android.util.Log.d(
+                        "ColumbaApplication",
+                        "initializeReticulumService: Decrypted delivery identity key into memory (${deliveryKey?.size ?: 0} bytes)",
+                    )
                 } else {
                     android.util.Log.e(
                         "ColumbaApplication",
-                        "initializeReticulumService: Could not ensure identity file exists: ${fileResult.exceptionOrNull()}",
+                        "initializeReticulumService: Could not decrypt identity key: ${keyResult.exceptionOrNull()}",
                     )
                 }
             } else {
-                android.util.Log.d("ColumbaApplication", "initializeReticulumService: No active identity found, native stack will create default")
+                android.util.Log.d(
+                    "ColumbaApplication",
+                    "initializeReticulumService: No active identity found, native stack will create default",
+                )
             }
 
             // Initialize Reticulum with config from database
@@ -662,7 +700,7 @@ class ColumbaApplication : Application() {
                 ReticulumConfig(
                     storagePath = filesDir.absolutePath + "/reticulum",
                     enabledInterfaces = enabledInterfaces,
-                    identityFilePath = identityPath,
+                    deliveryIdentityKey = deliveryKey,
                     displayName = displayName,
                     logLevel = LogLevel.DEBUG,
                     allowAnonymous = false,

--- a/app/src/main/java/network/columba/app/ColumbaApplication.kt
+++ b/app/src/main/java/network/columba/app/ColumbaApplication.kt
@@ -360,22 +360,6 @@ class ColumbaApplication : Application() {
                 val startupConfig = startupConfigLoader.loadConfig()
                 val enabledInterfaces = startupConfig.interfaces
                 val activeIdentity = startupConfig.identity
-
-                // Fresh install: no identity AND onboarding not yet completed.
-                // Defer Reticulum init so the native stack doesn't auto-create an
-                // "Anonymous Peer" identity that then masks the onboarding flow
-                // (OnboardingViewModel treats any pre-existing identity as an upgrade).
-                // Onboarding completion calls InterfaceConfigManager.applyInterfaceChanges(),
-                // which will start the service with the user's chosen settings.
-                if (activeIdentity == null &&
-                    !settingsRepository.hasCompletedOnboardingFlow.first()
-                ) {
-                    android.util.Log.d(
-                        "ColumbaApplication",
-                        "Fresh install - deferring Reticulum init until onboarding completes",
-                    )
-                    return@launch
-                }
                 val preferOwnInstance = startupConfig.preferOwn
                 val rpcKey = startupConfig.rpcKey
                 val transportNodeEnabled = startupConfig.transport

--- a/app/src/main/java/network/columba/app/ColumbaApplication.kt
+++ b/app/src/main/java/network/columba/app/ColumbaApplication.kt
@@ -399,35 +399,8 @@ class ColumbaApplication : Application() {
                 android.util.Log.d("ColumbaApplication", "Transport node enabled: $transportNodeEnabled")
                 android.util.Log.d("ColumbaApplication", "Discover interfaces: $discoverInterfaces, autoconnect: $autoconnectDiscoveredCount")
 
-                // Decrypt the active identity's private key into memory so we can hand
-                // it to the native stack without ever writing plaintext to disk.
-                // Failure to decrypt falls through to `deliveryIdentityKey = null`,
-                // in which case the native stack creates a fresh identity.
-                var deliveryKey: ByteArray? = null
                 val displayName = activeIdentity?.displayName
-                if (activeIdentity != null) {
-                    android.util.Log.d(
-                        "ColumbaApplication",
-                        "Active identity: ${activeIdentity.displayName} " +
-                            "(${activeIdentity.identityHash.take(8)}...)",
-                    )
-                    val keyResult = identityKeyProvider.getDecryptedKeyData(activeIdentity.identityHash)
-                    if (keyResult.isSuccess) {
-                        deliveryKey = keyResult.getOrNull()
-                        android.util.Log.d(
-                            "ColumbaApplication",
-                            "Decrypted delivery identity key into memory (${deliveryKey?.size ?: 0} bytes)",
-                        )
-                    } else {
-                        android.util.Log.e(
-                            "ColumbaApplication",
-                            "Could not decrypt identity key: ${keyResult.exceptionOrNull()}",
-                        )
-                    }
-                    android.util.Log.d("ColumbaApplication", "Display name: $displayName")
-                } else {
-                    android.util.Log.d("ColumbaApplication", "No active identity found, native stack will create default")
-                }
+                val deliveryKey = decryptDeliveryKey(activeIdentity)
 
                 // Auto-initialize Reticulum with config from database
                 android.util.Log.d("ColumbaApplication", "Auto-initializing Reticulum...")

--- a/app/src/main/java/network/columba/app/ColumbaApplication.kt
+++ b/app/src/main/java/network/columba/app/ColumbaApplication.kt
@@ -767,13 +767,13 @@ class ColumbaApplication : Application() {
         if (activeIdentity == null) {
             android.util.Log.d(
                 "ColumbaApplication",
-                "initializeReticulumService: No active identity found, native stack will create default",
+                "decryptDeliveryKey: No active identity found, native stack will create default",
             )
             return null
         }
         android.util.Log.d(
             "ColumbaApplication",
-            "initializeReticulumService: Active identity: ${activeIdentity.displayName} " +
+            "decryptDeliveryKey: Active identity: ${activeIdentity.displayName} " +
                 "(${activeIdentity.identityHash.take(8)}...)",
         )
         val keyResult = identityKeyProvider.getDecryptedKeyData(activeIdentity.identityHash)
@@ -781,14 +781,14 @@ class ColumbaApplication : Application() {
             onSuccess = { key ->
                 android.util.Log.d(
                     "ColumbaApplication",
-                    "initializeReticulumService: Decrypted delivery identity key into memory (${key.size} bytes)",
+                    "decryptDeliveryKey: Decrypted delivery identity key into memory (${key.size} bytes)",
                 )
                 key
             },
             onFailure = { error ->
                 android.util.Log.e(
                     "ColumbaApplication",
-                    "initializeReticulumService: Could not decrypt identity key: $error",
+                    "decryptDeliveryKey: Could not decrypt identity key: $error",
                 )
                 null
             },

--- a/app/src/main/java/network/columba/app/ColumbaApplication.kt
+++ b/app/src/main/java/network/columba/app/ColumbaApplication.kt
@@ -181,6 +181,18 @@ class ColumbaApplication : Application() {
             } catch (e: Exception) {
                 android.util.Log.e("ColumbaApplication", "Identity key encryption migration failed", e)
             }
+            // Skip scrub if the active identity requires a password — in that case
+            // ColumbaApplication can't decrypt the key at startup (no UI prompt yet),
+            // so the on-disk identity file is still the only usable fallback for
+            // handing the identity to the native stack. Deleting it silently rotates
+            // the user onto a fresh ephemeral identity.
+            if (anyActiveIdentityRequiresPassword()) {
+                android.util.Log.w(
+                    "ColumbaApplication",
+                    "Skipping stale identity file scrub - active identity is password-protected",
+                )
+                return@launch
+            }
             try {
                 val reticulumDir = java.io.File(filesDir, "reticulum")
                 val staleIdentityFiles =
@@ -360,6 +372,23 @@ class ColumbaApplication : Application() {
                 val startupConfig = startupConfigLoader.loadConfig()
                 val enabledInterfaces = startupConfig.interfaces
                 val activeIdentity = startupConfig.identity
+
+                // Password-protected identity: we can't decrypt the key without a
+                // password prompt. Bailing out here keeps the existing identity file
+                // usable as a future unlock-flow input rather than silently booting
+                // a fresh ephemeral identity that severs contact with the user's
+                // peers. TODO: wire an unlock screen that resumes this init path.
+                if (activeIdentity != null &&
+                    identityRepository.requiresPassword(activeIdentity.identityHash)
+                ) {
+                    android.util.Log.w(
+                        "ColumbaApplication",
+                        "Active identity ${activeIdentity.identityHash.take(8)}... is password-protected - " +
+                            "skipping auto-init until an unlock flow provides the password",
+                    )
+                    return@launch
+                }
+
                 val preferOwnInstance = startupConfig.preferOwn
                 val rpcKey = startupConfig.rpcKey
                 val transportNodeEnabled = startupConfig.transport
@@ -653,6 +682,18 @@ class ColumbaApplication : Application() {
             val startupConfig = startupConfigLoader.loadConfig()
             val enabledInterfaces = startupConfig.interfaces
             val activeIdentity = startupConfig.identity
+
+            if (activeIdentity != null &&
+                identityRepository.requiresPassword(activeIdentity.identityHash)
+            ) {
+                android.util.Log.w(
+                    "ColumbaApplication",
+                    "initializeReticulumService: Active identity ${activeIdentity.identityHash.take(8)}... " +
+                        "is password-protected - skipping init until an unlock flow provides the password",
+                )
+                return
+            }
+
             val preferOwnInstance = startupConfig.preferOwn
             val rpcKey = startupConfig.rpcKey
             val transportNodeEnabled = startupConfig.transport
@@ -711,6 +752,21 @@ class ColumbaApplication : Application() {
         } catch (e: Exception) {
             android.util.Log.e("ColumbaApplication", "initializeReticulumService: Error during initialization", e)
         }
+    }
+
+    /**
+     * True when the currently active identity is password-protected. Used to gate
+     * both the stale-file scrub and Reticulum auto-init: without a password prompt
+     * we can't decrypt the key, and deleting the on-disk file would silently rotate
+     * the user onto a fresh ephemeral identity.
+     */
+    private suspend fun anyActiveIdentityRequiresPassword(): Boolean {
+        val active =
+            runCatching { identityRepository.getActiveIdentitySync() }.getOrNull()
+                ?: return false
+        return runCatching {
+            identityRepository.requiresPassword(active.identityHash)
+        }.getOrDefault(false)
     }
 
     /**

--- a/app/src/main/java/network/columba/app/ColumbaApplication.kt
+++ b/app/src/main/java/network/columba/app/ColumbaApplication.kt
@@ -176,10 +176,25 @@ class ColumbaApplication : Application() {
         // weight. Best-effort zero-overwrite + delete — true secure erase isn't achievable
         // on wear-levelled / journalled storage, but we remove the dangling-reference risk.
         applicationScope.launch(Dispatchers.IO) {
-            try {
-                identityRepository.runEncryptionMigration()
-            } catch (e: Exception) {
-                android.util.Log.e("ColumbaApplication", "Identity key encryption migration failed", e)
+            // Gate the scrub on full migration success. If migration throws, returns
+            // Result.failure, or reports any per-identity failureCount > 0, the on-disk
+            // identity_<hash> files are still the only copy of the key for at least one
+            // identity — deleting them here would permanently destroy it on upgraders
+            // hitting a transient Keystore or DB error on first boot.
+            val migrationSucceeded =
+                try {
+                    val result = identityRepository.runEncryptionMigration()
+                    result.isSuccess && (result.getOrNull()?.failureCount ?: 1) == 0
+                } catch (e: Exception) {
+                    android.util.Log.e("ColumbaApplication", "Identity key encryption migration failed", e)
+                    false
+                }
+            if (!migrationSucceeded) {
+                android.util.Log.w(
+                    "ColumbaApplication",
+                    "Skipping stale identity file scrub - encryption migration did not fully succeed",
+                )
+                return@launch
             }
             // Skip scrub if the active identity requires a password — in that case
             // ColumbaApplication can't decrypt the key at startup (no UI prompt yet),

--- a/app/src/main/java/network/columba/app/ColumbaApplication.kt
+++ b/app/src/main/java/network/columba/app/ColumbaApplication.kt
@@ -423,6 +423,22 @@ class ColumbaApplication : Application() {
                 val displayName = activeIdentity?.displayName
                 val deliveryKey = decryptDeliveryKey(activeIdentity)
 
+                // Bail before Reticulum init if we have an active identity in Room but
+                // couldn't produce its key bytes. Proceeding would start the native stack
+                // with NativeIdentity.create() (a fresh ephemeral identity) while Room
+                // still has the original active — the mismatch is invisible post-init
+                // because the service check only asserts `existingActive != null`. Most
+                // common cause: first-launch race where decryptDeliveryKey runs before
+                // runEncryptionMigration has populated the Keystore-wrapped blob.
+                if (activeIdentity != null && deliveryKey == null) {
+                    android.util.Log.e(
+                        "ColumbaApplication",
+                        "Active identity ${activeIdentity.identityHash.take(8)}... present but key decryption " +
+                            "returned null - skipping init to avoid silently substituting a fresh identity",
+                    )
+                    return@launch
+                }
+
                 // Auto-initialize Reticulum with config from database
                 android.util.Log.d("ColumbaApplication", "Auto-initializing Reticulum...")
                 val config =
@@ -703,6 +719,18 @@ class ColumbaApplication : Application() {
 
             val displayName = activeIdentity?.displayName
             val deliveryKey = decryptDeliveryKey(activeIdentity)
+
+            // Same guard as the cold-start path: don't init with a null key when an
+            // active identity exists, or the native stack silently substitutes a fresh
+            // ephemeral identity.
+            if (activeIdentity != null && deliveryKey == null) {
+                android.util.Log.e(
+                    "ColumbaApplication",
+                    "initializeReticulumService: Active identity ${activeIdentity.identityHash.take(8)}... " +
+                        "present but key decryption returned null - skipping init",
+                )
+                return
+            }
 
             // Initialize Reticulum with config from database
             android.util.Log.d("ColumbaApplication", "initializeReticulumService: Initializing Reticulum...")

--- a/app/src/main/java/network/columba/app/ui/screens/onboarding/pages/WelcomePage.kt
+++ b/app/src/main/java/network/columba/app/ui/screens/onboarding/pages/WelcomePage.kt
@@ -1,6 +1,8 @@
 package network.columba.app.ui.screens.onboarding.pages
 
+import androidx.compose.foundation.Image
 import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
@@ -10,22 +12,23 @@ import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.verticalScroll
-import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.filled.Sensors
-import androidx.compose.material.icons.outlined.Cancel
 import androidx.compose.material3.Button
-import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.draw.scale
+import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
+import network.columba.app.R
 
 /**
  * Welcome page - introduces privacy-first messaging.
@@ -48,13 +51,32 @@ fun WelcomePage(
     ) {
         Spacer(modifier = Modifier.weight(1f))
 
-        // App icon
-        Icon(
-            imageVector = Icons.Default.Sensors,
-            contentDescription = "Columba",
-            modifier = Modifier.size(80.dp),
-            tint = MaterialTheme.colorScheme.primary,
-        )
+        // App icon: adaptive launcher background + foreground, circle-clipped.
+        // The gradient background fills the circle. The foreground vector bakes in
+        // both the adaptive-icon safe-zone padding and an internal scaleX/Y=0.65,
+        // so we apply a visual scale (no layout impact) to make the logo read at
+        // launcher scale.
+        Box(
+            modifier =
+                Modifier
+                    .size(120.dp)
+                    .clip(CircleShape),
+            contentAlignment = Alignment.Center,
+        ) {
+            Image(
+                painter = painterResource(id = R.drawable.ic_launcher_background),
+                contentDescription = null,
+                modifier = Modifier.fillMaxSize(),
+            )
+            Image(
+                painter = painterResource(id = R.drawable.ic_launcher_foreground),
+                contentDescription = "Columba",
+                modifier =
+                    Modifier
+                        .fillMaxSize()
+                        .scale(2.3f),
+            )
+        }
 
         Spacer(modifier = Modifier.height(24.dp))
 
@@ -140,11 +162,10 @@ private fun PrivacyFeature(
         verticalAlignment = Alignment.CenterVertically,
         horizontalArrangement = Arrangement.Center,
     ) {
-        Icon(
-            imageVector = Icons.Outlined.Cancel,
-            contentDescription = null,
-            modifier = Modifier.size(20.dp),
-            tint = MaterialTheme.colorScheme.primary,
+        Text(
+            text = "\u2022",
+            style = MaterialTheme.typography.bodyLarge,
+            color = MaterialTheme.colorScheme.primary,
         )
         Spacer(modifier = Modifier.size(8.dp))
         Text(

--- a/app/src/main/java/network/columba/app/ui/screens/onboarding/pages/WelcomePage.kt
+++ b/app/src/main/java/network/columba/app/ui/screens/onboarding/pages/WelcomePage.kt
@@ -74,7 +74,7 @@ fun WelcomePage(
                 modifier =
                     Modifier
                         .fillMaxSize()
-                        .scale(2.3f),
+                        .scale(1.55f),
             )
         }
 

--- a/app/src/main/java/network/columba/app/viewmodel/OnboardingViewModel.kt
+++ b/app/src/main/java/network/columba/app/viewmodel/OnboardingViewModel.kt
@@ -4,6 +4,12 @@ import android.content.Context
 import android.util.Log
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
+import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.launch
 import network.columba.app.data.model.TcpCommunityServers
 import network.columba.app.data.repository.IdentityRepository
 import network.columba.app.repository.InterfaceRepository
@@ -13,12 +19,6 @@ import network.columba.app.service.InterfaceConfigManager
 import network.columba.app.ui.screens.onboarding.OnboardingInterfaceType
 import network.columba.app.ui.screens.onboarding.OnboardingState
 import network.columba.app.util.BatteryOptimizationManager
-import dagger.hilt.android.lifecycle.HiltViewModel
-import kotlinx.coroutines.flow.MutableStateFlow
-import kotlinx.coroutines.flow.StateFlow
-import kotlinx.coroutines.flow.asStateFlow
-import kotlinx.coroutines.flow.first
-import kotlinx.coroutines.launch
 import javax.inject.Inject
 
 /**
@@ -48,22 +48,18 @@ class OnboardingViewModel
 
         /**
          * Check if onboarding has already been completed.
+         *
+         * Trust the persisted flag alone. A previous heuristic treated "any active
+         * identity exists" as evidence of a pre-onboarding upgrade and auto-marked
+         * onboarding complete, but the native stack now auto-creates an identity
+         * on cold start so that signal fires on fresh installs too and skips the
+         * welcome flow. Users upgrading from the brief pre-onboarding window will
+         * see onboarding once and can Skip to keep their data.
          */
         private fun checkOnboardingStatus() {
             viewModelScope.launch {
                 try {
                     val hasCompleted = settingsRepository.hasCompletedOnboardingFlow.first()
-                    if (!hasCompleted) {
-                        // Check if this is an upgrade from a pre-onboarding version:
-                        // existing identity means user already set up the app
-                        val existingIdentity = identityRepository.getActiveIdentitySync()
-                        if (existingIdentity != null) {
-                            Log.d(TAG, "Existing identity found - marking onboarding complete (upgrade detected)")
-                            settingsRepository.markOnboardingCompleted()
-                            _state.value = _state.value.copy(isLoading = false, hasCompletedOnboarding = true)
-                            return@launch
-                        }
-                    }
                     _state.value =
                         _state.value.copy(
                             isLoading = false,

--- a/app/src/test/java/network/columba/app/ui/screens/onboarding/pages/WelcomePageTest.kt
+++ b/app/src/test/java/network/columba/app/ui/screens/onboarding/pages/WelcomePageTest.kt
@@ -87,9 +87,11 @@ class WelcomePageTest {
         }
 
         // Then
-        composeTestRule.onNodeWithText(
-            "Your identity is generated and stored securely on your device. You control it completely.",
-        ).assertIsDisplayed()
+        composeTestRule
+            .onNodeWithText(
+                "Your identity is generated and stored securely on your device. You control it completely.",
+            ).performScrollTo()
+            .assertIsDisplayed()
     }
 
     @Test
@@ -319,9 +321,11 @@ class WelcomePageTest {
         composeTestRule.onNodeWithText("No phone number").assertIsDisplayed()
         composeTestRule.onNodeWithText("No email address").assertIsDisplayed()
         composeTestRule.onNodeWithText("No sign-up or accounts").assertIsDisplayed()
-        composeTestRule.onNodeWithText(
-            "Your identity is generated and stored securely on your device. You control it completely.",
-        ).assertIsDisplayed()
+        composeTestRule
+            .onNodeWithText(
+                "Your identity is generated and stored securely on your device. You control it completely.",
+            ).performScrollTo()
+            .assertIsDisplayed()
         composeTestRule.onNodeWithText("Get Started").performScrollTo().assertIsDisplayed()
         composeTestRule.onNodeWithText("Restore from backup").performScrollTo().assertIsDisplayed()
     }

--- a/app/src/test/java/network/columba/app/viewmodel/OnboardingViewModelTest.kt
+++ b/app/src/test/java/network/columba/app/viewmodel/OnboardingViewModelTest.kt
@@ -233,11 +233,10 @@ class OnboardingViewModelTest {
         }
 
     @Test
-    fun `upgrade check failure still dismisses loading and does not mark onboarding complete`() =
+    fun `onboarding status read failure still dismisses loading and does not mark onboarding complete`() =
         runTest {
-            // Given: DataStore returns false and identity check throws
-            coEvery { mockSettingsRepository.hasCompletedOnboardingFlow } returns MutableStateFlow(false)
-            coEvery { mockIdentityRepository.getActiveIdentitySync() } throws RuntimeException("DB error")
+            // Given: DataStore read throws (Keystore/DB/etc. error)
+            coEvery { mockSettingsRepository.hasCompletedOnboardingFlow } throws RuntimeException("DataStore error")
 
             // When: ViewModel is created
             val viewModel = createViewModel()

--- a/app/src/test/java/network/columba/app/viewmodel/OnboardingViewModelTest.kt
+++ b/app/src/test/java/network/columba/app/viewmodel/OnboardingViewModelTest.kt
@@ -2,14 +2,6 @@ package network.columba.app.viewmodel
 
 import androidx.arch.core.executor.testing.InstantTaskExecutorRule
 import app.cash.turbine.test
-import network.columba.app.data.database.entity.InterfaceEntity
-import network.columba.app.data.db.entity.LocalIdentityEntity
-import network.columba.app.data.repository.IdentityRepository
-import network.columba.app.repository.InterfaceRepository
-import network.columba.app.repository.SettingsRepository
-import network.columba.app.reticulum.model.InterfaceConfig
-import network.columba.app.service.InterfaceConfigManager
-import network.columba.app.ui.screens.onboarding.OnboardingInterfaceType
 import io.mockk.Runs
 import io.mockk.clearAllMocks
 import io.mockk.coEvery
@@ -25,6 +17,14 @@ import kotlinx.coroutines.test.advanceUntilIdle
 import kotlinx.coroutines.test.resetMain
 import kotlinx.coroutines.test.runTest
 import kotlinx.coroutines.test.setMain
+import network.columba.app.data.database.entity.InterfaceEntity
+import network.columba.app.data.db.entity.LocalIdentityEntity
+import network.columba.app.data.repository.IdentityRepository
+import network.columba.app.repository.InterfaceRepository
+import network.columba.app.repository.SettingsRepository
+import network.columba.app.reticulum.model.InterfaceConfig
+import network.columba.app.service.InterfaceConfigManager
+import network.columba.app.ui.screens.onboarding.OnboardingInterfaceType
 import org.junit.After
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
@@ -170,26 +170,27 @@ class OnboardingViewModelTest {
             }
         }
 
-    // ========== Upgrade Detection Tests ==========
+    // ========== Onboarding Status Tests ==========
 
     @Test
-    fun `detects upgrade when identity exists but onboarding not marked complete`() =
+    fun `shows onboarding on fresh install even if an identity already exists`() =
         runTest {
-            // Given: DataStore has no onboarding key (returns false) but an identity exists
+            // Cold boot of the app creates a Reticulum identity before the user hits Welcome,
+            // so "identity exists + hasCompleted=false" is the fresh-install shape — not a
+            // pre-onboarding upgrade. Trusting the persisted flag alone keeps the welcome
+            // flow visible; users upgrading from the brief pre-onboarding window can Skip.
             coEvery { mockSettingsRepository.hasCompletedOnboardingFlow } returns MutableStateFlow(false)
             coEvery { mockIdentityRepository.getActiveIdentitySync() } returns createTestIdentity()
 
-            // When: ViewModel is created
             val viewModel = createViewModel()
             advanceUntilIdle()
 
-            // Then: Upgrade should be detected, onboarding marked complete
             viewModel.state.test {
                 val state = awaitItem()
-                assertTrue("Should detect upgrade and mark onboarding complete", state.hasCompletedOnboarding)
+                assertFalse("Should show onboarding regardless of existing identity", state.hasCompletedOnboarding)
                 assertFalse(state.isLoading)
             }
-            coVerify { mockSettingsRepository.markOnboardingCompleted() }
+            coVerify(exactly = 0) { mockSettingsRepository.markOnboardingCompleted() }
         }
 
     @Test
@@ -432,8 +433,7 @@ class OnboardingViewModelTest {
         runTest {
             val viewModel = createViewModel()
             val testIdentity = createTestIdentity()
-            // First call (upgrade check in init) returns null, second call (completeOnboarding) returns identity
-            coEvery { mockIdentityRepository.getActiveIdentitySync() } returnsMany listOf(null, testIdentity)
+            coEvery { mockIdentityRepository.getActiveIdentitySync() } returns testIdentity
             coEvery { mockIdentityRepository.updateDisplayName(any(), any()) } returns Result.success(Unit)
             advanceUntilIdle()
 
@@ -453,8 +453,7 @@ class OnboardingViewModelTest {
         runTest {
             val viewModel = createViewModel()
             val testIdentity = createTestIdentity()
-            // First call (upgrade check in init) returns null, second call (completeOnboarding) returns identity
-            coEvery { mockIdentityRepository.getActiveIdentitySync() } returnsMany listOf(null, testIdentity)
+            coEvery { mockIdentityRepository.getActiveIdentitySync() } returns testIdentity
             coEvery { mockIdentityRepository.updateDisplayName(any(), any()) } returns Result.success(Unit)
             advanceUntilIdle()
 
@@ -676,8 +675,7 @@ class OnboardingViewModelTest {
         runTest {
             val viewModel = createViewModel()
             val testIdentity = createTestIdentity()
-            // First call (upgrade check in init) returns null, second call (skipOnboarding) returns identity
-            coEvery { mockIdentityRepository.getActiveIdentitySync() } returnsMany listOf(null, testIdentity)
+            coEvery { mockIdentityRepository.getActiveIdentitySync() } returns testIdentity
             coEvery { mockIdentityRepository.updateDisplayName(any(), any()) } returns Result.success(Unit)
             every { mockInterfaceRepository.allInterfaces } returns MutableStateFlow(emptyList())
             advanceUntilIdle()

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -19,7 +19,7 @@ serialization = "1.10.0"
 coil = "2.7.0"
 
 # JitPack-published libraries (formerly git submodules)
-reticulumKt = "v0.0.3"
+reticulumKt = "v0.0.4"
 lxmfKt = "v0.0.3"
 lxstKt = "v0.0.2"
 

--- a/reticulum/src/main/java/network/columba/app/reticulum/model/ReticulumConfig.kt
+++ b/reticulum/src/main/java/network/columba/app/reticulum/model/ReticulumConfig.kt
@@ -128,6 +128,29 @@ data class ReticulumConfig(
             this == null || other == null -> false
             else -> contentEquals(other)
         }
+
+    // Render deliveryIdentityKey as "[N bytes]" so a stray log of the config doesn't
+    // leak the JVM object reference (which exposes non-null presence) or, worse, the
+    // raw bytes. Rest of the fields are plain data and go through their own toString.
+    override fun toString(): String =
+        "ReticulumConfig(" +
+            "storagePath=$storagePath, " +
+            "enabledInterfaces=$enabledInterfaces, " +
+            "identityFilePath=$identityFilePath, " +
+            "deliveryIdentityKey=${deliveryIdentityKey?.let { "[${it.size} bytes]" }}, " +
+            "displayName=$displayName, " +
+            "logLevel=$logLevel, " +
+            "allowAnonymous=$allowAnonymous, " +
+            "batteryProfile=$batteryProfile, " +
+            "preferOwnInstance=$preferOwnInstance, " +
+            "rpcKey=$rpcKey, " +
+            "enableTransport=$enableTransport, " +
+            "discoverInterfaces=$discoverInterfaces, " +
+            "autoconnectDiscoveredInterfaces=$autoconnectDiscoveredInterfaces, " +
+            "autoconnectIfacOnly=$autoconnectIfacOnly, " +
+            "interfaceDiscoverySources=$interfaceDiscoverySources, " +
+            "requiredDiscoveryValue=$requiredDiscoveryValue" +
+            ")"
 }
 
 /**

--- a/reticulum/src/main/java/network/columba/app/reticulum/model/ReticulumConfig.kt
+++ b/reticulum/src/main/java/network/columba/app/reticulum/model/ReticulumConfig.kt
@@ -75,7 +75,60 @@ data class ReticulumConfig(
      * providing spam prevention. Range: 8-20, default: 14.
      */
     val requiredDiscoveryValue: Int = 14,
-)
+) {
+    // Data-class-generated equals/hashCode use reference equality for ByteArray, so
+    // two configs with identical key bytes would otherwise never compare equal. Override
+    // to use contentEquals/contentHashCode for the key field; everything else is handled
+    // by the standard == on each property.
+    @Suppress("CyclomaticComplexMethod") // Field-by-field equality: one branch per property
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (other !is ReticulumConfig) return false
+        return storagePath == other.storagePath &&
+            enabledInterfaces == other.enabledInterfaces &&
+            identityFilePath == other.identityFilePath &&
+            deliveryIdentityKey.contentEqualsNullable(other.deliveryIdentityKey) &&
+            displayName == other.displayName &&
+            logLevel == other.logLevel &&
+            allowAnonymous == other.allowAnonymous &&
+            batteryProfile == other.batteryProfile &&
+            preferOwnInstance == other.preferOwnInstance &&
+            rpcKey == other.rpcKey &&
+            enableTransport == other.enableTransport &&
+            discoverInterfaces == other.discoverInterfaces &&
+            autoconnectDiscoveredInterfaces == other.autoconnectDiscoveredInterfaces &&
+            autoconnectIfacOnly == other.autoconnectIfacOnly &&
+            interfaceDiscoverySources == other.interfaceDiscoverySources &&
+            requiredDiscoveryValue == other.requiredDiscoveryValue
+    }
+
+    override fun hashCode(): Int {
+        var result = storagePath.hashCode()
+        result = 31 * result + enabledInterfaces.hashCode()
+        result = 31 * result + (identityFilePath?.hashCode() ?: 0)
+        result = 31 * result + (deliveryIdentityKey?.contentHashCode() ?: 0)
+        result = 31 * result + (displayName?.hashCode() ?: 0)
+        result = 31 * result + logLevel.hashCode()
+        result = 31 * result + allowAnonymous.hashCode()
+        result = 31 * result + batteryProfile.hashCode()
+        result = 31 * result + preferOwnInstance.hashCode()
+        result = 31 * result + (rpcKey?.hashCode() ?: 0)
+        result = 31 * result + enableTransport.hashCode()
+        result = 31 * result + discoverInterfaces.hashCode()
+        result = 31 * result + autoconnectDiscoveredInterfaces
+        result = 31 * result + autoconnectIfacOnly.hashCode()
+        result = 31 * result + (interfaceDiscoverySources?.hashCode() ?: 0)
+        result = 31 * result + requiredDiscoveryValue
+        return result
+    }
+
+    private fun ByteArray?.contentEqualsNullable(other: ByteArray?): Boolean =
+        when {
+            this == null && other == null -> true
+            this == null || other == null -> false
+            else -> contentEquals(other)
+        }
+}
 
 /**
  * Sealed class representing different Reticulum network interface types.

--- a/reticulum/src/main/java/network/columba/app/reticulum/model/ReticulumConfig.kt
+++ b/reticulum/src/main/java/network/columba/app/reticulum/model/ReticulumConfig.kt
@@ -4,6 +4,16 @@ data class ReticulumConfig(
     val storagePath: String,
     val enabledInterfaces: List<InterfaceConfig>,
     val identityFilePath: String? = null,
+    /**
+     * Raw 64-byte delivery-identity private key (X25519_prv || Ed25519_prv) kept in
+     * memory for the lifetime of this init. When non-null, the native stack constructs
+     * the delivery identity via `NativeIdentity.fromBytes(deliveryIdentityKey)` and
+     * never writes or reads `identityFilePath`. Callers that hold the key encrypted
+     * at rest (e.g. Android Keystore-wrapped in the app's DB) should pass the
+     * decrypted bytes here and leave `identityFilePath` null so the plaintext key
+     * does not touch disk.
+     */
+    val deliveryIdentityKey: ByteArray? = null,
     val displayName: String? = null,
     val logLevel: LogLevel = LogLevel.INFO,
     val allowAnonymous: Boolean = false,

--- a/reticulum/src/main/java/network/columba/app/reticulum/protocol/NativeReticulumProtocol.kt
+++ b/reticulum/src/main/java/network/columba/app/reticulum/protocol/NativeReticulumProtocol.kt
@@ -2,6 +2,18 @@ package network.columba.app.reticulum.protocol
 
 import android.util.Log
 import androidx.room.Room
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asSharedFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
 import network.columba.app.reticulum.model.AnnounceEvent
 import network.columba.app.reticulum.model.BatteryProfile
 import network.columba.app.reticulum.model.DestinationType
@@ -15,18 +27,6 @@ import network.columba.app.reticulum.model.PacketReceipt
 import network.columba.app.reticulum.model.PacketType
 import network.columba.app.reticulum.model.ReceivedPacket
 import network.columba.app.reticulum.model.ReticulumConfig
-import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.SupervisorJob
-import kotlinx.coroutines.cancel
-import kotlinx.coroutines.flow.Flow
-import kotlinx.coroutines.flow.MutableSharedFlow
-import kotlinx.coroutines.flow.MutableStateFlow
-import kotlinx.coroutines.flow.StateFlow
-import kotlinx.coroutines.flow.asSharedFlow
-import kotlinx.coroutines.flow.asStateFlow
-import kotlinx.coroutines.launch
-import kotlinx.coroutines.withContext
 import network.reticulum.Reticulum
 import network.reticulum.common.DestinationDirection
 import network.reticulum.lxmf.LXMFConstants
@@ -284,10 +284,17 @@ class NativeReticulumProtocol(
 
     private fun initializeRouter(config: ReticulumConfig): NativeIdentity {
         val identity =
-            if (config.identityFilePath != null) {
-                NativeIdentity.fromFile(config.identityFilePath!!) ?: NativeIdentity.create()
-            } else {
-                NativeIdentity.create()
+            when {
+                // Preferred path: caller decrypted the key in memory (e.g. from an
+                // Android Keystore-wrapped blob) and handed us raw bytes. Avoids
+                // ever writing the plaintext key to disk.
+                config.deliveryIdentityKey != null ->
+                    NativeIdentity.fromBytes(config.deliveryIdentityKey!!) ?: NativeIdentity.create()
+                // Legacy path: load from a plaintext file on disk.
+                config.identityFilePath != null ->
+                    NativeIdentity.fromFile(config.identityFilePath!!) ?: NativeIdentity.create()
+                // No identity provided — create a fresh one.
+                else -> NativeIdentity.create()
             }
         deliveryIdentity = identity
 
@@ -414,11 +421,17 @@ class NativeReticulumProtocol(
 
                 initializePersistentStores(config.storagePath)
 
-                // Start Reticulum
+                // Start Reticulum with a fresh in-memory transport identity so the
+                // node-level RPC private key never touches disk. Transport identity
+                // continuity across app restarts isn't load-bearing on a phone client
+                // (unlike a fixed-location relay where established paths matter).
+                // Passing an override also triggers reticulum-kt to scrub and delete
+                // any stale $storagePath/transport_identity left from a prior run.
                 reticulum =
                     Reticulum.start(
                         configDir = config.storagePath,
                         enableTransport = config.enableTransport,
+                        transportIdentity = NativeIdentity.create(),
                     )
 
                 val identity = initializeRouter(config)

--- a/reticulum/src/main/java/network/columba/app/reticulum/protocol/NativeReticulumProtocol.kt
+++ b/reticulum/src/main/java/network/columba/app/reticulum/protocol/NativeReticulumProtocol.kt
@@ -288,11 +288,26 @@ class NativeReticulumProtocol(
                 // Preferred path: caller decrypted the key in memory (e.g. from an
                 // Android Keystore-wrapped blob) and handed us raw bytes. Avoids
                 // ever writing the plaintext key to disk.
-                config.deliveryIdentityKey != null ->
-                    NativeIdentity.fromBytes(config.deliveryIdentityKey!!) ?: NativeIdentity.create()
+                config.deliveryIdentityKey != null -> {
+                    val loaded = NativeIdentity.fromBytes(config.deliveryIdentityKey!!)
+                    if (loaded == null) {
+                        // Malformed bytes, wrong length, etc. Silently falling through
+                        // would start Reticulum with a brand-new ephemeral identity
+                        // while Room still has the original marked active — messages
+                        // would appear to come from an identity the user never saw.
+                        // Log loudly so the mismatch is at least observable.
+                        Log.e(TAG, "NativeIdentity.fromBytes returned null for deliveryIdentityKey - creating fresh identity instead")
+                    }
+                    loaded ?: NativeIdentity.create()
+                }
                 // Legacy path: load from a plaintext file on disk.
-                config.identityFilePath != null ->
-                    NativeIdentity.fromFile(config.identityFilePath!!) ?: NativeIdentity.create()
+                config.identityFilePath != null -> {
+                    val loaded = NativeIdentity.fromFile(config.identityFilePath!!)
+                    if (loaded == null) {
+                        Log.e(TAG, "NativeIdentity.fromFile returned null for ${config.identityFilePath} - creating fresh identity instead")
+                    }
+                    loaded ?: NativeIdentity.create()
+                }
                 // No identity provided — create a fresh one.
                 else -> NativeIdentity.create()
             }

--- a/reticulum/src/main/java/network/columba/app/reticulum/protocol/NativeReticulumProtocol.kt
+++ b/reticulum/src/main/java/network/columba/app/reticulum/protocol/NativeReticulumProtocol.kt
@@ -450,6 +450,10 @@ class NativeReticulumProtocol(
                     )
 
                 val identity = initializeRouter(config)
+                // Key bytes are now inside NativeIdentity; drop them from the cached
+                // config so each setBatteryProfile copy doesn't carry the key for the
+                // session. Shortens the in-memory lifetime of the raw key material.
+                lastConfig = lastConfig?.copy(deliveryIdentityKey = null)
 
                 // Create and register network interfaces from config
                 NativeInterfaceFactory.appContext = appContext

--- a/reticulum/src/main/java/network/columba/app/reticulum/protocol/NativeReticulumProtocol.kt
+++ b/reticulum/src/main/java/network/columba/app/reticulum/protocol/NativeReticulumProtocol.kt
@@ -549,6 +549,11 @@ class NativeReticulumProtocol(
                 reticulum = null
                 deliveryIdentity = null
                 deliveryDestination = null
+                // Drop the ReticulumConfig reference so the delivery-identity key bytes
+                // it carries (and any copies via setBatteryProfile) become GC-eligible.
+                // True in-memory zeroing isn't achievable on the JVM, but releasing the
+                // strong reference matches the key lifecycle care elsewhere in this flow.
+                lastConfig = null
                 Transport.customJobIntervalMs = null
                 Transport.customTablesCullIntervalMs = null
                 Transport.customAnnouncesCheckIntervalMs = null


### PR DESCRIPTION
## Summary

No plaintext identity key touches disk during normal operation anymore. The user's LXMF identity now flows from the Keystore-encrypted DB blob → decrypt in memory → handed to reticulum-kt via the new `ReticulumConfig.deliveryIdentityKey` field. The transport identity is freshly generated per session via the in-memory override added in [torlando-tech/reticulum-kt#28](https://github.com/torlando-tech/reticulum-kt/pull/28).

Together this removes the two plaintext-key files that previously lived under `filesDir/reticulum/` (`transport_identity` and `identity_<hash>`), which were the main reason the `reticulum/` directory has had to be excluded from Android Auto Backup.

## Changes

- **Bump reticulum-kt submodule** to pick up the `transportIdentity` parameter on `Reticulum.start()`.

- **`ReticulumConfig.deliveryIdentityKey: ByteArray?`** — when non-null, `NativeReticulumProtocol.initializeRouter` constructs the delivery identity via `NativeIdentity.fromBytes()` and never touches `identityFilePath`. The file-based path is kept for backward compatibility and for the explicit export/import UX.

- **Fresh transport identity per session.** `NativeReticulumProtocol.initialize` now passes `transportIdentity = NativeIdentity.create()` to `Reticulum.start()`. Passing an override also makes reticulum-kt zero-overwrite + delete any stale `$storagePath/transport_identity` from a previous file-backed run. Transport-level identity continuity isn't load-bearing on a phone client (unlike a fixed-location relay).

- **`ColumbaApplication`** (both cold-start and service-reinit paths) now calls `IdentityKeyProvider.getDecryptedKeyData(hash)` to unwrap the Keystore-encrypted key into memory, then passes the bytes as `ReticulumConfig.deliveryIdentityKey`. The prior `ensureIdentityFileExists` + `identityFilePath` pre-step is gone from the init path. `ensureIdentityFileExists` itself stays alive because the explicit export/import UX still uses it.

- **Stale-file cleanup** on `onCreate`: zero-overwrite then delete any `reticulum/identity_*` files left from a previous run. Best-effort — true secure erase isn't achievable on wear-levelled / journalled storage, but the dangling-reference liability is gone.

## Backup rules

Unchanged in this PR. The `reticulum/` exclusion still applies, but it now only covers routing/discovery state rather than private keys. A future PR could relax the exclusion if we decide the routing state is safe to restore across devices.

## Verification

- [x] `:reticulum:compileDebugKotlin`
- [x] `:app:compileNoSentryDebugKotlin`
- [x] `:app:testNoSentryDebugUnitTest`
- [x] `:reticulum:testDebugUnitTest`
- [ ] Manual: install, verify identity persists across app restart (DB is the source of truth, file no longer written), verify send/receive works.

🤖 Generated with [Claude Code](https://claude.com/claude-code)