### PR TITLE
Backport: guard PRAGMA journal_mode and synchronous against Room transactions

### DIFF
--- a/data/src/main/java/com/lxmf/messenger/data/di/DatabaseModule.kt
+++ b/data/src/main/java/com/lxmf/messenger/data/di/DatabaseModule.kt
@@ -1732,9 +1732,11 @@ object DatabaseModule {
                 // changed while a transaction is active (it raises SQLITE_ERROR: "Safety
                 // level may not be changed inside a transaction"). Room's InvalidationTracker
                 // can invoke onCreate() from within an internal transaction, so we guard
-                // these two PRAGMAs with an inTransaction() check. onOpen() is always called
-                // outside of a transaction, so the PRAGMAs will always be applied on
-                // subsequent database opens, even if they were skipped during onCreate().
+                // these two PRAGMAs with an inTransaction() check. onOpen() is typically
+                // called outside of a transaction in current Room versions, so the skipped
+                // PRAGMAs get applied on the next open. The guard is also our defense if
+                // a future Room version ever calls onOpen() transactionally — we'd just
+                // log the skip instead of crashing.
                 if (!db.inTransaction()) {
                     db.query("PRAGMA journal_mode=WAL").use { cursor ->
                         if (cursor.moveToFirst() && !cursor.getString(0).equals("wal", ignoreCase = true)) {
@@ -1744,6 +1746,12 @@ object DatabaseModule {
                     db.query("PRAGMA synchronous=FULL").use {
                         /* drain row */ it.moveToFirst()
                     }
+                } else {
+                    Log.d(
+                        "Columba/DB",
+                        "applyPragmas: inside transaction, skipping journal_mode and synchronous " +
+                            "(will retry on next transaction-free callback)",
+                    )
                 }
                 db.query("PRAGMA wal_autocheckpoint=100").use {
                     /* drain row */ it.moveToFirst()

--- a/data/src/main/java/com/lxmf/messenger/data/di/DatabaseModule.kt
+++ b/data/src/main/java/com/lxmf/messenger/data/di/DatabaseModule.kt
@@ -1727,13 +1727,23 @@ object DatabaseModule {
                 // activated mode). Android's SupportSQLiteDatabase rejects execSQL for
                 // any statement that produces rows, so everything must go through
                 // query() and close the cursor even if we don't care about the value.
-                db.query("PRAGMA journal_mode=WAL").use { cursor ->
-                    if (cursor.moveToFirst() && !cursor.getString(0).equals("wal", ignoreCase = true)) {
-                        Log.e("Columba/DB", "journal_mode=WAL not activated; mode=${cursor.getString(0)}")
+                //
+                // SQLite does not allow PRAGMA journal_mode or PRAGMA synchronous to be
+                // changed while a transaction is active (it raises SQLITE_ERROR: "Safety
+                // level may not be changed inside a transaction"). Room's InvalidationTracker
+                // can invoke onCreate() from within an internal transaction, so we guard
+                // these two PRAGMAs with an inTransaction() check. onOpen() is always called
+                // outside of a transaction, so the PRAGMAs will always be applied on
+                // subsequent database opens, even if they were skipped during onCreate().
+                if (!db.inTransaction()) {
+                    db.query("PRAGMA journal_mode=WAL").use { cursor ->
+                        if (cursor.moveToFirst() && !cursor.getString(0).equals("wal", ignoreCase = true)) {
+                            Log.e("Columba/DB", "journal_mode=WAL not activated; mode=${cursor.getString(0)}")
+                        }
                     }
-                }
-                db.query("PRAGMA synchronous=FULL").use {
-                    /* drain row */ it.moveToFirst()
+                    db.query("PRAGMA synchronous=FULL").use {
+                        /* drain row */ it.moveToFirst()
+                    }
                 }
                 db.query("PRAGMA wal_autocheckpoint=100").use {
                     /* drain row */ it.moveToFirst()


### PR DESCRIPTION
## Summary

Backport of #809 (`seer/fix/db-pragma-transaction-guard`) to `release/v0.10.x`.

Carries over the two commits from the source branch, rewritten against the release branch's `com.lxmf.messenger.data.di.DatabaseModule` path (main uses `network.columba.app.data.di`):

- **fabae79** — backport of `f60eaa4`: guard `PRAGMA journal_mode=WAL` and `PRAGMA synchronous=FULL` behind `db.inTransaction()`. Room's `InvalidationTracker` can invoke `onCreate()` from inside an internal transaction, and SQLite rejects those two PRAGMAs with `SQLITE_ERROR: "Safety level may not be changed inside a transaction"`. Skipped PRAGMAs are retried on the next transaction-free `onOpen()`.
- **53de279** — backport of `c6db02b`: address greptile feedback — add `Log.d` on the else branch so first-install skipped PRAGMAs are visible during debug, and reframe the comment so the onOpen() fallback isn't asserted as a Room API guarantee.

File changed: `data/src/main/java/com/lxmf/messenger/data/di/DatabaseModule.kt` (same function, same logic, same line counts as the main-branch commits).

## Test plan

- [ ] Verify first-install (`onCreate` path) no longer crashes with `SQLITE_ERROR: Safety level may not be changed inside a transaction`.
- [ ] Verify subsequent app launches still activate `journal_mode=WAL` and `synchronous=FULL` via `onOpen`.
- [ ] Confirm `wal_autocheckpoint` and `busy_timeout` PRAGMAs still run on both callbacks (they aren't guarded).
- [ ] Confirm the `Log.d` skip line fires on first install in a debug build.

https://claude.ai/code/session_01B69nEFj8tDdLFTUfYjNLYy