### PR TITLE
fix: ignore CancellationException in rapid interface toggles

### DIFF
--- a/app/src/main/java/network/columba/app/viewmodel/InterfaceManagementViewModel.kt
+++ b/app/src/main/java/network/columba/app/viewmodel/InterfaceManagementViewModel.kt
@@ -5,6 +5,7 @@ import android.util.Log
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
@@ -1045,7 +1046,7 @@ class InterfaceManagementViewModel
                         fetchInterfaceStatus()
                         kotlinx.coroutines.delay(4000)
                         fetchInterfaceStatus()
-                    } catch (e: kotlinx.coroutines.CancellationException) {
+                    } catch (e: CancellationException) {
                         // Quick successive toggles cancel the in-flight sync so the
                         // next one wins. That's by design, not a failure — rethrow
                         // so the coroutine honours cancellation instead of flipping

--- a/app/src/main/java/network/columba/app/viewmodel/InterfaceManagementViewModel.kt
+++ b/app/src/main/java/network/columba/app/viewmodel/InterfaceManagementViewModel.kt
@@ -4,15 +4,6 @@ import android.bluetooth.BluetoothAdapter
 import android.util.Log
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
-import network.columba.app.data.database.entity.InterfaceEntity
-import network.columba.app.data.model.BleConnectionsState
-import network.columba.app.data.repository.BleStatusRepository
-import network.columba.app.repository.InterfaceRepository
-import network.columba.app.reticulum.model.InterfaceConfig
-import network.columba.app.reticulum.protocol.ReticulumProtocol
-import network.columba.app.service.InterfaceConfigManager
-import network.columba.app.util.validation.InputValidator
-import network.columba.app.util.validation.ValidationResult
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -24,6 +15,15 @@ import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
+import network.columba.app.data.database.entity.InterfaceEntity
+import network.columba.app.data.model.BleConnectionsState
+import network.columba.app.data.repository.BleStatusRepository
+import network.columba.app.repository.InterfaceRepository
+import network.columba.app.reticulum.model.InterfaceConfig
+import network.columba.app.reticulum.protocol.ReticulumProtocol
+import network.columba.app.service.InterfaceConfigManager
+import network.columba.app.util.validation.InputValidator
+import network.columba.app.util.validation.ValidationResult
 import org.json.JSONObject
 import javax.inject.Inject
 
@@ -1045,6 +1045,12 @@ class InterfaceManagementViewModel
                         fetchInterfaceStatus()
                         kotlinx.coroutines.delay(4000)
                         fetchInterfaceStatus()
+                    } catch (e: kotlinx.coroutines.CancellationException) {
+                        // Quick successive toggles cancel the in-flight sync so the
+                        // next one wins. That's by design, not a failure — rethrow
+                        // so the coroutine honours cancellation instead of flipping
+                        // the "Failed to Apply Changes" banner on.
+                        throw e
                     } catch (e: Exception) {
                         Log.e(TAG, "Failed to sync native interfaces: ${e.message}", e)
                         // Hot-reload failed and the caller has already shown a success toast for


### PR DESCRIPTION
## Summary
- Rapid interface toggles (e.g. disabling two interfaces in quick succession) were surfacing "Failed to Apply Changes — StandaloneCoroutine was cancelled" even though the cancellation was intentional.
- \`syncNativeInterfaces()\` cancels its own in-flight job on every call so back-to-back toggles collapse into a single reload. The catch-all \`catch (e: Exception)\` was swallowing the resulting \`CancellationException\` and flipping the error banner on, even though the UI state settled correctly seconds later.

## Fix
Add a \`catch (e: CancellationException) { throw e }\` ahead of the generic catch so the coroutine honours its cancellation. Real failures still surface the banner and re-arm the retry button.

## Reproduction
1. Open Interface Management with 3–4 interfaces enabled.
2. Disable two interfaces in quick succession (within ~1s).
3. Before fix: \`Failed to Apply Changes\` dialog appears; interface state still settles a moment later but user sees a false error.
4. After fix: no dialog, interfaces settle silently.

## Test plan
- [x] \`./gradlew :app:compileNoSentryDebugKotlin :app:detekt\`
- [ ] Manual: repro the quick-toggle scenario, verify no error dialog