### PR TITLE
fix: route all PRAGMAs through db.query() so Android accepts them

### DIFF
--- a/data/src/main/java/network/columba/app/data/di/DatabaseModule.kt
+++ b/data/src/main/java/network/columba/app/data/di/DatabaseModule.kt
@@ -56,16 +56,24 @@ object DatabaseModule {
     val DURABILITY_CALLBACK: RoomDatabase.Callback =
         object : RoomDatabase.Callback() {
             private fun applyPragmas(db: SupportSQLiteDatabase) {
-                // journal_mode returns the resulting mode as a row; use query() so a
-                // silent failure (e.g. filesystem that doesn't support WAL) is detectable.
+                // All four PRAGMAs return a result row (either the new value or the
+                // activated mode). Android's SupportSQLiteDatabase rejects execSQL for
+                // any statement that produces rows, so everything must go through
+                // query() and close the cursor even if we don't care about the value.
                 db.query("PRAGMA journal_mode=WAL").use { cursor ->
                     if (cursor.moveToFirst() && !cursor.getString(0).equals("wal", ignoreCase = true)) {
                         Log.e("Columba/DB", "journal_mode=WAL not activated; mode=${cursor.getString(0)}")
                     }
                 }
-                db.execSQL("PRAGMA synchronous=FULL")
-                db.execSQL("PRAGMA wal_autocheckpoint=100")
-                db.execSQL("PRAGMA busy_timeout=5000")
+                db.query("PRAGMA synchronous=FULL").use {
+                    /* drain row */ it.moveToFirst()
+                }
+                db.query("PRAGMA wal_autocheckpoint=100").use {
+                    /* drain row */ it.moveToFirst()
+                }
+                db.query("PRAGMA busy_timeout=5000").use {
+                    /* drain row */ it.moveToFirst()
+                }
             }
 
             override fun onCreate(db: SupportSQLiteDatabase) = applyPragmas(db)


### PR DESCRIPTION
## Summary

Follow-up to #799 (already merged). My original durability patch used `db.execSQL()` for four PRAGMAs but Android's `SupportSQLiteDatabase.execSQL()` refuses any statement that produces a result row — and **all four** of those PRAGMAs return one:

- `PRAGMA journal_mode=WAL` — returns the activated mode
- `PRAGMA synchronous=FULL` — returns the new value
- `PRAGMA wal_autocheckpoint=100` — returns the previous value
- `PRAGMA busy_timeout=5000` — returns the new value

Greptile flagged the silent-failure aspect of `journal_mode` in #799 and I switched just that one to `db.query()` — but didn't realize the same `execSQL`-rejects-row-returning-PRAGMAs rule applies to the other three. So #799 merged fine, but on a real device the `:reticulum` service process crashes with:

```
SQLiteException: unknown error (code 0 SQLITE_OK[0]):
  Queries can be performed using SQLiteDatabase query or rawQuery methods only.
    at DatabaseModule.DURABILITY_CALLBACK.applyPragmas(DatabaseModule.kt:67)
```

Routes all four PRAGMAs through `db.query().use { it.moveToFirst() }`. Verified on a real Redmi Note 9 Pro (Android 13): `network.columba.app` starts cleanly, service process reports `Service started` without error, no SQLite exceptions.

## Why this wasn't caught

Compile-time signatures of `execSQL` and `query` are identical; the failure is runtime, on Android's `FrameworkSQLiteDatabase` specifically. None of the tests on the JVM side exercise Android's SupportSQLiteDatabase wrapper. An `androidTest` that instantiates the Room DB and calls `getWritableDatabase()` would catch this class of bug — worth adding as a follow-up.

## Test plan

- [x] `:data:compileDebugKotlin :app:compileSentryDebugKotlin` pass
- [x] Cold-start on real device, no SQLiteException in service process logs
- [x] Compatible with dev build (`0.10.6.0131-dev`)