### PR TITLE
fix: pass IFAC passphrase through to TCPClientInterface factory

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -19,7 +19,7 @@ serialization = "1.10.0"
 coil = "2.7.0"
 
 # JitPack-published libraries (formerly git submodules)
-reticulumKt = "v0.0.6"
+reticulumKt = "v0.0.7"
 lxmfKt = "v0.0.4"
 lxstKt = "v0.0.3"
 

--- a/reticulum/src/main/java/network/columba/app/reticulum/protocol/NativeInterfaceFactory.kt
+++ b/reticulum/src/main/java/network/columba/app/reticulum/protocol/NativeInterfaceFactory.kt
@@ -260,6 +260,7 @@ internal object NativeInterfaceFactory {
                     useKissFraming = config.kissFraming,
                     keepAlive = false, // Disable for mobile battery
                     ifacNetname = config.networkName,
+                    ifacNetkey = config.passphrase,
                 )
 
             is InterfaceConfig.UDP ->


### PR DESCRIPTION
## Summary

`NativeInterfaceFactory` was only wiring `ifacNetname` into the
`TCPClientInterface` ctor — it silently dropped `ifacNetkey` (the user's
passphrase). That asymmetry produces a broken but *not obviously broken*
IFAC key and causes interop to fail silently with every peer that uses
a full (network_name + passphrase) configuration.

```kotlin
// before
TCPClientInterface(
    ...
    ifacNetname = config.networkName,
)

// after
TCPClientInterface(
    ...
    ifacNetname = config.networkName,
    ifacNetkey = config.passphrase,
)
```

## Why this looked like a reticulum-kt IFAC bug

This is the proximate cause of the reticulum-kt#29 symptom: Columba's
announces arrive at a Python RNS peer but get silently dropped at IFAC
verification. The reporter reasonably attributed it to reticulum-kt
because wire traffic was the only thing they could observe, and the
outer appearance is exactly "Kotlin produces IFAC bytes that Python
won't verify."

`IfacUtils.deriveIfacCredentials` accepts a netname-only configuration
without error and returns credentials derived from a 32-byte
`fullHash(netname)` origin. Python RNS (and a correctly-passed Kotlin
config) derives from a 64-byte `fullHash(netname) + fullHash(netkey)`
origin. Same HKDF salt, different input → different key → Ed25519
signatures that the peer can't verify → silent drop.

reticulum-kt's IFAC primitives are byte-identical to Python RNS at every
conformance layer I could build: primitives (HKDF, Ed25519, mask
transform), wire-E2E (live TCP between a Kotlin peer and a Python peer
with matching IFAC). The bug only manifests through Columba's factory.

## Verification

Reproduced the failure and confirmed the fix with a live rnsd:

1. Spin up `rnsd` locally with a `TCPServerInterface` on 0.0.0.0:4242,
   `network_name = columba-test`, `passphrase = columba-test-secret-2026`,
   `enable_transport = Yes`.
2. Configure the same TCP interface in Columba pointing at the rnsd.
3. **Before fix** (current debug build of `main`): Columba's logcat shows
   `Broadcasting to <hash> on 1 interfaces: [local ifac test]` over and
   over; rnsd's log shows the TCP connection accepted but **no `Valid
   announce`** entries for the Columba socket.
4. **After fix** (this patch, local composite-build APK): within 1s of
   reconnect, rnsd logs `Valid announce for <020ef14edc8d1091...> 1 hops
   away, received on TCPInterface[Client on IFAC TCP Server/10.0.0.249:...]`
   and `Rebroadcasting announce for <020ef14edc8d1091...> with hop count 1`.
   The destination hash matches what Columba's logcat showed it was
   announcing. Sideband on the same rnsd now sees it.

## Out of scope (follow-up needed)

- **RNode**: `RNodeConnectionHelper` doesn't pass `ifacNetname`/`ifacNetkey`
  *at all*, and reticulum-kt's `RNodeInterface` ctor doesn't currently
  accept them. Fixing RNode IFAC interop needs a reticulum-kt change first.
- **TCPServer**: `NativeInterfaceFactory` marks it "not yet supported in
  native stack" — nothing to fix here until that lands.
- Conformance test: worth adding a regression test in reticulum-conformance
  `tests/wire/` that runs with only `ifacNetname` set (no passphrase) on
  one peer — that would have caught this if my bridge's test harness
  supported asymmetric IFAC config.

## Test plan

- [x] Local reproducer (broken before, fixed after) with real rnsd and
      real .249 device.
- [ ] CI passes.
- [ ] Greptile review: 5/5.

🤖 Generated with [Claude Code](https://claude.com/claude-code)