### PR TITLE
Surface announce filters as sticky chip rows; rebrand Nodes → Sites

### DIFF
--- a/app/src/main/java/network/columba/app/ui/components/AnnounceFilterChips.kt
+++ b/app/src/main/java/network/columba/app/ui/components/AnnounceFilterChips.kt
@@ -38,13 +38,15 @@ private val INTERFACE_OPTIONS: List<Pair<InterfaceType, String>> =
 
 /**
  * Two always-visible rows of filter chips for the announce stream:
- *   1. Aspect: All / Peers / Nodes / Relays / Audio
+ *   1. Aspect: All / Peers / Sites / Relays / Audio
  *   2. Interface: All / Local / TCP / Bluetooth / RNode / Other
  *
  * The "All" chip in each row represents "no filter active". Tapping it clears
  * the row; tapping any other chip deselects All. Note the two rows use different
  * underlying semantics (aspect = positive include, interface = restrict), but
- * both surface the same "All = unfiltered" UX.
+ * both surface the same "All = unfiltered" UX. The aspect row prevents the user
+ * from deselecting every chip (would otherwise produce a blank list with no
+ * selected indicator) — the final tap snaps back to All.
  */
 @Composable
 fun AnnounceFilterChips(
@@ -168,6 +170,13 @@ private fun toggleAspect(
     onShowAudioChange: (Boolean) -> Unit,
 ) {
     val isActive = active.contains(aspect)
+    // If this tap would leave no aspect chip selected, snap back to All instead
+    // of producing a blank list with no visual indicator of what's filtering it.
+    if (isActive && active.size == 1) {
+        onNodeTypesChange(setOf(NodeType.PEER, NodeType.NODE, NodeType.PROPAGATION_NODE))
+        onShowAudioChange(true)
+        return
+    }
     when (aspect) {
         AspectChip.PEER -> onNodeTypesChange(selectedNodeTypes.withToggled(NodeType.PEER, !isActive))
         AspectChip.NODE -> onNodeTypesChange(selectedNodeTypes.withToggled(NodeType.NODE, !isActive))

--- a/app/src/main/java/network/columba/app/ui/components/AnnounceFilterChips.kt
+++ b/app/src/main/java/network/columba/app/ui/components/AnnounceFilterChips.kt
@@ -1,0 +1,183 @@
+package network.columba.app.ui.components
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.lazy.LazyRow
+import androidx.compose.foundation.lazy.items
+import androidx.compose.material3.FilterChip
+import androidx.compose.material3.FilterChipDefaults
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import network.columba.app.data.model.InterfaceType
+import network.columba.app.reticulum.model.NodeType
+
+private enum class AspectChip(
+    val label: String,
+) {
+    PEER("Peers"),
+    NODE("Sites"),
+    RELAY("Relays"),
+    AUDIO("Audio"),
+}
+
+private val ALL_ASPECTS = setOf(AspectChip.PEER, AspectChip.NODE, AspectChip.RELAY, AspectChip.AUDIO)
+
+private val INTERFACE_OPTIONS: List<Pair<InterfaceType, String>> =
+    listOf(
+        InterfaceType.AUTO_INTERFACE to "Local",
+        InterfaceType.TCP_CLIENT to "TCP",
+        InterfaceType.ANDROID_BLE to "Bluetooth",
+        InterfaceType.RNODE to "RNode",
+        InterfaceType.UNKNOWN to "Other",
+    )
+
+/**
+ * Two always-visible rows of filter chips for the announce stream:
+ *   1. Aspect: All / Peers / Nodes / Relays / Audio
+ *   2. Interface: All / Local / TCP / Bluetooth / RNode / Other
+ *
+ * The "All" chip in each row represents "no filter active". Tapping it clears
+ * the row; tapping any other chip deselects All. Note the two rows use different
+ * underlying semantics (aspect = positive include, interface = restrict), but
+ * both surface the same "All = unfiltered" UX.
+ */
+@Composable
+fun AnnounceFilterChips(
+    selectedNodeTypes: Set<NodeType>,
+    showAudio: Boolean,
+    selectedInterfaceTypes: Set<InterfaceType>,
+    onNodeTypesChange: (Set<NodeType>) -> Unit,
+    onShowAudioChange: (Boolean) -> Unit,
+    onInterfaceTypesChange: (Set<InterfaceType>) -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    val activeAspects: Set<AspectChip> =
+        buildSet {
+            if (selectedNodeTypes.contains(NodeType.PEER)) add(AspectChip.PEER)
+            if (selectedNodeTypes.contains(NodeType.NODE)) add(AspectChip.NODE)
+            if (selectedNodeTypes.contains(NodeType.PROPAGATION_NODE)) add(AspectChip.RELAY)
+            if (showAudio) add(AspectChip.AUDIO)
+        }
+
+    Surface(
+        modifier = modifier.fillMaxWidth(),
+        color = MaterialTheme.colorScheme.surface,
+        tonalElevation = 1.dp,
+    ) {
+        androidx.compose.foundation.layout.Column {
+            AspectChipRow(
+                activeAspects = activeAspects,
+                onAspectToggle = { aspect ->
+                    toggleAspect(
+                        aspect = aspect,
+                        active = activeAspects,
+                        selectedNodeTypes = selectedNodeTypes,
+                        onNodeTypesChange = onNodeTypesChange,
+                        onShowAudioChange = onShowAudioChange,
+                    )
+                },
+                onAllClick = {
+                    onNodeTypesChange(setOf(NodeType.PEER, NodeType.NODE, NodeType.PROPAGATION_NODE))
+                    onShowAudioChange(true)
+                },
+            )
+            InterfaceChipRow(
+                selected = selectedInterfaceTypes,
+                onToggle = { type ->
+                    val next =
+                        if (selectedInterfaceTypes.contains(type)) {
+                            selectedInterfaceTypes - type
+                        } else {
+                            selectedInterfaceTypes + type
+                        }
+                    onInterfaceTypesChange(next)
+                },
+                onAllClick = { onInterfaceTypesChange(emptySet()) },
+            )
+        }
+    }
+}
+
+@Composable
+private fun AspectChipRow(
+    activeAspects: Set<AspectChip>,
+    onAspectToggle: (AspectChip) -> Unit,
+    onAllClick: () -> Unit,
+) {
+    LazyRow(
+        modifier = Modifier.fillMaxWidth(),
+        contentPadding = PaddingValues(horizontal = 12.dp, vertical = 6.dp),
+        horizontalArrangement = Arrangement.spacedBy(8.dp),
+    ) {
+        item(key = "aspect-all") {
+            FilterChip(
+                selected = activeAspects == ALL_ASPECTS,
+                onClick = onAllClick,
+                label = { Text("All") },
+                colors = FilterChipDefaults.filterChipColors(),
+            )
+        }
+        items(AspectChip.entries.toList(), key = { "aspect-${it.name}" }) { aspect ->
+            FilterChip(
+                selected = activeAspects.contains(aspect),
+                onClick = { onAspectToggle(aspect) },
+                label = { Text(aspect.label) },
+            )
+        }
+    }
+}
+
+@Composable
+private fun InterfaceChipRow(
+    selected: Set<InterfaceType>,
+    onToggle: (InterfaceType) -> Unit,
+    onAllClick: () -> Unit,
+) {
+    LazyRow(
+        modifier = Modifier.fillMaxWidth(),
+        contentPadding = PaddingValues(horizontal = 12.dp, vertical = 6.dp),
+        horizontalArrangement = Arrangement.spacedBy(8.dp),
+    ) {
+        item(key = "iface-all") {
+            FilterChip(
+                selected = selected.isEmpty(),
+                onClick = onAllClick,
+                label = { Text("All") },
+            )
+        }
+        items(INTERFACE_OPTIONS, key = { "iface-${it.first.name}" }) { (type, label) ->
+            FilterChip(
+                selected = selected.contains(type),
+                onClick = { onToggle(type) },
+                label = { Text(label) },
+            )
+        }
+    }
+}
+
+private fun toggleAspect(
+    aspect: AspectChip,
+    active: Set<AspectChip>,
+    selectedNodeTypes: Set<NodeType>,
+    onNodeTypesChange: (Set<NodeType>) -> Unit,
+    onShowAudioChange: (Boolean) -> Unit,
+) {
+    val isActive = active.contains(aspect)
+    when (aspect) {
+        AspectChip.PEER -> onNodeTypesChange(selectedNodeTypes.withToggled(NodeType.PEER, !isActive))
+        AspectChip.NODE -> onNodeTypesChange(selectedNodeTypes.withToggled(NodeType.NODE, !isActive))
+        AspectChip.RELAY ->
+            onNodeTypesChange(selectedNodeTypes.withToggled(NodeType.PROPAGATION_NODE, !isActive))
+        AspectChip.AUDIO -> onShowAudioChange(!isActive)
+    }
+}
+
+private fun Set<NodeType>.withToggled(
+    type: NodeType,
+    include: Boolean,
+): Set<NodeType> = if (include) this + type else this - type

--- a/app/src/main/java/network/columba/app/ui/components/PeerCard.kt
+++ b/app/src/main/java/network/columba/app/ui/components/PeerCard.kt
@@ -303,7 +303,9 @@ fun NodeTypeBadge(nodeType: String) {
             "PEER" -> "Peer" to MaterialTheme.colorScheme.primary
             "PROPAGATION_NODE" -> "Relay" to MaterialTheme.colorScheme.secondary
             "PHONE" -> "Phone" to MaterialTheme.colorScheme.error
-            else -> "Site" to MaterialTheme.colorScheme.tertiary
+            // Unknown/future node types: keep protocol terminology rather than
+            // silently aliasing to "Site", which is reserved for NomadNet nodes.
+            else -> "Node" to MaterialTheme.colorScheme.tertiary
         }
 
     Surface(

--- a/app/src/main/java/network/columba/app/ui/components/PeerCard.kt
+++ b/app/src/main/java/network/columba/app/ui/components/PeerCard.kt
@@ -43,13 +43,13 @@ import androidx.compose.ui.text.font.FontFamily
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
+import kotlinx.coroutines.delay
 import network.columba.app.data.model.InterfaceType
 import network.columba.app.data.repository.Announce
 import network.columba.app.ui.theme.MeshConnected
 import network.columba.app.ui.theme.MeshLimited
 import network.columba.app.ui.theme.MeshOffline
 import network.columba.app.util.formatTimeSince
-import kotlinx.coroutines.delay
 
 /**
  * Shared peer card component used by both AnnounceStreamScreen and SavedPeersScreen.
@@ -299,11 +299,11 @@ fun InterfaceTypeIcon(
 fun NodeTypeBadge(nodeType: String) {
     val (text, color) =
         when (nodeType) {
-            "NODE" -> "Node" to MaterialTheme.colorScheme.tertiary
+            "NODE" -> "Site" to MaterialTheme.colorScheme.tertiary
             "PEER" -> "Peer" to MaterialTheme.colorScheme.primary
             "PROPAGATION_NODE" -> "Relay" to MaterialTheme.colorScheme.secondary
             "PHONE" -> "Phone" to MaterialTheme.colorScheme.error
-            else -> "Node" to MaterialTheme.colorScheme.tertiary
+            else -> "Site" to MaterialTheme.colorScheme.tertiary
         }
 
     Surface(

--- a/app/src/main/java/network/columba/app/ui/screens/AnnounceDetailScreen.kt
+++ b/app/src/main/java/network/columba/app/ui/screens/AnnounceDetailScreen.kt
@@ -258,8 +258,6 @@ fun AnnounceDetailScreen(
 
                 // Show "Set as My Relay" button for propagation nodes
                 if (announceNonNull.nodeType == "PROPAGATION_NODE") {
-                    val isCurrentRelay by viewModel.isMyRelayFlow(destinationHash).collectAsState(initial = false)
-
                     Button(
                         onClick = {
                             viewModel.setAsMyRelay(announceNonNull.destinationHash)
@@ -272,13 +270,13 @@ fun AnnounceDetailScreen(
                         colors =
                             ButtonDefaults.buttonColors(
                                 containerColor =
-                                    if (isCurrentRelay) {
+                                    if (isMyRelay) {
                                         MaterialTheme.colorScheme.tertiary
                                     } else {
                                         MaterialTheme.colorScheme.secondary
                                     },
                             ),
-                        enabled = !isCurrentRelay,
+                        enabled = !isMyRelay,
                     ) {
                         Icon(
                             imageVector = Icons.Default.Hub,
@@ -287,7 +285,7 @@ fun AnnounceDetailScreen(
                         )
                         Spacer(modifier = Modifier.width(8.dp))
                         Text(
-                            text = if (isCurrentRelay) "Current Relay" else "Set as My Relay",
+                            text = if (isMyRelay) "Current Relay" else "Set as My Relay",
                             style = MaterialTheme.typography.titleMedium,
                             fontWeight = FontWeight.SemiBold,
                         )

--- a/app/src/main/java/network/columba/app/ui/screens/AnnounceDetailScreen.kt
+++ b/app/src/main/java/network/columba/app/ui/screens/AnnounceDetailScreen.kt
@@ -358,7 +358,7 @@ fun AnnounceDetailScreen(
                     }
                 }
 
-                // Show "Browse Node" button for NomadNet content nodes
+                // Show "Browse Site" button for NomadNet content nodes
                 if (announceNonNull.aspect == "nomadnetwork.node") {
                     Button(
                         onClick = {
@@ -381,7 +381,7 @@ fun AnnounceDetailScreen(
                         )
                         Spacer(modifier = Modifier.width(8.dp))
                         Text(
-                            text = "Browse Node",
+                            text = "Browse Site",
                             style = MaterialTheme.typography.titleMedium,
                             fontWeight = FontWeight.SemiBold,
                         )

--- a/app/src/main/java/network/columba/app/ui/screens/AnnounceStreamScreen.kt
+++ b/app/src/main/java/network/columba/app/ui/screens/AnnounceStreamScreen.kt
@@ -1,7 +1,6 @@
 package network.columba.app.ui.screens
 
 import android.widget.Toast
-import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -10,22 +9,18 @@ import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.consumeWindowInsets
 import androidx.compose.foundation.layout.fillMaxSize
-import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.offset
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.rememberLazyListState
-import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.shape.RoundedCornerShape
-import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Campaign
 import androidx.compose.material.icons.filled.Chat
 import androidx.compose.material.icons.filled.Delete
 import androidx.compose.material.icons.filled.DeleteSweep
-import androidx.compose.material.icons.filled.FilterList
 import androidx.compose.material.icons.filled.Info
 import androidx.compose.material.icons.filled.KeyboardArrowUp
 import androidx.compose.material.icons.filled.MoreVert
@@ -34,8 +29,6 @@ import androidx.compose.material.icons.filled.Star
 import androidx.compose.material.icons.filled.StarBorder
 import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.ButtonDefaults
-import androidx.compose.material3.Checkbox
-import androidx.compose.material3.CheckboxDefaults
 import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.DropdownMenu
 import androidx.compose.material3.DropdownMenuItem
@@ -68,16 +61,16 @@ import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.paging.compose.LazyPagingItems
 import androidx.paging.compose.collectAsLazyPagingItems
-import network.columba.app.data.model.InterfaceType
+import kotlinx.coroutines.launch
 import network.columba.app.data.repository.Announce
 import network.columba.app.reticulum.model.NodeType
+import network.columba.app.ui.components.AnnounceFilterChips
 import network.columba.app.ui.components.NodeTypeBadge
 import network.columba.app.ui.components.OtherBadge
 import network.columba.app.ui.components.PeerCard
 import network.columba.app.ui.components.SearchableTopAppBar
 import network.columba.app.ui.components.simpleVerticalScrollbar
 import network.columba.app.viewmodel.AnnounceStreamViewModel
-import kotlinx.coroutines.launch
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
@@ -114,9 +107,6 @@ fun AnnounceStreamScreen(
     // Context menu state
     var showContextMenu by remember { mutableStateOf(false) }
     var contextMenuAnnounce by remember { mutableStateOf<Announce?>(null) }
-
-    // Filter dialog state
-    var showFilterDialog by remember { mutableStateOf(false) }
 
     // Delete dialog state
     var showDeleteDialog by remember { mutableStateOf(false) }
@@ -191,14 +181,6 @@ fun AnnounceStreamScreen(
                             )
                         }
                     }
-                    // Filter button
-                    IconButton(onClick = { showFilterDialog = true }) {
-                        Icon(
-                            imageVector = Icons.Default.FilterList,
-                            contentDescription = "Filter node types",
-                            tint = MaterialTheme.colorScheme.onPrimaryContainer,
-                        )
-                    }
                     // Overflow menu
                     Box {
                         IconButton(onClick = { showOverflowMenu = true }) {
@@ -237,131 +219,126 @@ fun AnnounceStreamScreen(
             )
         },
     ) { paddingValues ->
-        Box(
-            modifier = Modifier.fillMaxSize(),
+        Column(
+            modifier =
+                Modifier
+                    .fillMaxSize()
+                    .padding(paddingValues)
+                    .consumeWindowInsets(paddingValues),
         ) {
-            if (pagingItems.itemCount == 0) {
-                EmptyAnnounceState(
-                    modifier =
-                        Modifier
-                            .fillMaxSize()
-                            .padding(paddingValues),
-                )
-            } else {
-                LazyColumn(
-                    state = listState,
-                    modifier =
-                        Modifier
-                            .fillMaxSize()
-                            .padding(paddingValues)
-                            .consumeWindowInsets(paddingValues)
-                            .simpleVerticalScrollbar(listState),
-                    contentPadding = PaddingValues(16.dp),
-                    verticalArrangement = Arrangement.spacedBy(12.dp),
-                ) {
-                    items(
-                        count = pagingItems.itemCount,
-                        key = pagingItems.stableKey(),
-                    ) { index ->
-                        val announce = pagingItems[index]
-                        if (announce != null) {
-                            Box {
-                                AnnounceCard(
-                                    announce = announce,
-                                    onClick = {
-                                        onPeerClick(announce.destinationHash, announce.peerName)
-                                    },
-                                    onFavoriteClick = {
-                                        viewModel.toggleContact(announce.destinationHash)
-                                    },
-                                    onLongPress = {
-                                        contextMenuAnnounce = announce
-                                        showContextMenu = true
-                                    },
-                                )
-
-                                // Show context menu for this announce
-                                if (showContextMenu && contextMenuAnnounce == announce) {
-                                    PeerContextMenu(
-                                        expanded = true,
-                                        onDismiss = { showContextMenu = false },
+            AnnounceFilterChips(
+                selectedNodeTypes = selectedNodeTypes,
+                showAudio = showAudioAnnounces,
+                selectedInterfaceTypes = selectedInterfaceTypes,
+                onNodeTypesChange = viewModel::updateSelectedNodeTypes,
+                onShowAudioChange = viewModel::updateShowAudioAnnounces,
+                onInterfaceTypesChange = viewModel::updateSelectedInterfaceTypes,
+            )
+            Box(
+                modifier = Modifier.fillMaxSize(),
+            ) {
+                if (pagingItems.itemCount == 0) {
+                    EmptyAnnounceState(
+                        modifier = Modifier.fillMaxSize(),
+                    )
+                } else {
+                    LazyColumn(
+                        state = listState,
+                        modifier =
+                            Modifier
+                                .fillMaxSize()
+                                .simpleVerticalScrollbar(listState),
+                        contentPadding = PaddingValues(16.dp),
+                        verticalArrangement = Arrangement.spacedBy(12.dp),
+                    ) {
+                        items(
+                            count = pagingItems.itemCount,
+                            key = pagingItems.stableKey(),
+                        ) { index ->
+                            val announce = pagingItems[index]
+                            if (announce != null) {
+                                Box {
+                                    AnnounceCard(
                                         announce = announce,
-                                        onToggleFavorite = {
-                                            viewModel.toggleContact(announce.destinationHash)
-                                        },
-                                        onStartChat = {
-                                            onStartChat(announce.destinationHash, announce.peerName)
-                                        },
-                                        onViewDetails = {
+                                        onClick = {
                                             onPeerClick(announce.destinationHash, announce.peerName)
                                         },
-                                        onDeleteAnnounce = {
-                                            announceToDelete = announce
-                                            showDeleteDialog = true
+                                        onFavoriteClick = {
+                                            viewModel.toggleContact(announce.destinationHash)
+                                        },
+                                        onLongPress = {
+                                            contextMenuAnnounce = announce
+                                            showContextMenu = true
                                         },
                                     )
+
+                                    // Show context menu for this announce
+                                    if (showContextMenu && contextMenuAnnounce == announce) {
+                                        PeerContextMenu(
+                                            expanded = true,
+                                            onDismiss = { showContextMenu = false },
+                                            announce = announce,
+                                            onToggleFavorite = {
+                                                viewModel.toggleContact(announce.destinationHash)
+                                            },
+                                            onStartChat = {
+                                                onStartChat(announce.destinationHash, announce.peerName)
+                                            },
+                                            onViewDetails = {
+                                                onPeerClick(announce.destinationHash, announce.peerName)
+                                            },
+                                            onDeleteAnnounce = {
+                                                announceToDelete = announce
+                                                showDeleteDialog = true
+                                            },
+                                        )
+                                    }
                                 }
                             }
                         }
+
+                        // Bottom spacing for navigation bar (fixed height since M3 NavigationBar consumes the insets)
+                        item {
+                            Spacer(modifier = Modifier.height(100.dp))
+                        }
                     }
 
-                    // Bottom spacing for navigation bar (fixed height since M3 NavigationBar consumes the insets)
-                    item {
-                        Spacer(modifier = Modifier.height(100.dp))
-                    }
-                }
-
-                // New announces indicator button
-                if (newAnnouncesCount > 0) {
-                    FloatingActionButton(
-                        onClick = {
-                            coroutineScope.launch {
-                                listState.animateScrollToItem(0)
-                                newAnnouncesCount = 0
-                            }
-                        },
-                        modifier =
-                            Modifier
-                                .align(Alignment.TopCenter)
-                                .padding(top = paddingValues.calculateTopPadding() + 8.dp),
-                        containerColor = MaterialTheme.colorScheme.primary,
-                        contentColor = MaterialTheme.colorScheme.onPrimary,
-                    ) {
-                        Row(
-                            modifier = Modifier.padding(horizontal = 16.dp),
-                            horizontalArrangement = Arrangement.spacedBy(8.dp),
-                            verticalAlignment = Alignment.CenterVertically,
+                    // New announces indicator button
+                    if (newAnnouncesCount > 0) {
+                        FloatingActionButton(
+                            onClick = {
+                                coroutineScope.launch {
+                                    listState.animateScrollToItem(0)
+                                    newAnnouncesCount = 0
+                                }
+                            },
+                            modifier =
+                                Modifier
+                                    .align(Alignment.TopCenter)
+                                    .padding(top = 8.dp),
+                            containerColor = MaterialTheme.colorScheme.primary,
+                            contentColor = MaterialTheme.colorScheme.onPrimary,
                         ) {
-                            Icon(
-                                imageVector = Icons.Default.KeyboardArrowUp,
-                                contentDescription = "Scroll to top",
-                            )
-                            Text(
-                                text = "$newAnnouncesCount",
-                                style = MaterialTheme.typography.labelLarge,
-                                fontWeight = FontWeight.Bold,
-                            )
+                            Row(
+                                modifier = Modifier.padding(horizontal = 16.dp),
+                                horizontalArrangement = Arrangement.spacedBy(8.dp),
+                                verticalAlignment = Alignment.CenterVertically,
+                            ) {
+                                Icon(
+                                    imageVector = Icons.Default.KeyboardArrowUp,
+                                    contentDescription = "Scroll to top",
+                                )
+                                Text(
+                                    text = "$newAnnouncesCount",
+                                    style = MaterialTheme.typography.labelLarge,
+                                    fontWeight = FontWeight.Bold,
+                                )
+                            }
                         }
                     }
                 }
             }
         }
-    }
-
-    // Show filter dialog
-    if (showFilterDialog) {
-        NodeTypeFilterDialog(
-            selectedTypes = selectedNodeTypes,
-            showAudio = showAudioAnnounces,
-            selectedInterfaceTypes = selectedInterfaceTypes,
-            onDismiss = { showFilterDialog = false },
-            onConfirm = { newSelection, newShowAudio, newInterfaceTypes ->
-                viewModel.updateSelectedNodeTypes(newSelection)
-                viewModel.updateShowAudioAnnounces(newShowAudio)
-                viewModel.updateSelectedInterfaceTypes(newInterfaceTypes)
-                showFilterDialog = false
-            },
-        )
     }
 
     // Delete announce confirmation dialog
@@ -393,230 +370,6 @@ fun AnnounceStreamScreen(
             },
         )
     }
-}
-
-@Composable
-fun NodeTypeFilterDialog(
-    selectedTypes: Set<NodeType>,
-    showAudio: Boolean,
-    selectedInterfaceTypes: Set<InterfaceType> = emptySet(),
-    onDismiss: () -> Unit,
-    onConfirm: (Set<NodeType>, Boolean, Set<InterfaceType>) -> Unit,
-) {
-    var tempSelection by remember { mutableStateOf(selectedTypes) }
-    var tempShowAudio by remember { mutableStateOf(showAudio) }
-    var tempInterfaceSelection by remember { mutableStateOf(selectedInterfaceTypes) }
-
-    AlertDialog(
-        onDismissRequest = onDismiss,
-        title = {
-            Text(
-                text = "Filter Announces",
-                style = MaterialTheme.typography.titleLarge,
-                fontWeight = FontWeight.Bold,
-            )
-        },
-        text = {
-            Column(
-                modifier = Modifier.fillMaxWidth().verticalScroll(rememberScrollState()),
-                verticalArrangement = Arrangement.spacedBy(8.dp),
-            ) {
-                Text(
-                    text = "Node Types",
-                    style = MaterialTheme.typography.titleSmall,
-                    fontWeight = FontWeight.Bold,
-                    color = MaterialTheme.colorScheme.primary,
-                )
-
-                // Checkbox for each node type (PHONE is shown via the audio toggle, not here)
-                NodeType.entries.filter { it != NodeType.PHONE }.forEach { nodeType ->
-                    val (displayName, description) =
-                        when (nodeType) {
-                            NodeType.NODE -> "Node" to "Nomadnet nodes"
-                            NodeType.PEER -> "Peer" to "Nodes you can message with"
-                            NodeType.PROPAGATION_NODE -> "Relay" to "Relay/repeater nodes for signal propagation"
-                            NodeType.PHONE -> error("PHONE filtered above")
-                        }
-
-                    Row(
-                        modifier =
-                            Modifier
-                                .fillMaxWidth()
-                                .clickable {
-                                    tempSelection =
-                                        if (tempSelection.contains(nodeType)) {
-                                            tempSelection - nodeType
-                                        } else {
-                                            tempSelection + nodeType
-                                        }
-                                }.padding(vertical = 4.dp),
-                        verticalAlignment = Alignment.CenterVertically,
-                        horizontalArrangement = Arrangement.spacedBy(12.dp),
-                    ) {
-                        Checkbox(
-                            checked = tempSelection.contains(nodeType),
-                            onCheckedChange = { isChecked ->
-                                tempSelection =
-                                    if (isChecked) {
-                                        tempSelection + nodeType
-                                    } else {
-                                        tempSelection - nodeType
-                                    }
-                            },
-                            colors =
-                                CheckboxDefaults.colors(
-                                    checkedColor = MaterialTheme.colorScheme.tertiary,
-                                    checkmarkColor = MaterialTheme.colorScheme.onTertiary,
-                                ),
-                        )
-
-                        Column(modifier = Modifier.weight(1f)) {
-                            Text(
-                                text = displayName,
-                                style = MaterialTheme.typography.bodyLarge,
-                                fontWeight = FontWeight.SemiBold,
-                                color = MaterialTheme.colorScheme.onSurface,
-                            )
-                            Text(
-                                text = description,
-                                style = MaterialTheme.typography.bodySmall,
-                                color = MaterialTheme.colorScheme.onSurfaceVariant,
-                            )
-                        }
-                    }
-                }
-
-                // Audio announces filter
-                Row(
-                    modifier =
-                        Modifier
-                            .fillMaxWidth()
-                            .clickable {
-                                tempShowAudio = !tempShowAudio
-                            }.padding(vertical = 4.dp),
-                    verticalAlignment = Alignment.CenterVertically,
-                    horizontalArrangement = Arrangement.spacedBy(12.dp),
-                ) {
-                    Checkbox(
-                        checked = tempShowAudio,
-                        onCheckedChange = { tempShowAudio = it },
-                        colors =
-                            CheckboxDefaults.colors(
-                                checkedColor = MaterialTheme.colorScheme.error,
-                                checkmarkColor = MaterialTheme.colorScheme.onError,
-                            ),
-                    )
-
-                    Column(modifier = Modifier.weight(1f)) {
-                        Text(
-                            text = "Audio",
-                            style = MaterialTheme.typography.bodyLarge,
-                            fontWeight = FontWeight.SemiBold,
-                            color = MaterialTheme.colorScheme.onSurface,
-                        )
-                        Text(
-                            text = "Show audio call announces",
-                            style = MaterialTheme.typography.bodySmall,
-                            color = MaterialTheme.colorScheme.onSurfaceVariant,
-                        )
-                    }
-                }
-
-                Spacer(modifier = Modifier.height(8.dp))
-                HorizontalDivider()
-                Spacer(modifier = Modifier.height(8.dp))
-
-                // Interface type filter section
-                Text(
-                    text = "Interface",
-                    style = MaterialTheme.typography.titleSmall,
-                    fontWeight = FontWeight.Bold,
-                    color = MaterialTheme.colorScheme.primary,
-                )
-
-                Text(
-                    text = "Filter by receiving interface (none selected = show all):",
-                    style = MaterialTheme.typography.bodySmall,
-                    color = MaterialTheme.colorScheme.onSurfaceVariant,
-                )
-
-                Spacer(modifier = Modifier.height(4.dp))
-
-                // Filterable interface types (exclude UNKNOWN for cleaner UX)
-                val interfaceTypes =
-                    listOf(
-                        InterfaceType.AUTO_INTERFACE to ("Local" to "AutoInterface (IPv6 link-local)"),
-                        InterfaceType.TCP_CLIENT to ("TCP" to "TCP connections (backbone links)"),
-                        InterfaceType.ANDROID_BLE to ("Bluetooth" to "Bluetooth Low Energy"),
-                        InterfaceType.RNODE to ("RNode" to "RNode radio interface"),
-                        InterfaceType.UNKNOWN to ("Other" to "Unknown or unrecognized interfaces"),
-                    )
-
-                interfaceTypes.forEach { (interfaceType, nameDesc) ->
-                    val (displayName, description) = nameDesc
-
-                    Row(
-                        modifier =
-                            Modifier
-                                .fillMaxWidth()
-                                .clickable {
-                                    tempInterfaceSelection =
-                                        if (tempInterfaceSelection.contains(interfaceType)) {
-                                            tempInterfaceSelection - interfaceType
-                                        } else {
-                                            tempInterfaceSelection + interfaceType
-                                        }
-                                }.padding(vertical = 4.dp),
-                        verticalAlignment = Alignment.CenterVertically,
-                        horizontalArrangement = Arrangement.spacedBy(12.dp),
-                    ) {
-                        Checkbox(
-                            checked = tempInterfaceSelection.contains(interfaceType),
-                            onCheckedChange = { isChecked ->
-                                tempInterfaceSelection =
-                                    if (isChecked) {
-                                        tempInterfaceSelection + interfaceType
-                                    } else {
-                                        tempInterfaceSelection - interfaceType
-                                    }
-                            },
-                            colors =
-                                CheckboxDefaults.colors(
-                                    checkedColor = MaterialTheme.colorScheme.secondary,
-                                    checkmarkColor = MaterialTheme.colorScheme.onSecondary,
-                                ),
-                        )
-
-                        Column(modifier = Modifier.weight(1f)) {
-                            Text(
-                                text = displayName,
-                                style = MaterialTheme.typography.bodyLarge,
-                                fontWeight = FontWeight.SemiBold,
-                                color = MaterialTheme.colorScheme.onSurface,
-                            )
-                            Text(
-                                text = description,
-                                style = MaterialTheme.typography.bodySmall,
-                                color = MaterialTheme.colorScheme.onSurfaceVariant,
-                            )
-                        }
-                    }
-                }
-            }
-        },
-        confirmButton = {
-            TextButton(
-                onClick = { onConfirm(tempSelection, tempShowAudio, tempInterfaceSelection) },
-            ) {
-                Text("Apply")
-            }
-        },
-        dismissButton = {
-            TextButton(onClick = onDismiss) {
-                Text("Cancel")
-            }
-        },
-    )
 }
 
 @androidx.compose.runtime.Stable
@@ -754,6 +507,9 @@ fun AnnounceStreamContent(
     modifier: Modifier = Modifier,
 ) {
     val pagingItems = viewModel.announces.collectAsLazyPagingItems()
+    val selectedNodeTypes by viewModel.selectedNodeTypes.collectAsState()
+    val showAudioAnnounces by viewModel.showAudioAnnounces.collectAsState()
+    val selectedInterfaceTypes by viewModel.selectedInterfaceTypes.collectAsState()
 
     // Context menu state
     var showContextMenu by remember { mutableStateOf(false) }
@@ -809,78 +565,88 @@ fun AnnounceStreamContent(
     // This prevents flickering when new announces arrive and trigger a refresh
     val isLoading = pagingItems.loadState.refresh is androidx.paging.LoadState.Loading
 
-    when {
-        isLoading && pagingItems.itemCount == 0 -> {
-            LoadingNetworkState(modifier = modifier.fillMaxSize())
-        }
-        !isLoading && pagingItems.itemCount == 0 -> {
-            EmptyAnnounceState(modifier = modifier.fillMaxSize())
-        }
-        else -> {
-            LazyColumn(
-                state = listState,
-                modifier =
-                    modifier
-                        .fillMaxSize()
-                        .simpleVerticalScrollbar(listState),
-                contentPadding = PaddingValues(16.dp),
-                verticalArrangement = Arrangement.spacedBy(12.dp),
-            ) {
-                items(
-                    count = pagingItems.itemCount,
-                    key = pagingItems.stableKey(),
-                ) { index ->
-                    val announce = pagingItems[index]
-                    if (announce != null) {
-                        Box {
-                            AnnounceCard(
-                                announce = announce,
-                                onClick = {
-                                    onPeerClick(announce.destinationHash, announce.peerName)
-                                },
-                                onFavoriteClick = {
-                                    viewModel.toggleContact(announce.destinationHash)
-                                },
-                                onLongPress = {
-                                    contextMenuAnnounce = announce
-                                    showContextMenu = true
-                                },
-                            )
-
-                            // Show context menu for this announce
-                            if (showContextMenu && contextMenuAnnounce == announce) {
-                                PeerContextMenu(
-                                    expanded = true,
-                                    onDismiss = { showContextMenu = false },
+    Column(modifier = modifier.fillMaxSize()) {
+        AnnounceFilterChips(
+            selectedNodeTypes = selectedNodeTypes,
+            showAudio = showAudioAnnounces,
+            selectedInterfaceTypes = selectedInterfaceTypes,
+            onNodeTypesChange = viewModel::updateSelectedNodeTypes,
+            onShowAudioChange = viewModel::updateShowAudioAnnounces,
+            onInterfaceTypesChange = viewModel::updateSelectedInterfaceTypes,
+        )
+        when {
+            isLoading && pagingItems.itemCount == 0 -> {
+                LoadingNetworkState(modifier = Modifier.fillMaxSize())
+            }
+            !isLoading && pagingItems.itemCount == 0 -> {
+                EmptyAnnounceState(modifier = Modifier.fillMaxSize())
+            }
+            else -> {
+                LazyColumn(
+                    state = listState,
+                    modifier =
+                        Modifier
+                            .fillMaxSize()
+                            .simpleVerticalScrollbar(listState),
+                    contentPadding = PaddingValues(16.dp),
+                    verticalArrangement = Arrangement.spacedBy(12.dp),
+                ) {
+                    items(
+                        count = pagingItems.itemCount,
+                        key = pagingItems.stableKey(),
+                    ) { index ->
+                        val announce = pagingItems[index]
+                        if (announce != null) {
+                            Box {
+                                AnnounceCard(
                                     announce = announce,
-                                    onToggleFavorite = {
-                                        viewModel.toggleContact(announce.destinationHash)
-                                    },
-                                    onStartChat = {
-                                        onStartChat(announce.destinationHash, announce.peerName)
-                                    },
-                                    onViewDetails = {
+                                    onClick = {
                                         onPeerClick(announce.destinationHash, announce.peerName)
                                     },
-                                    onDeleteAnnounce = {
-                                        announceToDelete = announce
-                                        showDeleteDialog = true
+                                    onFavoriteClick = {
+                                        viewModel.toggleContact(announce.destinationHash)
+                                    },
+                                    onLongPress = {
+                                        contextMenuAnnounce = announce
+                                        showContextMenu = true
                                     },
                                 )
+
+                                // Show context menu for this announce
+                                if (showContextMenu && contextMenuAnnounce == announce) {
+                                    PeerContextMenu(
+                                        expanded = true,
+                                        onDismiss = { showContextMenu = false },
+                                        announce = announce,
+                                        onToggleFavorite = {
+                                            viewModel.toggleContact(announce.destinationHash)
+                                        },
+                                        onStartChat = {
+                                            onStartChat(announce.destinationHash, announce.peerName)
+                                        },
+                                        onViewDetails = {
+                                            onPeerClick(announce.destinationHash, announce.peerName)
+                                        },
+                                        onDeleteAnnounce = {
+                                            announceToDelete = announce
+                                            showDeleteDialog = true
+                                        },
+                                    )
+                                }
                             }
                         }
                     }
-                }
 
-                // Bottom spacing for navigation bar
-                item {
-                    Spacer(modifier = Modifier.height(100.dp))
+                    // Bottom spacing for navigation bar
+                    item {
+                        Spacer(modifier = Modifier.height(100.dp))
+                    }
                 }
             }
         }
     }
 
-    // Delete announce confirmation dialog
+    // Delete announce confirmation dialog (sibling of Column — outside filter chip surface)
     val announceForDelete = announceToDelete
     if (showDeleteDialog && announceForDelete != null) {
         DeleteAnnounceDialog(

--- a/app/src/main/java/network/columba/app/ui/screens/ContactsScreen.kt
+++ b/app/src/main/java/network/columba/app/ui/screens/ContactsScreen.kt
@@ -38,7 +38,6 @@ import androidx.compose.material.icons.filled.Delete
 import androidx.compose.material.icons.filled.DeleteSweep
 import androidx.compose.material.icons.filled.Edit
 import androidx.compose.material.icons.filled.Error
-import androidx.compose.material.icons.filled.FilterList
 import androidx.compose.material.icons.filled.HourglassEmpty
 import androidx.compose.material.icons.filled.Hub
 import androidx.compose.material.icons.filled.Info
@@ -96,6 +95,7 @@ import androidx.compose.ui.draw.clip
 import androidx.compose.ui.hapticfeedback.HapticFeedbackType
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalHapticFeedback
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontFamily
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextOverflow
@@ -103,6 +103,8 @@ import androidx.compose.ui.unit.DpOffset
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.viewmodel.compose.viewModel
+import kotlinx.coroutines.launch
+import network.columba.app.R
 import network.columba.app.data.db.entity.ContactStatus
 import network.columba.app.data.model.EnrichedContact
 import network.columba.app.ui.components.AddContactConfirmationDialog
@@ -113,14 +115,11 @@ import network.columba.app.util.formatRelativeTime
 import network.columba.app.util.validation.InputValidator
 import network.columba.app.util.validation.ValidationConstants
 import network.columba.app.util.validation.ValidationResult
-import androidx.compose.ui.res.stringResource
-import network.columba.app.R
 import network.columba.app.viewmodel.AddContactResult
 import network.columba.app.viewmodel.AnnounceStreamViewModel
 import network.columba.app.viewmodel.ContactsViewModel
 import network.columba.app.viewmodel.SharedImageViewModel
 import network.columba.app.viewmodel.SharedTextViewModel
-import kotlinx.coroutines.launch
 
 private const val TAG = "ContactsScreen"
 
@@ -158,15 +157,11 @@ fun ContactsScreen(
         .rememberSaveable { mutableStateOf(ContactsTab.MY_CONTACTS) }
 
     // Network tab state
-    val selectedNodeTypes by announceViewModel.selectedNodeTypes.collectAsState()
-    val showAudioAnnounces by announceViewModel.showAudioAnnounces.collectAsState()
-    val selectedInterfaceTypes by announceViewModel.selectedInterfaceTypes.collectAsState()
     val announceSearchQuery by announceViewModel.searchQuery.collectAsState()
     val announceCount by announceViewModel.announceCount.collectAsState()
     val isAnnouncing by announceViewModel.isAnnouncing.collectAsState()
     val announceSuccess by announceViewModel.announceSuccess.collectAsState()
     val announceError by announceViewModel.announceError.collectAsState()
-    var showNodeTypeFilterDialog by remember { mutableStateOf(false) }
     var showNetworkOverflowMenu by remember { mutableStateOf(false) }
     var showClearAllAnnouncesDialog by remember { mutableStateOf(false) }
 
@@ -285,13 +280,6 @@ fun ContactsScreen(
                                         contentDescription = "Announce now",
                                     )
                                 }
-                            }
-                            // Filter button
-                            IconButton(onClick = { showNodeTypeFilterDialog = true }) {
-                                Icon(
-                                    imageVector = Icons.Default.FilterList,
-                                    contentDescription = "Filter node types",
-                                )
                             }
                             // Overflow menu
                             Box {
@@ -878,22 +866,6 @@ fun ContactsScreen(
             },
             onRemoveContact = {
                 viewModel.deleteContact(pendingContact.destinationHash)
-            },
-        )
-    }
-
-    // Node type filter dialog (for Network tab)
-    if (showNodeTypeFilterDialog) {
-        NodeTypeFilterDialog(
-            selectedTypes = selectedNodeTypes,
-            showAudio = showAudioAnnounces,
-            selectedInterfaceTypes = selectedInterfaceTypes,
-            onDismiss = { showNodeTypeFilterDialog = false },
-            onConfirm = { newSelection, newShowAudio, newInterfaceTypes ->
-                announceViewModel.updateSelectedNodeTypes(newSelection)
-                announceViewModel.updateShowAudioAnnounces(newShowAudio)
-                announceViewModel.updateSelectedInterfaceTypes(newInterfaceTypes)
-                showNodeTypeFilterDialog = false
             },
         )
     }

--- a/app/src/test/java/network/columba/app/ui/components/PeerCardTest.kt
+++ b/app/src/test/java/network/columba/app/ui/components/PeerCardTest.kt
@@ -396,8 +396,9 @@ class PeerCardTest {
             )
         }
 
-        // Then - should display "Site" as default (else branch)
-        composeTestRule.onNodeWithText("Site").assertIsDisplayed()
+        // Then - unknown node types fall through to "Node" (protocol default),
+        // not "Site" (which is reserved for known NomadNet nodes).
+        composeTestRule.onNodeWithText("Node").assertIsDisplayed()
     }
 
     // ========== Signal Strength Indicator Tests ==========

--- a/app/src/test/java/network/columba/app/ui/components/PeerCardTest.kt
+++ b/app/src/test/java/network/columba/app/ui/components/PeerCardTest.kt
@@ -396,8 +396,8 @@ class PeerCardTest {
             )
         }
 
-        // Then - should display "Node" as default (else branch)
-        composeTestRule.onNodeWithText("Node").assertIsDisplayed()
+        // Then - should display "Site" as default (else branch)
+        composeTestRule.onNodeWithText("Site").assertIsDisplayed()
     }
 
     // ========== Signal Strength Indicator Tests ==========

--- a/app/src/test/java/network/columba/app/ui/screens/AnnounceStreamScreenTest.kt
+++ b/app/src/test/java/network/columba/app/ui/screens/AnnounceStreamScreenTest.kt
@@ -20,6 +20,7 @@ import network.columba.app.data.repository.Announce
 import network.columba.app.reticulum.model.NodeType
 import network.columba.app.test.RegisterComponentActivityRule
 import network.columba.app.viewmodel.AnnounceStreamViewModel
+import org.junit.Assert.assertEquals
 import org.junit.Assert.assertTrue
 import org.junit.Rule
 import org.junit.Test
@@ -234,6 +235,32 @@ class AnnounceStreamScreenTest {
         assertTrue(
             "updateSelectedNodeTypes should have been called with a set containing NODE",
             capturedTypes?.contains(NodeType.NODE) == true,
+        )
+    }
+
+    @Test
+    fun filterChips_deselectingLastAspect_snapsBackToAll() {
+        // Single aspect selected: PEER only, audio off → activeAspects = {PEER}.
+        val mockViewModel =
+            createMockAnnounceStreamViewModel(
+                selectedNodeTypes = setOf(NodeType.PEER),
+                showAudioAnnounces = false,
+            )
+        var capturedTypes: Set<NodeType>? = null
+        every { mockViewModel.updateSelectedNodeTypes(any()) } answers { capturedTypes = firstArg() }
+
+        composeTestRule.setContent {
+            AnnounceStreamScreen(viewModel = mockViewModel)
+        }
+
+        // Tapping the only active chip would leave no aspect selected;
+        // the component should snap to all-types instead of producing an empty filter.
+        composeTestRule.onNodeWithText("Peers").performClick()
+
+        assertEquals(
+            "Deselecting the last active aspect should snap to all types, not empty",
+            setOf(NodeType.PEER, NodeType.NODE, NodeType.PROPAGATION_NODE),
+            capturedTypes,
         )
     }
 

--- a/app/src/test/java/network/columba/app/ui/screens/AnnounceStreamScreenTest.kt
+++ b/app/src/test/java/network/columba/app/ui/screens/AnnounceStreamScreenTest.kt
@@ -247,20 +247,27 @@ class AnnounceStreamScreenTest {
                 showAudioAnnounces = false,
             )
         var capturedTypes: Set<NodeType>? = null
+        var capturedShowAudio: Boolean? = null
         every { mockViewModel.updateSelectedNodeTypes(any()) } answers { capturedTypes = firstArg() }
+        every { mockViewModel.updateShowAudioAnnounces(any()) } answers { capturedShowAudio = firstArg() }
 
         composeTestRule.setContent {
             AnnounceStreamScreen(viewModel = mockViewModel)
         }
 
         // Tapping the only active chip would leave no aspect selected;
-        // the component should snap to all-types instead of producing an empty filter.
+        // the component should snap to ALL (node types + audio) instead of producing an empty filter.
         composeTestRule.onNodeWithText("Peers").performClick()
 
         assertEquals(
-            "Deselecting the last active aspect should snap to all types, not empty",
+            "Deselecting the last active aspect should snap to all node types, not empty",
             setOf(NodeType.PEER, NodeType.NODE, NodeType.PROPAGATION_NODE),
             capturedTypes,
+        )
+        assertEquals(
+            "Snap-back should also re-enable showAudioAnnounces to match All-chip semantics",
+            true,
+            capturedShowAudio,
         )
     }
 

--- a/app/src/test/java/network/columba/app/ui/screens/AnnounceStreamScreenTest.kt
+++ b/app/src/test/java/network/columba/app/ui/screens/AnnounceStreamScreenTest.kt
@@ -221,6 +221,8 @@ class AnnounceStreamScreenTest {
     @Test
     fun filterChips_tappingAspect_callsViewModel() {
         val mockViewModel = createMockAnnounceStreamViewModel()
+        var capturedTypes: Set<NodeType>? = null
+        every { mockViewModel.updateSelectedNodeTypes(any()) } answers { capturedTypes = firstArg() }
 
         composeTestRule.setContent {
             AnnounceStreamScreen(viewModel = mockViewModel)
@@ -229,11 +231,19 @@ class AnnounceStreamScreenTest {
         composeTestRule.onNodeWithText("Sites").performClick()
 
         verify { mockViewModel.updateSelectedNodeTypes(match { it.contains(NodeType.NODE) }) }
+        assertTrue(
+            "updateSelectedNodeTypes should have been called with a set containing NODE",
+            capturedTypes?.contains(NodeType.NODE) == true,
+        )
     }
 
     @Test
     fun filterChips_tappingInterface_callsViewModel() {
         val mockViewModel = createMockAnnounceStreamViewModel()
+        var capturedInterfaces: Set<InterfaceType>? = null
+        every {
+            mockViewModel.updateSelectedInterfaceTypes(any())
+        } answers { capturedInterfaces = firstArg() }
 
         composeTestRule.setContent {
             AnnounceStreamScreen(viewModel = mockViewModel)
@@ -242,6 +252,10 @@ class AnnounceStreamScreenTest {
         composeTestRule.onNodeWithText("TCP").performClick()
 
         verify { mockViewModel.updateSelectedInterfaceTypes(setOf(InterfaceType.TCP_CLIENT)) }
+        assertTrue(
+            "updateSelectedInterfaceTypes should have been called with TCP_CLIENT",
+            capturedInterfaces == setOf(InterfaceType.TCP_CLIENT),
+        )
     }
 
     // ========== Test Helpers ==========

--- a/app/src/test/java/network/columba/app/ui/screens/AnnounceStreamScreenTest.kt
+++ b/app/src/test/java/network/columba/app/ui/screens/AnnounceStreamScreenTest.kt
@@ -8,11 +8,6 @@ import androidx.compose.ui.test.onNodeWithContentDescription
 import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.performClick
 import androidx.paging.PagingData
-import network.columba.app.data.model.InterfaceType
-import network.columba.app.data.repository.Announce
-import network.columba.app.reticulum.model.NodeType
-import network.columba.app.test.RegisterComponentActivityRule
-import network.columba.app.viewmodel.AnnounceStreamViewModel
 import io.mockk.Runs
 import io.mockk.every
 import io.mockk.just
@@ -20,6 +15,11 @@ import io.mockk.mockk
 import io.mockk.verify
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.flowOf
+import network.columba.app.data.model.InterfaceType
+import network.columba.app.data.repository.Announce
+import network.columba.app.reticulum.model.NodeType
+import network.columba.app.test.RegisterComponentActivityRule
+import network.columba.app.viewmodel.AnnounceStreamViewModel
 import org.junit.Assert.assertTrue
 import org.junit.Rule
 import org.junit.Test
@@ -77,17 +77,6 @@ class AnnounceStreamScreenTest {
         }
 
         composeTestRule.onNodeWithContentDescription("Announce now").assertIsDisplayed()
-    }
-
-    @Test
-    fun announceStreamScreen_displaysFilterButton() {
-        val mockViewModel = createMockAnnounceStreamViewModel()
-
-        composeTestRule.setContent {
-            AnnounceStreamScreen(viewModel = mockViewModel)
-        }
-
-        composeTestRule.onNodeWithContentDescription("Filter node types").assertIsDisplayed()
     }
 
     // ========== Announce Button Tests ==========
@@ -197,72 +186,62 @@ class AnnounceStreamScreenTest {
         composeTestRule.onNodeWithText("Listening for announces...").assertIsDisplayed()
     }
 
-    // ========== Filter Dialog Tests ==========
+    // ========== Filter Chip Tests ==========
 
     @Test
-    fun filterButton_click_opensFilterDialog() {
+    fun filterChips_alwaysVisibleAboveList() {
         val mockViewModel = createMockAnnounceStreamViewModel()
 
         composeTestRule.setContent {
             AnnounceStreamScreen(viewModel = mockViewModel)
         }
 
-        // Click filter button
-        composeTestRule.onNodeWithContentDescription("Filter node types").performClick()
-
-        // Filter dialog should appear
-        composeTestRule.onNodeWithText("Filter Announces").assertIsDisplayed()
+        // Chip rows should render without any interaction — aspect row labels.
+        composeTestRule.onNodeWithText("Peers").assertIsDisplayed()
+        composeTestRule.onNodeWithText("Sites").assertIsDisplayed()
+        composeTestRule.onNodeWithText("Relays").assertIsDisplayed()
+        composeTestRule.onNodeWithText("Audio").assertIsDisplayed()
     }
 
     @Test
-    fun filterDialog_displaysNodeTypeOptions() {
+    fun filterChips_displayInterfaceOptions() {
         val mockViewModel = createMockAnnounceStreamViewModel()
 
         composeTestRule.setContent {
             AnnounceStreamScreen(viewModel = mockViewModel)
         }
 
-        // Open filter dialog
-        composeTestRule.onNodeWithContentDescription("Filter node types").performClick()
-
-        // Verify node type options are displayed
-        composeTestRule.onNodeWithText("Node").assertIsDisplayed()
-        composeTestRule.onNodeWithText("Peer").assertIsDisplayed()
-        composeTestRule.onNodeWithText("Relay").assertIsDisplayed()
+        composeTestRule.onNodeWithText("Local").assertIsDisplayed()
+        composeTestRule.onNodeWithText("TCP").assertIsDisplayed()
+        composeTestRule.onNodeWithText("Bluetooth").assertIsDisplayed()
+        composeTestRule.onNodeWithText("RNode").assertIsDisplayed()
+        composeTestRule.onNodeWithText("Other").assertIsDisplayed()
     }
 
     @Test
-    fun nodeTypeFilterDialog_standalone_displaysCorrectly() {
+    fun filterChips_tappingAspect_callsViewModel() {
+        val mockViewModel = createMockAnnounceStreamViewModel()
+
         composeTestRule.setContent {
-            NodeTypeFilterDialog(
-                selectedTypes = setOf(NodeType.PEER),
-                showAudio = true,
-                onDismiss = {},
-                onConfirm = { _, _, _ -> },
-            )
+            AnnounceStreamScreen(viewModel = mockViewModel)
         }
 
-        composeTestRule.onNodeWithText("Filter Announces").assertIsDisplayed()
-        composeTestRule.onNodeWithText("Node Types").assertIsDisplayed()
-        composeTestRule.onNodeWithText("Node").assertIsDisplayed()
-        composeTestRule.onNodeWithText("Peer").assertIsDisplayed()
-        composeTestRule.onNodeWithText("Relay").assertIsDisplayed()
+        composeTestRule.onNodeWithText("Sites").performClick()
+
+        verify { mockViewModel.updateSelectedNodeTypes(match { it.contains(NodeType.NODE) }) }
     }
 
     @Test
-    fun nodeTypeFilterDialog_displaysAudioOption() {
+    fun filterChips_tappingInterface_callsViewModel() {
+        val mockViewModel = createMockAnnounceStreamViewModel()
+
         composeTestRule.setContent {
-            NodeTypeFilterDialog(
-                selectedTypes = setOf(NodeType.PEER),
-                showAudio = true,
-                onDismiss = {},
-                onConfirm = { _, _, _ -> },
-            )
+            AnnounceStreamScreen(viewModel = mockViewModel)
         }
 
-        // Audio option may require scrolling, so check existence rather than displayed
-        composeTestRule.onNodeWithText("Audio").assertExists()
-        composeTestRule.onNodeWithText("Show audio call announces").assertExists()
+        composeTestRule.onNodeWithText("TCP").performClick()
+
+        verify { mockViewModel.updateSelectedInterfaceTypes(setOf(InterfaceType.TCP_CLIENT)) }
     }
 
     // ========== Test Helpers ==========


### PR DESCRIPTION
## Summary

- **Discoverability fix:** replaces the hidden filter icon + `AlertDialog` with two always-visible, horizontally-scrollable M3 `FilterChip` rows (aspect + interface). The NomadNet site browser was effectively invisible before (peers → tap filter → check Node → Apply → tap announce → Browse); now it's one chip tap.
- **Cleanup:** deletes `NodeTypeFilterDialog` (~220 lines) and the duplicate filter button + state in `ContactsScreen`'s Network tab. New `AnnounceFilterChips` component is shared between the standalone `AnnounceStreamScreen` and the embedded `AnnounceStreamContent`.
- **Rebrand:** user-facing copy for the NomadNet `NodeType.NODE` aspect changes from "Node" → "Site" (aspect chip label, `NodeTypeBadge`, "Browse Site" button on the detail screen). NomadNet nodes are frequently dynamic forums / chatrooms / services, so "Site" fits better than "Page" and is more approachable than the protocol-native "Node". Internal `NodeType.NODE` identifiers and the screen title "Discovered Nodes" (which covers all destination kinds) are unchanged.

## M3 notes

- `FilterChip` (selected-state styling + leading checkmark), not `AssistChip`
- Explicit "All" chip per row: selected iff no filter is active; tapping "All" clears the row
- Chip rows are sticky (above the list, not inside it), following standard filterable-list patterns
- `LazyRow` so narrow phones don't clip

## Test plan

- [x] Unit tests: full `:app:testNoSentryDebugUnitTest` suite green (both old dialog-based tests removed, new chip-visibility + chip-interaction tests added)
- [x] Manual: installed on SM-G998U1 (Android 15) and SM-F966U1 (Android 16) — chips render, tapping aspect/interface chips filters the stream, "All" clears, "Browse Site" still navigates from the detail screen
- [ ] Reviewer to sanity-check that the default `selectedNodeTypes = {PEER}` still makes sense — with chips visible, new users can now discover Sites/Relays/Audio in one tap; no behavior change to the default filter itself

🤖 Generated with [Claude Code](https://claude.com/claude-code)