### PR TITLE
Refresh interface online status when library state changes

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -19,7 +19,7 @@ serialization = "1.10.0"
 coil = "2.7.0"
 
 # JitPack-published libraries (formerly git submodules)
-reticulumKt = "v0.0.8"
+reticulumKt = "v0.0.9"
 lxmfKt = "v0.0.4"
 lxstKt = "v0.0.3"
 

--- a/reticulum/src/main/java/network/columba/app/reticulum/protocol/NativeInterfaceFactory.kt
+++ b/reticulum/src/main/java/network/columba/app/reticulum/protocol/NativeInterfaceFactory.kt
@@ -145,16 +145,20 @@ internal object NativeInterfaceFactory {
         iface: network.reticulum.interfaces.Interface,
     ) {
         val collectorScope = scope ?: return
-        // Replace any previous collector (restartInterface() can re-register under the same name).
-        onlineObservers.remove(name)?.cancel()
-        val job =
+        // Atomically replace any previous collector under the same key
+        // (restartInterface() re-registers under the same name, and
+        // ConcurrentHashMap#compute serialises with concurrent remove()s
+        // in stopInterface() so a racing teardown either cancels the
+        // freshly-launched job or runs entirely before it is stored).
+        onlineObservers.compute(name) { _, previous ->
+            previous?.cancel()
             iface.online
                 .drop(1)
                 .onEach { online ->
                     Log.d(TAG, "Interface $name online → $online")
                     notifyListeners()
                 }.launchIn(collectorScope)
-        onlineObservers[name] = job
+        }
     }
 
     @Suppress("TooGenericExceptionCaught")

--- a/reticulum/src/main/java/network/columba/app/reticulum/protocol/NativeInterfaceFactory.kt
+++ b/reticulum/src/main/java/network/columba/app/reticulum/protocol/NativeInterfaceFactory.kt
@@ -19,6 +19,7 @@ import network.reticulum.transport.Transport
  * Creates and registers reticulum-kt network interfaces from Columba [InterfaceConfig] objects.
  * Matches Carina's InterfaceManager pattern: diff-based sync, async BLE startup.
  */
