### PR TITLE
Register MIGRATION_2_3 + destinationRatchetStore in NativeReticulumProtocol

### DIFF
--- a/reticulum/src/main/java/network/columba/app/reticulum/protocol/NativeReticulumProtocol.kt
+++ b/reticulum/src/main/java/network/columba/app/reticulum/protocol/NativeReticulumProtocol.kt
@@ -355,6 +355,7 @@ class NativeReticulumProtocol(
                     "reticulum.db",
                 ).addMigrations(
                     network.reticulum.android.db.ReticulumDatabase.MIGRATION_1_2,
+                    network.reticulum.android.db.ReticulumDatabase.MIGRATION_2_3,
                 ).build()
 
         val executor =
@@ -380,6 +381,9 @@ class NativeReticulumProtocol(
         Transport.discoveryStore =
             network.reticulum.android.db.store
                 .RoomDiscoveryStore(db.discoveredInterfaceDao(), executor)
+        Transport.destinationRatchetStore =
+            network.reticulum.android.db.store
+                .RoomDestinationRatchetStore(db.destinationRatchetDao(), executor)
         network.reticulum.identity.Identity.identityStore =
             network.reticulum.android.db.store.RoomIdentityStore(
                 db.knownDestinationDao(),
@@ -389,9 +393,10 @@ class NativeReticulumProtocol(
 
         network.reticulum.android.db
             .FileMigrator(
-                db,
-                "$configDir/storage",
-                "$configDir/cache",
+                db = db,
+                storagePath = "$configDir/storage",
+                cachePath = "$configDir/cache",
+                lxmfRatchetsPath = "$configDir/lxmf/ratchets",
             ).migrateIfNeeded()
 
         Log.i(TAG, "Native Reticulum Room stores initialized")
@@ -403,6 +408,7 @@ class NativeReticulumProtocol(
         Transport.tunnelStore = null
         Transport.announceStore = null
         Transport.discoveryStore = null
+        Transport.destinationRatchetStore = null
         network.reticulum.identity.Identity.identityStore = null
 
         reticulumDbWriteExecutor?.let { executor ->


### PR DESCRIPTION
## Summary

**Critical bug found during manual verification of #793.** Columba builds its own `ReticulumDatabase` in `NativeReticulumProtocol` rather than going through rns-android's `ReticulumService` (since PR #785 the Reticulum stack runs in-process). When reticulum-kt v0.0.6 added `MIGRATION_2_3` + the `destination_ratchets` table + `RoomDestinationRatchetStore`, rns-android's `ReticulumService` was updated but Columba's duplicate setup wasn't — so v0.0.6 APKs would:

1. Open the existing v2 reticulum.db
2. Throw `IllegalStateException: A migration from 2 to 3 was required but not found` at `RoomIdentityStore.loadAllKnownDestinations`
3. `Failed to initialize Reticulum: ...`
4. LXMF-kt's ratchet code, unable to find the now-expected `Transport.destinationRatchetStore`, falls back to writing ratchet **private keys** to `files/reticulum/lxmf/ratchets/<hash>.ratchets`

This silently defeated the whole #791-through-#793 backup-unlock chain on any device that already had a v2 reticulum.db.

## Changes

Mirror `rns-android/ReticulumService.onCreate`'s DB setup in `NativeReticulumProtocol.initializePersistentStores`:

- Add `MIGRATION_2_3` to the `addMigrations` call.
- Wire `Transport.destinationRatchetStore = RoomDestinationRatchetStore(db.destinationRatchetDao(), executor)`.
- Pass `lxmfRatchetsPath = "$configDir/lxmf/ratchets"` to `FileMigrator` so it imports legacy LXMF ratchet files into the new table and scrubs the directory.
- Null out `Transport.destinationRatchetStore` in `closePersistentStores` alongside the other store references.

## Verification

Device-verified on 10.0.0.71:

**Before fix (versionCode 1006122):**
```
files/reticulum/lxmf/ratchets/ : 6 files totaling ~18KB
reticulum.db schema: v2 (missing destination_ratchets table)
Logcat: IllegalStateException: A migration from 2 to 3 was required but not found
```

**After fix (versionCode 1006123):**
```
$ adb logcat | grep FileMigrator
FileMigrator: Migrated 6 destination ratchets
NativeReticulumProtocol: Native Reticulum Room stores initialized

$ adb shell run-as network.columba.app ls files/reticulum/lxmf/
propagation_nodes    # (non-sensitive, public info)

$ sqlite3 reticulum.db "SELECT COUNT(*) FROM destination_ratchets"
5    # (6 migrated, one dedup on upsert)
```

## Follow-up thought

Columba having its own copy of the Room setup instead of reusing rns-android's is a footgun — reticulum-kt's FileMigrator and stores are designed as one coherent unit, and every upstream schema change has to be mirrored here. Worth considering consolidating post-verification. Not in scope for this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)