### PR TITLE
Bump reticulum-kt to v0.0.8

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -19,7 +19,7 @@ serialization = "1.10.0"
 coil = "2.7.0"
 
 # JitPack-published libraries (formerly git submodules)
-reticulumKt = "v0.0.7"
+reticulumKt = "v0.0.8"
 lxmfKt = "v0.0.4"
 lxstKt = "v0.0.3"
 


### PR DESCRIPTION
## Summary

Picks up two merged fixes in [reticulum-kt](https://github.com/torlando-tech/reticulum-kt) that together resolve multi-hop NomadNet page request failures observed during go-live testing.

- [torlando-tech/reticulum-kt#39](https://github.com/torlando-tech/reticulum-kt/pull/39) — Transport no longer HEADER_2-wraps link DATA packets on 2+ hop paths, so intermediate transports can forward them via their `link_table` instead of dropping them as *"in transport for other transport instance"*.
- [torlando-tech/reticulum-kt#40](https://github.com/torlando-tech/reticulum-kt/pull/40) — HKDF output-length cap removed to match Python RNS's non-standard counter-wrap behavior; unblocks IFAC on packets with mask length > 8160 bytes (the exact condition hit by chunked Resource transfers over IFAC).

## Observed symptom without this bump

On a phone running v0.0.7, a NomadNet page request to any 2-hop destination logs:

```
NomadNet: link established, RTT=283ms
[Transport] Outbound LINK packet: dest=<linkId>, context=REQUEST, size=99
[Transport] TX PACKET: flags=0x5c hops=0 dest=<linkId>... size=115
... (no inbound packets) ...
NomadNet: page request FAILED callback
[Link] Link <linkId> closed (reason: 2)
```

`flags=0x5c` = HEADER_2 + TRANSPORT + LINK + DATA and `size=115` (vs the HEADER_1 pack size of 99) confirm the packet is being HEADER_2-wrapped with the `linkId` as `transport_id` — the exact bug fixed by #39. Intermediate transports drop it as *"other transport instance"*, the request never reaches the NomadNet node, and the link times out.

No Columba code changes are required beyond the version bump — the fix is entirely inside reticulum-kt's `Transport.processOutbound`.

## Test plan

- [ ] Build succeeds: `./gradlew :app:assembleNoSentryDebug`
- [ ] Install on test phone and load a NomadNet page at 2+ hops — expect the page content to render instead of "Page request failed"
- [ ] Direct (1-hop) messaging continues to work — regression check for the HEADER_1 path

🤖 Generated with [Claude Code](https://claude.com/claude-code)