### PR TITLE
Bump LXMF-kt to v0.0.4

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -20,7 +20,7 @@ coil = "2.7.0"
 
 # JitPack-published libraries (formerly git submodules)
 reticulumKt = "v0.0.6"
-lxmfKt = "v0.0.3"
+lxmfKt = "v0.0.4"
 lxstKt = "v0.0.3"
 
 [libraries]


### PR DESCRIPTION
Pulls in LXMF-kt PR #7 — the ratchet filename fix that appends \`.ratchets\` to match the Python LXMF reference, plus a best-effort one-time migration that renames legacy \`<hash>\` files to \`<hash>.ratchets\`.

No behavioural change for Columba itself: \`rns-android\` uses the Keystore-wrapped \`DestinationRatchetStore\` introduced in reticulum-kt v0.0.6, so the filename on disk is dormant. Value is for cross-implementation interop (Sideband migration, etc.).

Closes out the last open item in the backup/interop cleanup chain.

## Verification

- [x] \`:app:assembleNoSentryDebug\` against v0.0.4 from JitPack

🤖 Generated with [Claude Code](https://claude.com/claude-code)