### PR TITLE
Route to IdentityUnlockScreen when Keystore-wrapped identity can't be decrypted after restore

### DIFF
--- a/app/src/main/java/network/columba/app/ColumbaApplication.kt
+++ b/app/src/main/java/network/columba/app/ColumbaApplication.kt
@@ -448,8 +448,15 @@ class ColumbaApplication : Application() {
                         "Active identity ${activeIdentity.identityHash.take(8)}... present but key decryption " +
                             "returned null - skipping init to avoid silently substituting a fresh identity",
                     )
+                    // Raise the unlock flag so the UI routes to IdentityUnlockScreen
+                    // instead of showing a broken chats tab. Most common cause is an
+                    // Auto Backup restore on a new device — the encrypted key blob
+                    // came back but the Keystore AES key that produced it didn't.
+                    settingsRepository.setNeedsIdentityUnlock(true)
                     return@launch
                 }
+                // Clear any stale flag from a previous failed boot.
+                settingsRepository.setNeedsIdentityUnlock(false)
 
                 // Auto-initialize Reticulum with config from database
                 android.util.Log.d("ColumbaApplication", "Auto-initializing Reticulum...")
@@ -741,8 +748,10 @@ class ColumbaApplication : Application() {
                     "initializeReticulumService: Active identity ${activeIdentity.identityHash.take(8)}... " +
                         "present but key decryption returned null - skipping init",
                 )
+                settingsRepository.setNeedsIdentityUnlock(true)
                 return
             }
+            settingsRepository.setNeedsIdentityUnlock(false)
 
             // Initialize Reticulum with config from database
             android.util.Log.d("ColumbaApplication", "initializeReticulumService: Initializing Reticulum...")

--- a/app/src/main/java/network/columba/app/MainActivity.kt
+++ b/app/src/main/java/network/columba/app/MainActivity.kt
@@ -630,12 +630,18 @@ fun ColumbaNavigation(
     }
 
     // If `needsIdentityUnlock` flips after the NavHost has already started (e.g.
