### PR TITLE
About card: AGPLv3 label, catalog-driven protocol versions, settings-flow state preservation

### DIFF
--- a/app/src/main/java/network/columba/app/ui/screens/settings/cards/AboutCard.kt
+++ b/app/src/main/java/network/columba/app/ui/screens/settings/cards/AboutCard.kt
@@ -147,7 +147,7 @@ fun AboutCard(
                 verticalArrangement = Arrangement.spacedBy(4.dp),
             ) {
                 Text(
-                    text = "MIT License",
+                    text = "GNU AGPLv3",
                     style = MaterialTheme.typography.bodySmall,
                     color = MaterialTheme.colorScheme.onSurfaceVariant,
                 )

--- a/app/src/main/java/network/columba/app/viewmodel/SettingsViewModel.kt
+++ b/app/src/main/java/network/columba/app/viewmodel/SettingsViewModel.kt
@@ -458,6 +458,7 @@ class SettingsViewModel
                             reticulumVersion = _state.value.reticulumVersion,
                             lxmfVersion = _state.value.lxmfVersion,
                             bleReticulumVersion = _state.value.bleReticulumVersion,
+                            lxstVersion = _state.value.lxstVersion,
                             // Preserve card expansion states
                             cardExpansionStates = _state.value.cardExpansionStates,
                             // Preserve update checker state from loadUpdateSettings()

--- a/app/src/main/java/network/columba/app/viewmodel/SettingsViewModel.kt
+++ b/app/src/main/java/network/columba/app/viewmodel/SettingsViewModel.kt
@@ -3,22 +3,6 @@ package network.columba.app.viewmodel
 import android.util.Log
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
-import network.columba.app.data.model.EnrichedContact
-import network.columba.app.data.model.ImageCompressionPreset
-import network.columba.app.data.repository.ContactRepository
-import network.columba.app.data.repository.IdentityRepository
-import network.columba.app.map.MapTileSourceManager
-import network.columba.app.repository.InterfaceRepository
-import network.columba.app.repository.SettingsRepository
-import network.columba.app.reticulum.model.BatteryProfile
-import network.columba.app.reticulum.model.NetworkStatus
-import network.columba.app.reticulum.protocol.ReticulumProtocol
-import network.columba.app.service.AvailableRelaysState
-import network.columba.app.service.PropagationNodeManager
-import network.columba.app.service.RelayInfo
-import network.columba.app.service.TelemetryCollectorManager
-import network.columba.app.ui.theme.AppTheme
-import network.columba.app.ui.theme.PresetTheme
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.FlowPreview
@@ -35,6 +19,22 @@ import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
+import network.columba.app.data.model.EnrichedContact
+import network.columba.app.data.model.ImageCompressionPreset
+import network.columba.app.data.repository.ContactRepository
+import network.columba.app.data.repository.IdentityRepository
+import network.columba.app.map.MapTileSourceManager
+import network.columba.app.repository.InterfaceRepository
+import network.columba.app.repository.SettingsRepository
+import network.columba.app.reticulum.model.BatteryProfile
+import network.columba.app.reticulum.model.NetworkStatus
+import network.columba.app.reticulum.protocol.ReticulumProtocol
+import network.columba.app.service.AvailableRelaysState
+import network.columba.app.service.PropagationNodeManager
+import network.columba.app.service.RelayInfo
+import network.columba.app.service.TelemetryCollectorManager
+import network.columba.app.ui.theme.AppTheme
+import network.columba.app.ui.theme.PresetTheme
 import javax.inject.Inject
 
 /**
@@ -537,10 +537,17 @@ class SettingsViewModel
                     previousState.wasUsingSharedInstance
                 }
 
+            // Preserve protocol versions — they're populated asynchronously by
+            // fetchProtocolVersions() and aren't part of the settings flow's shape,
+            // so they'd revert to null on every settings emission without this.
             _state.value =
                 newState.copy(
                     sharedInstanceOnline = initializedOnline,
                     wasUsingSharedInstance = wasUsingShared,
+                    reticulumVersion = previousState.reticulumVersion,
+                    lxmfVersion = previousState.lxmfVersion,
+                    bleReticulumVersion = previousState.bleReticulumVersion,
+                    lxstVersion = previousState.lxstVersion,
                 )
             Log.d(
                 TAG,

--- a/reticulum/build.gradle.kts
+++ b/reticulum/build.gradle.kts
@@ -19,6 +19,12 @@ android {
             // armeabi-v7a restored: pycodec2 removed in favor of LXST (Kotlin/C++)
             abiFilters += listOf("armeabi-v7a", "arm64-v8a", "x86_64")
         }
+
+        // Expose the pinned library versions to Kotlin source so NativeReticulumProtocol
+        // can report them to the About card without hardcoding (and drifting from reality).
+        buildConfigField("String", "RNS_KT_VERSION", "\"${libs.versions.reticulumKt.get().removePrefix("v")}\"")
+        buildConfigField("String", "LXMF_KT_VERSION", "\"${libs.versions.lxmfKt.get().removePrefix("v")}\"")
+        buildConfigField("String", "LXST_KT_VERSION", "\"${libs.versions.lxstKt.get().removePrefix("v")}\"")
     }
 
     compileOptions {
@@ -34,7 +40,7 @@ android {
 
     buildFeatures {
         aidl = true
-        buildConfig = false
+        buildConfig = true
     }
 
     testOptions {

--- a/reticulum/src/main/java/network/columba/app/reticulum/protocol/NativeReticulumProtocol.kt
+++ b/reticulum/src/main/java/network/columba/app/reticulum/protocol/NativeReticulumProtocol.kt
@@ -35,6 +35,7 @@ import network.reticulum.lxmf.LXMessage
 import network.reticulum.transport.Transport
 import org.json.JSONObject
 import org.msgpack.core.MessagePack
+import tech.torlando.columba.reticulum.BuildConfig
 import network.columba.app.reticulum.model.Destination as ColumbaDestination
 import network.columba.app.reticulum.model.Identity as ColumbaIdentity
 import network.columba.app.reticulum.model.Link as ColumbaLink
@@ -1877,13 +1878,13 @@ class NativeReticulumProtocol(
 
     // ==================== Version Info ====================
 
-    override suspend fun getReticulumVersion(): String? = "Reticulum-kt 0.0.3"
+    override suspend fun getReticulumVersion(): String? = "Reticulum-kt ${BuildConfig.RNS_KT_VERSION}"
 
-    override suspend fun getLxmfVersion(): String? = "LXMF-kt 0.0.3"
+    override suspend fun getLxmfVersion(): String? = "LXMF-kt ${BuildConfig.LXMF_KT_VERSION}"
 
     override suspend fun getBleReticulumVersion(): String? = null
 
-    override suspend fun getLxstVersion(): String? = "LXST-kt 0.0.3"
+    override suspend fun getLxstVersion(): String? = "LXST-kt ${BuildConfig.LXST_KT_VERSION}"
 
     // ==================== Blocking & Transport ====================
 

--- a/reticulum/src/main/java/network/columba/app/reticulum/protocol/NativeReticulumProtocol.kt
+++ b/reticulum/src/main/java/network/columba/app/reticulum/protocol/NativeReticulumProtocol.kt
@@ -1877,9 +1877,9 @@ class NativeReticulumProtocol(
 
     // ==================== Version Info ====================
 
-    override suspend fun getReticulumVersion(): String? = "Reticulum-kt 0.1.0"
+    override suspend fun getReticulumVersion(): String? = "Reticulum-kt 0.0.3"
 
-    override suspend fun getLxmfVersion(): String? = "LXMF-kt 0.1.0"
+    override suspend fun getLxmfVersion(): String? = "LXMF-kt 0.0.3"
 
     override suspend fun getBleReticulumVersion(): String? = null
 

--- a/reticulum/src/main/java/network/columba/app/reticulum/protocol/NativeReticulumProtocol.kt
+++ b/reticulum/src/main/java/network/columba/app/reticulum/protocol/NativeReticulumProtocol.kt
@@ -1883,7 +1883,7 @@ class NativeReticulumProtocol(
 
     override suspend fun getBleReticulumVersion(): String? = null
 
-    override suspend fun getLxstVersion(): String? = "LXST-kt 0.0.1"
+    override suspend fun getLxstVersion(): String? = "LXST-kt 0.0.3"
 
     // ==================== Blocking & Transport ====================
 


### PR DESCRIPTION
## Summary
Three related tweaks to the Settings → About card:

1. **License label**: \`"MIT License"\` → \`"GNU AGPLv3"\` (the LICENSE file has been AGPLv3 all along; the UI was stale).
2. **Catalog-driven protocol versions**: version strings for Reticulum-kt / LXMF-kt / LXST-kt now come from \`gradle/libs.versions.toml\` via \`BuildConfig\`, not hardcoded strings. Bumping a library pin auto-updates the About card — no more drift.
3. **State-preservation fix**: the LXST row (and friends) was rendering briefly then disappearing. Root cause: \`applySettingsUpdate()\` rebuilt \`_state\` from the settings flow without protocol-version fields, clobbering whatever \`fetchProtocolVersions\` had populated. Now preserved explicitly in the merge.

## Copyright line stays the same
\`© 2025–{year} Columba Contributors\` is correct under AGPLv3. FSF copyright assignment only applies to official GNU projects; third-party AGPL software uses contributor-held copyright as the ecosystem norm.

## Changes
- \`AboutCard.kt\`: \`"MIT License"\` → \`"GNU AGPLv3"\`
- \`reticulum/build.gradle.kts\`: flip \`buildConfig = true\`, add three \`buildConfigField\` entries reading \`libs.versions.{reticulumKt,lxmfKt,lxstKt}\` with the \`v\` prefix stripped for display.
- \`NativeReticulumProtocol.kt\`: three hardcoded version strings replaced with \`BuildConfig.RNS_KT_VERSION\` / \`LXMF_KT_VERSION\` / \`LXST_KT_VERSION\` refs.
- \`SettingsViewModel.applySettingsUpdate()\`: preserve \`reticulumVersion\`, \`lxmfVersion\`, \`bleReticulumVersion\`, \`lxstVersion\` from \`previousState\` so settings-flow emissions don't clobber the async-populated protocol versions.

## Test plan
- [x] \`./gradlew :app:assembleSentryDebug\` succeeds
- [x] Device install: About card shows "GNU AGPLv3"
- [x] Device install: Protocol Versions row shows LXST alongside Reticulum/LXMF and persists (no flicker)

🤖 Generated with [Claude Code](https://claude.com/claude-code)