### PR TITLE
Eliminate plaintext identity-file window in createIdentity/importIdentity paths

### DIFF
--- a/app/src/main/java/network/columba/app/ColumbaApplication.kt
+++ b/app/src/main/java/network/columba/app/ColumbaApplication.kt
@@ -210,13 +210,15 @@ class ColumbaApplication : Application() {
             }
             try {
                 val reticulumDir = java.io.File(filesDir, "reticulum")
-                // Two layouts to scrub:
-                //   - reticulum/identity_<hash>  (legacy NativeReticulumProtocol layout)
-                //   - reticulum/identities/<hash> (current layout — NativeReticulumProtocol's
-                //     create/import/recover APIs still write here between user action and
-                //     the next cold boot, so this is the catch-up cleanup)
-                // The reticulum-kt FileMigrator handles the LXMF per-destination ratchet
-                // directory (reticulum/lxmf/ratchets/) upstream.
+                // Both layouts are now write-free in normal operation — the
+                // createIdentityWithName / importIdentityFile refactor returns
+                // the key via ReticulumConfig.deliveryIdentityKey in memory.
+                // These scrub passes exist purely to clean up stale files left
+                // by earlier builds on upgrade:
+                //   - reticulum/identity_<hash>   (pre-#785 flat layout)
+                //   - reticulum/identities/<hash> (post-#785, pre-this-refactor)
+                // The reticulum-kt FileMigrator handles the LXMF per-destination
+                // ratchet directory (reticulum/lxmf/ratchets/) upstream.
                 val staleIdentityFiles =
                     (reticulumDir.listFiles { f -> f.isFile && f.name.startsWith("identity_") } ?: emptyArray()) +
                         (java.io.File(reticulumDir, "identities").listFiles { f -> f.isFile } ?: emptyArray())

--- a/app/src/main/java/network/columba/app/migration/MigrationImporter.kt
+++ b/app/src/main/java/network/columba/app/migration/MigrationImporter.kt
@@ -740,13 +740,6 @@ class MigrationImporter
                 )
             database.localIdentityDao().insert(entity)
 
-            // Write key file directly for Python/RNS compatibility
-            try {
-                File(filePath).writeBytes(keyData)
-            } catch (e: Exception) {
-                Log.w(TAG, "Failed to write identity file to $filePath", e)
-            }
-
             return true
         }
 

--- a/app/src/main/java/network/columba/app/migration/MigrationImporter.kt
+++ b/app/src/main/java/network/columba/app/migration/MigrationImporter.kt
@@ -5,6 +5,11 @@ import android.net.Uri
 import android.util.Base64
 import android.util.Log
 import androidx.room.withTransaction
+import dagger.hilt.android.qualifiers.ApplicationContext
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.withContext
+import kotlinx.serialization.json.Json
 import network.columba.app.data.crypto.IdentityKeyEncryptor
 import network.columba.app.data.crypto.WrongPasswordException
 import network.columba.app.data.database.InterfaceDatabase
@@ -21,13 +26,7 @@ import network.columba.app.data.db.entity.PeerIdentityEntity
 import network.columba.app.data.model.InterfaceType
 import network.columba.app.data.util.HashUtils
 import network.columba.app.repository.SettingsRepository
-import network.columba.app.reticulum.protocol.ReticulumProtocol
 import network.columba.app.service.PropagationNodeManager
-import dagger.hilt.android.qualifiers.ApplicationContext
-import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.flow.first
-import kotlinx.coroutines.withContext
-import kotlinx.serialization.json.Json
 import java.io.File
 import java.io.FileOutputStream
 import java.util.zip.ZipInputStream
@@ -49,7 +48,6 @@ class MigrationImporter
         @ApplicationContext private val context: Context,
         private val database: ColumbaDatabase,
         private val interfaceDatabase: InterfaceDatabase,
-        private val reticulumProtocol: ReticulumProtocol,
         private val settingsRepository: SettingsRepository,
         private val propagationNodeManager: PropagationNodeManager,
         private val keyEncryptor: IdentityKeyEncryptor,
@@ -706,30 +704,10 @@ class MigrationImporter
                 return false
             }
 
-            // Create the identity file path
-            val identityDir = File(context.filesDir, "reticulum")
-            identityDir.mkdirs()
-            val filePath = File(identityDir, "identity_${identityExport.identityHash}").absolutePath
-
-            // Try to recover/import the identity via Reticulum
-            try {
-                val result =
-                    reticulumProtocol.recoverIdentityFile(
-                        identityExport.identityHash,
-                        keyData,
-                        filePath,
-                    )
-                val success = result["success"] as? Boolean ?: false
-                if (!success) {
-                    Log.w(
-                        TAG,
-                        "Reticulum failed to recover identity: ${result["error"]}",
-                    )
-                    // Fall back to direct database insert
-                }
-            } catch (e: Exception) {
-                Log.w(TAG, "Reticulum recovery failed, using direct insert", e)
-            }
+            // No disk-side write here anymore: delivery keys live Keystore-
+            // wrapped in Room (imported below). The native stack reads them
+            // via ReticulumConfig.deliveryIdentityKey at init time.
+            val filePath = ""
 
             // Encrypt the key data with device key for secure storage
             val (encryptedKeyData, keyVersion) =

--- a/app/src/main/java/network/columba/app/viewmodel/IdentityManagerViewModel.kt
+++ b/app/src/main/java/network/columba/app/viewmodel/IdentityManagerViewModel.kt
@@ -5,11 +5,6 @@ import android.net.Uri
 import android.util.Log
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
-import network.columba.app.data.db.entity.LocalIdentityEntity
-import network.columba.app.data.repository.IdentityRepository
-import network.columba.app.reticulum.protocol.ReticulumProtocol
-import network.columba.app.service.InterfaceConfigManager
-import network.columba.app.util.Base32
 import dagger.hilt.android.lifecycle.HiltViewModel
 import dagger.hilt.android.qualifiers.ApplicationContext
 import kotlinx.coroutines.Dispatchers