-    // a later identity decryption failure), redirect to the unlock screen.
+    // a later identity decryption failure), redirect to the unlock screen. The
+    // currentDestination null-check gates on the NavHost actually having called
+    // setGraph() — without it we can fire in the recomposition window between
+    // `startDestination` resolving and the NavHost branch materializing, and
+    // `navController.graph` throws IllegalStateException. In that window the
+    // first LaunchedEffect has already picked IdentityUnlock as the start
+    // destination, so no redirect is needed here.
     LaunchedEffect(onboardingState.hasCompletedOnboarding, needsIdentityUnlock) {
         if (startDestination == null) return@LaunchedEffect
-        val currentRoute = navController.currentDestination?.route
+        val currentDestination = navController.currentDestination ?: return@LaunchedEffect
         if (!onboardingState.hasCompletedOnboarding) return@LaunchedEffect
-        if (needsIdentityUnlock && currentRoute != Screen.IdentityUnlock.route) {
+        if (needsIdentityUnlock && currentDestination.route != Screen.IdentityUnlock.route) {
             Log.d("ColumbaNavigation", "Redirecting to IdentityUnlock (key decryption failed)")
             navController.navigate(Screen.IdentityUnlock.route) {
                 popUpTo(navController.graph.startDestinationId) { inclusive = true }

--- a/app/src/main/java/network/columba/app/MainActivity.kt
+++ b/app/src/main/java/network/columba/app/MainActivity.kt
@@ -1089,6 +1089,13 @@ fun ColumbaNavigation(
                             composable(Screen.IdentityUnlock.route) {
                                 network.columba.app.ui.screens.IdentityUnlockScreen(
                                     onResolved = {
+                                        // ColumbaApplication bailed out of Reticulum init when
+                                        // the key decrypt failed at cold-start. Now that the
+                                        // re-wrap put a usable encryptedKeyData back on the row,
+                                        // kick the service so the native stack comes up with
+                                        // the restored identity — otherwise the user lands on
+                                        // Chats with read-only history and sends silently fail.
+                                        settingsViewModel.restartService()
                                         navController.navigate(Screen.Chats.route) {
                                             popUpTo(Screen.IdentityUnlock.route) { inclusive = true }
                                         }

--- a/app/src/main/java/network/columba/app/MainActivity.kt
+++ b/app/src/main/java/network/columba/app/MainActivity.kt
@@ -22,6 +22,7 @@ import androidx.activity.result.contract.ActivityResultContracts
 import androidx.compose.animation.core.tween
 import androidx.compose.animation.fadeIn
 import androidx.compose.animation.fadeOut
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.material.icons.Icons
@@ -612,36 +613,32 @@ fun ColumbaNavigation(
     val onboardingState by onboardingViewModel.state.collectAsState()
     val needsIdentityUnlock by onboardingViewModel.needsIdentityUnlock.collectAsState()
 
-    // Determine start destination based on onboarding + unlock status
-    // IMPORTANT: Use remember to compute this only once. Without remember,
-    // the startDestination would be recalculated when onboardingState loads
-    // asynchronously from DataStore, which causes NavHost to reset to the
-    // new startDestination and discard any pending navigation.
-    val startDestination =
-        remember {
+    // Determine start destination based on onboarding + unlock status.
+    // Held null until onboardingState finishes loading from DataStore, then
+    // latched to the resolved route. The NavHost isn't rendered until this
+    // is non-null, so the splash screen covers the async load and the user
+    // never sees the Welcome wizard flash for a frame before the redirect.
+    var startDestination by remember { mutableStateOf<String?>(null) }
+    LaunchedEffect(onboardingState.isLoading, onboardingState.hasCompletedOnboarding, needsIdentityUnlock) {
+        if (onboardingState.isLoading || startDestination != null) return@LaunchedEffect
+        startDestination =
             when {
                 onboardingState.hasCompletedOnboarding && needsIdentityUnlock -> Screen.IdentityUnlock.route
                 onboardingState.hasCompletedOnboarding -> Screen.Chats.route
                 else -> Screen.Welcome.route
             }
-        }
+    }
 
-    // Handle edge case: user completed onboarding but we started at Welcome
-    // because onboardingState was still loading when startDestination was computed
+    // If `needsIdentityUnlock` flips after the NavHost has already started (e.g.
+    // a later identity decryption failure), redirect to the unlock screen.
     LaunchedEffect(onboardingState.hasCompletedOnboarding, needsIdentityUnlock) {
+        if (startDestination == null) return@LaunchedEffect
         val currentRoute = navController.currentDestination?.route
         if (!onboardingState.hasCompletedOnboarding) return@LaunchedEffect
         if (needsIdentityUnlock && currentRoute != Screen.IdentityUnlock.route) {
             Log.d("ColumbaNavigation", "Redirecting to IdentityUnlock (key decryption failed)")
             navController.navigate(Screen.IdentityUnlock.route) {
                 popUpTo(navController.graph.startDestinationId) { inclusive = true }
-            }
-            return@LaunchedEffect
-        }
-        if (currentRoute == Screen.Welcome.route && pendingNavigation.value == null) {
-            Log.d("ColumbaNavigation", "Redirecting to Chats (onboarding already completed)")
-            navController.navigate(Screen.Chats.route) {
-                popUpTo(Screen.Welcome.route) { inclusive = true }
             }
         }
     }
@@ -1053,1099 +1050,1104 @@ fun ColumbaNavigation(
                         onReconnect = { settingsViewModel.restartService() },
                         hasCompletedOnboarding = onboardingState.hasCompletedOnboarding,
                     )
-                    NavHost(
-                        modifier = Modifier.weight(1f),
-                        navController = navController,
-                        startDestination = startDestination,
-                        enterTransition = { fadeIn(tween(150)) },
-                        exitTransition = { fadeOut(tween(75)) },
-                        popEnterTransition = { fadeIn(tween(150)) },
-                        popExitTransition = { fadeOut(tween(75)) },
-                    ) {
-                        composable(Screen.Welcome.route) {
-                            OnboardingPagerScreen(
-                                onOnboardingComplete = { navigateToRNodeWizard ->
-                                    navController.navigate(Screen.Chats.route) {
-                                        popUpTo(Screen.Welcome.route) { inclusive = true }
-                                    }
-                                    // Navigate to RNode wizard if LoRa Radio was selected
-                                    if (navigateToRNodeWizard) {
-                                        navController.navigate("rnode_wizard")
-                                    }
-                                },
-                                onImportData = {
-                                    navController.navigate("migration")
-                                },
-                            )
-                        }
-
-                        composable(Screen.IdentityUnlock.route) {
-                            network.columba.app.ui.screens.IdentityUnlockScreen(
-                                onResolved = {
-                                    navController.navigate(Screen.Chats.route) {
-                                        popUpTo(Screen.IdentityUnlock.route) { inclusive = true }
-                                    }
-                                },
-                            )
-                        }
-
-                        composable(Screen.Chats.route) {
-                            DoubleBackToExitHandler(Screen.Chats.route)
-                            ChatsScreen(
-                                onChatClick = { destinationHash, peerName ->
-                                    val encodedHash = Uri.encode(destinationHash)
-                                    val encodedName = Uri.encode(peerName)
-                                    navController.navigate("messaging/$encodedHash/$encodedName")
-                                },
-                                onViewPeerDetails = { peerHash ->
-                                    val encodedHash = Uri.encode(peerHash)
-                                    navController.navigate("announce_detail/$encodedHash")
-                                },
-                                onLocateOnMap = { peerHash ->
-                                    mapViewModel.focusOnContact(peerHash)
-                                    navController.navigate(Screen.Map.route) {
-                                        popUpTo(navController.graph.startDestinationId) {
-                                            saveState = true
+                    val resolvedStartDestination = startDestination
+                    if (resolvedStartDestination == null) {
+                        Box(modifier = Modifier.weight(1f))
+                    } else {
+                        NavHost(
+                            modifier = Modifier.weight(1f),
+                            navController = navController,
+                            startDestination = resolvedStartDestination,
+                            enterTransition = { fadeIn(tween(150)) },
+                            exitTransition = { fadeOut(tween(75)) },
+                            popEnterTransition = { fadeIn(tween(150)) },
+                            popExitTransition = { fadeOut(tween(75)) },
+                        ) {
+                            composable(Screen.Welcome.route) {
+                                OnboardingPagerScreen(
+                                    onOnboardingComplete = { navigateToRNodeWizard ->
+                                        navController.navigate(Screen.Chats.route) {
+                                            popUpTo(Screen.Welcome.route) { inclusive = true }
                                         }
-                                        launchSingleTop = true
-                                        restoreState = true
-                                    }
-                                },
-                                onNavigateToQrScanner = {
-                                    navController.navigate("qr_scanner")
-                                },
-                                settingsViewModel = settingsViewModel,
-                            )
-                        }
-
-                        composable(
-                            route = "${Screen.Announces.route}?filterType={filterType}",
-                            arguments =
-                                listOf(
-                                    navArgument("filterType") {
-                                        type = NavType.StringType
-                                        nullable = true
-                                        defaultValue = null
-                                    },
-                                ),
-                        ) { backStackEntry ->
-                            val filterType = backStackEntry.arguments?.getString("filterType")
-                            AnnounceStreamScreen(
-                                initialFilterType = filterType,
-                                onPeerClick = { destinationHash, _ ->
-                                    val encodedHash = Uri.encode(destinationHash)
-                                    navController.navigate("announce_detail/$encodedHash")
-                                },
-                                onStartChat = { destinationHash, peerName ->
-                                    val encodedHash = Uri.encode(destinationHash)
-                                    val encodedName = Uri.encode(peerName)
-                                    navController.navigate("messaging/$encodedHash/$encodedName")
-                                },
-                            )
-                        }
-
-                        composable(Screen.Contacts.route) {
-                            DoubleBackToExitHandler(Screen.Contacts.route)
-                            val contactsViewModel: ContactsViewModel = hiltViewModel()
-                            ContactsScreen(
-                                onContactClick = { destinationHash, displayName ->
-                                    val encodedHash = Uri.encode(destinationHash)
-                                    navController.navigate("announce_detail/$encodedHash")
-                                },
-                                onViewPeerDetails = { destinationHash ->
-                                    val encodedHash = Uri.encode(destinationHash)
-                                    navController.navigate("announce_detail/$encodedHash")
-                                },
-                                onLocateOnMap = { peerHash ->
-                                    mapViewModel.focusOnContact(peerHash)
-                                    navController.navigate(Screen.Map.route) {
-                                        popUpTo(navController.graph.startDestinationId) {
-                                            saveState = true
+                                        // Navigate to RNode wizard if LoRa Radio was selected
+                                        if (navigateToRNodeWizard) {
+                                            navController.navigate("rnode_wizard")
                                         }
-                                        launchSingleTop = true
-                                        restoreState = true
-                                    }
-                                },
-                                onNavigateToQrScanner = {
-                                    navController.navigate("qr_scanner")
-                                },
-                                pendingDeepLinkContact = pendingContactAdd,
-                                onDeepLinkContactProcessed = {
-                                    pendingContactAdd = null
-                                },
-                                onNavigateToConversation = { destinationHash ->
-                                    val contacts = contactsViewModel.contacts.value
-                                    val contact = contacts.find { it.destinationHash == destinationHash }
-                                    val peerName = contact?.displayName ?: destinationHash.take(16)
-                                    val encodedHash = Uri.encode(destinationHash)
-                                    val encodedName = Uri.encode(peerName)
-                                    navController.navigate("messaging/$encodedHash/$encodedName")
-                                },
-                                onStartChat = { destinationHash, peerName ->
-                                    val encodedHash = Uri.encode(destinationHash)
-                                    val encodedName = Uri.encode(peerName)
-                                    navController.navigate("messaging/$encodedHash/$encodedName")
-                                },
-                            )
-                        }
-
-                        composable(Screen.Map.route) {
-                            DoubleBackToExitHandler(Screen.Map.route)
-                            MapScreen(
-                                viewModel = mapViewModel,
-                                onNavigateToConversation = { destinationHash ->
-                                    // Navigate to messaging screen with the contact
-                                    val encodedHash = Uri.encode(destinationHash)
-                                    // Use a placeholder name - the messaging screen will fetch the actual name
-                                    navController.navigate("messaging/$encodedHash/Contact")
-                                },
-                                onNavigateToOfflineMaps = {
-                                    navController.navigate("offline_maps")
-                                },
-                                onNavigateToRNodeWizardWithParams = { frequency, bandwidth, sf, cr ->
-                                    navController.navigate(
-                                        "rnode_wizard?loraFrequency=${frequency ?: -1L}" +
-                                            "&loraBandwidth=${bandwidth ?: -1}" +
-                                            "&loraSf=${sf ?: -1}" +
-                                            "&loraCr=${cr ?: -1}",
-                                    )
-                                },
-                                permissionSheetDismissed = mapPermissionSheetDismissed,
-                                onPermissionSheetDismissed = { mapPermissionSheetDismissed = true },
-                                permissionCardDismissed = mapPermissionCardDismissed,
-                                onPermissionCardDismissed = { mapPermissionCardDismissed = true },
-                            )
-                        }
-
-                        // Map with focus location (for discovered interfaces)
-                        composable(
-                            route =
-                                "map_focus?lat={lat}&lon={lon}&label={label}&type={type}&height={height}" +
-                                    "&reachableOn={reachableOn}&port={port}&frequency={frequency}&bandwidth={bandwidth}" +
-                                    "&sf={sf}&cr={cr}&modulation={modulation}&status={status}&lastHeard={lastHeard}&hops={hops}",
-                            arguments =
-                                listOf(
-                                    navArgument("lat") {
-                                        type = NavType.FloatType
-                                        defaultValue = 0f
                                     },
-                                    navArgument("lon") {
-                                        type = NavType.FloatType
-                                        defaultValue = 0f
+                                    onImportData = {
+                                        navController.navigate("migration")
                                     },
-                                    navArgument("label") {
-                                        type = NavType.StringType
-                                        defaultValue = ""
-                                    },
-                                    navArgument("type") {
-                                        type = NavType.StringType
-                                        defaultValue = ""
-                                    },
-                                    navArgument("height") {
-                                        type = NavType.FloatType
-                                        defaultValue = Float.NaN
-                                    },
-                                    navArgument("reachableOn") {
-                                        type = NavType.StringType
-                                        defaultValue = ""
-                                    },
-                                    navArgument("port") {
-                                        type = NavType.IntType
-                                        defaultValue = -1
-                                    },
-                                    navArgument("frequency") {
-                                        type = NavType.LongType
-                                        defaultValue = -1L
-                                    },
-                                    navArgument("bandwidth") {
-                                        type = NavType.IntType
-                                        defaultValue = -1
-                                    },
-                                    navArgument("sf") {
-                                        type = NavType.IntType
-                                        defaultValue = -1
-                                    },
-                                    navArgument("cr") {
-                                        type = NavType.IntType
-                                        defaultValue = -1
-                                    },
-                                    navArgument("modulation") {
-                                        type = NavType.StringType
-                                        defaultValue = ""
-                                    },
-                                    navArgument("status") {
-                                        type = NavType.StringType
-                                        defaultValue = ""
-                                    },
-                                    navArgument("lastHeard") {
-                                        type = NavType.LongType
-                                        defaultValue = -1L
-                                    },
-                                    navArgument("hops") {
-                                        type = NavType.IntType
-                                        defaultValue = -1
-                                    },
-                                ),
-                        ) { backStackEntry ->
-                            val lat = backStackEntry.arguments?.getFloat("lat")?.toDouble()
-                            val lon = backStackEntry.arguments?.getFloat("lon")?.toDouble()
-                            val label = backStackEntry.arguments?.getString("label")
-                            val type = backStackEntry.arguments?.getString("type")
-                            val height = backStackEntry.arguments?.getFloat("height")?.toDouble()
-                            val reachableOn = backStackEntry.arguments?.getString("reachableOn")
-                            val port = backStackEntry.arguments?.getInt("port")
-                            val frequency = backStackEntry.arguments?.getLong("frequency")
-                            val bandwidth = backStackEntry.arguments?.getInt("bandwidth")
-                            val sf = backStackEntry.arguments?.getInt("sf")
-                            val cr = backStackEntry.arguments?.getInt("cr")
-                            val modulation = backStackEntry.arguments?.getString("modulation")
-                            val status = backStackEntry.arguments?.getString("status")
-                            val lastHeard = backStackEntry.arguments?.getLong("lastHeard")
-                            val hops = backStackEntry.arguments?.getInt("hops")
-
-                            // Build FocusInterfaceDetails if we have valid lat/lon
-                            val focusDetails =
-                                buildFocusInterfaceDetails(
-                                    lat = lat,
-                                    lon = lon,
-                                    label = label,
-                                    type = type,
-                                    height = height,
-                                    reachableOn = reachableOn,
-                                    port = port,
-                                    frequency = frequency,
-                                    bandwidth = bandwidth,
-                                    sf = sf,
-                                    cr = cr,
-                                    modulation = modulation,
-                                    status = status,
-                                    lastHeard = lastHeard,
-                                    hops = hops,
                                 )
+                            }
 
-                            MapScreen(
-                                viewModel = mapViewModel,
-                                onNavigateToConversation = { destinationHash ->
-                                    val encodedHash = Uri.encode(destinationHash)
-                                    navController.navigate("messaging/$encodedHash/Contact")
-                                },
-                                onNavigateToOfflineMaps = {
-                                    navController.navigate("offline_maps")
-                                },
-                                onNavigateToRNodeWizardWithParams = { frequency, bandwidth, sf, cr ->
-                                    navController.navigate(
-                                        "rnode_wizard?loraFrequency=${frequency ?: -1L}" +
-                                            "&loraBandwidth=${bandwidth ?: -1}" +
-                                            "&loraSf=${sf ?: -1}" +
-                                            "&loraCr=${cr ?: -1}",
+                            composable(Screen.IdentityUnlock.route) {
+                                network.columba.app.ui.screens.IdentityUnlockScreen(
+                                    onResolved = {
+                                        navController.navigate(Screen.Chats.route) {
+                                            popUpTo(Screen.IdentityUnlock.route) { inclusive = true }
+                                        }
+                                    },
+                                )
+                            }
+
+                            composable(Screen.Chats.route) {
+                                DoubleBackToExitHandler(Screen.Chats.route)
+                                ChatsScreen(
+                                    onChatClick = { destinationHash, peerName ->
+                                        val encodedHash = Uri.encode(destinationHash)
+                                        val encodedName = Uri.encode(peerName)
+                                        navController.navigate("messaging/$encodedHash/$encodedName")
+                                    },
+                                    onViewPeerDetails = { peerHash ->
+                                        val encodedHash = Uri.encode(peerHash)
+                                        navController.navigate("announce_detail/$encodedHash")
+                                    },
+                                    onLocateOnMap = { peerHash ->
+                                        mapViewModel.focusOnContact(peerHash)
+                                        navController.navigate(Screen.Map.route) {
+                                            popUpTo(navController.graph.startDestinationId) {
+                                                saveState = true
+                                            }
+                                            launchSingleTop = true
+                                            restoreState = true
+                                        }
+                                    },
+                                    onNavigateToQrScanner = {
+                                        navController.navigate("qr_scanner")
+                                    },
+                                    settingsViewModel = settingsViewModel,
+                                )
+                            }
+
+                            composable(
+                                route = "${Screen.Announces.route}?filterType={filterType}",
+                                arguments =
+                                    listOf(
+                                        navArgument("filterType") {
+                                            type = NavType.StringType
+                                            nullable = true
+                                            defaultValue = null
+                                        },
+                                    ),
+                            ) { backStackEntry ->
+                                val filterType = backStackEntry.arguments?.getString("filterType")
+                                AnnounceStreamScreen(
+                                    initialFilterType = filterType,
+                                    onPeerClick = { destinationHash, _ ->
+                                        val encodedHash = Uri.encode(destinationHash)
+                                        navController.navigate("announce_detail/$encodedHash")
+                                    },
+                                    onStartChat = { destinationHash, peerName ->
+                                        val encodedHash = Uri.encode(destinationHash)
+                                        val encodedName = Uri.encode(peerName)
+                                        navController.navigate("messaging/$encodedHash/$encodedName")
+                                    },
+                                )
+                            }
+
+                            composable(Screen.Contacts.route) {
+                                DoubleBackToExitHandler(Screen.Contacts.route)
+                                val contactsViewModel: ContactsViewModel = hiltViewModel()
+                                ContactsScreen(
+                                    onContactClick = { destinationHash, displayName ->
+                                        val encodedHash = Uri.encode(destinationHash)
+                                        navController.navigate("announce_detail/$encodedHash")
+                                    },
+                                    onViewPeerDetails = { destinationHash ->
+                                        val encodedHash = Uri.encode(destinationHash)
+                                        navController.navigate("announce_detail/$encodedHash")
+                                    },
+                                    onLocateOnMap = { peerHash ->
+                                        mapViewModel.focusOnContact(peerHash)
+                                        navController.navigate(Screen.Map.route) {
+                                            popUpTo(navController.graph.startDestinationId) {
+                                                saveState = true
+                                            }
+                                            launchSingleTop = true
+                                            restoreState = true
+                                        }
+                                    },
+                                    onNavigateToQrScanner = {
+                                        navController.navigate("qr_scanner")
+                                    },
+                                    pendingDeepLinkContact = pendingContactAdd,
+                                    onDeepLinkContactProcessed = {
+                                        pendingContactAdd = null
+                                    },
+                                    onNavigateToConversation = { destinationHash ->
+                                        val contacts = contactsViewModel.contacts.value
+                                        val contact = contacts.find { it.destinationHash == destinationHash }
+                                        val peerName = contact?.displayName ?: destinationHash.take(16)
+                                        val encodedHash = Uri.encode(destinationHash)
+                                        val encodedName = Uri.encode(peerName)
+                                        navController.navigate("messaging/$encodedHash/$encodedName")
+                                    },
+                                    onStartChat = { destinationHash, peerName ->
+                                        val encodedHash = Uri.encode(destinationHash)
+                                        val encodedName = Uri.encode(peerName)
+                                        navController.navigate("messaging/$encodedHash/$encodedName")
+                                    },
+                                )
+                            }
+
+                            composable(Screen.Map.route) {
+                                DoubleBackToExitHandler(Screen.Map.route)
+                                MapScreen(
+                                    viewModel = mapViewModel,
+                                    onNavigateToConversation = { destinationHash ->
+                                        // Navigate to messaging screen with the contact
+                                        val encodedHash = Uri.encode(destinationHash)
+                                        // Use a placeholder name - the messaging screen will fetch the actual name
+                                        navController.navigate("messaging/$encodedHash/Contact")
+                                    },
+                                    onNavigateToOfflineMaps = {
+                                        navController.navigate("offline_maps")
+                                    },
+                                    onNavigateToRNodeWizardWithParams = { frequency, bandwidth, sf, cr ->
+                                        navController.navigate(
+                                            "rnode_wizard?loraFrequency=${frequency ?: -1L}" +
+                                                "&loraBandwidth=${bandwidth ?: -1}" +
+                                                "&loraSf=${sf ?: -1}" +
+                                                "&loraCr=${cr ?: -1}",
+                                        )
+                                    },
+                                    permissionSheetDismissed = mapPermissionSheetDismissed,
+                                    onPermissionSheetDismissed = { mapPermissionSheetDismissed = true },
+                                    permissionCardDismissed = mapPermissionCardDismissed,
+                                    onPermissionCardDismissed = { mapPermissionCardDismissed = true },
+                                )
+                            }
+
+                            // Map with focus location (for discovered interfaces)
+                            composable(
+                                route =
+                                    "map_focus?lat={lat}&lon={lon}&label={label}&type={type}&height={height}" +
+                                        "&reachableOn={reachableOn}&port={port}&frequency={frequency}&bandwidth={bandwidth}" +
+                                        "&sf={sf}&cr={cr}&modulation={modulation}&status={status}&lastHeard={lastHeard}&hops={hops}",
+                                arguments =
+                                    listOf(
+                                        navArgument("lat") {
+                                            type = NavType.FloatType
+                                            defaultValue = 0f
+                                        },
+                                        navArgument("lon") {
+                                            type = NavType.FloatType
+                                            defaultValue = 0f
+                                        },
+                                        navArgument("label") {
+                                            type = NavType.StringType
+                                            defaultValue = ""
+                                        },
+                                        navArgument("type") {
+                                            type = NavType.StringType
+                                            defaultValue = ""
+                                        },
+                                        navArgument("height") {
+                                            type = NavType.FloatType
+                                            defaultValue = Float.NaN
+                                        },
+                                        navArgument("reachableOn") {
+                                            type = NavType.StringType
+                                            defaultValue = ""
+                                        },
+                                        navArgument("port") {
+                                            type = NavType.IntType
+                                            defaultValue = -1
+                                        },
+                                        navArgument("frequency") {
+                                            type = NavType.LongType
+                                            defaultValue = -1L
+                                        },
+                                        navArgument("bandwidth") {
+                                            type = NavType.IntType
+                                            defaultValue = -1
+                                        },
+                                        navArgument("sf") {
+                                            type = NavType.IntType
+                                            defaultValue = -1
+                                        },
+                                        navArgument("cr") {
+                                            type = NavType.IntType
+                                            defaultValue = -1
+                                        },
+                                        navArgument("modulation") {
+                                            type = NavType.StringType
+                                            defaultValue = ""
+                                        },
+                                        navArgument("status") {
+                                            type = NavType.StringType
+                                            defaultValue = ""
+                                        },
+                                        navArgument("lastHeard") {
+                                            type = NavType.LongType
+                                            defaultValue = -1L
+                                        },
+                                        navArgument("hops") {
+                                            type = NavType.IntType
+                                            defaultValue = -1
+                                        },
+                                    ),
+                            ) { backStackEntry ->
+                                val lat = backStackEntry.arguments?.getFloat("lat")?.toDouble()
+                                val lon = backStackEntry.arguments?.getFloat("lon")?.toDouble()
+                                val label = backStackEntry.arguments?.getString("label")
+                                val type = backStackEntry.arguments?.getString("type")
+                                val height = backStackEntry.arguments?.getFloat("height")?.toDouble()
+                                val reachableOn = backStackEntry.arguments?.getString("reachableOn")
+                                val port = backStackEntry.arguments?.getInt("port")
+                                val frequency = backStackEntry.arguments?.getLong("frequency")
+                                val bandwidth = backStackEntry.arguments?.getInt("bandwidth")
+                                val sf = backStackEntry.arguments?.getInt("sf")
+                                val cr = backStackEntry.arguments?.getInt("cr")
+                                val modulation = backStackEntry.arguments?.getString("modulation")
+                                val status = backStackEntry.arguments?.getString("status")
+                                val lastHeard = backStackEntry.arguments?.getLong("lastHeard")
+                                val hops = backStackEntry.arguments?.getInt("hops")
+
+                                // Build FocusInterfaceDetails if we have valid lat/lon
+                                val focusDetails =
+                                    buildFocusInterfaceDetails(
+                                        lat = lat,
+                                        lon = lon,
+                                        label = label,
+                                        type = type,
+                                        height = height,
+                                        reachableOn = reachableOn,
+                                        port = port,
+                                        frequency = frequency,
+                                        bandwidth = bandwidth,
+                                        sf = sf,
+                                        cr = cr,
+                                        modulation = modulation,
+                                        status = status,
+                                        lastHeard = lastHeard,
+                                        hops = hops,
                                     )
-                                },
-                                focusLatitude = if (lat != 0.0) lat else null,
-                                focusLongitude = if (lon != 0.0) lon else null,
-                                focusLabel = label?.ifEmpty { null },
-                                focusInterfaceDetails = focusDetails,
-                                permissionSheetDismissed = mapPermissionSheetDismissed,
-                                onPermissionSheetDismissed = { mapPermissionSheetDismissed = true },
-                                permissionCardDismissed = mapPermissionCardDismissed,
-                                onPermissionCardDismissed = { mapPermissionCardDismissed = true },
-                            )
-                        }
 
-                        composable(Screen.Identity.route) {
-                            IdentityScreen(
-                                onBackClick = { navController.popBackStack() },
-                                settingsViewModel = settingsViewModel,
-                                onNavigateToBleStatus = {
-                                    navController.navigate("ble_connection_status")
-                                },
-                                onNavigateToInterfaceStats = { interfaceId ->
-                                    navController.navigate("interface_stats/$interfaceId")
-                                },
-                                onNavigateToInterfaceManagement = {
-                                    navController.navigate("interface_management")
-                                },
-                            )
-                        }
-
-                        composable(Screen.Settings.route) {
-                            DoubleBackToExitHandler(Screen.Settings.route)
-                            SettingsScreen(
-                                viewModel = settingsViewModel,
-                                crashReportManager = crashReportManager,
-                                onNavigateToInterfaces = {
-                                    navController.navigate("interface_management")
-                                },
-                                onNavigateToIdentity = {
-                                    navController.navigate("my_identity")
-                                },
-                                onNavigateToNetworkStatus = {
-                                    navController.navigate("network_status")
-                                },
-                                onNavigateToIdentityManager = {
-                                    navController.navigate("identity_manager")
-                                },
-                                onNavigateToNotifications = {
-                                    navController.navigate("notification_settings")
-                                },
-                                onNavigateToCustomThemes = {
-                                    navController.navigate("theme_management")
-                                },
-                                onNavigateToMigration = {
-                                    navController.navigate("migration")
-                                },
-                                onNavigateToApkSharing = {
-                                    navController.navigate("apk_sharing")
-                                },
-                                onNavigateToAnnounces = { filterType ->
-                                    selectedTab = 1 // Announces tab
-                                    val route =
-                                        if (filterType != null) {
-                                            "${Screen.Announces.route}?filterType=$filterType"
-                                        } else {
-                                            Screen.Announces.route
-                                        }
-                                    navController.navigate(route) {
-                                        popUpTo(navController.graph.startDestinationId) {
-                                            saveState = true
-                                        }
-                                        launchSingleTop = true
-                                        restoreState = false // Don't restore state so filter applies
-                                    }
-                                },
-                                onNavigateToFlasher = {
-                                    navController.navigate("rnode_flasher")
-                                },
-                                onNavigateToBlockedUsers = {
-                                    navController.navigate("blocked_users")
-                                },
-                            )
-                        }
-
-                        composable(
-                            route =
-                                "usb_device_action" +
-                                    "?usbDeviceId={usbDeviceId}" +
-                                    "&usbVendorId={usbVendorId}" +
-                                    "&usbProductId={usbProductId}" +
-                                    "&usbDeviceName={usbDeviceName}",
-                            arguments =
-                                listOf(
-                                    navArgument("usbDeviceId") {
-                                        type = NavType.IntType
-                                        defaultValue = -1
+                                MapScreen(
+                                    viewModel = mapViewModel,
+                                    onNavigateToConversation = { destinationHash ->
+                                        val encodedHash = Uri.encode(destinationHash)
+                                        navController.navigate("messaging/$encodedHash/Contact")
                                     },
-                                    navArgument("usbVendorId") {
-                                        type = NavType.IntType
-                                        defaultValue = -1
+                                    onNavigateToOfflineMaps = {
+                                        navController.navigate("offline_maps")
                                     },
-                                    navArgument("usbProductId") {
-                                        type = NavType.IntType
-                                        defaultValue = -1
+                                    onNavigateToRNodeWizardWithParams = { frequency, bandwidth, sf, cr ->
+                                        navController.navigate(
+                                            "rnode_wizard?loraFrequency=${frequency ?: -1L}" +
+                                                "&loraBandwidth=${bandwidth ?: -1}" +
+                                                "&loraSf=${sf ?: -1}" +
+                                                "&loraCr=${cr ?: -1}",
+                                        )
                                     },
-                                    navArgument("usbDeviceName") {
-                                        type = NavType.StringType
-                                        defaultValue = ""
-                                        nullable = true
-                                    },
-                                ),
-                        ) { backStackEntry ->
-                            val usbDeviceId = backStackEntry.arguments?.getInt("usbDeviceId") ?: -1
-                            val usbVendorId = backStackEntry.arguments?.getInt("usbVendorId") ?: -1
-                            val usbProductId = backStackEntry.arguments?.getInt("usbProductId") ?: -1
-                            val usbDeviceName = backStackEntry.arguments?.getString("usbDeviceName") ?: "USB Device"
-
-                            // State for disable transport operation
-                            val context = androidx.compose.ui.platform.LocalContext.current
-                            val coroutineScope = androidx.compose.runtime.rememberCoroutineScope()
-                            var isDisablingTransport by androidx.compose.runtime.remember {
-                                androidx.compose.runtime.mutableStateOf(false)
-                            }
-                            var disableTransportResult: Boolean? by androidx.compose.runtime.remember {
-                                androidx.compose.runtime.mutableStateOf(null)
+                                    focusLatitude = if (lat != 0.0) lat else null,
+                                    focusLongitude = if (lon != 0.0) lon else null,
+                                    focusLabel = label?.ifEmpty { null },
+                                    focusInterfaceDetails = focusDetails,
+                                    permissionSheetDismissed = mapPermissionSheetDismissed,
+                                    onPermissionSheetDismissed = { mapPermissionSheetDismissed = true },
+                                    permissionCardDismissed = mapPermissionCardDismissed,
+                                    onPermissionCardDismissed = { mapPermissionCardDismissed = true },
+                                )
                             }
 
-                            network.columba.app.ui.screens.UsbDeviceActionScreen(
-                                deviceName = usbDeviceName,
-                                onNavigateBack = { navController.popBackStack() },
-                                onFlashFirmware = {
-                                    val route =
-                                        "rnode_flasher" +
-                                            "?usbDeviceId=$usbDeviceId" +
-                                            "&usbVendorId=$usbVendorId" +
-                                            "&usbProductId=$usbProductId" +
-                                            "&usbDeviceName=${Uri.encode(usbDeviceName)}"
-                                    navController.navigate(route) {
-                                        popUpTo("usb_device_action") { inclusive = true }
-                                    }
-                                },
-                                onConfigureRNode = {
-                                    val route =
-                                        "rnode_wizard?connectionType=usb" +
-                                            "&usbDeviceId=$usbDeviceId" +
-                                            "&usbVendorId=$usbVendorId" +
-                                            "&usbProductId=$usbProductId" +
-                                            "&usbDeviceName=${Uri.encode(usbDeviceName)}"
-                                    navController.navigate(route) {
-                                        popUpTo("usb_device_action") { inclusive = true }
-                                    }
-                                },
-                                onConfigureTransport = {
-                                    val route =
-                                        "rnode_wizard?connectionType=usb" +
-                                            "&transportMode=true" +
-                                            "&usbDeviceId=$usbDeviceId" +
-                                            "&usbVendorId=$usbVendorId" +
-                                            "&usbProductId=$usbProductId" +
-                                            "&usbDeviceName=${Uri.encode(usbDeviceName)}"
-                                    navController.navigate(route) {
-                                        popUpTo("usb_device_action") { inclusive = true }
-                                    }
-                                },
-                                onDisableTransport = {
-                                    isDisablingTransport = true
-                                    coroutineScope.launch {
-                                        val flasher =
-                                            network.columba.app.reticulum.flasher
-                                                .RNodeFlasher(context)
-                                        val success = flasher.tncModeController.disableTncMode(usbDeviceId)
-                                        isDisablingTransport = false
-                                        disableTransportResult = success
-                                    }
-                                },
-                                isDisablingTransport = isDisablingTransport,
-                                disableTransportResult = disableTransportResult,
-                                onDismissDisableResult = { disableTransportResult = null },
-                            )
-                        }
+                            composable(Screen.Identity.route) {
+                                IdentityScreen(
+                                    onBackClick = { navController.popBackStack() },
+                                    settingsViewModel = settingsViewModel,
+                                    onNavigateToBleStatus = {
+                                        navController.navigate("ble_connection_status")
+                                    },
+                                    onNavigateToInterfaceStats = { interfaceId ->
+                                        navController.navigate("interface_stats/$interfaceId")
+                                    },
+                                    onNavigateToInterfaceManagement = {
+                                        navController.navigate("interface_management")
+                                    },
+                                )
+                            }
 
-                        composable(
-                            route =
-                                "rnode_flasher?skipDetection={skipDetection}&tncConfigOnly={tncConfigOnly}" +
-                                    "&usbDeviceId={usbDeviceId}" +
-                                    "&usbVendorId={usbVendorId}&usbProductId={usbProductId}&usbDeviceName={usbDeviceName}",
-                            arguments =
-                                listOf(
-                                    navArgument("skipDetection") {
-                                        type = NavType.BoolType
-                                        defaultValue = false
+                            composable(Screen.Settings.route) {
+                                DoubleBackToExitHandler(Screen.Settings.route)
+                                SettingsScreen(
+                                    viewModel = settingsViewModel,
+                                    crashReportManager = crashReportManager,
+                                    onNavigateToInterfaces = {
+                                        navController.navigate("interface_management")
                                     },
-                                    navArgument("tncConfigOnly") {
-                                        type = NavType.BoolType
-                                        defaultValue = false
+                                    onNavigateToIdentity = {
+                                        navController.navigate("my_identity")
                                     },
-                                    navArgument("usbDeviceId") {
-                                        type = NavType.IntType
-                                        defaultValue = -1
+                                    onNavigateToNetworkStatus = {
+                                        navController.navigate("network_status")
                                     },
-                                    navArgument("usbVendorId") {
-                                        type = NavType.IntType
-                                        defaultValue = -1
+                                    onNavigateToIdentityManager = {
+                                        navController.navigate("identity_manager")
                                     },
-                                    navArgument("usbProductId") {
-                                        type = NavType.IntType
-                                        defaultValue = -1
+                                    onNavigateToNotifications = {
+                                        navController.navigate("notification_settings")
                                     },
-                                    navArgument("usbDeviceName") {
-                                        type = NavType.StringType
-                                        defaultValue = ""
-                                        nullable = true
+                                    onNavigateToCustomThemes = {
+                                        navController.navigate("theme_management")
                                     },
-                                ),
-                        ) { backStackEntry ->
-                            val skipDetection = backStackEntry.arguments?.getBoolean("skipDetection") ?: false
-                            val tncConfigOnly = backStackEntry.arguments?.getBoolean("tncConfigOnly") ?: false
-                            val usbDeviceId = backStackEntry.arguments?.getInt("usbDeviceId") ?: -1
-                            RNodeFlasherScreen(
-                                onNavigateBack = { navController.popBackStack() },
-                                onComplete = { navController.popBackStack() },
-                                onNavigateToRNodeWizard = {
-                                    navController.navigate("rnode_wizard")
-                                },
-                                skipDetection = skipDetection,
-                                tncConfigOnly = tncConfigOnly,
-                                preselectedUsbDeviceId = if (usbDeviceId > 0) usbDeviceId else null,
-                            )
-                        }
+                                    onNavigateToMigration = {
+                                        navController.navigate("migration")
+                                    },
+                                    onNavigateToApkSharing = {
+                                        navController.navigate("apk_sharing")
+                                    },
+                                    onNavigateToAnnounces = { filterType ->
+                                        selectedTab = 1 // Announces tab
+                                        val route =
+                                            if (filterType != null) {
+                                                "${Screen.Announces.route}?filterType=$filterType"
+                                            } else {
+                                                Screen.Announces.route
+                                            }
+                                        navController.navigate(route) {
+                                            popUpTo(navController.graph.startDestinationId) {
+                                                saveState = true
+                                            }
+                                            launchSingleTop = true
+                                            restoreState = false // Don't restore state so filter applies
+                                        }
+                                    },
+                                    onNavigateToFlasher = {
+                                        navController.navigate("rnode_flasher")
+                                    },
+                                    onNavigateToBlockedUsers = {
+                                        navController.navigate("blocked_users")
+                                    },
+                                )
+                            }
 
-                        composable("interface_management") {
-                            InterfaceManagementScreen(
-                                onNavigateBack = { navController.popBackStack() },
-                                onNavigateToRNodeWizard = { interfaceId ->
-                                    if (interfaceId != null) {
-                                        navController.navigate("rnode_wizard?interfaceId=$interfaceId")
-                                    } else {
+                            composable(
+                                route =
+                                    "usb_device_action" +
+                                        "?usbDeviceId={usbDeviceId}" +
+                                        "&usbVendorId={usbVendorId}" +
+                                        "&usbProductId={usbProductId}" +
+                                        "&usbDeviceName={usbDeviceName}",
+                                arguments =
+                                    listOf(
+                                        navArgument("usbDeviceId") {
+                                            type = NavType.IntType
+                                            defaultValue = -1
+                                        },
+                                        navArgument("usbVendorId") {
+                                            type = NavType.IntType
+                                            defaultValue = -1
+                                        },
+                                        navArgument("usbProductId") {
+                                            type = NavType.IntType
+                                            defaultValue = -1
+                                        },
+                                        navArgument("usbDeviceName") {
+                                            type = NavType.StringType
+                                            defaultValue = ""
+                                            nullable = true
+                                        },
+                                    ),
+                            ) { backStackEntry ->
+                                val usbDeviceId = backStackEntry.arguments?.getInt("usbDeviceId") ?: -1
+                                val usbVendorId = backStackEntry.arguments?.getInt("usbVendorId") ?: -1
+                                val usbProductId = backStackEntry.arguments?.getInt("usbProductId") ?: -1
+                                val usbDeviceName = backStackEntry.arguments?.getString("usbDeviceName") ?: "USB Device"
+
+                                // State for disable transport operation
+                                val context = androidx.compose.ui.platform.LocalContext.current
+                                val coroutineScope = androidx.compose.runtime.rememberCoroutineScope()
+                                var isDisablingTransport by androidx.compose.runtime.remember {
+                                    androidx.compose.runtime.mutableStateOf(false)
+                                }
+                                var disableTransportResult: Boolean? by androidx.compose.runtime.remember {
+                                    androidx.compose.runtime.mutableStateOf(null)
+                                }
+
+                                network.columba.app.ui.screens.UsbDeviceActionScreen(
+                                    deviceName = usbDeviceName,
+                                    onNavigateBack = { navController.popBackStack() },
+                                    onFlashFirmware = {
+                                        val route =
+                                            "rnode_flasher" +
+                                                "?usbDeviceId=$usbDeviceId" +
+                                                "&usbVendorId=$usbVendorId" +
+                                                "&usbProductId=$usbProductId" +
+                                                "&usbDeviceName=${Uri.encode(usbDeviceName)}"
+                                        navController.navigate(route) {
+                                            popUpTo("usb_device_action") { inclusive = true }
+                                        }
+                                    },
+                                    onConfigureRNode = {
+                                        val route =
+                                            "rnode_wizard?connectionType=usb" +
+                                                "&usbDeviceId=$usbDeviceId" +
+                                                "&usbVendorId=$usbVendorId" +
+                                                "&usbProductId=$usbProductId" +
+                                                "&usbDeviceName=${Uri.encode(usbDeviceName)}"
+                                        navController.navigate(route) {
+                                            popUpTo("usb_device_action") { inclusive = true }
+                                        }
+                                    },
+                                    onConfigureTransport = {
+                                        val route =
+                                            "rnode_wizard?connectionType=usb" +
+                                                "&transportMode=true" +
+                                                "&usbDeviceId=$usbDeviceId" +
+                                                "&usbVendorId=$usbVendorId" +
+                                                "&usbProductId=$usbProductId" +
+                                                "&usbDeviceName=${Uri.encode(usbDeviceName)}"
+                                        navController.navigate(route) {
+                                            popUpTo("usb_device_action") { inclusive = true }
+                                        }
+                                    },
+                                    onDisableTransport = {
+                                        isDisablingTransport = true
+                                        coroutineScope.launch {
+                                            val flasher =
+                                                network.columba.app.reticulum.flasher
+                                                    .RNodeFlasher(context)
+                                            val success = flasher.tncModeController.disableTncMode(usbDeviceId)
+                                            isDisablingTransport = false
+                                            disableTransportResult = success
+                                        }
+                                    },
+                                    isDisablingTransport = isDisablingTransport,
+                                    disableTransportResult = disableTransportResult,
+                                    onDismissDisableResult = { disableTransportResult = null },
+                                )
+                            }
+
+                            composable(
+                                route =
+                                    "rnode_flasher?skipDetection={skipDetection}&tncConfigOnly={tncConfigOnly}" +
+                                        "&usbDeviceId={usbDeviceId}" +
+                                        "&usbVendorId={usbVendorId}&usbProductId={usbProductId}&usbDeviceName={usbDeviceName}",
+                                arguments =
+                                    listOf(
+                                        navArgument("skipDetection") {
+                                            type = NavType.BoolType
+                                            defaultValue = false
+                                        },
+                                        navArgument("tncConfigOnly") {
+                                            type = NavType.BoolType
+                                            defaultValue = false
+                                        },
+                                        navArgument("usbDeviceId") {
+                                            type = NavType.IntType
+                                            defaultValue = -1
+                                        },
+                                        navArgument("usbVendorId") {
+                                            type = NavType.IntType
+                                            defaultValue = -1
+                                        },
+                                        navArgument("usbProductId") {
+                                            type = NavType.IntType
+                                            defaultValue = -1
+                                        },
+                                        navArgument("usbDeviceName") {
+                                            type = NavType.StringType
+                                            defaultValue = ""
+                                            nullable = true
+                                        },
+                                    ),
+                            ) { backStackEntry ->
+                                val skipDetection = backStackEntry.arguments?.getBoolean("skipDetection") ?: false
+                                val tncConfigOnly = backStackEntry.arguments?.getBoolean("tncConfigOnly") ?: false
+                                val usbDeviceId = backStackEntry.arguments?.getInt("usbDeviceId") ?: -1
+                                RNodeFlasherScreen(
+                                    onNavigateBack = { navController.popBackStack() },
+                                    onComplete = { navController.popBackStack() },
+                                    onNavigateToRNodeWizard = {
                                         navController.navigate("rnode_wizard")
-                                    }
-                                },
-                                onNavigateToTcpClientWizard = {
-                                    navController.navigate("tcp_client_wizard")
-                                },
-                                onNavigateToInterfaceStats = { interfaceId ->
-                                    navController.navigate("interface_stats/$interfaceId")
-                                },
-                                onNavigateToDiscoveredInterfaces = {
-                                    navController.navigate("discovered_interfaces")
-                                },
-                            )
-                        }
+                                    },
+                                    skipDetection = skipDetection,
+                                    tncConfigOnly = tncConfigOnly,
+                                    preselectedUsbDeviceId = if (usbDeviceId > 0) usbDeviceId else null,
+                                )
+                            }
 
-                        composable("discovered_interfaces") {
-                            DiscoveredInterfacesScreen(
-                                onNavigateBack = { navController.popBackStack() },
-                                onNavigateToTcpClientWizard = { host, port, name, ifacNet, ifacKey ->
-                                    val encodedHost = Uri.encode(host)
-                                    val encodedName = Uri.encode(name)
-                                    val ifacNetParam =
-                                        if (!ifacNet.isNullOrEmpty()) "&ifacNetname=${Uri.encode(ifacNet)}" else ""
-                                    val ifacKeyParam =
-                                        if (!ifacKey.isNullOrEmpty()) "&ifacNetkey=${Uri.encode(ifacKey)}" else ""
-                                    navController.navigate(
-                                        "tcp_client_wizard?host=$encodedHost&port=$port&name=$encodedName" +
-                                            ifacNetParam + ifacKeyParam,
-                                    )
-                                },
-                                onNavigateToMapWithInterface = { details ->
-                                    val encodedLabel = Uri.encode(details.name)
-                                    val encodedType = Uri.encode(details.type)
-                                    val encodedReachableOn = Uri.encode(details.reachableOn ?: "")
-                                    val encodedModulation = Uri.encode(details.modulation ?: "")
-                                    val encodedStatus = Uri.encode(details.status ?: "")
-                                    navController.navigate(
-                                        "map_focus?lat=${details.latitude}&lon=${details.longitude}" +
-                                            "&label=$encodedLabel&type=$encodedType" +
-                                            "&height=${details.height ?: Float.NaN}" +
-                                            "&reachableOn=$encodedReachableOn&port=${details.port ?: -1}" +
-                                            "&frequency=${details.frequency ?: -1L}&bandwidth=${details.bandwidth ?: -1}" +
-                                            "&sf=${details.spreadingFactor ?: -1}&cr=${details.codingRate ?: -1}" +
-                                            "&modulation=$encodedModulation&status=$encodedStatus" +
-                                            "&lastHeard=${details.lastHeard ?: -1L}&hops=${details.hops ?: -1}",
-                                    )
-                                },
-                                onNavigateToRNodeWizardWithParams = { frequency, bandwidth, sf, cr ->
-                                    navController.navigate(
-                                        "rnode_wizard?loraFrequency=${frequency ?: -1L}" +
-                                            "&loraBandwidth=${bandwidth ?: -1}" +
-                                            "&loraSf=${sf ?: -1}" +
-                                            "&loraCr=${cr ?: -1}",
-                                    )
-                                },
-                            )
-                        }
+                            composable("interface_management") {
+                                InterfaceManagementScreen(
+                                    onNavigateBack = { navController.popBackStack() },
+                                    onNavigateToRNodeWizard = { interfaceId ->
+                                        if (interfaceId != null) {
+                                            navController.navigate("rnode_wizard?interfaceId=$interfaceId")
+                                        } else {
+                                            navController.navigate("rnode_wizard")
+                                        }
+                                    },
+                                    onNavigateToTcpClientWizard = {
+                                        navController.navigate("tcp_client_wizard")
+                                    },
+                                    onNavigateToInterfaceStats = { interfaceId ->
+                                        navController.navigate("interface_stats/$interfaceId")
+                                    },
+                                    onNavigateToDiscoveredInterfaces = {
+                                        navController.navigate("discovered_interfaces")
+                                    },
+                                )
+                            }
 
-                        composable(
-                            route =
-                                "tcp_client_wizard?interfaceId={interfaceId}&host={host}&port={port}&name={name}" +
-                                    "&ifacNetname={ifacNetname}&ifacNetkey={ifacNetkey}",
-                            arguments =
-                                listOf(
-                                    navArgument("interfaceId") {
-                                        type = NavType.LongType
-                                        defaultValue = -1L
+                            composable("discovered_interfaces") {
+                                DiscoveredInterfacesScreen(
+                                    onNavigateBack = { navController.popBackStack() },
+                                    onNavigateToTcpClientWizard = { host, port, name, ifacNet, ifacKey ->
+                                        val encodedHost = Uri.encode(host)
+                                        val encodedName = Uri.encode(name)
+                                        val ifacNetParam =
+                                            if (!ifacNet.isNullOrEmpty()) "&ifacNetname=${Uri.encode(ifacNet)}" else ""
+                                        val ifacKeyParam =
+                                            if (!ifacKey.isNullOrEmpty()) "&ifacNetkey=${Uri.encode(ifacKey)}" else ""
+                                        navController.navigate(
+                                            "tcp_client_wizard?host=$encodedHost&port=$port&name=$encodedName" +
+                                                ifacNetParam + ifacKeyParam,
+                                        )
                                     },
-                                    navArgument("host") {
-                                        type = NavType.StringType
-                                        defaultValue = ""
+                                    onNavigateToMapWithInterface = { details ->
+                                        val encodedLabel = Uri.encode(details.name)
+                                        val encodedType = Uri.encode(details.type)
+                                        val encodedReachableOn = Uri.encode(details.reachableOn ?: "")
+                                        val encodedModulation = Uri.encode(details.modulation ?: "")
+                                        val encodedStatus = Uri.encode(details.status ?: "")
+                                        navController.navigate(
+                                            "map_focus?lat=${details.latitude}&lon=${details.longitude}" +
+                                                "&label=$encodedLabel&type=$encodedType" +
+                                                "&height=${details.height ?: Float.NaN}" +
+                                                "&reachableOn=$encodedReachableOn&port=${details.port ?: -1}" +
+                                                "&frequency=${details.frequency ?: -1L}&bandwidth=${details.bandwidth ?: -1}" +
+                                                "&sf=${details.spreadingFactor ?: -1}&cr=${details.codingRate ?: -1}" +
+                                                "&modulation=$encodedModulation&status=$encodedStatus" +
+                                                "&lastHeard=${details.lastHeard ?: -1L}&hops=${details.hops ?: -1}",
+                                        )
                                     },
-                                    navArgument("port") {
-                                        type = NavType.IntType
-                                        defaultValue = 0
+                                    onNavigateToRNodeWizardWithParams = { frequency, bandwidth, sf, cr ->
+                                        navController.navigate(
+                                            "rnode_wizard?loraFrequency=${frequency ?: -1L}" +
+                                                "&loraBandwidth=${bandwidth ?: -1}" +
+                                                "&loraSf=${sf ?: -1}" +
+                                                "&loraCr=${cr ?: -1}",
+                                        )
                                     },
-                                    navArgument("name") {
-                                        type = NavType.StringType
-                                        defaultValue = ""
-                                    },
-                                    navArgument("ifacNetname") {
-                                        type = NavType.StringType
-                                        defaultValue = ""
-                                    },
-                                    navArgument("ifacNetkey") {
-                                        type = NavType.StringType
-                                        defaultValue = ""
-                                    },
-                                ),
-                        ) { backStackEntry ->
-                            val interfaceId = backStackEntry.arguments?.getLong("interfaceId") ?: -1L
-                            val host = backStackEntry.arguments?.getString("host") ?: ""
-                            val port = backStackEntry.arguments?.getInt("port") ?: 0
-                            val name = backStackEntry.arguments?.getString("name") ?: ""
-                            val ifacNetname = backStackEntry.arguments?.getString("ifacNetname") ?: ""
-                            val ifacNetkey = backStackEntry.arguments?.getString("ifacNetkey") ?: ""
-                            TcpClientWizardScreen(
-                                onNavigateBack = { navController.popBackStack() },
-                                onComplete = {
-                                    navController.navigate("interface_management") {
-                                        popUpTo("interface_management") { inclusive = true }
-                                    }
-                                },
-                                interfaceId = if (interfaceId > 0) interfaceId else null,
-                                initialHost = host.ifEmpty { null },
-                                initialPort = if (port > 0) port else null,
-                                initialName = name.ifEmpty { null },
-                                initialIfacNetname = ifacNetname.ifEmpty { null },
-                                initialIfacNetkey = ifacNetkey.ifEmpty { null },
-                            )
-                        }
+                                )
+                            }
 
-                        composable(
-                            route =
-                                "rnode_wizard?interfaceId={interfaceId}" +
-                                    "&connectionType={connectionType}" +
-                                    "&transportMode={transportMode}" +
-                                    "&usbDeviceId={usbDeviceId}" +
-                                    "&usbVendorId={usbVendorId}" +
-                                    "&usbProductId={usbProductId}" +
-                                    "&usbDeviceName={usbDeviceName}" +
-                                    "&loraFrequency={loraFrequency}" +
-                                    "&loraBandwidth={loraBandwidth}" +
-                                    "&loraSf={loraSf}" +
-                                    "&loraCr={loraCr}",
-                            arguments =
-                                listOf(
-                                    navArgument("interfaceId") {
-                                        type = NavType.LongType
-                                        defaultValue = -1L
-                                    },
-                                    navArgument("connectionType") {
-                                        type = NavType.StringType
-                                        nullable = true
-                                        defaultValue = null
-                                    },
-                                    navArgument("transportMode") {
-                                        type = NavType.BoolType
-                                        defaultValue = false
-                                    },
-                                    navArgument("usbDeviceId") {
-                                        type = NavType.IntType
-                                        defaultValue = -1
-                                    },
-                                    navArgument("usbVendorId") {
-                                        type = NavType.IntType
-                                        defaultValue = -1
-                                    },
-                                    navArgument("usbProductId") {
-                                        type = NavType.IntType
-                                        defaultValue = -1
-                                    },
-                                    navArgument("usbDeviceName") {
-                                        type = NavType.StringType
-                                        nullable = true
-                                        defaultValue = null
-                                    },
-                                    navArgument("loraFrequency") {
-                                        type = NavType.LongType
-                                        defaultValue = -1L
-                                    },
-                                    navArgument("loraBandwidth") {
-                                        type = NavType.IntType
-                                        defaultValue = -1
-                                    },
-                                    navArgument("loraSf") {
-                                        type = NavType.IntType
-                                        defaultValue = -1
-                                    },
-                                    navArgument("loraCr") {
-                                        type = NavType.IntType
-                                        defaultValue = -1
-                                    },
-                                ),
-                        ) { backStackEntry ->
-                            val interfaceId = backStackEntry.arguments?.getLong("interfaceId") ?: -1L
-                            val connectionType = backStackEntry.arguments?.getString("connectionType")
-                            val transportMode = backStackEntry.arguments?.getBoolean("transportMode") ?: false
-                            val usbDeviceId = backStackEntry.arguments?.getInt("usbDeviceId") ?: -1
-                            val usbVendorId = backStackEntry.arguments?.getInt("usbVendorId") ?: -1
-                            val usbProductId = backStackEntry.arguments?.getInt("usbProductId") ?: -1
-                            val usbDeviceName = backStackEntry.arguments?.getString("usbDeviceName")
-                            val loraFrequency = backStackEntry.arguments?.getLong("loraFrequency") ?: -1L
-                            val loraBandwidth = backStackEntry.arguments?.getInt("loraBandwidth") ?: -1
-                            val loraSf = backStackEntry.arguments?.getInt("loraSf") ?: -1
-                            val loraCr = backStackEntry.arguments?.getInt("loraCr") ?: -1
-                            network.columba.app.ui.screens.rnode.RNodeWizardScreen(
-                                editingInterfaceId = if (interfaceId >= 0) interfaceId else null,
-                                preselectedConnectionType = connectionType,
-                                preselectedUsbDeviceId = if (usbDeviceId >= 0) usbDeviceId else null,
-                                preselectedUsbVendorId = if (usbVendorId >= 0) usbVendorId else null,
-                                preselectedUsbProductId = if (usbProductId >= 0) usbProductId else null,
-                                preselectedUsbDeviceName = usbDeviceName,
-                                preselectedLoraFrequency = if (loraFrequency > 0) loraFrequency else null,
-                                preselectedLoraBandwidth = if (loraBandwidth > 0) loraBandwidth else null,
-                                preselectedLoraSf = if (loraSf > 0) loraSf else null,
-                                preselectedLoraCr = if (loraCr > 0) loraCr else null,
-                                transportMode = transportMode,
-                                onNavigateBack = { navController.popBackStack() },
-                                onComplete = {
-                                    if (transportMode) {
-                                        navController.popBackStack()
-                                    } else {
+                            composable(
+                                route =
+                                    "tcp_client_wizard?interfaceId={interfaceId}&host={host}&port={port}&name={name}" +
+                                        "&ifacNetname={ifacNetname}&ifacNetkey={ifacNetkey}",
+                                arguments =
+                                    listOf(
+                                        navArgument("interfaceId") {
+                                            type = NavType.LongType
+                                            defaultValue = -1L
+                                        },
+                                        navArgument("host") {
+                                            type = NavType.StringType
+                                            defaultValue = ""
+                                        },
+                                        navArgument("port") {
+                                            type = NavType.IntType
+                                            defaultValue = 0
+                                        },
+                                        navArgument("name") {
+                                            type = NavType.StringType
+                                            defaultValue = ""
+                                        },
+                                        navArgument("ifacNetname") {
+                                            type = NavType.StringType
+                                            defaultValue = ""
+                                        },
+                                        navArgument("ifacNetkey") {
+                                            type = NavType.StringType
+                                            defaultValue = ""
+                                        },
+                                    ),
+                            ) { backStackEntry ->
+                                val interfaceId = backStackEntry.arguments?.getLong("interfaceId") ?: -1L
+                                val host = backStackEntry.arguments?.getString("host") ?: ""
+                                val port = backStackEntry.arguments?.getInt("port") ?: 0
+                                val name = backStackEntry.arguments?.getString("name") ?: ""
+                                val ifacNetname = backStackEntry.arguments?.getString("ifacNetname") ?: ""
+                                val ifacNetkey = backStackEntry.arguments?.getString("ifacNetkey") ?: ""
+                                TcpClientWizardScreen(
+                                    onNavigateBack = { navController.popBackStack() },
+                                    onComplete = {
                                         navController.navigate("interface_management") {
                                             popUpTo("interface_management") { inclusive = true }
                                         }
-                                    }
-                                },
-                            )
-                        }
-
-                        composable(
-                            route = "interface_stats/{interfaceId}",
-                            arguments =
-                                listOf(
-                                    navArgument("interfaceId") {
-                                        type = NavType.LongType
                                     },
-                                ),
-                        ) { backStackEntry ->
-                            network.columba.app.ui.screens.InterfaceStatsScreen(
-                                onNavigateBack = { navController.popBackStack() },
-                                onNavigateToEdit = { interfaceId, interfaceType ->
-                                    // Route to appropriate wizard based on interface type
-                                    val route =
-                                        when (interfaceType) {
-                                            "TCPClient" -> "tcp_client_wizard?interfaceId=$interfaceId"
-                                            "RNode" -> "rnode_wizard?interfaceId=$interfaceId"
-                                            else -> "rnode_wizard?interfaceId=$interfaceId"
+                                    interfaceId = if (interfaceId > 0) interfaceId else null,
+                                    initialHost = host.ifEmpty { null },
+                                    initialPort = if (port > 0) port else null,
+                                    initialName = name.ifEmpty { null },
+                                    initialIfacNetname = ifacNetname.ifEmpty { null },
+                                    initialIfacNetkey = ifacNetkey.ifEmpty { null },
+                                )
+                            }
+
+                            composable(
+                                route =
+                                    "rnode_wizard?interfaceId={interfaceId}" +
+                                        "&connectionType={connectionType}" +
+                                        "&transportMode={transportMode}" +
+                                        "&usbDeviceId={usbDeviceId}" +
+                                        "&usbVendorId={usbVendorId}" +
+                                        "&usbProductId={usbProductId}" +
+                                        "&usbDeviceName={usbDeviceName}" +
+                                        "&loraFrequency={loraFrequency}" +
+                                        "&loraBandwidth={loraBandwidth}" +
+                                        "&loraSf={loraSf}" +
+                                        "&loraCr={loraCr}",
+                                arguments =
+                                    listOf(
+                                        navArgument("interfaceId") {
+                                            type = NavType.LongType
+                                            defaultValue = -1L
+                                        },
+                                        navArgument("connectionType") {
+                                            type = NavType.StringType
+                                            nullable = true
+                                            defaultValue = null
+                                        },
+                                        navArgument("transportMode") {
+                                            type = NavType.BoolType
+                                            defaultValue = false
+                                        },
+                                        navArgument("usbDeviceId") {
+                                            type = NavType.IntType
+                                            defaultValue = -1
+                                        },
+                                        navArgument("usbVendorId") {
+                                            type = NavType.IntType
+                                            defaultValue = -1
+                                        },
+                                        navArgument("usbProductId") {
+                                            type = NavType.IntType
+                                            defaultValue = -1
+                                        },
+                                        navArgument("usbDeviceName") {
+                                            type = NavType.StringType
+                                            nullable = true
+                                            defaultValue = null
+                                        },
+                                        navArgument("loraFrequency") {
+                                            type = NavType.LongType
+                                            defaultValue = -1L
+                                        },
+                                        navArgument("loraBandwidth") {
+                                            type = NavType.IntType
+                                            defaultValue = -1
+                                        },
+                                        navArgument("loraSf") {
+                                            type = NavType.IntType
+                                            defaultValue = -1
+                                        },
+                                        navArgument("loraCr") {
+                                            type = NavType.IntType
+                                            defaultValue = -1
+                                        },
+                                    ),
+                            ) { backStackEntry ->
+                                val interfaceId = backStackEntry.arguments?.getLong("interfaceId") ?: -1L
+                                val connectionType = backStackEntry.arguments?.getString("connectionType")
+                                val transportMode = backStackEntry.arguments?.getBoolean("transportMode") ?: false
+                                val usbDeviceId = backStackEntry.arguments?.getInt("usbDeviceId") ?: -1
+                                val usbVendorId = backStackEntry.arguments?.getInt("usbVendorId") ?: -1
+                                val usbProductId = backStackEntry.arguments?.getInt("usbProductId") ?: -1
+                                val usbDeviceName = backStackEntry.arguments?.getString("usbDeviceName")
+                                val loraFrequency = backStackEntry.arguments?.getLong("loraFrequency") ?: -1L
+                                val loraBandwidth = backStackEntry.arguments?.getInt("loraBandwidth") ?: -1
+                                val loraSf = backStackEntry.arguments?.getInt("loraSf") ?: -1
+                                val loraCr = backStackEntry.arguments?.getInt("loraCr") ?: -1
+                                network.columba.app.ui.screens.rnode.RNodeWizardScreen(
+                                    editingInterfaceId = if (interfaceId >= 0) interfaceId else null,
+                                    preselectedConnectionType = connectionType,
+                                    preselectedUsbDeviceId = if (usbDeviceId >= 0) usbDeviceId else null,
+                                    preselectedUsbVendorId = if (usbVendorId >= 0) usbVendorId else null,
+                                    preselectedUsbProductId = if (usbProductId >= 0) usbProductId else null,
+                                    preselectedUsbDeviceName = usbDeviceName,
+                                    preselectedLoraFrequency = if (loraFrequency > 0) loraFrequency else null,
+                                    preselectedLoraBandwidth = if (loraBandwidth > 0) loraBandwidth else null,
+                                    preselectedLoraSf = if (loraSf > 0) loraSf else null,
+                                    preselectedLoraCr = if (loraCr > 0) loraCr else null,
+                                    transportMode = transportMode,
+                                    onNavigateBack = { navController.popBackStack() },
+                                    onComplete = {
+                                        if (transportMode) {
+                                            navController.popBackStack()
+                                        } else {
+                                            navController.navigate("interface_management") {
+                                                popUpTo("interface_management") { inclusive = true }
+                                            }
                                         }
-                                    navController.navigate(route)
-                                },
-                            )
-                        }
-
-                        composable("notification_settings") {
-                            NotificationSettingsScreen(
-                                onNavigateBack = { navController.popBackStack() },
-                            )
-                        }
-
-                        composable("blocked_users") {
-                            BlockedUsersScreen(
-                                onBackClick = { navController.popBackStack() },
-                            )
-                        }
-
-                        composable("theme_management") {
-                            ThemeManagementScreen(
-                                onBackClick = { navController.popBackStack() },
-                                onCreateTheme = {
-                                    navController.navigate("theme_editor")
-                                },
-                                onEditTheme = { themeId ->
-                                    navController.navigate("theme_editor/$themeId")
-                                },
-                                onApplyTheme = { themeId ->
-                                    settingsViewModel.applyCustomTheme(themeId)
-                                },
-                            )
-                        }
-
-                        composable("theme_editor") {
-                            ThemeEditorScreen(
-                                themeId = null,
-                                onBackClick = { navController.popBackStack() },
-                                onSave = { navController.popBackStack() },
-                            )
-                        }
-
-                        composable(
-                            route = "theme_editor/{themeId}",
-                            arguments =
-                                listOf(
-                                    navArgument("themeId") { type = NavType.LongType },
-                                ),
-                        ) { backStackEntry ->
-                            val themeId = backStackEntry.arguments?.getLong("themeId")
-
-                            ThemeEditorScreen(
-                                themeId = themeId,
-                                onBackClick = { navController.popBackStack() },
-                                onSave = { navController.popBackStack() },
-                            )
-                        }
-
-                        composable("ble_connection_status") {
-                            BleConnectionStatusScreen(
-                                onBackClick = { navController.popBackStack() },
-                            )
-                        }
-
-                        composable(
-                            "identity_manager?base32Key={base32Key}",
-                            arguments =
-                                listOf(
-                                    navArgument("base32Key") {
-                                        type = NavType.StringType
-                                        nullable = true
-                                        defaultValue = null
                                     },
-                                ),
-                        ) { backStackEntry ->
-                            val base32Key = backStackEntry.arguments?.getString("base32Key")
-                            IdentityManagerScreen(
-                                onNavigateBack = { navController.popBackStack() },
-                                prefilledBase32Key = base32Key,
-                            )
-                        }
+                                )
+                            }
 
-                        composable("migration") {
-                            MigrationScreen(
-                                onNavigateBack = { navController.popBackStack() },
-                                onImportComplete = {
-                                    // Service restart is handled by MigrationViewModel,
-                                    // just navigate to chats after import completes
-                                    navController.navigate("chats") {
-                                        popUpTo(0) { inclusive = true }
-                                    }
-                                },
-                            )
-                        }
+                            composable(
+                                route = "interface_stats/{interfaceId}",
+                                arguments =
+                                    listOf(
+                                        navArgument("interfaceId") {
+                                            type = NavType.LongType
+                                        },
+                                    ),
+                            ) { backStackEntry ->
+                                network.columba.app.ui.screens.InterfaceStatsScreen(
+                                    onNavigateBack = { navController.popBackStack() },
+                                    onNavigateToEdit = { interfaceId, interfaceType ->
+                                        // Route to appropriate wizard based on interface type
+                                        val route =
+                                            when (interfaceType) {
+                                                "TCPClient" -> "tcp_client_wizard?interfaceId=$interfaceId"
+                                                "RNode" -> "rnode_wizard?interfaceId=$interfaceId"
+                                                else -> "rnode_wizard?interfaceId=$interfaceId"
+                                            }
+                                        navController.navigate(route)
+                                    },
+                                )
+                            }
 
-                        composable("apk_sharing") {
-                            ApkSharingScreen(
-                                onNavigateBack = { navController.popBackStack() },
-                            )
-                        }
+                            composable("notification_settings") {
+                                NotificationSettingsScreen(
+                                    onNavigateBack = { navController.popBackStack() },
+                                )
+                            }
 
-                        composable("my_identity") {
-                            MyIdentityScreen(
-                                onNavigateBack = { navController.popBackStack() },
-                                settingsViewModel = settingsViewModel,
-                                onNavigateToIdentityManager = {
-                                    navController.navigate("identity_manager")
-                                },
-                            )
-                        }
+                            composable("blocked_users") {
+                                BlockedUsersScreen(
+                                    onBackClick = { navController.popBackStack() },
+                                )
+                            }
 
-                        composable("network_status") {
-                            IdentityScreen(
-                                onBackClick = { navController.popBackStack() },
-                                settingsViewModel = settingsViewModel,
-                                onNavigateToBleStatus = {
-                                    navController.navigate("ble_connection_status")
-                                },
-                                onNavigateToInterfaceStats = { interfaceId ->
-                                    navController.navigate("interface_stats/$interfaceId")
-                                },
-                                onNavigateToInterfaceManagement = {
-                                    navController.navigate("interface_management")
-                                },
-                            )
-                        }
+                            composable("theme_management") {
+                                ThemeManagementScreen(
+                                    onBackClick = { navController.popBackStack() },
+                                    onCreateTheme = {
+                                        navController.navigate("theme_editor")
+                                    },
+                                    onEditTheme = { themeId ->
+                                        navController.navigate("theme_editor/$themeId")
+                                    },
+                                    onApplyTheme = { themeId ->
+                                        settingsViewModel.applyCustomTheme(themeId)
+                                    },
+                                )
+                            }
 
-                        composable("qr_scanner") {
-                            val contactsViewModel: ContactsViewModel = hiltViewModel()
-                            QrScannerScreen(
-                                onBackClick = { navController.popBackStack() },
-                                onQrScanned = { qrData ->
-                                    // Contact addition now handled by confirmation dialog
-                                },
-                                onNavigateToConversation = { destinationHash ->
-                                    // Contact already exists - navigate to conversation
-                                    val contacts = contactsViewModel.contacts.value
-                                    val contact = contacts.find { it.destinationHash == destinationHash }
-                                    val peerName = contact?.displayName ?: destinationHash.take(16)
-                                    val encodedHash = Uri.encode(destinationHash)
-                                    val encodedName = Uri.encode(peerName)
-                                    navController.navigate("messaging/$encodedHash/$encodedName")
-                                },
-                                contactsViewModel = contactsViewModel,
-                            )
-                        }
+                            composable("theme_editor") {
+                                ThemeEditorScreen(
+                                    themeId = null,
+                                    onBackClick = { navController.popBackStack() },
+                                    onSave = { navController.popBackStack() },
+                                )
+                            }
 
-                        composable(
-                            route = "messaging/{destinationHash}/{peerName}",
-                            arguments =
-                                listOf(
-                                    navArgument("destinationHash") { type = NavType.StringType },
-                                    navArgument("peerName") { type = NavType.StringType },
-                                ),
-                        ) { backStackEntry ->
-                            val destinationHash = backStackEntry.arguments?.getString("destinationHash").orEmpty()
-                            val peerName = backStackEntry.arguments?.getString("peerName").orEmpty()
+                            composable(
+                                route = "theme_editor/{themeId}",
+                                arguments =
+                                    listOf(
+                                        navArgument("themeId") { type = NavType.LongType },
+                                    ),
+                            ) { backStackEntry ->
+                                val themeId = backStackEntry.arguments?.getLong("themeId")
 
-                            MessagingScreen(
-                                destinationHash = destinationHash,
-                                peerName = peerName,
-                                onBackClick = { navController.popBackStack() },
-                                onPeerClick = {
-                                    val encodedHash = Uri.encode(destinationHash)
-                                    navController.navigate("announce_detail/$encodedHash")
-                                },
-                                onViewMessageDetails = { messageId ->
-                                    val encodedId = Uri.encode(messageId)
-                                    navController.navigate("message_detail/$encodedId")
-                                },
-                                onVoiceCall = { profileCode ->
-                                    val encodedHash = Uri.encode(destinationHash)
-                                    navController.navigate("voice_call/$encodedHash?profileCode=$profileCode")
-                                },
-                                onLocateOnMap = { peerHash ->
-                                    mapViewModel.focusOnContact(peerHash)
-                                    navController.navigate(Screen.Map.route) {
-                                        popUpTo(navController.graph.startDestinationId) {
-                                            saveState = true
+                                ThemeEditorScreen(
+                                    themeId = themeId,
+                                    onBackClick = { navController.popBackStack() },
+                                    onSave = { navController.popBackStack() },
+                                )
+                            }
+
+                            composable("ble_connection_status") {
+                                BleConnectionStatusScreen(
+                                    onBackClick = { navController.popBackStack() },
+                                )
+                            }
+
+                            composable(
+                                "identity_manager?base32Key={base32Key}",
+                                arguments =
+                                    listOf(
+                                        navArgument("base32Key") {
+                                            type = NavType.StringType
+                                            nullable = true
+                                            defaultValue = null
+                                        },
+                                    ),
+                            ) { backStackEntry ->
+                                val base32Key = backStackEntry.arguments?.getString("base32Key")
+                                IdentityManagerScreen(
+                                    onNavigateBack = { navController.popBackStack() },
+                                    prefilledBase32Key = base32Key,
+                                )
+                            }
+
+                            composable("migration") {
+                                MigrationScreen(
+                                    onNavigateBack = { navController.popBackStack() },
+                                    onImportComplete = {
+                                        // Service restart is handled by MigrationViewModel,
+                                        // just navigate to chats after import completes
+                                        navController.navigate("chats") {
+                                            popUpTo(0) { inclusive = true }
                                         }
-                                        launchSingleTop = true
-                                        restoreState = true
-                                    }
-                                },
-                            )
-                        }
+                                    },
+                                )
+                            }
 
-                        composable(
-                            route = "message_detail/{messageId}",
-                            arguments =
-                                listOf(
-                                    navArgument("messageId") { type = NavType.StringType },
-                                ),
-                        ) { backStackEntry ->
-                            val messageId = backStackEntry.arguments?.getString("messageId").orEmpty()
+                            composable("apk_sharing") {
+                                ApkSharingScreen(
+                                    onNavigateBack = { navController.popBackStack() },
+                                )
+                            }
 
-                            MessageDetailScreen(
-                                messageId = messageId,
-                                onBackClick = { navController.popBackStack() },
-                            )
-                        }
+                            composable("my_identity") {
+                                MyIdentityScreen(
+                                    onNavigateBack = { navController.popBackStack() },
+                                    settingsViewModel = settingsViewModel,
+                                    onNavigateToIdentityManager = {
+                                        navController.navigate("identity_manager")
+                                    },
+                                )
+                            }
 
-                        composable(
-                            route = "announce_detail/{destinationHash}",
-                            arguments =
-                                listOf(
-                                    navArgument("destinationHash") { type = NavType.StringType },
-                                ),
-                        ) { backStackEntry ->
-                            val destinationHash = backStackEntry.arguments?.getString("destinationHash").orEmpty()
+                            composable("network_status") {
+                                IdentityScreen(
+                                    onBackClick = { navController.popBackStack() },
+                                    settingsViewModel = settingsViewModel,
+                                    onNavigateToBleStatus = {
+                                        navController.navigate("ble_connection_status")
+                                    },
+                                    onNavigateToInterfaceStats = { interfaceId ->
+                                        navController.navigate("interface_stats/$interfaceId")
+                                    },
+                                    onNavigateToInterfaceManagement = {
+                                        navController.navigate("interface_management")
+                                    },
+                                )
+                            }
 
-                            AnnounceDetailScreen(
-                                destinationHash = destinationHash,
-                                onBackClick = { navController.popBackStack() },
-                                onViewAnnounce = { hash ->
-                                    navController.navigate("announce_detail/${Uri.encode(hash)}")
-                                },
-                                onStartChat = { destHash, peerName ->
-                                    // Navigate back to chats tab
-                                    selectedTab = 0
-                                    navController.navigate(Screen.Chats.route) {
-                                        popUpTo(navController.graph.startDestinationId) {
-                                            saveState = true
+                            composable("qr_scanner") {
+                                val contactsViewModel: ContactsViewModel = hiltViewModel()
+                                QrScannerScreen(
+                                    onBackClick = { navController.popBackStack() },
+                                    onQrScanned = { qrData ->
+                                        // Contact addition now handled by confirmation dialog
+                                    },
+                                    onNavigateToConversation = { destinationHash ->
+                                        // Contact already exists - navigate to conversation
+                                        val contacts = contactsViewModel.contacts.value
+                                        val contact = contacts.find { it.destinationHash == destinationHash }
+                                        val peerName = contact?.displayName ?: destinationHash.take(16)
+                                        val encodedHash = Uri.encode(destinationHash)
+                                        val encodedName = Uri.encode(peerName)
+                                        navController.navigate("messaging/$encodedHash/$encodedName")
+                                    },
+                                    contactsViewModel = contactsViewModel,
+                                )
+                            }
+
+                            composable(
+                                route = "messaging/{destinationHash}/{peerName}",
+                                arguments =
+                                    listOf(
+                                        navArgument("destinationHash") { type = NavType.StringType },
+                                        navArgument("peerName") { type = NavType.StringType },
+                                    ),
+                            ) { backStackEntry ->
+                                val destinationHash = backStackEntry.arguments?.getString("destinationHash").orEmpty()
+                                val peerName = backStackEntry.arguments?.getString("peerName").orEmpty()
+
+                                MessagingScreen(
+                                    destinationHash = destinationHash,
+                                    peerName = peerName,
+                                    onBackClick = { navController.popBackStack() },
+                                    onPeerClick = {
+                                        val encodedHash = Uri.encode(destinationHash)
+                                        navController.navigate("announce_detail/$encodedHash")
+                                    },
+                                    onViewMessageDetails = { messageId ->
+                                        val encodedId = Uri.encode(messageId)
+                                        navController.navigate("message_detail/$encodedId")
+                                    },
+                                    onVoiceCall = { profileCode ->
+                                        val encodedHash = Uri.encode(destinationHash)
+                                        navController.navigate("voice_call/$encodedHash?profileCode=$profileCode")
+                                    },
+                                    onLocateOnMap = { peerHash ->
+                                        mapViewModel.focusOnContact(peerHash)
+                                        navController.navigate(Screen.Map.route) {
+                                            popUpTo(navController.graph.startDestinationId) {
+                                                saveState = true
+                                            }
+                                            launchSingleTop = true
+                                            restoreState = true
                                         }
-                                        launchSingleTop = true
-                                        restoreState = true
-                                    }
-                                    // Then navigate to the messaging screen
-                                    val encodedHash = Uri.encode(destHash)
-                                    val encodedName = Uri.encode(peerName)
-                                    navController.navigate("messaging/$encodedHash/$encodedName")
-                                },
-                                onBrowseNode = { destHash ->
-                                    navController.navigate("nomadnet_browser/$destHash")
-                                },
-                            )
-                        }
-
-                        // NomadNet Browser screen
-                        composable(
-                            route = "nomadnet_browser/{destinationHash}?path={path}",
-                            arguments =
-                                listOf(
-                                    navArgument("destinationHash") { type = NavType.StringType },
-                                    navArgument("path") {
-                                        type = NavType.StringType
-                                        defaultValue = "/page/index.mu"
                                     },
-                                ),
-                        ) { backStackEntry ->
-                            val destHash = backStackEntry.arguments?.getString("destinationHash").orEmpty()
-                            val path = backStackEntry.arguments?.getString("path") ?: "/page/index.mu"
-                            NomadNetBrowserScreen(
-                                destinationHash = destHash,
-                                initialPath = path,
-                                onBackClick = { navController.popBackStack() },
-                                onOpenConversation = { conversationHash ->
-                                    val encodedHash = Uri.encode(conversationHash)
-                                    val encodedName = Uri.encode(conversationHash.take(12))
-                                    navController.navigate("messaging/$encodedHash/$encodedName")
-                                },
-                            )
-                        }
+                                )
+                            }
 
-                        // Offline Maps management screen
-                        composable("offline_maps") {
-                            OfflineMapsScreen(
-                                onNavigateBack = { navController.popBackStack() },
-                                onNavigateToDownload = { navController.navigate("offline_map_download") },
-                                onNavigateToUpdate = { regionId ->
-                                    navController.navigate("offline_map_download?updateRegionId=$regionId")
-                                },
-                            )
-                        }
+                            composable(
+                                route = "message_detail/{messageId}",
+                                arguments =
+                                    listOf(
+                                        navArgument("messageId") { type = NavType.StringType },
+                                    ),
+                            ) { backStackEntry ->
+                                val messageId = backStackEntry.arguments?.getString("messageId").orEmpty()
 
-                        // Offline Map download wizard (with optional update parameter)
-                        composable(
-                            route = "offline_map_download?updateRegionId={updateRegionId}",
-                            arguments =
-                                listOf(
-                                    navArgument("updateRegionId") {
-                                        type = NavType.LongType
-                                        defaultValue = -1L
+                                MessageDetailScreen(
+                                    messageId = messageId,
+                                    onBackClick = { navController.popBackStack() },
+                                )
+                            }
+
+                            composable(
+                                route = "announce_detail/{destinationHash}",
+                                arguments =
+                                    listOf(
+                                        navArgument("destinationHash") { type = NavType.StringType },
+                                    ),
+                            ) { backStackEntry ->
+                                val destinationHash = backStackEntry.arguments?.getString("destinationHash").orEmpty()
+
+                                AnnounceDetailScreen(
+                                    destinationHash = destinationHash,
+                                    onBackClick = { navController.popBackStack() },
+                                    onViewAnnounce = { hash ->
+                                        navController.navigate("announce_detail/${Uri.encode(hash)}")
                                     },
-                                ),
-                        ) { backStackEntry ->
-                            val updateRegionId = backStackEntry.arguments?.getLong("updateRegionId") ?: -1L
-                            OfflineMapDownloadScreen(
-                                onNavigateBack = { navController.popBackStack() },
-                                onDownloadComplete = { navController.popBackStack() },
-                                updateRegionId = if (updateRegionId > 0) updateRegionId else null,
-                            )
-                        }
-
-                        // Voice Call Screen (outgoing/active call)
-                        composable(
-                            route = "voice_call/{destinationHash}?autoAnswer={autoAnswer}&profileCode={profileCode}",
-                            arguments =
-                                listOf(
-                                    navArgument("destinationHash") { type = NavType.StringType },
-                                    navArgument("autoAnswer") {
-                                        type = NavType.BoolType
-                                        defaultValue = false
+                                    onStartChat = { destHash, peerName ->
+                                        // Navigate back to chats tab
+                                        selectedTab = 0
+                                        navController.navigate(Screen.Chats.route) {
+                                            popUpTo(navController.graph.startDestinationId) {
+                                                saveState = true
+                                            }
+                                            launchSingleTop = true
+                                            restoreState = true
+                                        }
+                                        // Then navigate to the messaging screen
+                                        val encodedHash = Uri.encode(destHash)
+                                        val encodedName = Uri.encode(peerName)
+                                        navController.navigate("messaging/$encodedHash/$encodedName")
                                     },
-                                    navArgument("profileCode") {
-                                        type = NavType.IntType
-                                        defaultValue = -1 // -1 means use default
+                                    onBrowseNode = { destHash ->
+                                        navController.navigate("nomadnet_browser/$destHash")
                                     },
-                                ),
-                        ) { backStackEntry ->
-                            val destinationHash = backStackEntry.arguments?.getString("destinationHash").orEmpty()
-                            val autoAnswer = backStackEntry.arguments?.getBoolean("autoAnswer") ?: false
-                            val profileCodeArg = backStackEntry.arguments?.getInt("profileCode") ?: -1
-                            val profileCode = if (profileCodeArg == -1) null else profileCodeArg
+                                )
+                            }
 
-                            VoiceCallScreen(
-                                destinationHash = destinationHash,
-                                onEndCall = exitCallFlow,
-                                autoAnswer = autoAnswer,
-                                profileCode = profileCode,
-                            )
-                        }
+                            // NomadNet Browser screen
+                            composable(
+                                route = "nomadnet_browser/{destinationHash}?path={path}",
+                                arguments =
+                                    listOf(
+                                        navArgument("destinationHash") { type = NavType.StringType },
+                                        navArgument("path") {
+                                            type = NavType.StringType
+                                            defaultValue = "/page/index.mu"
+                                        },
+                                    ),
+                            ) { backStackEntry ->
+                                val destHash = backStackEntry.arguments?.getString("destinationHash").orEmpty()
+                                val path = backStackEntry.arguments?.getString("path") ?: "/page/index.mu"
+                                NomadNetBrowserScreen(
+                                    destinationHash = destHash,
+                                    initialPath = path,
+                                    onBackClick = { navController.popBackStack() },
+                                    onOpenConversation = { conversationHash ->
+                                        val encodedHash = Uri.encode(conversationHash)
+                                        val encodedName = Uri.encode(conversationHash.take(12))
+                                        navController.navigate("messaging/$encodedHash/$encodedName")
+                                    },
+                                )
+                            }
 
-                        // Incoming Call Screen
-                        composable(
-                            route = "incoming_call/{identityHash}",
-                            arguments =
-                                listOf(
-                                    navArgument("identityHash") { type = NavType.StringType },
-                                ),
-                        ) { backStackEntry ->
-                            val identityHash = backStackEntry.arguments?.getString("identityHash").orEmpty()
+                            // Offline Maps management screen
+                            composable("offline_maps") {
+                                OfflineMapsScreen(
+                                    onNavigateBack = { navController.popBackStack() },
+                                    onNavigateToDownload = { navController.navigate("offline_map_download") },
+                                    onNavigateToUpdate = { regionId ->
+                                        navController.navigate("offline_map_download?updateRegionId=$regionId")
+                                    },
+                                )
+                            }
 
-                            IncomingCallScreen(
-                                identityHash = identityHash,
-                                onCallAnswered = {
-                                    // Navigate to voice call screen when answered
-                                    val encodedHash = Uri.encode(identityHash)
-                                    navController.navigate("voice_call/$encodedHash") {
-                                        popUpTo("incoming_call/$identityHash") { inclusive = true }
-                                    }
-                                },
-                                onCallDeclined = exitCallFlow,
-                            )
+                            // Offline Map download wizard (with optional update parameter)
+                            composable(
+                                route = "offline_map_download?updateRegionId={updateRegionId}",
+                                arguments =
+                                    listOf(
+                                        navArgument("updateRegionId") {
+                                            type = NavType.LongType
+                                            defaultValue = -1L
+                                        },
+                                    ),
+                            ) { backStackEntry ->
+                                val updateRegionId = backStackEntry.arguments?.getLong("updateRegionId") ?: -1L
+                                OfflineMapDownloadScreen(
+                                    onNavigateBack = { navController.popBackStack() },
+                                    onDownloadComplete = { navController.popBackStack() },
+                                    updateRegionId = if (updateRegionId > 0) updateRegionId else null,
+                                )
+                            }
+
+                            // Voice Call Screen (outgoing/active call)
+                            composable(
+                                route = "voice_call/{destinationHash}?autoAnswer={autoAnswer}&profileCode={profileCode}",
+                                arguments =
+                                    listOf(
+                                        navArgument("destinationHash") { type = NavType.StringType },
+                                        navArgument("autoAnswer") {
+                                            type = NavType.BoolType
+                                            defaultValue = false
+                                        },
+                                        navArgument("profileCode") {
+                                            type = NavType.IntType
+                                            defaultValue = -1 // -1 means use default
+                                        },
+                                    ),
+                            ) { backStackEntry ->
+                                val destinationHash = backStackEntry.arguments?.getString("destinationHash").orEmpty()
+                                val autoAnswer = backStackEntry.arguments?.getBoolean("autoAnswer") ?: false
+                                val profileCodeArg = backStackEntry.arguments?.getInt("profileCode") ?: -1
+                                val profileCode = if (profileCodeArg == -1) null else profileCodeArg
+
+                                VoiceCallScreen(
+                                    destinationHash = destinationHash,
+                                    onEndCall = exitCallFlow,
+                                    autoAnswer = autoAnswer,
+                                    profileCode = profileCode,
+                                )
+                            }
+
+                            // Incoming Call Screen
+                            composable(
+                                route = "incoming_call/{identityHash}",
+                                arguments =
+                                    listOf(
+                                        navArgument("identityHash") { type = NavType.StringType },
+                                    ),
+                            ) { backStackEntry ->
+                                val identityHash = backStackEntry.arguments?.getString("identityHash").orEmpty()
+
+                                IncomingCallScreen(
+                                    identityHash = identityHash,
+                                    onCallAnswered = {
+                                        // Navigate to voice call screen when answered
+                                        val encodedHash = Uri.encode(identityHash)
+                                        navController.navigate("voice_call/$encodedHash") {
+                                            popUpTo("incoming_call/$identityHash") { inclusive = true }
+                                        }
+                                    },
+                                    onCallDeclined = exitCallFlow,
+                                )
+                            }
                         }
                     }
                 }

--- a/app/src/main/java/network/columba/app/MainActivity.kt
+++ b/app/src/main/java/network/columba/app/MainActivity.kt
@@ -65,6 +65,9 @@ import androidx.navigation.compose.composable
 import androidx.navigation.compose.currentBackStackEntryAsState
 import androidx.navigation.compose.rememberNavController
 import androidx.navigation.navArgument
+import dagger.hilt.android.AndroidEntryPoint
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.launch
 import network.columba.app.notifications.CallNotificationHelper
 import network.columba.app.repository.InterfaceRepository
 import network.columba.app.repository.SettingsRepository
@@ -113,9 +116,6 @@ import network.columba.app.viewmodel.OnboardingViewModel
 import network.columba.app.viewmodel.SettingsViewModel
 import network.columba.app.viewmodel.SharedImageViewModel
 import network.columba.app.viewmodel.SharedTextViewModel
-import dagger.hilt.android.AndroidEntryPoint
-import kotlinx.coroutines.flow.first
-import kotlinx.coroutines.launch
 import tech.torlando.lxst.core.CallCoordinator
 import tech.torlando.lxst.core.CallState
 import javax.inject.Inject
@@ -540,6 +540,8 @@ sealed class Screen(
 ) {
     object Welcome : Screen("welcome", "Welcome", Icons.Default.Sensors)
 
+    object IdentityUnlock : Screen("identity_unlock", "Restore Identity", Icons.Default.Sensors)
+
     object Chats : Screen("chats", "Chats", Icons.Default.Chat)
 
     object Announces : Screen("announce_stream", "Announces", Icons.Default.Sensors)
@@ -608,29 +610,35 @@ fun ColumbaNavigation(
     // Access OnboardingViewModel to check onboarding status
     val onboardingViewModel: OnboardingViewModel = hiltViewModel()
     val onboardingState by onboardingViewModel.state.collectAsState()
+    val needsIdentityUnlock by onboardingViewModel.needsIdentityUnlock.collectAsState()
 
-    // Determine start destination based on onboarding status
+    // Determine start destination based on onboarding + unlock status
     // IMPORTANT: Use remember to compute this only once. Without remember,
     // the startDestination would be recalculated when onboardingState loads
     // asynchronously from DataStore, which causes NavHost to reset to the
     // new startDestination and discard any pending navigation.
     val startDestination =
         remember {
-            if (onboardingState.hasCompletedOnboarding) {
-                Screen.Chats.route
-            } else {
-                Screen.Welcome.route
+            when {
+                onboardingState.hasCompletedOnboarding && needsIdentityUnlock -> Screen.IdentityUnlock.route
+                onboardingState.hasCompletedOnboarding -> Screen.Chats.route
+                else -> Screen.Welcome.route
             }
         }
 
     // Handle edge case: user completed onboarding but we started at Welcome
     // because onboardingState was still loading when startDestination was computed
-    LaunchedEffect(onboardingState.hasCompletedOnboarding) {
+    LaunchedEffect(onboardingState.hasCompletedOnboarding, needsIdentityUnlock) {
         val currentRoute = navController.currentDestination?.route
-        if (onboardingState.hasCompletedOnboarding &&
-            currentRoute == Screen.Welcome.route &&
-            pendingNavigation.value == null
-        ) {
+        if (!onboardingState.hasCompletedOnboarding) return@LaunchedEffect
+        if (needsIdentityUnlock && currentRoute != Screen.IdentityUnlock.route) {
+            Log.d("ColumbaNavigation", "Redirecting to IdentityUnlock (key decryption failed)")
+            navController.navigate(Screen.IdentityUnlock.route) {
+                popUpTo(navController.graph.startDestinationId) { inclusive = true }
+            }
+            return@LaunchedEffect
+        }
+        if (currentRoute == Screen.Welcome.route && pendingNavigation.value == null) {
             Log.d("ColumbaNavigation", "Redirecting to Chats (onboarding already completed)")
             navController.navigate(Screen.Chats.route) {
                 popUpTo(Screen.Welcome.route) { inclusive = true }
@@ -1067,6 +1075,16 @@ fun ColumbaNavigation(
                                 },
                                 onImportData = {
                                     navController.navigate("migration")
+                                },
+                            )
+                        }
+
+                        composable(Screen.IdentityUnlock.route) {
+                            network.columba.app.ui.screens.IdentityUnlockScreen(
+                                onResolved = {
+                                    navController.navigate(Screen.Chats.route) {
+                                        popUpTo(Screen.IdentityUnlock.route) { inclusive = true }
+                                    }
                                 },
                             )
                         }

--- a/app/src/main/java/network/columba/app/repository/SettingsRepository.kt
+++ b/app/src/main/java/network/columba/app/repository/SettingsRepository.kt
@@ -18,13 +18,6 @@ import androidx.datastore.preferences.core.longPreferencesKey
 import androidx.datastore.preferences.core.stringPreferencesKey
 import androidx.datastore.preferences.core.stringSetPreferencesKey
 import androidx.datastore.preferences.preferencesDataStore
-import network.columba.app.data.model.ImageCompressionPreset
-import network.columba.app.data.repository.CustomThemeRepository
-import network.columba.app.reticulum.model.BatteryProfile
-import network.columba.app.service.persistence.ServiceSettingsAccessor
-import network.columba.app.ui.theme.AppTheme
-import network.columba.app.ui.theme.CustomTheme
-import network.columba.app.ui.theme.PresetTheme
 import dagger.hilt.android.qualifiers.ApplicationContext
 import kotlinx.coroutines.channels.awaitClose
 import kotlinx.coroutines.flow.Flow
@@ -34,6 +27,13 @@ import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.flatMapLatest
 import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.flow.map
+import network.columba.app.data.model.ImageCompressionPreset
+import network.columba.app.data.repository.CustomThemeRepository
+import network.columba.app.reticulum.model.BatteryProfile
+import network.columba.app.service.persistence.ServiceSettingsAccessor
+import network.columba.app.ui.theme.AppTheme
+import network.columba.app.ui.theme.CustomTheme
+import network.columba.app.ui.theme.PresetTheme
 import javax.inject.Inject
 import javax.inject.Singleton
 
@@ -71,6 +71,7 @@ class SettingsRepository
 
             // Onboarding preferences
             val HAS_COMPLETED_ONBOARDING = booleanPreferencesKey("has_completed_onboarding")
+            val NEEDS_IDENTITY_UNLOCK = booleanPreferencesKey("needs_identity_unlock")
 
             // Auto-announce preferences
             val AUTO_ANNOUNCE_ENABLED = booleanPreferencesKey("auto_announce_enabled")
@@ -435,6 +436,42 @@ class SettingsRepository
         suspend fun markOnboardingCompleted() {
             context.dataStore.edit { preferences ->
                 preferences[PreferencesKeys.HAS_COMPLETED_ONBOARDING] = true
+            }
+        }
+
+        /**
+         * Reset onboarding completion so the user is routed back to the welcome
+         * flow. Called from the identity-unlock "start fresh" path after we've
+         * deleted the undecryptable identity row — the user needs to re-create
+         * an identity from scratch, which onboarding handles.
+         */
+        suspend fun clearOnboardingCompleted() {
+            context.dataStore.edit { preferences ->
+                preferences.remove(PreferencesKeys.HAS_COMPLETED_ONBOARDING)
+            }
+        }
+
+        /**
+         * True when the active identity's encrypted key blob couldn't be unwrapped
+         * by the device Keystore — typically because the user restored a backup
+         * on a new device. The Keystore-wrapped `encryptedKeyData` survived in
+         * Room, but the Keystore AES key that produced it did not (Keystore keys
+         * are app-UID-bound and don't cross uninstall). UI routes to the
+         * identity-unlock screen so the user can re-import their identity file.
+         */
+        val needsIdentityUnlockFlow: Flow<Boolean> =
+            context.dataStore.data
+                .map { preferences ->
+                    preferences[PreferencesKeys.NEEDS_IDENTITY_UNLOCK] ?: false
+                }.distinctUntilChanged()
+
+        suspend fun setNeedsIdentityUnlock(value: Boolean) {
+            context.dataStore.edit { preferences ->
+                if (value) {
+                    preferences[PreferencesKeys.NEEDS_IDENTITY_UNLOCK] = true
+                } else {
+                    preferences.remove(PreferencesKeys.NEEDS_IDENTITY_UNLOCK)
+                }
             }
         }
 

--- a/app/src/main/java/network/columba/app/ui/screens/IdentityUnlockScreen.kt
+++ b/app/src/main/java/network/columba/app/ui/screens/IdentityUnlockScreen.kt
@@ -211,9 +211,10 @@ fun IdentityUnlockScreen(
             text = {
                 Text(
                     "This removes your old identity and takes you through onboarding to create " +
-                        "a new one. Your restored messages and contacts will remain visible, but " +
-                        "you won't be able to continue any existing conversations — the peers on " +
-                        "the other side won't recognize the new identity.",
+                        "a new one. Your restored messages and contacts were tied to the old " +
+                        "identity, so they'll disappear from the app — and peers on the other " +
+                        "side of any existing conversations won't recognize the new identity. " +
+                        "The app will restart to finish setting up.",
                 )
             },
             confirmButton = {

--- a/app/src/main/java/network/columba/app/ui/screens/IdentityUnlockScreen.kt
+++ b/app/src/main/java/network/columba/app/ui/screens/IdentityUnlockScreen.kt
@@ -1,0 +1,319 @@
+package network.columba.app.ui.screens
+
+import android.net.Uri
+import androidx.activity.compose.rememberLauncherForActivityResult
+import androidx.activity.result.contract.ActivityResultContracts
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.WindowInsets
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.statusBars
+import androidx.compose.foundation.layout.windowInsetsPadding
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Info
+import androidx.compose.material.icons.filled.Lock
+import androidx.compose.material3.AlertDialog
+import androidx.compose.material3.Button
+import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.FilledTonalButton
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.unit.dp
+import androidx.hilt.navigation.compose.hiltViewModel
+import network.columba.app.viewmodel.IdentityUnlockUiState
+import network.columba.app.viewmodel.IdentityUnlockViewModel
+
+/**
+ * Screen shown after an Auto Backup restore when the active identity's
+ * Keystore-wrapped key blob survived the restore but the Keystore AES key
+ * that produced it didn't (Keystore keys are app-UID-bound and don't cross
+ * the uninstall boundary). The user picks: import the `.identity` file they
+ * saved before the phone swap, or start fresh with a new identity.
+ */
+@Composable
+fun IdentityUnlockScreen(
+    onResolved: () -> Unit,
+    viewModel: IdentityUnlockViewModel = hiltViewModel(),
+) {
+    val uiState by viewModel.uiState.collectAsState()
+    val activeIdentity by viewModel.activeIdentity.collectAsState()
+
+    val importLauncher =
+        rememberLauncherForActivityResult(
+            contract = ActivityResultContracts.OpenDocument(),
+        ) { uri: Uri? ->
+            uri?.let { viewModel.importIdentityFile(it) }
+        }
+
+    var showStartFreshConfirm by remember { mutableStateOf(false) }
+    var showExplainer by remember { mutableStateOf(false) }
+
+    LaunchedEffect(uiState) {
+        if (uiState is IdentityUnlockUiState.Restored || uiState is IdentityUnlockUiState.StartedFresh) {
+            onResolved()
+        }
+    }
+
+    Surface(
+        modifier = Modifier.fillMaxSize(),
+        color = MaterialTheme.colorScheme.background,
+    ) {
+        Column(
+            modifier =
+                Modifier
+                    .fillMaxSize()
+                    .windowInsetsPadding(WindowInsets.statusBars)
+                    .verticalScroll(rememberScrollState())
+                    .padding(horizontal = 24.dp),
+            horizontalAlignment = Alignment.CenterHorizontally,
+        ) {
+            Spacer(Modifier.height(32.dp))
+
+            Icon(
+                imageVector = Icons.Default.Lock,
+                contentDescription = null,
+                modifier = Modifier.size(72.dp),
+                tint = MaterialTheme.colorScheme.primary,
+            )
+
+            Spacer(Modifier.height(24.dp))
+
+            Text(
+                text = "Restore your identity",
+                style = MaterialTheme.typography.headlineMedium,
+                fontWeight = FontWeight.Bold,
+                textAlign = TextAlign.Center,
+            )
+
+            Spacer(Modifier.height(16.dp))
+
+            Text(
+                text =
+                    "Your messages and contacts were restored from backup, but your identity " +
+                        "keys couldn't come back across devices. Import the identity file you " +
+                        "saved before switching phones to continue using the same identity — or " +
+                        "start fresh with a new one.",
+                style = MaterialTheme.typography.bodyMedium,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+                textAlign = TextAlign.Center,
+            )
+
+            activeIdentity?.let { identity ->
+                Spacer(Modifier.height(12.dp))
+                Text(
+                    text = "Looking for: ${identity.displayName} (${identity.identityHash.take(8)}…)",
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                )
+            }
+
+            Spacer(Modifier.height(32.dp))
+
+            when (val state = uiState) {
+                is IdentityUnlockUiState.Loading -> {
+                    LoadingBlock(state.message)
+                }
+                is IdentityUnlockUiState.Error -> {
+                    ErrorBlock(state.message) {
+                        viewModel.cancelHashMismatch() // resets to Idle
+                    }
+                }
+                is IdentityUnlockUiState.HashMismatch -> {
+                    HashMismatchDialog(
+                        imported = state.importedHash,
+                        active = state.activeHash,
+                        onConfirm = { viewModel.confirmReplaceMismatched() },
+                        onDismiss = { viewModel.cancelHashMismatch() },
+                    )
+                }
+                else -> Unit
+            }
+
+            Button(
+                onClick = {
+                    // `.identity` files don't have a well-known MIME, so we
+                    // open anything and let the parser reject invalid files.
+                    importLauncher.launch(arrayOf("*/*"))
+                },
+                modifier =
+                    Modifier
+                        .fillMaxWidth()
+                        .height(56.dp),
+                shape = RoundedCornerShape(12.dp),
+                enabled = uiState !is IdentityUnlockUiState.Loading,
+            ) {
+                Text(
+                    text = "Import identity file",
+                    style = MaterialTheme.typography.titleMedium,
+                )
+            }
+
+            Spacer(Modifier.height(12.dp))
+
+            FilledTonalButton(
+                onClick = { showStartFreshConfirm = true },
+                modifier =
+                    Modifier
+                        .fillMaxWidth()
+                        .height(56.dp),
+                shape = RoundedCornerShape(12.dp),
+                enabled = uiState !is IdentityUnlockUiState.Loading,
+            ) {
+                Text(
+                    text = "Start fresh",
+                    style = MaterialTheme.typography.titleMedium,
+                )
+            }
+
+            Spacer(Modifier.height(12.dp))
+
+            TextButton(onClick = { showExplainer = true }) {
+                Icon(
+                    imageVector = Icons.Default.Info,
+                    contentDescription = null,
+                    modifier = Modifier.size(16.dp),
+                )
+                Spacer(Modifier.size(4.dp))
+                Text(text = "Why did this happen?")
+            }
+
+            Spacer(Modifier.height(24.dp))
+        }
+    }
+
+    if (showStartFreshConfirm) {
+        AlertDialog(
+            onDismissRequest = { showStartFreshConfirm = false },
+            title = { Text("Start fresh?") },
+            text = {
+                Text(
+                    "This removes your old identity and takes you through onboarding to create " +
+                        "a new one. Your restored messages and contacts will remain visible, but " +
+                        "you won't be able to continue any existing conversations — the peers on " +
+                        "the other side won't recognize the new identity.",
+                )
+            },
+            confirmButton = {
+                TextButton(onClick = {
+                    showStartFreshConfirm = false
+                    viewModel.startFresh()
+                }) { Text("Start fresh") }
+            },
+            dismissButton = {
+                TextButton(onClick = { showStartFreshConfirm = false }) { Text("Cancel") }
+            },
+        )
+    }
+
+    if (showExplainer) {
+        AlertDialog(
+            onDismissRequest = { showExplainer = false },
+            title = { Text("Why this happens") },
+            text = {
+                Text(
+                    "Your identity's private key is wrapped with a hardware-backed Android " +
+                        "Keystore key. Keystore keys are tied to the app's install ID and don't " +
+                        "cross a factory reset or device swap — even when the app data is " +
+                        "restored from cloud backup. That's why messages and contacts came " +
+                        "back but the identity couldn't decrypt itself.\n\n" +
+                        "Importing the identity file you exported before switching devices " +
+                        "lets us re-wrap the same identity with this device's Keystore key.",
+                )
+            },
+            confirmButton = {
+                TextButton(onClick = { showExplainer = false }) { Text("Got it") }
+            },
+        )
+    }
+}
+
+@Composable
+private fun LoadingBlock(message: String) {
+    Column(
+        modifier = Modifier.fillMaxWidth(),
+        horizontalAlignment = Alignment.CenterHorizontally,
+    ) {
+        CircularProgressIndicator()
+        Spacer(Modifier.height(8.dp))
+        Text(
+            text = message,
+            style = MaterialTheme.typography.bodyMedium,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+        )
+        Spacer(Modifier.height(16.dp))
+    }
+}
+
+@Composable
+private fun ErrorBlock(
+    message: String,
+    onDismiss: () -> Unit,
+) {
+    Box(
+        modifier =
+            Modifier
+                .fillMaxWidth()
+                .padding(bottom = 16.dp),
+        contentAlignment = Alignment.Center,
+    ) {
+        Column(
+            horizontalAlignment = Alignment.CenterHorizontally,
+            verticalArrangement = Arrangement.spacedBy(8.dp),
+        ) {
+            Text(
+                text = message,
+                style = MaterialTheme.typography.bodyMedium,
+                color = MaterialTheme.colorScheme.error,
+                textAlign = TextAlign.Center,
+            )
+            TextButton(onClick = onDismiss) { Text("Try again") }
+        }
+    }
+}
+
+@Composable
+private fun HashMismatchDialog(
+    imported: String,
+    active: String,
+    onConfirm: () -> Unit,
+    onDismiss: () -> Unit,
+) {
+    AlertDialog(
+        onDismissRequest = onDismiss,
+        title = { Text("Different identity") },
+        text = {
+            Text(
+                "The file you picked holds a different identity than the one on this device.\n\n" +
+                    "Imported: ${imported.take(8)}…\n" +
+                    "Existing: ${active.take(8)}…\n\n" +
+                    "Replace the existing one? Your restored messages and contacts will stay " +
+                    "but won't be usable with this new identity.",
+            )
+        },
+        confirmButton = { TextButton(onClick = onConfirm) { Text("Replace") } },
+        dismissButton = { TextButton(onClick = onDismiss) { Text("Cancel") } },
+    )
+}

--- a/app/src/main/java/network/columba/app/ui/screens/IdentityUnlockScreen.kt
+++ b/app/src/main/java/network/columba/app/ui/screens/IdentityUnlockScreen.kt
@@ -72,7 +72,12 @@ fun IdentityUnlockScreen(
     var showExplainer by remember { mutableStateOf(false) }
 
     LaunchedEffect(uiState) {
-        if (uiState is IdentityUnlockUiState.Restored || uiState is IdentityUnlockUiState.StartedFresh) {
+        // `StartedFresh` deliberately isn't handled here: the ViewModel kills
+        // the process immediately after emitting it, so any in-process
+        // navigation would race the shutdown and misroute to Chats with no
+        // active identity. The next cold launch lands on the onboarding flow
+        // because Start Fresh also cleared `HAS_COMPLETED_ONBOARDING`.
+        if (uiState is IdentityUnlockUiState.Restored) {
             onResolved()
         }
     }
@@ -138,7 +143,7 @@ fun IdentityUnlockScreen(
                 }
                 is IdentityUnlockUiState.Error -> {
                     ErrorBlock(state.message) {
-                        viewModel.cancelHashMismatch() // resets to Idle
+                        viewModel.dismissError()
                     }
                 }
                 is IdentityUnlockUiState.HashMismatch -> {

--- a/app/src/main/java/network/columba/app/ui/screens/tcpclient/ReviewConfigureStep.kt
+++ b/app/src/main/java/network/columba/app/ui/screens/tcpclient/ReviewConfigureStep.kt
@@ -7,7 +7,6 @@ import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
-import androidx.compose.foundation.layout.imePadding
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.rememberScrollState
@@ -51,7 +50,6 @@ fun ReviewConfigureStep(viewModel: TcpClientWizardViewModel) {
         modifier =
             Modifier
                 .fillMaxSize()
-                .imePadding()
                 .padding(16.dp)
                 .verticalScroll(rememberScrollState()),
     ) {
@@ -286,8 +284,5 @@ fun ReviewConfigureStep(viewModel: TcpClientWizardViewModel) {
                 }
             }
         }
-
-        // Bottom spacing for navigation bar
-        Spacer(Modifier.height(100.dp))
     }
 }

--- a/app/src/main/java/network/columba/app/ui/screens/tcpclient/TcpClientWizardScreen.kt
+++ b/app/src/main/java/network/columba/app/ui/screens/tcpclient/TcpClientWizardScreen.kt
@@ -6,6 +6,7 @@ import androidx.compose.animation.slideInHorizontally
 import androidx.compose.animation.slideOutHorizontally
 import androidx.compose.animation.togetherWith
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.imePadding
 import androidx.compose.foundation.layout.navigationBarsPadding
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material.icons.Icons
@@ -124,7 +125,7 @@ fun TcpClientWizardScreen(
                         viewModel.goToNextStep()
                     }
                 },
-                modifier = Modifier.navigationBarsPadding(),
+                modifier = Modifier.imePadding().navigationBarsPadding(),
             )
         },
     ) { paddingValues ->

--- a/app/src/main/java/network/columba/app/viewmodel/IdentityUnlockViewModel.kt
+++ b/app/src/main/java/network/columba/app/viewmodel/IdentityUnlockViewModel.kt
@@ -216,16 +216,19 @@ class IdentityUnlockViewModel
         }
 
         private fun restartApp() {
+            // Target MainActivity by explicit ComponentName, not
+            // `getLaunchIntentForPackage`. Debug builds add TestHostActivity as
+            // a MAIN/LAUNCHER for instrumented tests, and the package manager
+            // is free to resolve either — we'd land on an empty test harness
+            // roughly half the time otherwise.
             val launchIntent =
-                context.packageManager.getLaunchIntentForPackage(context.packageName)
-            if (launchIntent == null) {
-                Log.w(TAG, "No launch intent for ${context.packageName}; can't restart cleanly")
-                return
-            }
-            launchIntent.addFlags(
-                android.content.Intent.FLAG_ACTIVITY_NEW_TASK or
-                    android.content.Intent.FLAG_ACTIVITY_CLEAR_TASK,
-            )
+                android.content.Intent().apply {
+                    setClassName(context, "network.columba.app.MainActivity")
+                    addFlags(
+                        android.content.Intent.FLAG_ACTIVITY_NEW_TASK or
+                            android.content.Intent.FLAG_ACTIVITY_CLEAR_TASK,
+                    )
+                }
             context.startActivity(launchIntent)
             Log.d(TAG, "Killing process to complete Start Fresh clean slate")
             android.os.Process.killProcess(android.os.Process.myPid())

--- a/app/src/main/java/network/columba/app/viewmodel/IdentityUnlockViewModel.kt
+++ b/app/src/main/java/network/columba/app/viewmodel/IdentityUnlockViewModel.kt
@@ -1,0 +1,254 @@
+package network.columba.app.viewmodel
+
+import android.content.Context
+import android.net.Uri
+import android.util.Log
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import dagger.hilt.android.lifecycle.HiltViewModel
+import dagger.hilt.android.qualifiers.ApplicationContext
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.SharingStarted
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.stateIn
+import kotlinx.coroutines.launch
+import network.columba.app.data.db.entity.LocalIdentityEntity
+import network.columba.app.data.repository.IdentityRepository
+import network.columba.app.repository.SettingsRepository
+import network.columba.app.reticulum.protocol.ReticulumProtocol
+import javax.inject.Inject
+
+private const val TAG = "IdentityUnlockVM"
+
+/**
+ * ViewModel for the screen shown after an Auto Backup restore when the active
+ * identity row is present but its Keystore-wrapped `encryptedKeyData` can't be
+ * decrypted by the new device's Keystore. Drives two recovery paths: import the
+ * identity `.identity` file the user had saved, or start fresh with a new one.
+ */
+@HiltViewModel
+class IdentityUnlockViewModel
+    @Inject
+    constructor(
+        @ApplicationContext private val context: Context,
+        private val identityRepository: IdentityRepository,
+        private val settingsRepository: SettingsRepository,
+        private val reticulumProtocol: ReticulumProtocol,
+    ) : ViewModel() {
+        private val _uiState = MutableStateFlow<IdentityUnlockUiState>(IdentityUnlockUiState.Idle)
+        val uiState: StateFlow<IdentityUnlockUiState> = _uiState.asStateFlow()
+
+        val activeIdentity: StateFlow<LocalIdentityEntity?> =
+            identityRepository.activeIdentity.stateIn(
+                scope = viewModelScope,
+                started = SharingStarted.WhileSubscribed(5000L),
+                initialValue = null,
+            )
+
+        /**
+         * Parse the imported identity file and, if its hash matches the active
+         * identity, re-wrap the key with the new device's Keystore and clear
+         * the `needs_identity_unlock` flag. Hash mismatch surfaces a confirm
+         * prompt via [IdentityUnlockUiState.HashMismatch]; the user can confirm
+         * (replaces the active row) or cancel.
+         */
+        fun importIdentityFile(fileUri: Uri) {
+            viewModelScope.launch {
+                _uiState.value = IdentityUnlockUiState.Loading("Reading identity file...")
+
+                val active = identityRepository.getActiveIdentitySync()
+                if (active == null) {
+                    _uiState.value = IdentityUnlockUiState.Error("No active identity to restore into")
+                    return@launch
+                }
+
+                val fileData =
+                    try {
+                        context.contentResolver
+                            .openInputStream(fileUri)
+                            ?.use { it.readBytes() }
+                            ?: run {
+                                _uiState.value =
+                                    IdentityUnlockUiState.Error("Couldn't open file")
+                                return@launch
+                            }
+                    } catch (e: Exception) {
+                        _uiState.value =
+                            IdentityUnlockUiState.Error("Couldn't read file: ${e.message}")
+                        return@launch
+                    }
+
+                val parse = reticulumProtocol.importIdentityFile(fileData, active.displayName)
+                if (parse["success"] != true) {
+                    _uiState.value =
+                        IdentityUnlockUiState.Error(
+                            parse["error"] as? String ?: "File is not a valid identity",
+                        )
+                    return@launch
+                }
+                val importedHash =
+                    parse["identity_hash"] as? String
+                        ?: run {
+                            _uiState.value = IdentityUnlockUiState.Error("No hash in parse result")
+                            return@launch
+                        }
+                val keyData =
+                    parse["key_data"] as? ByteArray
+                        ?: run {
+                            _uiState.value = IdentityUnlockUiState.Error("No key material in file")
+                            return@launch
+                        }
+
+                if (importedHash != active.identityHash) {
+                    Log.w(
+                        TAG,
+                        "Imported identity hash ${importedHash.take(8)}... doesn't match active " +
+                            "${active.identityHash.take(8)}...",
+                    )
+                    _uiState.value =
+                        IdentityUnlockUiState.HashMismatch(
+                            importedHash = importedHash,
+                            activeHash = active.identityHash,
+                            keyData = keyData,
+                        )
+                    return@launch
+                }
+
+                completeRewrap(active.identityHash, keyData)
+            }
+        }
+
+        /**
+         * Called after the user explicitly confirms importing an identity whose
+         * hash doesn't match the existing active row. We delete the orphaned
+         * row, then create a fresh one from the imported bytes and set it
+         * active. Conversations tied to the old hash are left in Room but will
+         * appear dormant (no active identity can decrypt them); a future PR
+         * could offer to purge them.
+         */
+        fun confirmReplaceMismatched() {
+            val current = _uiState.value
+            if (current !is IdentityUnlockUiState.HashMismatch) return
+            viewModelScope.launch {
+                _uiState.value = IdentityUnlockUiState.Loading("Replacing identity...")
+
+                // Derive destination hash fresh from the imported identity — the
+                // protocol already computed it during parse, but we re-parse here
+                // so we don't need to carry it through HashMismatch state.
+                val active = identityRepository.getActiveIdentitySync()
+                if (active != null) {
+                    identityRepository
+                        .deleteIdentity(active.identityHash)
+                        .onFailure {
+                            _uiState.value =
+                                IdentityUnlockUiState.Error(
+                                    "Couldn't remove old identity row: ${it.message}",
+                                )
+                            return@launch
+                        }
+                }
+
+                val parse =
+                    reticulumProtocol.importIdentityFile(current.keyData, active?.displayName ?: "")
+                val destHash =
+                    parse["destination_hash"] as? String
+                        ?: run {
+                            _uiState.value =
+                                IdentityUnlockUiState.Error("Couldn't compute destination hash")
+                            return@launch
+                        }
+
+                val result =
+                    identityRepository.createIdentity(
+                        identityHash = current.importedHash,
+                        displayName = active?.displayName ?: "Imported Identity",
+                        destinationHash = destHash,
+                        filePath = "",
+                        keyData = current.keyData,
+                    )
+                result
+                    .onSuccess {
+                        identityRepository.switchActiveIdentity(current.importedHash)
+                        settingsRepository.setNeedsIdentityUnlock(false)
+                        _uiState.value = IdentityUnlockUiState.Restored
+                    }.onFailure { e ->
+                        _uiState.value =
+                            IdentityUnlockUiState.Error(
+                                "Couldn't save imported identity: ${e.message}",
+                            )
+                    }
+            }
+        }
+
+        fun cancelHashMismatch() {
+            if (_uiState.value is IdentityUnlockUiState.HashMismatch) {
+                _uiState.value = IdentityUnlockUiState.Idle
+            }
+        }
+
+        /**
+         * Delete the undecryptable identity and send the user back through
+         * onboarding to create a new one. Messages and contacts tied to the old
+         * identity hash remain in Room but are effectively orphaned — the user
+         * can see their history but won't be able to continue any conversation.
+         */
+        fun startFresh() {
+            viewModelScope.launch {
+                _uiState.value = IdentityUnlockUiState.Loading("Starting fresh...")
+                val active = identityRepository.getActiveIdentitySync()
+                active?.let { identityRepository.deleteIdentity(it.identityHash) }
+                settingsRepository.clearOnboardingCompleted()
+                settingsRepository.setNeedsIdentityUnlock(false)
+                _uiState.value = IdentityUnlockUiState.StartedFresh
+            }
+        }
+
+        private suspend fun completeRewrap(
+            identityHash: String,
+            keyData: ByteArray,
+        ) {
+            _uiState.value = IdentityUnlockUiState.Loading("Unlocking identity...")
+            identityRepository
+                .rewrapKeyWithDeviceKey(identityHash, keyData)
+                .onSuccess {
+                    settingsRepository.setNeedsIdentityUnlock(false)
+                    _uiState.value = IdentityUnlockUiState.Restored
+                }.onFailure { e ->
+                    _uiState.value =
+                        IdentityUnlockUiState.Error("Couldn't save identity key: ${e.message}")
+                }
+        }
+    }
+
+sealed class IdentityUnlockUiState {
+    object Idle : IdentityUnlockUiState()
+
+    data class Loading(
+        val message: String,
+    ) : IdentityUnlockUiState()
+
+    data class Error(
+        val message: String,
+    ) : IdentityUnlockUiState()
+
+    data class HashMismatch(
+        val importedHash: String,
+        val activeHash: String,
+        val keyData: ByteArray,
+    ) : IdentityUnlockUiState() {
+        override fun equals(other: Any?): Boolean {
+            if (this === other) return true
+            if (other !is HashMismatch) return false
+            return importedHash == other.importedHash &&
+                activeHash == other.activeHash &&
+                keyData.contentEquals(other.keyData)
+        }
+
+        override fun hashCode(): Int = importedHash.hashCode()
+    }
+
+    object Restored : IdentityUnlockUiState()
+
+    object StartedFresh : IdentityUnlockUiState()
+}

--- a/app/src/main/java/network/columba/app/viewmodel/IdentityUnlockViewModel.kt
+++ b/app/src/main/java/network/columba/app/viewmodel/IdentityUnlockViewModel.kt
@@ -171,7 +171,19 @@ class IdentityUnlockViewModel
                     )
                 result
                     .onSuccess {
-                        identityRepository.switchActiveIdentity(current.importedHash)
+                        // If switch fails the new row exists but isActive=0,
+                        // so the next boot sees no active identity and Chats
+                        // silently breaks. Surface the failure and leave the
+                        // unlock flag set so we route back here next launch.
+                        val switched =
+                            identityRepository.switchActiveIdentity(current.importedHash)
+                        switched.onFailure { e ->
+                            _uiState.value =
+                                IdentityUnlockUiState.Error(
+                                    "Couldn't activate imported identity: ${e.message}",
+                                )
+                            return@launch
+                        }
                         settingsRepository.setNeedsIdentityUnlock(false)
                         _uiState.value = IdentityUnlockUiState.Restored
                     }.onFailure { e ->

--- a/app/src/main/java/network/columba/app/viewmodel/IdentityUnlockViewModel.kt
+++ b/app/src/main/java/network/columba/app/viewmodel/IdentityUnlockViewModel.kt
@@ -188,10 +188,20 @@ class IdentityUnlockViewModel
         }
 
         /**
-         * Delete the undecryptable identity and send the user back through
-         * onboarding to create a new one. Messages and contacts tied to the old
-         * identity hash remain in Room but are effectively orphaned — the user
-         * can see their history but won't be able to continue any conversation.
+         * Delete the undecryptable identity and restart the process. The running
+         * ReticulumService still holds the old identity in native memory, and
+         * the app's auto-create-identity path only fires during cold startup
+         * (`ColumbaApplication.onCreate` → `reticulumProtocol.initialize`). If
+         * we tried to navigate to onboarding in-process, OnboardingViewModel's
+         * `completeOnboarding` would find no active identity in Room and the
+         * user's chosen display name would silently drop on the floor. Killing
+         * the process gives the next launch a clean slate: no active identity,
+         * no onboarding flag, native stack creates a fresh identity, the
+         * auto-create path persists it to Room, and onboarding runs normally.
+         *
+         * Messages and contacts tied to the old identity hash are still in Room
+         * after the row is deleted, but the UI filters conversations by active
+         * identity — they won't render and the user effectively starts empty.
          */
         fun startFresh() {
             viewModelScope.launch {
@@ -201,7 +211,24 @@ class IdentityUnlockViewModel
                 settingsRepository.clearOnboardingCompleted()
                 settingsRepository.setNeedsIdentityUnlock(false)
                 _uiState.value = IdentityUnlockUiState.StartedFresh
+                restartApp()
             }
+        }
+
+        private fun restartApp() {
+            val launchIntent =
+                context.packageManager.getLaunchIntentForPackage(context.packageName)
+            if (launchIntent == null) {
+                Log.w(TAG, "No launch intent for ${context.packageName}; can't restart cleanly")
+                return
+            }
+            launchIntent.addFlags(
+                android.content.Intent.FLAG_ACTIVITY_NEW_TASK or
+                    android.content.Intent.FLAG_ACTIVITY_CLEAR_TASK,
+            )
+            context.startActivity(launchIntent)
+            Log.d(TAG, "Killing process to complete Start Fresh clean slate")
+            android.os.Process.killProcess(android.os.Process.myPid())
         }
 
         private suspend fun completeRewrap(

--- a/app/src/main/java/network/columba/app/viewmodel/IdentityUnlockViewModel.kt
+++ b/app/src/main/java/network/columba/app/viewmodel/IdentityUnlockViewModel.kt
@@ -100,6 +100,14 @@ class IdentityUnlockViewModel
                             return@launch
                         }
 
+                val destHash =
+                    parse["destination_hash"] as? String
+                        ?: run {
+                            _uiState.value =
+                                IdentityUnlockUiState.Error("No destination hash in parse result")
+                            return@launch
+                        }
+
                 if (importedHash != active.identityHash) {
                     Log.w(
                         TAG,
@@ -111,6 +119,7 @@ class IdentityUnlockViewModel
                             importedHash = importedHash,
                             activeHash = active.identityHash,
                             keyData = keyData,
+                            destHash = destHash,
                         )
                     return@launch
                 }
@@ -133,9 +142,12 @@ class IdentityUnlockViewModel
             viewModelScope.launch {
                 _uiState.value = IdentityUnlockUiState.Loading("Replacing identity...")
 
-                // Derive destination hash fresh from the imported identity — the
-                // protocol already computed it during parse, but we re-parse here
-                // so we don't need to carry it through HashMismatch state.
+                // `importedHash`, `keyData`, and `destHash` are all carried
+                // through `HashMismatch` from the initial parse — no need to
+                // re-invoke the protocol here. Re-parsing with the already-
+                // extracted 64-byte `keyData` would fail anyway since
+                // `importIdentityFile` expects raw file bytes, not pre-parsed
+                // key material.
                 val active = identityRepository.getActiveIdentitySync()
                 if (active != null) {
                     identityRepository
@@ -149,21 +161,11 @@ class IdentityUnlockViewModel
                         }
                 }
 
-                val parse =
-                    reticulumProtocol.importIdentityFile(current.keyData, active?.displayName ?: "")
-                val destHash =
-                    parse["destination_hash"] as? String
-                        ?: run {
-                            _uiState.value =
-                                IdentityUnlockUiState.Error("Couldn't compute destination hash")
-                            return@launch
-                        }
-
                 val result =
                     identityRepository.createIdentity(
                         identityHash = current.importedHash,
                         displayName = active?.displayName ?: "Imported Identity",
-                        destinationHash = destHash,
+                        destinationHash = current.destHash,
                         filePath = "",
                         keyData = current.keyData,
                     )
@@ -188,6 +190,19 @@ class IdentityUnlockViewModel
         }
 
         /**
+         * Reset from a terminal `Error` state back to `Idle` so the user can
+         * retry. `cancelHashMismatch` only handles the mismatch-confirm path;
+         * without this, the "Try again" button in `ErrorBlock` was a no-op
+         * once an import failed — leaving the user stuck on the error message
+         * with no way to start over.
+         */
+        fun dismissError() {
+            if (_uiState.value is IdentityUnlockUiState.Error) {
+                _uiState.value = IdentityUnlockUiState.Idle
+            }
+        }
+
+        /**
          * Delete the undecryptable identity and restart the process. The running
          * ReticulumService still holds the old identity in native memory, and
          * the app's auto-create-identity path only fires during cold startup
@@ -207,7 +222,21 @@ class IdentityUnlockViewModel
             viewModelScope.launch {
                 _uiState.value = IdentityUnlockUiState.Loading("Starting fresh...")
                 val active = identityRepository.getActiveIdentitySync()
-                active?.let { identityRepository.deleteIdentity(it.identityHash) }
+                if (active != null) {
+                    identityRepository
+                        .deleteIdentity(active.identityHash)
+                        .onFailure { e ->
+                            // If the row deletion fails and we press on to the
+                            // restart, the undecryptable identity stays active
+                            // and the next launch routes right back to this
+                            // screen — a silent infinite loop for the user.
+                            _uiState.value =
+                                IdentityUnlockUiState.Error(
+                                    "Couldn't remove old identity: ${e.message}",
+                                )
+                            return@launch
+                        }
+                }
                 settingsRepository.clearOnboardingCompleted()
                 settingsRepository.setNeedsIdentityUnlock(false)
                 _uiState.value = IdentityUnlockUiState.StartedFresh
@@ -266,16 +295,24 @@ sealed class IdentityUnlockUiState {
         val importedHash: String,
         val activeHash: String,
         val keyData: ByteArray,
+        val destHash: String,
     ) : IdentityUnlockUiState() {
         override fun equals(other: Any?): Boolean {
             if (this === other) return true
             if (other !is HashMismatch) return false
             return importedHash == other.importedHash &&
                 activeHash == other.activeHash &&
-                keyData.contentEquals(other.keyData)
+                keyData.contentEquals(other.keyData) &&
+                destHash == other.destHash
         }
 
-        override fun hashCode(): Int = importedHash.hashCode()
+        override fun hashCode(): Int {
+            var result = importedHash.hashCode()
+            result = 31 * result + activeHash.hashCode()
+            result = 31 * result + keyData.contentHashCode()
+            result = 31 * result + destHash.hashCode()
+            return result
+        }
     }
 
     object Restored : IdentityUnlockUiState()

--- a/app/src/main/java/network/columba/app/viewmodel/OnboardingViewModel.kt
+++ b/app/src/main/java/network/columba/app/viewmodel/OnboardingViewModel.kt
@@ -6,9 +6,11 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.launch
 import network.columba.app.data.model.TcpCommunityServers
 import network.columba.app.data.repository.IdentityRepository
@@ -41,6 +43,20 @@ class OnboardingViewModel
 
         private val _state = MutableStateFlow(OnboardingState())
         val state: StateFlow<OnboardingState> = _state.asStateFlow()
+
+        /**
+         * True when the active identity's Keystore-wrapped key blob survived a
+         * backup restore but the Keystore AES key that produced it did not
+         * (Keystore keys are app-UID-bound and don't cross uninstall). Navigation
+         * routes to IdentityUnlockScreen so the user can re-import their identity
+         * file rather than landing on a chats tab that can't send anything.
+         */
+        val needsIdentityUnlock: StateFlow<Boolean> =
+            settingsRepository.needsIdentityUnlockFlow.stateIn(
+                scope = viewModelScope,
+                started = SharingStarted.WhileSubscribed(5000L),
+                initialValue = false,
+            )
 
         init {
             checkOnboardingStatus()

--- a/app/src/test/java/network/columba/app/viewmodel/OnboardingViewModelTest.kt
+++ b/app/src/test/java/network/columba/app/viewmodel/OnboardingViewModelTest.kt
@@ -60,6 +60,7 @@ class OnboardingViewModelTest {
 
         // Default stubs for SettingsRepository
         coEvery { mockSettingsRepository.hasCompletedOnboardingFlow } returns MutableStateFlow(false)
+        coEvery { mockSettingsRepository.needsIdentityUnlockFlow } returns MutableStateFlow(false)
         coEvery { mockSettingsRepository.markOnboardingCompleted() } just Runs
 
         // Default stubs for IdentityRepository

--- a/data/src/main/java/network/columba/app/data/repository/IdentityRepository.kt
+++ b/data/src/main/java/network/columba/app/data/repository/IdentityRepository.kt
@@ -4,16 +4,16 @@ import android.content.Context
 import android.net.Uri
 import android.util.Log
 import androidx.core.content.FileProvider
+import dagger.hilt.android.qualifiers.ApplicationContext
+import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.withContext
 import network.columba.app.data.crypto.IdentityKeyEncryptor
 import network.columba.app.data.crypto.IdentityKeyMigrator
 import network.columba.app.data.crypto.IdentityKeyProvider
 import network.columba.app.data.db.ColumbaDatabase
 import network.columba.app.data.db.dao.LocalIdentityDao
 import network.columba.app.data.db.entity.LocalIdentityEntity
-import dagger.hilt.android.qualifiers.ApplicationContext
-import kotlinx.coroutines.CoroutineDispatcher
-import kotlinx.coroutines.flow.Flow
-import kotlinx.coroutines.withContext
 import java.io.File
 import javax.inject.Inject
 import javax.inject.Singleton
@@ -326,7 +326,8 @@ class IdentityRepository
 
                     // Try to recover from the stored filePath (e.g. default_identity)
                     val storedFile = File(identity.filePath)
-                    if (storedFile.exists() && storedFile.length() == 64L &&
+                    if (storedFile.exists() &&
+                        storedFile.length() == 64L &&
                         storedFile.absolutePath != canonicalPath.absolutePath
                     ) {
                         Log.i(TAG, "Found identity file at stored path for $hashPrefix..., copying to canonical")
@@ -377,7 +378,10 @@ class IdentityRepository
         /**
          * Update the database filePath if it differs from the canonical path.
          */
-        private suspend fun updateFilePathIfNeeded(identity: LocalIdentityEntity, canonicalPath: File) {
+        private suspend fun updateFilePathIfNeeded(
+            identity: LocalIdentityEntity,
+            canonicalPath: File,
+        ) {
             if (identity.filePath != canonicalPath.absolutePath) {
                 Log.i(TAG, "Updating filePath for ${identity.identityHash.take(8)}...")
                 identityDao.updateFilePath(identity.identityHash, canonicalPath.absolutePath)
@@ -556,6 +560,36 @@ class IdentityRepository
         // ==================== Key Encryption Management ====================
 
         /**
+         * Re-wrap a raw identity key with the current device Keystore key and
+         * overwrite `encryptedKeyData` on the matching identity row.
+         *
+         * Used by the identity-unlock flow after an Auto Backup restore on a
+         * new device — the Keystore-wrapped blob survived the restore but the
+         * Keystore AES key that produced it did not (Keystore keys don't cross
+         * the uninstall boundary). The user re-imports their `.identity` file,
+         * we parse the raw 64 bytes out of it, and this method rewrites the
+         * row so the next `decryptDeliveryKey` call succeeds.
+         */
+        suspend fun rewrapKeyWithDeviceKey(
+            identityHash: String,
+            keyData: ByteArray,
+        ): Result<Unit> =
+            withContext(ioDispatcher) {
+                try {
+                    val encrypted = keyEncryptor.encryptWithDeviceKey(keyData)
+                    identityDao.updateEncryptedKeyData(
+                        identityHash = identityHash,
+                        encryptedKeyData = encrypted,
+                        version = IdentityKeyEncryptor.VERSION_DEVICE_ONLY.toInt(),
+                    )
+                    Result.success(Unit)
+                } catch (e: Exception) {
+                    Log.e(TAG, "Failed to re-wrap key for ${identityHash.take(8)}...", e)
+                    Result.failure(e)
+                }
+            }
+
+        /**
          * Run the encryption migration for all unencrypted identities.
          * This should be called during app initialization.
          */
@@ -563,15 +597,16 @@ class IdentityRepository
             withContext(ioDispatcher) {
                 Log.i(TAG, "Running identity key encryption migration...")
                 val result = keyMigrator.migrateUnencryptedIdentities()
-                result.onSuccess { migrationResult ->
-                    Log.i(
-                        TAG,
-                        "Encryption migration completed: ${migrationResult.successCount} succeeded, " +
-                            "${migrationResult.failureCount} failed",
-                    )
-                }.onFailure { e ->
-                    Log.e(TAG, "Encryption migration failed", e)
-                }
+                result
+                    .onSuccess { migrationResult ->
+                        Log.i(
+                            TAG,
+                            "Encryption migration completed: ${migrationResult.successCount} succeeded, " +
+                                "${migrationResult.failureCount} failed",
+                        )
+                    }.onFailure { e ->
+                        Log.e(TAG, "Encryption migration failed", e)
+                    }
                 result
             }
 

--- a/data/src/main/java/network/columba/app/data/repository/IdentityRepository.kt
+++ b/data/src/main/java/network/columba/app/data/repository/IdentityRepository.kt
@@ -576,6 +576,18 @@ class IdentityRepository
         ): Result<Unit> =
             withContext(ioDispatcher) {
                 try {
+                    // Enforce the same 64-byte contract createIdentity holds
+                    // itself to. If a caller ever hands us a mis-sized blob
+                    // we'd happily encrypt it and write a row that later
+                    // fails mysteriously deep inside the native stack; better
+                    // to fail loud at the boundary.
+                    if (keyData.size != 64) {
+                        return@withContext Result.failure(
+                            IllegalArgumentException(
+                                "Identity key must be 64 bytes (got ${keyData.size})",
+                            ),
+                        )
+                    }
                     val encrypted = keyEncryptor.encryptWithDeviceKey(keyData)
                     identityDao.updateEncryptedKeyData(
                         identityHash = identityHash,

--- a/reticulum/src/main/java/network/columba/app/reticulum/protocol/NativeReticulumProtocol.kt
+++ b/reticulum/src/main/java/network/columba/app/reticulum/protocol/NativeReticulumProtocol.kt
@@ -949,11 +949,13 @@ class NativeReticulumProtocol(
         filePath: String,
     ): ByteArray =
         withContext(Dispatchers.IO) {
-            // Caller already holds the decrypted 64-byte key from the Keystore-
-            // wrapped DB blob. We just write it to the user-chosen export path.
-            // Parent dir is expected to exist (typically a cache dir or SAF
-            // scratch file); if it doesn't, let the IOException propagate.
-            java.io.File(filePath).writeBytes(keyData)
+            // Caller holds the decrypted 64-byte key from the Keystore-wrapped
+            // DB blob and wraps it into a FileProvider cache file itself. Since
+            // natively-created identities store `filePath = ""` (no plaintext
+            // file on disk), writing here would ENOENT — and the caller doesn't
+            // need us to, the bytes it gets back are what it serves to the
+            // share sheet. `filePath` is kept on the interface for the handful
+            // of remaining callers that still pass a real path.
             keyData
         }
 


### PR DESCRIPTION
## Summary

Auto Backup (from #790/#791/#793) now restores conversations, contacts, and RNS routing state on a new device — but the identity's Keystore-wrapped key blob can't be decrypted on the new device, because Keystore AES keys are app-UID-bound and don't cross uninstall/reinstall. Before this PR, `ColumbaApplication` was silently bailing out of Reticulum init and leaving the user on a chats tab that couldn't send anything. This wires a dedicated recovery screen.

## Flow

1. `ColumbaApplication` decrypt site (cold-start + `initializeReticulumService`): on `deliveryKey == null` with a non-null active identity, set `needs_identity_unlock = true` in DataStore.
2. `OnboardingViewModel` exposes `needsIdentityUnlock: StateFlow<Boolean>` backed by `SettingsRepository.needsIdentityUnlockFlow`.
3. `MainActivity.ColumbaNavigation` routes to `Screen.IdentityUnlock` as the start destination (or via `LaunchedEffect` if the flag flips while running) whenever onboarding is completed but the unlock flag is set.
4. `IdentityUnlockScreen` presents two CTAs:
   - **Import identity file** — SAF picker → `NativeReticulumProtocol.importIdentityFile(bytes)` parses the identity → if hash matches the active row, `IdentityRepository.rewrapKeyWithDeviceKey` re-wraps with the new device's Keystore key and overwrites `encryptedKeyData`. On hash mismatch, user gets a confirm dialog before we delete the old row and insert a new active identity.
   - **Start fresh** — deletes the undecryptable identity, clears `HAS_COMPLETED_ONBOARDING`, routes back through onboarding.
5. "Why did this happen?" explainer explains the Keystore boundary in plain English.
6. On success (`Restored` or `StartedFresh` terminal state), `onResolved` pops the navigation stack back to Chats.

Messages and contacts stay visible at the DB level throughout — they're not encrypted at the Room level and the UI can still show them. Sending requires a usable identity, which is what this flow restores.

## Files

- `SettingsRepository`: new `NEEDS_IDENTITY_UNLOCK` key + `needsIdentityUnlockFlow` + `setNeedsIdentityUnlock` + `clearOnboardingCompleted`.
- `ColumbaApplication`: set/clear the flag at both decrypt sites.
- `OnboardingViewModel`: expose `needsIdentityUnlock` StateFlow. (`OnboardingViewModelTest` updated to stub the new flow.)
- `IdentityRepository`: new `rewrapKeyWithDeviceKey(hash, keyData)` — the re-wrap step.
- `IdentityUnlockViewModel` (new): drives the screen's three terminal states.
- `IdentityUnlockScreen` (new): Compose UI.
- `MainActivity`: new `Screen.IdentityUnlock` + routing + composable registration.

## No crypto, no schema changes

This PR is purely a UX/routing addition on top of existing behavior. The decision tree explicitly chose Option A (UX path) over Option B (add a password-wrapped backup envelope) — crypto design was a domain the project author didn't want to over-commit on. Option B remains available as a future opt-in.

## Verification

- [x] `:app:assembleNoSentryDebug`
- [x] `:app:testNoSentryDebugUnitTest` (including updated `OnboardingViewModelTest`)
- [x] `:app:detekt`
- [ ] Manual: install on a device with an active identity, clear sharedprefs for the Keystore wrapping key (or simulate via factory reset + restore), verify the unlock screen appears and re-import restores the identity.

🤖 Generated with [Claude Code](https://claude.com/claude-code)