+@Suppress("TooManyFunctions") // cohesive interface-lifecycle helpers; splitting would obscure coordination
 internal object NativeInterfaceFactory {
     private const val TAG = "NativeInterfaceFactory"
 
@@ -145,13 +146,18 @@ internal object NativeInterfaceFactory {
         iface: network.reticulum.interfaces.Interface,
     ) {
         val collectorScope = scope ?: return
-        // Atomically replace any previous collector under the same key
-        // (restartInterface() re-registers under the same name, and
-        // ConcurrentHashMap#compute serialises with concurrent remove()s
-        // in stopInterface() so a racing teardown either cancels the
-        // freshly-launched job or runs entirely before it is stored).
+        // Atomically replace any previous collector under the same key.
+        // runningInterfaces is the source of truth for "this interface is
+        // currently managed"; stopInterface() removes it BEFORE
+        // onlineObservers, so a racing teardown that won the
+        // runningInterfaces lock first will leave us with an absent key —
+        // we detect that here and refuse to install the collector,
+        // preventing an orphaned observer from surviving teardown.
         onlineObservers.compute(name) { _, previous ->
             previous?.cancel()
+            if (!runningInterfaces.containsKey(name)) {
+                return@compute null
+            }
             iface.online
                 .drop(1)
                 .onEach { online ->
@@ -221,8 +227,13 @@ internal object NativeInterfaceFactory {
 
     private fun stopInterface(name: String) {
         rnodeRecoveryJobs.remove(name)?.cancel()
+        // Remove from runningInterfaces BEFORE onlineObservers so that a
+        // concurrent observeOnlineState() still sitting in its compute
+        // block sees the interface as unmanaged and bails out instead of
+        // leaving an orphaned collector behind.
+        val iface = runningInterfaces.remove(name)
         onlineObservers.remove(name)?.cancel()
-        val iface = runningInterfaces.remove(name) ?: return
+        if (iface == null) return
         try {
             val ref =
                 network.reticulum.interfaces.InterfaceAdapter

--- a/reticulum/src/main/java/network/columba/app/reticulum/protocol/NativeInterfaceFactory.kt
+++ b/reticulum/src/main/java/network/columba/app/reticulum/protocol/NativeInterfaceFactory.kt
@@ -5,7 +5,6 @@ import android.util.Log
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
-import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.flow.drop
 import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.onEach
@@ -137,8 +136,9 @@ internal object NativeInterfaceFactory {
      * the [notifyListeners] call in [registerAndTrack] (which emits a
      * snapshot with `online=${iface.online.value}`), so we drop(1) to
      * avoid a duplicate no-op notify for the initial replay StateFlow
-     * hands out on subscribe. [distinctUntilChanged] then coalesces any
-     * redundant writes from the subclass implementation.
+     * hands out on subscribe. StateFlow itself guarantees structural-equality
+     * deduplication at the emitter, so no explicit distinctUntilChanged() is
+     * needed here.
      */
     private fun observeOnlineState(
         name: String,
@@ -150,7 +150,6 @@ internal object NativeInterfaceFactory {
         val job =
             iface.online
                 .drop(1)
-                .distinctUntilChanged()
                 .onEach { online ->
                     Log.d(TAG, "Interface $name online → $online")
                     notifyListeners()

--- a/reticulum/src/main/java/network/columba/app/reticulum/protocol/NativeInterfaceFactory.kt
+++ b/reticulum/src/main/java/network/columba/app/reticulum/protocol/NativeInterfaceFactory.kt
@@ -4,6 +4,11 @@ import android.content.Context
 import android.util.Log
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.flow.distinctUntilChanged
+import kotlinx.coroutines.flow.drop
+import kotlinx.coroutines.flow.launchIn
+import kotlinx.coroutines.flow.onEach
 import kotlinx.coroutines.launch
 import network.columba.app.reticulum.model.InterfaceConfig
 import network.reticulum.interfaces.auto.AutoInterface
@@ -21,6 +26,17 @@ internal object NativeInterfaceFactory {
     /** Running interfaces keyed by config name. */
     private val runningInterfaces = java.util.concurrent.ConcurrentHashMap<String, network.reticulum.interfaces.Interface>()
     private val rnodeRecoveryJobs = java.util.concurrent.ConcurrentHashMap<String, kotlinx.coroutines.Job>()
+
+    /**
+     * Per-interface collector jobs watching [network.reticulum.interfaces.Interface.online].
+     * reticulum-kt v0.0.9+ exposes `online` as a `StateFlow<Boolean>`; some
+     * interface types (notably [network.reticulum.interfaces.rnode.RNodeInterface])
+     * don't flip online until their handshake completes 3-5s after
+     * registration. Without an observer the Columba UI caches the initial
+     * `false` value forever. This map keeps the collector jobs alive for
+     * the lifetime of the interface and lets us cancel them in [stopInterface].
+     */
+    private val onlineObservers = java.util.concurrent.ConcurrentHashMap<String, Job>()
     private val listeners = java.util.concurrent.CopyOnWriteArraySet<() -> Unit>()
 
     /** App context for BLE driver construction. */
@@ -109,8 +125,37 @@ internal object NativeInterfaceFactory {
             MulticastLockHelper.acquire(appContext)
         }
 
-        Log.i(TAG, "Started interface: $name (online=${iface.online.get()})")
+        observeOnlineState(name, iface)
+
+        Log.i(TAG, "Started interface: $name (online=${iface.online.value})")
         notifyListeners()
+    }
+
+    /**
+     * Collect the interface's online StateFlow and re-notify listeners on
+     * every distinct transition. The initial value was already surfaced via
+     * the [notifyListeners] call in [registerAndTrack] (which emits a
+     * snapshot with `online=${iface.online.value}`), so we drop(1) to
+     * avoid a duplicate no-op notify for the initial replay StateFlow
+     * hands out on subscribe. [distinctUntilChanged] then coalesces any
+     * redundant writes from the subclass implementation.
+     */
+    private fun observeOnlineState(
+        name: String,
+        iface: network.reticulum.interfaces.Interface,
+    ) {
+        val collectorScope = scope ?: return
+        // Replace any previous collector (restartInterface() can re-register under the same name).
+        onlineObservers.remove(name)?.cancel()
+        val job =
+            iface.online
+                .drop(1)
+                .distinctUntilChanged()
+                .onEach { online ->
+                    Log.d(TAG, "Interface $name online → $online")
+                    notifyListeners()
+                }.launchIn(collectorScope)
+        onlineObservers[name] = job
     }
 
     @Suppress("TooGenericExceptionCaught")
@@ -173,6 +218,7 @@ internal object NativeInterfaceFactory {
 
     private fun stopInterface(name: String) {
         rnodeRecoveryJobs.remove(name)?.cancel()
+        onlineObservers.remove(name)?.cancel()
         val iface = runningInterfaces.remove(name) ?: return
         try {
             val ref =

--- a/reticulum/src/main/java/network/columba/app/reticulum/protocol/RNodeRecoveryHelper.kt
+++ b/reticulum/src/main/java/network/columba/app/reticulum/protocol/RNodeRecoveryHelper.kt
@@ -27,7 +27,7 @@ internal object RNodeRecoveryHelper {
             while (isActive) {
                 if (runningInterfaces[config.name] !== iface || iface.detached.get()) return@launch
 
-                if (iface.online.get()) {
+                if (iface.online.value) {
                     wasOnline = true
                 } else if (wasOnline) {
                     Log.w(TAG, "RNode interface ${config.name} went offline; starting recovery")
@@ -58,7 +58,7 @@ internal object RNodeRecoveryHelper {
                 try {
                     while (isActive) {
                         val current = runningInterfaces[config.name]
-                        if (current?.online?.get() == true) return@launch
+                        if (current?.online?.value == true) return@launch
 
                         if (current != null) {
                             onStopInterface(config.name)
@@ -70,7 +70,7 @@ internal object RNodeRecoveryHelper {
                         var waitedMs = 0L
                         while (waitedMs < RNODE_RECOVERY_ATTEMPT_WINDOW_MS && isActive) {
                             val iface = runningInterfaces[config.name]
-                            if (iface?.online?.get() == true) return@launch
+                            if (iface?.online?.value == true) return@launch
                             kotlinx.coroutines.delay(500)
                             waitedMs += 500
                         }


### PR DESCRIPTION
## Summary

- Bumps `reticulumKt` v0.0.8 → v0.0.9 to pick up [reticulum-kt#45](https://github.com/torlando-tech/reticulum-kt/pull/45), which exposes `Interface.online` as a `StateFlow<Boolean>` instead of an `AtomicBoolean`.
- Wires `NativeInterfaceFactory` to collect the new flow and re-notify the existing listener chain on every distinct online transition, so the interface card refreshes when a subclass flips online after registration.
- Migrates the two `iface.online.get()` call sites (factory log line + `RNodeRecoveryHelper` health check) to `iface.online.value`.

## Motivation

`RNodeInterface` sets itself online ~4 seconds after registration, once the USB handshake completes and radio config is validated. Columba's `InterfaceMgmtVM` only saw the `online` value at the moment of registration (via `InterfaceAdapter.online` snapshotted into a domain model), so the card stayed grey forever even though the radio was fully functional. User confirmed this was purely cosmetic — traffic flowed, announces arrived, just the UI indicator was stuck.

Chose the library-side fix (expose a flow) rather than a Columba-side workaround (e.g., poll every second) because: the library already knew when the transition happened and simply lacked a notification hook. Adding one is a ~40-line Kotlin-idiomatic refactor in `reticulum-kt`.

## Stacked on

- [reticulum-kt#45](https://github.com/torlando-tech/reticulum-kt/pull/45) **must merge first**, and v0.0.9 must be tagged before this PR's JitPack-backed CI will be green. See the bottom of that PR's description for the rationale.

## Test plan

- [x] `./gradlew :app:assembleNoSentryDebug` — builds locally against the `refactor/interface-online-state-flow` branch via `includeBuild` (reverted before commit; settings.gradle.kts is clean).
- [x] `./gradlew :reticulum:testDebugUnitTest` — passes locally.
- [ ] **Manual (pending physical RNode):** start the app with an RNode interface configured. The card's online indicator should transition grey → green within ~5 seconds of the card first appearing, matching the handshake window.
- [ ] **Manual recovery:** yank USB while online. Card should flip back to offline within the recovery loop's detection window. (`RNodeRecoveryHelper` already handles this; now reads `iface.online.value` rather than `.get()`.)

## Implementation notes

- `observeOnlineState` uses `drop(1)` to skip `StateFlow`'s initial replay on subscribe — `registerAndTrack` already pushes a snapshot via its explicit `notifyListeners()` call, so without the drop every new interface would emit a duplicate no-op notify.
- `distinctUntilChanged()` coalesces any redundant writes from subclass implementations (e.g., `setOnline(false)` being called twice during teardown).
- Collectors are keyed by interface name in `onlineObservers` and cancelled in `stopInterface()` to prevent leaks. `restartInterface()` goes through `stopInterface → startInterface` which cancels-and-reinstalls cleanly.

Co-Authored-By: Claude Opus 4.7 (1M context)