### PR TITLE
Bump LXST-kt to v0.0.3 (JVM 21 target)

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -21,7 +21,7 @@ coil = "2.7.0"
 # JitPack-published libraries (formerly git submodules)
 reticulumKt = "v0.0.3"
 lxmfKt = "v0.0.3"
-lxstKt = "v0.0.2"
+lxstKt = "v0.0.3"
 
 [libraries]
 # JitPack-published Reticulum/LXMF/LXST stack (migrated from git submodules)


### PR DESCRIPTION
## Summary
Bumps \`lxstKt\` in \`gradle/libs.versions.toml\` from \`v0.0.2\` to \`v0.0.3\`.

v0.0.3 upgrades LXST-kt's bytecode target from JVM 17 to JVM 21, aligning it with reticulum-kt and LXMF-kt. No source changes required — AGP's D8 transparently handles the newer bytecode for columba's minSdk 24 target.

## Ordering with #786

This PR is branched off \`chore/migrate-libs-to-jitpack\` (#786). Until that merges, the diff against \`main\` will show the accumulated migration + bump. Once #786 lands on main, this PR collapses to a single-line diff.

No rebase needed — GitHub will recompute the diff automatically.

## Test plan
- [x] \`./gradlew --refresh-dependencies :app:assembleDebug\` succeeds with v0.0.3 in the catalog
- [ ] Post-merge device smoke test: LXST telephony still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)