### PR TITLE
Restore long-press → delete on interface cards

### DIFF
--- a/app/src/main/java/network/columba/app/ui/screens/InterfaceManagementScreen.kt
+++ b/app/src/main/java/network/columba/app/ui/screens/InterfaceManagementScreen.kt
@@ -285,6 +285,7 @@ fun InterfaceManagementScreen(
                                     InterfaceCard(
                                         interfaceEntity = iface,
                                         onClick = { onNavigateToInterfaceStats(iface.id) },
+                                        onClickLabel = stringResource(R.string.view_interface_details),
                                         onLongClick = { interfaceToDelete = iface },
                                         onLongClickLabel = stringResource(R.string.delete_interface),
                                         onToggle = { enabled ->
@@ -465,6 +466,7 @@ fun InterfaceManagementScreen(
 fun InterfaceCard(
     interfaceEntity: InterfaceEntity,
     onClick: (() -> Unit)? = null,
+    onClickLabel: String? = null,
     onLongClick: (() -> Unit)? = null,
     onLongClickLabel: String? = null,
     onToggle: (Boolean) -> Unit,
@@ -488,13 +490,16 @@ fun InterfaceCard(
                     when {
                         onClick != null && onLongClick != null ->
                             Modifier.combinedClickable(
+                                onClickLabel = onClickLabel,
                                 onClick = onClick,
                                 onLongClick = onLongClick,
                                 onLongClickLabel = onLongClickLabel,
                             )
-                        onClick != null -> Modifier.clickable(onClick = onClick)
+                        onClick != null ->
+                            Modifier.clickable(onClickLabel = onClickLabel, onClick = onClick)
                         onLongClick != null ->
                             Modifier.combinedClickable(
+                                onClickLabel = onClickLabel,
                                 onClick = {},
                                 onLongClick = onLongClick,
                                 onLongClickLabel = onLongClickLabel,

--- a/app/src/main/java/network/columba/app/ui/screens/InterfaceManagementScreen.kt
+++ b/app/src/main/java/network/columba/app/ui/screens/InterfaceManagementScreen.kt
@@ -69,10 +69,12 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.rotate
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
 import kotlinx.coroutines.delay
+import network.columba.app.R
 import network.columba.app.data.database.entity.InterfaceEntity
 import network.columba.app.reticulum.ble.util.BlePermissionManager
 import network.columba.app.ui.components.BlePermissionBottomSheet
@@ -284,7 +286,7 @@ fun InterfaceManagementScreen(
                                         interfaceEntity = iface,
                                         onClick = { onNavigateToInterfaceStats(iface.id) },
                                         onLongClick = { interfaceToDelete = iface },
-                                        onLongClickLabel = "Delete interface",
+                                        onLongClickLabel = stringResource(R.string.delete_interface),
                                         onToggle = { enabled ->
                                             val hasPermissions = BlePermissionManager.hasAllPermissions(context)
                                             viewModel.toggleInterface(iface.id, enabled, hasPermissions)

--- a/app/src/main/java/network/columba/app/ui/screens/InterfaceManagementScreen.kt
+++ b/app/src/main/java/network/columba/app/ui/screens/InterfaceManagementScreen.kt
@@ -483,8 +483,18 @@ fun InterfaceCard(
                 .then(
                     when {
                         onClick != null && onLongClick != null ->
-                            Modifier.combinedClickable(onClick = onClick, onLongClick = onLongClick)
+                            Modifier.combinedClickable(
+                                onClick = onClick,
+                                onLongClick = onLongClick,
+                                onLongClickLabel = "Delete interface",
+                            )
                         onClick != null -> Modifier.clickable(onClick = onClick)
+                        onLongClick != null ->
+                            Modifier.combinedClickable(
+                                onClick = {},
+                                onLongClick = onLongClick,
+                                onLongClickLabel = "Delete interface",
+                            )
                         else -> Modifier
                     },
                 ),

--- a/app/src/main/java/network/columba/app/ui/screens/InterfaceManagementScreen.kt
+++ b/app/src/main/java/network/columba/app/ui/screens/InterfaceManagementScreen.kt
@@ -11,7 +11,9 @@ import androidx.compose.animation.expandVertically
 import androidx.compose.animation.fadeIn
 import androidx.compose.animation.fadeOut
 import androidx.compose.animation.shrinkVertically
+import androidx.compose.foundation.ExperimentalFoundationApi
 import androidx.compose.foundation.clickable
+import androidx.compose.foundation.combinedClickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -70,12 +72,12 @@ import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
+import kotlinx.coroutines.delay
 import network.columba.app.data.database.entity.InterfaceEntity
 import network.columba.app.reticulum.ble.util.BlePermissionManager
 import network.columba.app.ui.components.BlePermissionBottomSheet
 import network.columba.app.ui.components.InterfaceConfigDialog
 import network.columba.app.viewmodel.InterfaceManagementViewModel
-import kotlinx.coroutines.delay
 
 /**
  * Screen for managing Reticulum network interfaces.
@@ -281,6 +283,7 @@ fun InterfaceManagementScreen(
                                     InterfaceCard(
                                         interfaceEntity = iface,
                                         onClick = { onNavigateToInterfaceStats(iface.id) },
+                                        onLongClick = { interfaceToDelete = iface },
                                         onToggle = { enabled ->
                                             val hasPermissions = BlePermissionManager.hasAllPermissions(context)
                                             viewModel.toggleInterface(iface.id, enabled, hasPermissions)
@@ -454,10 +457,12 @@ fun InterfaceManagementScreen(
     }
 }
 
+@OptIn(ExperimentalFoundationApi::class)
 @Composable
 fun InterfaceCard(
     interfaceEntity: InterfaceEntity,
     onClick: (() -> Unit)? = null,
+    onLongClick: (() -> Unit)? = null,
     onToggle: (Boolean) -> Unit,
     bluetoothState: Int,
     blePermissionsGranted: Boolean,
@@ -475,7 +480,14 @@ fun InterfaceCard(
         modifier =
             Modifier
                 .fillMaxWidth()
-                .then(if (onClick != null) Modifier.clickable(onClick = onClick) else Modifier),
+                .then(
+                    when {
+                        onClick != null && onLongClick != null ->
+                            Modifier.combinedClickable(onClick = onClick, onLongClick = onLongClick)
+                        onClick != null -> Modifier.clickable(onClick = onClick)
+                        else -> Modifier
+                    },
+                ),
         shape = RoundedCornerShape(12.dp),
         colors = CardDefaults.cardColors(containerColor = MaterialTheme.colorScheme.surfaceVariant),
     ) {

--- a/app/src/main/java/network/columba/app/ui/screens/InterfaceManagementScreen.kt
+++ b/app/src/main/java/network/columba/app/ui/screens/InterfaceManagementScreen.kt
@@ -284,6 +284,7 @@ fun InterfaceManagementScreen(
                                         interfaceEntity = iface,
                                         onClick = { onNavigateToInterfaceStats(iface.id) },
                                         onLongClick = { interfaceToDelete = iface },
+                                        onLongClickLabel = "Delete interface",
                                         onToggle = { enabled ->
                                             val hasPermissions = BlePermissionManager.hasAllPermissions(context)
                                             viewModel.toggleInterface(iface.id, enabled, hasPermissions)
@@ -463,6 +464,7 @@ fun InterfaceCard(
     interfaceEntity: InterfaceEntity,
     onClick: (() -> Unit)? = null,
     onLongClick: (() -> Unit)? = null,
+    onLongClickLabel: String? = null,
     onToggle: (Boolean) -> Unit,
     bluetoothState: Int,
     blePermissionsGranted: Boolean,
@@ -486,14 +488,14 @@ fun InterfaceCard(
                             Modifier.combinedClickable(
                                 onClick = onClick,
                                 onLongClick = onLongClick,
-                                onLongClickLabel = "Delete interface",
+                                onLongClickLabel = onLongClickLabel,
                             )
                         onClick != null -> Modifier.clickable(onClick = onClick)
                         onLongClick != null ->
                             Modifier.combinedClickable(
                                 onClick = {},
                                 onLongClick = onLongClick,
-                                onLongClickLabel = "Delete interface",
+                                onLongClickLabel = onLongClickLabel,
                             )
                         else -> Modifier
                     },

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -25,4 +25,5 @@
 
     <!-- Network Interfaces screen -->
     <string name="delete_interface">Delete interface</string>
+    <string name="view_interface_details">View interface details</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -22,4 +22,7 @@
     <string name="offline_banner_reconnecting">Reconnecting\u2026</string>
     <string name="offline_banner_reconnect">Reconnect</string>
     <string name="offline_banner_reconnecting_description">Reconnecting in progress</string>
+
+    <!-- Network Interfaces screen -->
+    <string name="delete_interface">Delete interface</string>
 </resources>


### PR DESCRIPTION
## Summary

`InterfaceManagementScreen` still wires the delete flow — `interfaceToDelete` state, `DeleteConfirmationDialog`, `viewModel.deleteInterface(iface.id)` — but nothing in the UI ever assigns `interfaceToDelete`. The gesture that used to set it was dropped when `InterfaceCard`'s click handling flattened from `combinedClickable` to plain `clickable`. Result: on the Network Interfaces page there's no way to remove an interface from the main list.

Symptoms on go-live testing: couldn't delete a stale RNode interface on .71 that needed to be recreated to re-pair with a different RNode device.

## Fix

- Add `onLongClick: (() -> Unit)? = null` to `InterfaceCard`
- Use `Modifier.combinedClickable(onClick, onLongClick)` when both are provided; fall back to plain `Modifier.clickable(onClick)` when only onClick is set; empty Modifier when neither. Preserves the onboarding `ConnectivityPage` callsites that don't pass `onLongClick`.
- Main screen callsite sets `onLongClick = { interfaceToDelete = iface }` — triggers the existing confirmation dialog, which triggers the existing VM delete path. No new behavior.

Opt-in annotation: `@OptIn(ExperimentalFoundationApi::class)` on `InterfaceCard` (only the card needs it; rest of file unchanged).

## Why this happened

The file was touched in a multi-screen refactor that unified click handling across several card components. `combinedClickable` requires the `ExperimentalFoundationApi` opt-in; when the refactor went to plain `clickable`, the opt-in annotation + the `onLongClick` plumbing disappeared together, and the now-dead `interfaceToDelete` state became invisible to compiler + runtime checks since the dialog still compiled.

## Test plan

- [x] Build: `./gradlew :app:assembleNoSentryDebug`
- [x] Install on .71; long-press an interface card; Delete dialog surfaces; confirm → interface removed
- [ ] Short-press (onClick) on interface card still navigates to stats screen (regression check)
- [ ] `ConnectivityPage` in onboarding still renders interface cards cleanly (callsites don't pass `onLongClick`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)