### PR TITLE
fix: route all PRAGMAs through db.query() so Android accepts them

### DIFF
--- a/data/src/main/java/com/lxmf/messenger/data/di/DatabaseModule.kt
+++ b/data/src/main/java/com/lxmf/messenger/data/di/DatabaseModule.kt
@@ -1723,16 +1723,24 @@ object DatabaseModule {
     val DURABILITY_CALLBACK: RoomDatabase.Callback =
         object : RoomDatabase.Callback() {
             private fun applyPragmas(db: SupportSQLiteDatabase) {
-                // journal_mode returns the resulting mode as a row; use query() so a
-                // silent failure (e.g. filesystem that doesn't support WAL) is detectable.
+                // All four PRAGMAs return a result row (either the new value or the
+                // activated mode). Android's SupportSQLiteDatabase rejects execSQL for
+                // any statement that produces rows, so everything must go through
+                // query() and close the cursor even if we don't care about the value.
                 db.query("PRAGMA journal_mode=WAL").use { cursor ->
                     if (cursor.moveToFirst() && !cursor.getString(0).equals("wal", ignoreCase = true)) {
                         Log.e("Columba/DB", "journal_mode=WAL not activated; mode=${cursor.getString(0)}")
                     }
                 }
-                db.execSQL("PRAGMA synchronous=FULL")
-                db.execSQL("PRAGMA wal_autocheckpoint=100")
-                db.execSQL("PRAGMA busy_timeout=5000")
+                db.query("PRAGMA synchronous=FULL").use {
+                    /* drain row */ it.moveToFirst()
+                }
+                db.query("PRAGMA wal_autocheckpoint=100").use {
+                    /* drain row */ it.moveToFirst()
+                }
+                db.query("PRAGMA busy_timeout=5000").use {
+                    /* drain row */ it.moveToFirst()
+                }
             }
 
             override fun onCreate(db: SupportSQLiteDatabase) = applyPragmas(db)


### PR DESCRIPTION
## Summary

Follow-up to #798 (already merged). My original durability patch used `db.execSQL()` for four PRAGMAs but Android's `SupportSQLiteDatabase.execSQL()` refuses any statement that produces a result row — and **all four** of those PRAGMAs return one:

- `PRAGMA journal_mode=WAL` — returns the activated mode
- `PRAGMA synchronous=FULL` — returns the new value
- `PRAGMA wal_autocheckpoint=100` — returns the previous value
- `PRAGMA busy_timeout=5000` — returns the new value

Greptile flagged the silent-failure aspect of `journal_mode` in the original PR, and I switched just that one to `db.query()` — but didn't realize the `execSQL`-rejects-row-returning-PRAGMAs rule applies to the other three too. So `0.10.6` shipped fine, then `0.10.7-beta` (which was the first release to actually exercise this path in production) crashed on startup with:

```
SQLiteException: unknown error (code 0 SQLITE_OK[0]):
  Queries can be performed using SQLiteDatabase query or rawQuery methods only.
    at DatabaseModule.DURABILITY_CALLBACK.applyPragmas(DatabaseModule.kt:67)
```

This patch routes **all** the PRAGMAs through `db.query().use { it.moveToFirst() }`, draining the result cursor. Verified end-to-end against a real Android device (Redmi Note 9 Pro, Android 13) — app starts cleanly, no SQLiteException in the service process logs.

## Why this wasn't caught before merge

`./gradlew :data:compileDebugKotlin` and `:app:compileSentryDebugKotlin` both passed because the compile-time signature of `execSQL(String)` is identical to `query(String)`. The failure is *runtime* and *platform-specific*: Android's `FrameworkSQLiteDatabase` is stricter than JVM's in-memory SQLite. None of the existing unit tests run on Android, so the rejection path never fires in CI. An `androidTest` that instantiates the Room DB would catch this — worth adding as a follow-up but out of scope for this patch.

## Test plan

- [x] `:data:compileDebugKotlin :app:compileSentryDebugKotlin` pass locally
- [x] Build + install on real Android device — no `SQLiteException` in service process logs on cold start
- [x] Service process reaches `ReticulumService: Service started` without error
- [ ] Included in 0.10.7-beta.1 retag / rebuild