@@ -20,6 +15,11 @@ import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
+import network.columba.app.data.db.entity.LocalIdentityEntity
+import network.columba.app.data.repository.IdentityRepository
+import network.columba.app.reticulum.protocol.ReticulumProtocol
+import network.columba.app.service.InterfaceConfigManager
+import network.columba.app.util.Base32
 import java.util.zip.GZIPInputStream
 import javax.inject.Inject
 
@@ -35,6 +35,7 @@ class IdentityManagerViewModel
     constructor(
         @ApplicationContext private val context: Context,
         private val identityRepository: IdentityRepository,
+        private val identityKeyProvider: network.columba.app.data.crypto.IdentityKeyProvider,
         private val reticulumProtocol: ReticulumProtocol,
         private val interfaceConfigManager: InterfaceConfigManager,
     ) : ViewModel() {
@@ -148,53 +149,17 @@ class IdentityManagerViewModel
          * If the identity file is missing but keyData is available in the database,
          * it will be recovered automatically.
          */
-        @Suppress("LongMethod") // Identity switch requires coordinated file and service operations
         fun switchToIdentity(identityHash: String) {
             viewModelScope.launch {
                 try {
                     _uiState.value = IdentityManagerUiState.Loading("Switching identity...")
 
-                    // Check if identity file exists and recover if needed
-                    val identity = identityRepository.getIdentity(identityHash)
-                    if (identity != null) {
-                        val identityFile = java.io.File(identity.filePath)
-                        val keyDataBackup = identity.keyData
-                        if (!identityFile.exists() && keyDataBackup != null) {
-                            Log.d(TAG, "Identity file missing, attempting recovery from backup keyData...")
-                            _uiState.value = IdentityManagerUiState.Loading("Recovering identity file...")
-
-                            val recoveryResult =
-                                reticulumProtocol.recoverIdentityFile(
-                                    identityHash = identityHash,
-                                    keyData = keyDataBackup,
-                                    filePath = identity.filePath,
-                                )
-
-                            val success = recoveryResult["success"] as? Boolean ?: false
-                            if (!success) {
-                                val error = recoveryResult["error"] as? String ?: "Unknown recovery error"
-                                Log.e(TAG, "Failed to recover identity file: $error")
-                                _uiState.value =
-                                    IdentityManagerUiState.Error(
-                                        "Failed to recover identity file: $error",
-                                    )
-                                return@launch
-                            }
-                            Log.d(TAG, "Identity file recovered successfully")
-                        } else if (!identityFile.exists()) {
-                            Log.e(TAG, "Identity file missing and no backup keyData available")
-                            _uiState.value =
-                                IdentityManagerUiState.Error(
-                                    "Identity file is missing and cannot be recovered",
-                                )
-                            return@launch
-                        }
-                    }
-
-                    // Note: InterfaceConfigManager.applyInterfaceChanges() will use
-                    // ensureIdentityFileExists() to verify/recover the identity file
-                    // and pass the correct identity_<hash> path to Python.
-                    // No need to copy to default_identity anymore.
+                    // The identity's private key lives Keystore-wrapped in Room
+                    // (LocalIdentityEntity.keyData / encryptedKeyData).
+                    // InterfaceConfigManager.applyInterfaceChanges decrypts it
+                    // on-demand and passes it to the native stack via
+                    // ReticulumConfig.deliveryIdentityKey — no plaintext file
+                    // has to exist on disk, so no recovery step here.
 
                     identityRepository
                         .switchActiveIdentity(identityHash)
@@ -249,16 +214,10 @@ class IdentityManagerViewModel
                         return@launch
                     }
 
-                    // Delete identity file via Python service
-                    val deleteResult = reticulumProtocol.deleteIdentityFile(identityHash)
-
-                    if (deleteResult["success"] != true) {
-                        val error = deleteResult["error"] as? String ?: "Unknown error"
-                        _uiState.value = IdentityManagerUiState.Error("Failed to delete identity file: $error")
-                        return@launch
-                    }
-
-                    // Delete from database (cascade delete will remove associated data)
+                    // Delete from database (cascade delete will remove associated data).
+                    // No disk-side cleanup: delivery keys live in Room now, not in
+                    // reticulum/identities/ — stale legacy files (if any) are scrubbed
+                    // at cold-start in ColumbaApplication.
                     identityRepository
                         .deleteIdentity(identityHash)
                         .onSuccess {
@@ -399,11 +358,21 @@ class IdentityManagerViewModel
                 try {
                     _uiState.value = IdentityManagerUiState.Loading("Exporting identity...")
 
-                    // Export via Python service
-                    val fileData = reticulumProtocol.exportIdentityFile(identityHash, filePath)
+                    // Decrypt the Keystore-wrapped key, hand it to the native
+                    // protocol which just writes it to the user-chosen scratch
+                    // path. No plaintext file touches reticulum/identities/.
+                    val keyData =
+                        identityKeyProvider.getDecryptedKeyData(identityHash).getOrElse { error ->
+                            _uiState.value =
+                                IdentityManagerUiState.Error(
+                                    "Failed to decrypt identity key: ${error.message}",
+                                )
+                            return@launch
+                        }
+                    val fileData = reticulumProtocol.exportIdentityFile(keyData, filePath)
 
                     if (fileData.isEmpty()) {
-                        _uiState.value = IdentityManagerUiState.Error("Failed to read identity file")
+                        _uiState.value = IdentityManagerUiState.Error("Failed to export identity")
                         return@launch
                     }
 
@@ -519,13 +488,22 @@ class IdentityManagerViewModel
                 try {
                     _uiState.value = IdentityManagerUiState.Loading("Exporting identity...")
 
-                    val fileData = withContext(Dispatchers.IO) {
-                        reticulumProtocol.exportIdentityFile(identityHash, filePath)
-                    }
+                    val keyData =
+                        identityKeyProvider.getDecryptedKeyData(identityHash).getOrElse { error ->
+                            _uiState.value =
+                                IdentityManagerUiState.Error(
+                                    "Failed to decrypt identity key: ${error.message}",
+                                )
+                            return@launch
+                        }
+                    val fileData =
+                        withContext(Dispatchers.IO) {
+                            reticulumProtocol.exportIdentityFile(keyData, filePath)
+                        }
 
                     if (fileData.isEmpty()) {
                         _uiState.value =
-                            IdentityManagerUiState.Error("Failed to read identity file")
+                            IdentityManagerUiState.Error("Failed to export identity")
                         return@launch
                     }
 

--- a/app/src/main/res/xml/backup_descriptor.xml
+++ b/app/src/main/res/xml/backup_descriptor.xml
@@ -7,6 +7,4 @@
     <include domain="database" path="." />
     <include domain="sharedpref" path="." />
     <include domain="file" path="." />
-    <!-- Transient plaintext identity files; scrubbed on cold boot. -->
-    <exclude domain="file" path="reticulum/identities" />
 </full-backup-content>

--- a/app/src/main/res/xml/backup_rules.xml
+++ b/app/src/main/res/xml/backup_rules.xml
@@ -15,30 +15,25 @@
   - Cache: EXCLUDED (Android default)
 
   The files/reticulum/ exclusion that earlier versions needed is gone:
-  the in-memory-identity refactor (PR #785) stopped writing plaintext
-  identity keys, reticulum-kt v0.0.5 moved RNS routing state to Room,
-  and v0.0.6 moved LXMF delivery-destination ratchets to Room.
+  - the in-memory-identity refactor (PR #785) stopped writing delivery
+    identity files,
+  - reticulum-kt v0.0.5 moved RNS routing state to Room,
+  - reticulum-kt v0.0.6 moved LXMF delivery-destination ratchets to Room,
+  - the createIdentityWithName / importIdentityFile / recoverIdentityFile
+    refactor eliminated the last plaintext-file writers.
 
-  The one remaining exclusion is `reticulum/identities/`. Those files
-  are written only by user-initiated create/import/recover flows and
-  deleted by the cold-start scrub on the next boot, but a scheduled
-  backup landing in that window would otherwise capture the plaintext
-  key. Android 9+ cloud backups are encrypted, but this defends against
-  unencrypted ADB/local backups as well.
+  Nothing in files/reticulum/ contains user secrets anymore.
 -->
 <data-extraction-rules>
     <cloud-backup>
         <include domain="database" path="." />
         <include domain="sharedpref" path="." />
         <include domain="file" path="." />
-        <!-- Transient plaintext identity files; scrubbed on cold boot. -->
-        <exclude domain="file" path="reticulum/identities" />
     </cloud-backup>
 
     <device-transfer>
         <include domain="database" path="." />
         <include domain="sharedpref" path="." />
         <include domain="file" path="." />
-        <exclude domain="file" path="reticulum/identities" />
     </device-transfer>
 </data-extraction-rules>

--- a/app/src/test/java/network/columba/app/migration/MigrationImporterEncryptionTest.kt
+++ b/app/src/test/java/network/columba/app/migration/MigrationImporterEncryptionTest.kt
@@ -3,7 +3,6 @@ package network.columba.app.migration
 import android.content.Context
 import android.net.Uri
 import androidx.test.core.app.ApplicationProvider
-import network.columba.app.data.crypto.IdentityKeyEncryptor
 import io.mockk.mockk
 import kotlinx.coroutines.test.runTest
 import kotlinx.serialization.encodeToString
@@ -45,7 +44,6 @@ class MigrationImporterEncryptionTest {
                 context = context,
                 database = mockk(),
                 interfaceDatabase = mockk(),
-                reticulumProtocol = mockk(),
                 settingsRepository = mockk(),
                 propagationNodeManager = mockk(),
                 keyEncryptor = mockk(),

--- a/app/src/test/java/network/columba/app/viewmodel/IdentityManagerViewModelTest.kt
+++ b/app/src/test/java/network/columba/app/viewmodel/IdentityManagerViewModelTest.kt
@@ -115,8 +115,14 @@ class IdentityManagerViewModelTest {
         mapOf(
             "identity_hash" to identityHash,
             "destination_hash" to destinationHash,
-            "file_path" to "/data/identity_$identityHash",
+            // Empty file_path = "no plaintext key on disk"; see
+            // NativeReticulumProtocol.buildIdentityResult.
+            "file_path" to "",
             "display_name" to "Test",
+            // key_data is the 64-byte raw private key the protocol hands
+            // to the caller for Keystore-wrapping. Must be non-null here so
+            // tests exercise the in-memory create/import path.
+            "key_data" to ByteArray(64) { it.toByte() },
         )
 
     private fun mockPythonError(): Map<String, Any> =
@@ -193,7 +199,7 @@ class IdentityManagerViewModelTest {
             // Given
             val pythonResult = mockPythonCreateSuccess()
             coEvery { mockProtocol.createIdentityWithName("Work") } returns pythonResult
-            coEvery { mockRepository.createIdentity(any(), any(), any(), any()) } returns
+            coEvery { mockRepository.createIdentity(any(), any(), any(), any(), any()) } returns
                 Result.success(
                     createTestIdentity(),
                 )
@@ -271,7 +277,7 @@ class IdentityManagerViewModelTest {
 
             // Given
             coEvery { mockProtocol.createIdentityWithName(any()) } returns mockPythonCreateSuccess()
-            coEvery { mockRepository.createIdentity(any(), any(), any(), any()) } returns
+            coEvery { mockRepository.createIdentity(any(), any(), any(), any(), any()) } returns
                 Result.failure(
                     RuntimeException("DB error"),
                 )
@@ -1268,7 +1274,7 @@ class IdentityManagerViewModelTest {
 
             // Given
             coEvery { mockProtocol.createIdentityWithName("My Work Identity") } returns mockPythonCreateSuccess()
-            coEvery { mockRepository.createIdentity(any(), any(), any(), any()) } returns
+            coEvery { mockRepository.createIdentity(any(), any(), any(), any(), any()) } returns
                 Result.success(
                     createTestIdentity(),
                 )

--- a/app/src/test/java/network/columba/app/viewmodel/IdentityManagerViewModelTest.kt
+++ b/app/src/test/java/network/columba/app/viewmodel/IdentityManagerViewModelTest.kt
@@ -5,10 +5,6 @@ import android.content.Context
 import android.net.Uri
 import androidx.arch.core.executor.testing.InstantTaskExecutorRule
 import app.cash.turbine.test
-import network.columba.app.data.db.entity.LocalIdentityEntity
-import network.columba.app.data.repository.IdentityRepository
-import network.columba.app.reticulum.protocol.ReticulumProtocol
-import network.columba.app.service.InterfaceConfigManager
 import io.mockk.clearAllMocks
 import io.mockk.coEvery
 import io.mockk.coVerify
@@ -24,6 +20,10 @@ import kotlinx.coroutines.test.resetMain
 import kotlinx.coroutines.test.runTest
 import kotlinx.coroutines.test.setMain
 import kotlinx.coroutines.withContext
+import network.columba.app.data.db.entity.LocalIdentityEntity
+import network.columba.app.data.repository.IdentityRepository
+import network.columba.app.reticulum.protocol.ReticulumProtocol
+import network.columba.app.service.InterfaceConfigManager
 import org.junit.After
 import org.junit.Assert.assertArrayEquals
 import org.junit.Assert.assertEquals
@@ -45,6 +45,7 @@ class IdentityManagerViewModelTest {
 
     private lateinit var mockContext: Context
     private lateinit var mockRepository: IdentityRepository
+    private lateinit var mockKeyProvider: network.columba.app.data.crypto.IdentityKeyProvider
     private lateinit var mockProtocol: ReticulumProtocol
     private lateinit var mockInterfaceConfigManager: InterfaceConfigManager
     private val testDispatcher = StandardTestDispatcher()
@@ -56,6 +57,7 @@ class IdentityManagerViewModelTest {
 
         mockContext = mockk(relaxed = true) // Android framework class
         mockRepository = mockk()
+        mockKeyProvider = mockk()
         mockProtocol = mockk()
         mockInterfaceConfigManager = mockk()
 
@@ -65,6 +67,10 @@ class IdentityManagerViewModelTest {
 
         // Default stub for InterfaceConfigManager
         coEvery { mockInterfaceConfigManager.applyInterfaceChanges() } returns Result.success(Unit)
+
+        // Default stub: any identity's Keystore-wrapped key decrypts cleanly.
+        coEvery { mockKeyProvider.getDecryptedKeyData(any(), any()) } returns
+            Result.success("stub_key_data".toByteArray())
     }
 
     @After
@@ -78,7 +84,13 @@ class IdentityManagerViewModelTest {
      * This ensures coroutines are properly tracked by the test infrastructure.
      */
     private fun createTestViewModel(): IdentityManagerViewModel =
-        IdentityManagerViewModel(mockContext, mockRepository, mockProtocol, mockInterfaceConfigManager)
+        IdentityManagerViewModel(
+            mockContext,
+            mockRepository,
+            mockKeyProvider,
+            mockProtocol,
+            mockInterfaceConfigManager,
+        )
 
     // ========== Helper Functions ==========
 
@@ -341,9 +353,8 @@ class IdentityManagerViewModelTest {
             // Given
             every { mockRepository.allIdentities } returns MutableStateFlow(emptyList())
             every { mockRepository.activeIdentity } returns MutableStateFlow(createTestIdentity(hash = "active", isActive = true))
-            val viewModel = IdentityManagerViewModel(mockContext, mockRepository, mockProtocol, mockInterfaceConfigManager)
+            val viewModel = IdentityManagerViewModel(mockContext, mockRepository, mockKeyProvider, mockProtocol, mockInterfaceConfigManager)
 
-            coEvery { mockProtocol.deleteIdentityFile("id1") } returns mapOf("success" to true)
             coEvery { mockRepository.deleteIdentity("id1") } returns Result.success(Unit)
 
             viewModel.uiState.test {
@@ -367,7 +378,7 @@ class IdentityManagerViewModelTest {
             // Given - trying to delete the active identity
             every { mockRepository.allIdentities } returns MutableStateFlow(emptyList())
             every { mockRepository.activeIdentity } returns MutableStateFlow(createTestIdentity(hash = "id1", isActive = true))
-            val viewModel = IdentityManagerViewModel(mockContext, mockRepository, mockProtocol, mockInterfaceConfigManager)
+            val viewModel = IdentityManagerViewModel(mockContext, mockRepository, mockKeyProvider, mockProtocol, mockInterfaceConfigManager)
 
             // WhileSubscribed requires active collector - subscribe to activeIdentity to start the flow
             val identityJob =
@@ -401,34 +412,9 @@ class IdentityManagerViewModelTest {
             identityJob.cancel()
         }
 
-    @Test
-    fun deleteIdentity_pythonError_transitionsToErrorState() =
-        runTest {
-            // Given
-            every { mockRepository.allIdentities } returns MutableStateFlow(emptyList())
-            every { mockRepository.activeIdentity } returns MutableStateFlow(createTestIdentity(hash = "active", isActive = true))
-            val viewModel = IdentityManagerViewModel(mockContext, mockRepository, mockProtocol, mockInterfaceConfigManager)
-
-            coEvery { mockProtocol.deleteIdentityFile("id1") } returns
-                mapOf(
-                    "success" to false,
-                    "error" to "File not found",
-                )
-
-            viewModel.uiState.test {
-                assertTrue(awaitItem() is IdentityManagerUiState.Idle)
-
-                // When
-                viewModel.deleteIdentity("id1")
-                testDispatcher.scheduler.advanceUntilIdle()
-
-                // Then
-                assertTrue(awaitItem() is IdentityManagerUiState.Loading)
-                val errorState = awaitItem()
-                assertTrue(errorState is IdentityManagerUiState.Error)
-                assertTrue((errorState as IdentityManagerUiState.Error).message.contains("File not found"))
-            }
-        }
+    // deleteIdentity_pythonError_transitionsToErrorState was removed along with
+    // the ReticulumProtocol.deleteIdentityFile API: delivery keys live Keystore-
+    // wrapped in Room now, no file to delete.
 
     @Test
     fun deleteIdentity_databaseError_transitionsToErrorState() =
@@ -436,9 +422,8 @@ class IdentityManagerViewModelTest {
             // Given
             every { mockRepository.allIdentities } returns MutableStateFlow(emptyList())
             every { mockRepository.activeIdentity } returns MutableStateFlow(createTestIdentity(hash = "active", isActive = true))
-            val viewModel = IdentityManagerViewModel(mockContext, mockRepository, mockProtocol, mockInterfaceConfigManager)
+            val viewModel = IdentityManagerViewModel(mockContext, mockRepository, mockKeyProvider, mockProtocol, mockInterfaceConfigManager)
 
-            coEvery { mockProtocol.deleteIdentityFile("id1") } returns mapOf("success" to true)
             coEvery { mockRepository.deleteIdentity("id1") } returns
                 Result.failure(
                     RuntimeException("DB error"),
@@ -621,7 +606,7 @@ class IdentityManagerViewModelTest {
             val fileData = "identity_data".toByteArray()
             val mockUri = mockk<Uri>()
 
-            coEvery { mockProtocol.exportIdentityFile("id1", any()) } returns fileData
+            coEvery { mockProtocol.exportIdentityFile(any<ByteArray>(), any()) } returns fileData
             coEvery { mockRepository.exportIdentity("id1", fileData) } returns Result.success(mockUri)
 
             viewModel.uiState.test {
@@ -645,7 +630,7 @@ class IdentityManagerViewModelTest {
             val viewModel = createTestViewModel()
 
             // Given
-            coEvery { mockProtocol.exportIdentityFile("id1", any()) } returns byteArrayOf()
+            coEvery { mockProtocol.exportIdentityFile(any<ByteArray>(), any()) } returns byteArrayOf()
 
             viewModel.uiState.test {
                 assertTrue(awaitItem() is IdentityManagerUiState.Idle)
@@ -658,7 +643,7 @@ class IdentityManagerViewModelTest {
                 assertTrue(awaitItem() is IdentityManagerUiState.Loading)
                 val errorState = awaitItem()
                 assertTrue(errorState is IdentityManagerUiState.Error)
-                assertEquals("Failed to read identity file", (errorState as IdentityManagerUiState.Error).message)
+                assertEquals("Failed to export identity", (errorState as IdentityManagerUiState.Error).message)
             }
         }
 
@@ -669,7 +654,7 @@ class IdentityManagerViewModelTest {
 
             // Given
             val fileData = "identity_data".toByteArray()
-            coEvery { mockProtocol.exportIdentityFile("id1", any()) } returns fileData
+            coEvery { mockProtocol.exportIdentityFile(any<ByteArray>(), any()) } returns fileData
             coEvery { mockRepository.exportIdentity("id1", fileData) } returns
                 Result.failure(
                     RuntimeException("FileProvider error"),
@@ -875,7 +860,7 @@ class IdentityManagerViewModelTest {
 
             // Given
             val fileData = ByteArray(64) { it.toByte() }
-            coEvery { mockProtocol.exportIdentityFile("id1", "/test/path") } returns fileData
+            coEvery { mockProtocol.exportIdentityFile(any<ByteArray>(), "/test/path") } returns fileData
 
             viewModel.uiState.test {
                 assertTrue(awaitItem() is IdentityManagerUiState.Idle)
@@ -904,7 +889,7 @@ class IdentityManagerViewModelTest {
             val viewModel = createTestViewModel()
 
             // Given
-            coEvery { mockProtocol.exportIdentityFile("id1", any()) } returns byteArrayOf()
+            coEvery { mockProtocol.exportIdentityFile(any<ByteArray>(), any()) } returns byteArrayOf()
 
             viewModel.uiState.test {
                 assertTrue(awaitItem() is IdentityManagerUiState.Idle)
@@ -917,7 +902,7 @@ class IdentityManagerViewModelTest {
                 assertTrue(awaitItem() is IdentityManagerUiState.Loading)
                 val errorState = awaitItem()
                 assertTrue(errorState is IdentityManagerUiState.Error)
-                assertEquals("Failed to read identity file", (errorState as IdentityManagerUiState.Error).message)
+                assertEquals("Failed to export identity", (errorState as IdentityManagerUiState.Error).message)
             }
         }
 
@@ -1093,7 +1078,7 @@ class IdentityManagerViewModelTest {
             val fileData = "identity_data".toByteArray()
             val mockUri = mockk<Uri>()
 
-            coEvery { mockProtocol.exportIdentityFile("id1", any()) } returns fileData
+            coEvery { mockProtocol.exportIdentityFile(any<ByteArray>(), any()) } returns fileData
             coEvery { mockRepository.exportIdentity("id1", fileData) } returns Result.success(mockUri)
 
             // When
@@ -1119,7 +1104,7 @@ class IdentityManagerViewModelTest {
             val destinationUri = mockk<Uri>()
             val mockContentResolver = mockk<ContentResolver>()
 
-            coEvery { mockProtocol.exportIdentityFile("id1", any()) } returns fileData
+            coEvery { mockProtocol.exportIdentityFile(any<ByteArray>(), any()) } returns fileData
             coEvery { mockRepository.exportIdentity("id1", fileData) } returns Result.success(sourceUri)
 
             viewModel.exportIdentity("id1", "/test/path")
@@ -1159,7 +1144,7 @@ class IdentityManagerViewModelTest {
             val destinationUri = mockk<Uri>()
             val mockContentResolver = mockk<ContentResolver>()
 
-            coEvery { mockProtocol.exportIdentityFile("id1", any()) } returns fileData
+            coEvery { mockProtocol.exportIdentityFile(any<ByteArray>(), any()) } returns fileData
             coEvery { mockRepository.exportIdentity("id1", fileData) } returns Result.success(sourceUri)
 
             viewModel.exportIdentity("id1", "/test/path")
@@ -1213,7 +1198,7 @@ class IdentityManagerViewModelTest {
             val secondDestinationUri = mockk<Uri>()
             val mockContentResolver = mockk<ContentResolver>()
 
-            coEvery { mockProtocol.exportIdentityFile("id1", any()) } returns fileData
+            coEvery { mockProtocol.exportIdentityFile(any<ByteArray>(), any()) } returns fileData
             coEvery { mockRepository.exportIdentity("id1", fileData) } returns Result.success(sourceUri)
 
             viewModel.exportIdentity("id1", "/test/path")
@@ -1306,9 +1291,8 @@ class IdentityManagerViewModelTest {
             // Given
             every { mockRepository.allIdentities } returns MutableStateFlow(emptyList())
             every { mockRepository.activeIdentity } returns MutableStateFlow(createTestIdentity(hash = "active", isActive = true))
-            val viewModel = IdentityManagerViewModel(mockContext, mockRepository, mockProtocol, mockInterfaceConfigManager)
+            val viewModel = IdentityManagerViewModel(mockContext, mockRepository, mockKeyProvider, mockProtocol, mockInterfaceConfigManager)
 
-            coEvery { mockProtocol.deleteIdentityFile("id_to_delete") } returns mapOf("success" to true)
             coEvery { mockRepository.deleteIdentity(any()) } returns Result.success(Unit)
 
             // When
@@ -1316,7 +1300,6 @@ class IdentityManagerViewModelTest {
             testDispatcher.scheduler.advanceUntilIdle()
 
             // Then - verify the calls were made and assert final state
-            coVerify { mockProtocol.deleteIdentityFile("id_to_delete") }
             coVerify { mockRepository.deleteIdentity("id_to_delete") }
             viewModel.uiState.test {
                 val state = awaitItem()

--- a/reticulum/src/main/java/network/columba/app/reticulum/protocol/MockReticulumProtocol.kt
+++ b/reticulum/src/main/java/network/columba/app/reticulum/protocol/MockReticulumProtocol.kt
@@ -1,5 +1,11 @@
 package network.columba.app.reticulum.protocol
 
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.flow
 import network.columba.app.reticulum.model.AnnounceEvent
 import network.columba.app.reticulum.model.Destination
 import network.columba.app.reticulum.model.DestinationType
@@ -14,12 +20,6 @@ import network.columba.app.reticulum.model.PacketReceipt
 import network.columba.app.reticulum.model.PacketType
 import network.columba.app.reticulum.model.ReceivedPacket
 import network.columba.app.reticulum.model.ReticulumConfig
-import kotlinx.coroutines.delay
-import kotlinx.coroutines.flow.Flow
-import kotlinx.coroutines.flow.MutableStateFlow
-import kotlinx.coroutines.flow.StateFlow
-import kotlinx.coroutines.flow.asStateFlow
-import kotlinx.coroutines.flow.flow
 import java.security.MessageDigest
 import java.security.SecureRandom
 
@@ -72,68 +72,42 @@ class MockReticulumProtocol : ReticulumProtocol {
     override suspend fun recallIdentity(hash: ByteArray): Identity? = null
 
     override suspend fun createIdentityWithName(displayName: String): Map<String, Any> {
-        // Mock implementation - generate a fake identity
-        val identityHash =
-            ByteArray(16)
-                .apply { random.nextBytes(this) }
-                .joinToString("") { "%02x".format(it) }
-        val destinationHash =
-            ByteArray(16)
-                .apply { random.nextBytes(this) }
-                .joinToString("") { "%02x".format(it) }
-
+        val identityHash = randomHex(16)
+        val destinationHash = randomHex(16)
         return mapOf(
+            "success" to true,
             "identity_hash" to identityHash,
             "destination_hash" to destinationHash,
-            "file_path" to "/mock/identities/$identityHash.identity",
+            "display_name" to displayName,
+            "public_key" to ByteArray(64).apply { random.nextBytes(this) },
+            "key_data" to ByteArray(64).apply { random.nextBytes(this) },
+            "file_path" to "",
         )
-    }
-
-    override suspend fun deleteIdentityFile(identityHash: String): Map<String, Any> {
-        // Mock implementation - always succeed
-        return mapOf("success" to true)
     }
 
     override suspend fun importIdentityFile(
         fileData: ByteArray,
         displayName: String,
     ): Map<String, Any> {
-        // Mock implementation - generate a fake identity
-        val identityHash =
-            ByteArray(16)
-                .apply { random.nextBytes(this) }
-                .joinToString("") { "%02x".format(it) }
-        val destinationHash =
-            ByteArray(16)
-                .apply { random.nextBytes(this) }
-                .joinToString("") { "%02x".format(it) }
-
+        val identityHash = randomHex(16)
+        val destinationHash = randomHex(16)
         return mapOf(
+            "success" to true,
             "identity_hash" to identityHash,
             "destination_hash" to destinationHash,
-            "file_path" to "/mock/identities/$identityHash.identity",
+            "display_name" to displayName,
+            "public_key" to ByteArray(64).apply { random.nextBytes(this) },
+            "key_data" to fileData.copyOf(),
+            "file_path" to "",
         )
     }
 
     override suspend fun exportIdentityFile(
-        identityHash: String,
-        filePath: String,
-    ): ByteArray {
-        // Mock implementation - return fake identity data
-        return ByteArray(256).apply { random.nextBytes(this) }
-    }
-
-    override suspend fun recoverIdentityFile(
-        identityHash: String,
         keyData: ByteArray,
         filePath: String,
-    ): Map<String, Any> {
-        // Mock implementation - pretend recovery succeeded
-        return mapOf(
-            "success" to true,
-            "file_path" to filePath,
-        )
-    }
+    ): ByteArray = keyData.copyOf()
+
+    private fun randomHex(bytes: Int): String = ByteArray(bytes).apply { random.nextBytes(this) }.joinToString("") { "%02x".format(it) }
 
     override suspend fun createDestination(
         identity: Identity,

--- a/reticulum/src/main/java/network/columba/app/reticulum/protocol/NativeReticulumProtocol.kt
+++ b/reticulum/src/main/java/network/columba/app/reticulum/protocol/NativeReticulumProtocol.kt
@@ -923,26 +923,7 @@ class NativeReticulumProtocol(
     override suspend fun createIdentityWithName(displayName: String): Map<String, Any> =
         withContext(Dispatchers.IO) {
             val identity = NativeIdentity.create()
-            val hexHash = identity.hexHash
-            val path = "$storagePath/identities/$hexHash"
-            java.io
-                .File(path)
-                .parentFile
-                ?.mkdirs()
-            identity.toFile(path)
-            mapOf(
-                "success" to true,
-                "identity_hash" to hexHash,
-                "display_name" to displayName,
-                "public_key" to identity.getPublicKey(),
-            )
-        }
-
-    override suspend fun deleteIdentityFile(identityHash: String): Map<String, Any> =
-        withContext(Dispatchers.IO) {
-            val path = "$storagePath/identities/$identityHash"
-            val deleted = java.io.File(path).delete()
-            mapOf("success" to deleted)
+            buildIdentityResult(identity, displayName)
         }
 
     override suspend fun importIdentityFile(
@@ -953,51 +934,60 @@ class NativeReticulumProtocol(
             val identity =
                 NativeIdentity.fromBytes(fileData)
                     ?: return@withContext mapOf("success" to false, "error" to "Invalid identity data")
-            val hexHash = identity.hexHash
-            val path = "$storagePath/identities/$hexHash"
-            java.io
-                .File(path)
-                .parentFile
-                ?.mkdirs()
-            identity.toFile(path)
-            mapOf(
-                "success" to true,
-                "identity_hash" to hexHash,
-                "display_name" to displayName,
-                "public_key" to identity.getPublicKey(),
-            )
+            buildIdentityResult(identity, displayName)
         }
 
     override suspend fun exportIdentityFile(
-        identityHash: String,
+        keyData: ByteArray,
         filePath: String,
     ): ByteArray =
         withContext(Dispatchers.IO) {
-            val path = "$storagePath/identities/$identityHash"
-            val file = java.io.File(path)
-            if (!file.exists()) throw java.io.FileNotFoundException("Identity file not found: $identityHash")
-            val data = file.readBytes()
-            // Also write to the export path
-            java.io.File(filePath).writeBytes(data)
-            data
+            // Caller already holds the decrypted 64-byte key from the Keystore-
+            // wrapped DB blob. We just write it to the user-chosen export path.
+            // Parent dir is expected to exist (typically a cache dir or SAF
+            // scratch file); if it doesn't, let the IOException propagate.
+            java.io.File(filePath).writeBytes(keyData)
+            keyData
         }
 
-    override suspend fun recoverIdentityFile(
-        identityHash: String,
-        keyData: ByteArray,
-        filePath: String,
-    ): Map<String, Any> =
-        withContext(Dispatchers.IO) {
-            val identity =
-                NativeIdentity.fromBytes(keyData)
-                    ?: return@withContext mapOf("success" to false, "error" to "Invalid key data")
-            identity.toFile(filePath)
-            mapOf(
-                "success" to true,
-                "identity_hash" to identity.hexHash,
-                "public_key" to identity.getPublicKey(),
+    /**
+     * Assemble the map returned by create/import. We do not write the private
+     * key to `$storagePath/identities/` — callers hand the raw bytes to
+     * `IdentityKeyProvider` which Keystore-wraps them before persistence, and
+     * the app layer passes `deliveryIdentityKey` in-memory to the native stack
+     * via `ReticulumConfig`.
+     *
+     * The LXMF delivery destination hash is computed locally from the identity
+     * without going through the live router, so identities can be created /
+     * imported regardless of whether the service is up or which identity is
+     * currently active.
+     */
+    private fun buildIdentityResult(
+        identity: NativeIdentity,
+        displayName: String,
+    ): Map<String, Any> {
+        val deliveryDest =
+            NativeDestination.create(
+                identity = identity,
+                direction = network.reticulum.common.DestinationDirection.IN,
+                type = NativeDestinationType.SINGLE,
+                appName = "lxmf",
+                "delivery",
             )
-        }
+        return mapOf(
+            "success" to true,
+            "identity_hash" to identity.hexHash,
+            "destination_hash" to deliveryDest.hexHash,
+            "display_name" to displayName,
+            "public_key" to identity.getPublicKey(),
+            "key_data" to identity.getPrivateKey(),
+            // Empty path signals "no file on disk" to legacy callers that still
+            // read `filePath` from LocalIdentityEntity — the key lives in Room
+            // now (encrypted via Android Keystore) and is fetched through
+            // IdentityKeyProvider.
+            "file_path" to "",
+        )
+    }
 
     // ==================== Phase 2: Message Sending ====================
 

--- a/reticulum/src/main/java/network/columba/app/reticulum/protocol/ReticulumProtocol.kt
+++ b/reticulum/src/main/java/network/columba/app/reticulum/protocol/ReticulumProtocol.kt
@@ -1,5 +1,10 @@
 package network.columba.app.reticulum.protocol
 
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.SharedFlow
+import kotlinx.coroutines.flow.StateFlow
 import network.columba.app.reticulum.model.AnnounceEvent
 import network.columba.app.reticulum.model.Destination
 import network.columba.app.reticulum.model.DestinationType
@@ -14,11 +19,6 @@ import network.columba.app.reticulum.model.PacketReceipt
 import network.columba.app.reticulum.model.PacketType
 import network.columba.app.reticulum.model.ReceivedPacket
 import network.columba.app.reticulum.model.ReticulumConfig
-import kotlinx.coroutines.flow.Flow
-import kotlinx.coroutines.flow.MutableSharedFlow
-import kotlinx.coroutines.flow.MutableStateFlow
-import kotlinx.coroutines.flow.SharedFlow
-import kotlinx.coroutines.flow.StateFlow
 
 /**
  * Clean abstraction layer for Reticulum Network Stack.
@@ -45,10 +45,16 @@ interface ReticulumProtocol {
 
     suspend fun recallIdentity(hash: ByteArray): Identity?
 
-    // Multi-identity management
+    // Multi-identity management.
+    //
+    // These methods never write plaintext private keys to the app's internal
+    // filesystem. `createIdentityWithName` and `importIdentityFile` return the
+    // raw 64-byte key via the `key_data` map entry; callers are expected to
+    // hand it to `IdentityKeyProvider` which wraps it with the Android
+    // Keystore before writing to Room. `exportIdentityFile` takes the already-
+    // decrypted bytes and writes to a user-chosen `filePath` (typically a SAF
+    // URI-backed scratch file) for the user to share via the system chooser.
     suspend fun createIdentityWithName(displayName: String): Map<String, Any>
-
-    suspend fun deleteIdentityFile(identityHash: String): Map<String, Any>
 
     suspend fun importIdentityFile(
         fileData: ByteArray,
@@ -56,15 +62,9 @@ interface ReticulumProtocol {
     ): Map<String, Any>
 
     suspend fun exportIdentityFile(
-        identityHash: String,
-        filePath: String,
-    ): ByteArray
-
-    suspend fun recoverIdentityFile(
-        identityHash: String,
         keyData: ByteArray,
         filePath: String,
-    ): Map<String, Any>
+    ): ByteArray
 
     // Destination management
     suspend fun createDestination(


### PR DESCRIPTION
## Summary

`NativeReticulumProtocol.createIdentityWithName` and `importIdentityFile` were writing raw 64-byte private keys to `files/reticulum/identities/<hash>` before the caller Keystore-wrapped them into Room. That left a **transient plaintext window** between user action and the next cold-boot scrub — long enough for Android Auto Backup to capture the key if it fired in that interval. The previous mitigation (#790 added a targeted `reticulum/identities` backup exclusion) closed the window for cloud backups but didn't help unencrypted ADB/local backups.

This PR closes the window at the source: no plaintext private key ever touches disk during create/import.

## Protocol API changes

- **`createIdentityWithName`** — create the `NativeIdentity` in memory, return the 64-byte key via `result["key_data"]` alongside the LXMF delivery-destination hash (computed locally from the identity; no router round-trip). No file write.
- **`importIdentityFile`** — parse the bytes the user imports, return them for Keystore-wrapping. No file write.
- **`exportIdentityFile`** — signature changes from `(identityHash, filePath)` to `(keyData, filePath)`. Callers decrypt via `IdentityKeyProvider` and hand the bytes in; the protocol just writes to the user-chosen export path (typically a cache scratch file for the system share sheet).
- **`deleteIdentityFile`** and **`recoverIdentityFile`** are gone. Nothing to delete when nothing is written; nothing to recover when the key lives Keystore-wrapped in Room.

## App-layer updates

- `IdentityManagerViewModel`: inject `IdentityKeyProvider`. Drop the file-existence check + recovery call in `switchToIdentity` (service gets the key in-memory via `ReticulumConfig.deliveryIdentityKey` from `InterfaceConfigManager`). Drop the `deleteIdentityFile` call in `deleteIdentity`. Fetch decrypted `keyData` before calling `exportIdentityFile`.
- `MigrationImporter`: drop the `recoverIdentityFile` call and the `ReticulumProtocol` dependency altogether.

## Backup rules

The `reticulum/identities` exclusion that #790 added can now go — the directory is never written. `backup_rules.xml` security policy comment updated to reflect the full chain of refactors that reached this state:

- #785 — delivery identity flows in-memory
- reticulum-kt #28 — transport identity in-memory
- reticulum-kt #30/31 — RNS routing state → Room
- reticulum-kt #32 — LXMF delivery ratchets → Room
- this PR — create/import/recover/export no longer use files

## Scrub

`ColumbaApplication` still scrubs `identity_<hash>` (pre-#785 layout) and `identities/<hash>` (post-#785, pre-this-refactor layout) on cold start — for upgraders. The comment now marks these as legacy-cleanup passes rather than active-window closers.

## Verification

- [x] `:app:assembleNoSentryDebug`
- [x] `:app:testNoSentryDebugUnitTest` (5810 pass / 15 skipped / 0 fail)
- [x] `:app:detekt`
- [ ] Manual: install on a device, create a new identity via the UI, verify no file lands in `files/reticulum/identities/`. Import an identity from a file, same check. Export an identity via the share sheet, verify the exported blob is valid. Run `bmgr backupnow` + uninstall + reinstall, confirm identity + data come back.

🤖 Generated with [Claude Code](https://claude.com/claude-code)