### PR TITLE
Stop interface-card subtitle from repeating the type label

### DIFF
--- a/app/src/main/java/network/columba/app/ui/screens/InterfaceManagementScreen.kt
+++ b/app/src/main/java/network/columba/app/ui/screens/InterfaceManagementScreen.kt
@@ -994,7 +994,6 @@ private fun getLocalIpAddress(): Pair<String?, Boolean> {
  * no useful detail beyond the type label itself — the caller drops the line
  * in that case to avoid visual repetition.
  */
-@Composable
 private fun getInterfaceDescription(interfaceEntity: InterfaceEntity): String {
     val json =
         try {
@@ -1041,7 +1040,7 @@ private fun getInterfaceDescription(interfaceEntity: InterfaceEntity): String {
         "AndroidBLE" -> {
             val deviceName = json.optString("device_name", "")
             val maxConns = json.optInt("max_connections", 7)
-            if (deviceName.isNotBlank()) "'$deviceName' · max $maxConns" else "max $maxConns peers"
+            if (deviceName.isNotBlank()) "'$deviceName' · max $maxConns peers" else "max $maxConns peers"
         }
         else -> ""
     }

--- a/app/src/main/java/network/columba/app/ui/screens/InterfaceManagementScreen.kt
+++ b/app/src/main/java/network/columba/app/ui/screens/InterfaceManagementScreen.kt
@@ -994,6 +994,7 @@ private fun getLocalIpAddress(): Pair<String?, Boolean> {
  * no useful detail beyond the type label itself — the caller drops the line
  * in that case to avoid visual repetition.
  */
+@Suppress("CyclomaticComplexMethod") // flat when-per-type; splitting would scatter related JSON-parsing logic
 private fun getInterfaceDescription(interfaceEntity: InterfaceEntity): String {
     val json =
         try {

--- a/app/src/main/java/network/columba/app/ui/screens/InterfaceManagementScreen.kt
+++ b/app/src/main/java/network/columba/app/ui/screens/InterfaceManagementScreen.kt
@@ -544,11 +544,14 @@ fun InterfaceCard(
                     style = MaterialTheme.typography.bodySmall,
                     color = MaterialTheme.colorScheme.onSurfaceVariant,
                 )
-                Text(
-                    text = getInterfaceDescription(interfaceEntity),
-                    style = MaterialTheme.typography.bodySmall,
-                    color = MaterialTheme.colorScheme.onSurfaceVariant,
-                )
+                val description = getInterfaceDescription(interfaceEntity)
+                if (description.isNotEmpty()) {
+                    Text(
+                        text = description,
+                        style = MaterialTheme.typography.bodySmall,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    )
+                }
                 // Error / permission prompt
                 val needsPermission = !blePermissionsGranted && interfaceEntity.isBleInterface()
                 if (needsPermission) {
@@ -986,25 +989,61 @@ private fun getLocalIpAddress(): Pair<String?, Boolean> {
 }
 
 /**
- * Get interface description including type and relevant details.
+ * Returns ONLY the per-type detail (host:port, connection method, etc.) that
+ * goes on a line below the type label. Returns the empty string when there's
+ * no useful detail beyond the type label itself — the caller drops the line
+ * in that case to avoid visual repetition.
  */
 @Composable
 private fun getInterfaceDescription(interfaceEntity: InterfaceEntity): String {
-    val typeLabel = getInterfaceTypeLabel(interfaceEntity.type)
+    val json =
+        try {
+            org.json.JSONObject(interfaceEntity.configJson)
+        } catch (_: Exception) {
+            return ""
+        }
     return when (interfaceEntity.type) {
+        "AutoInterface" -> {
+            val groupId = json.optString("group_id", "")
+            val scope = json.optString("discovery_scope", "link")
+            if (groupId.isNotBlank()) groupId else "scope: $scope"
+        }
+        "TCPClient" -> {
+            val host = json.optString("target_host", "")
+            val port = json.optInt("target_port", 4242)
+            if (host.isNotBlank()) "$host:$port" else ""
+        }
         "TCPServer" -> {
-            try {
-                val json = org.json.JSONObject(interfaceEntity.configJson)
-                val listenPort = json.optInt("listen_port", 4242)
-                val (localIp, isYggdrasil) = getLocalIpAddress()
-                val networkType = if (isYggdrasil) " (Yggdrasil)" else ""
-                val addressDisplay = formatAddressWithPort(localIp, listenPort, isYggdrasil)
-                "$typeLabel$networkType · $addressDisplay"
-            } catch (e: Exception) {
-                typeLabel
+            val listenPort = json.optInt("listen_port", 4242)
+            val (localIp, isYggdrasil) = getLocalIpAddress()
+            val networkPrefix = if (isYggdrasil) "Yggdrasil · " else ""
+            val addressDisplay = formatAddressWithPort(localIp, listenPort, isYggdrasil)
+            "$networkPrefix$addressDisplay"
+        }
+        "RNode" -> {
+            val connectionMode = json.optString("connection_mode", "classic")
+            val deviceName = json.optString("target_device_name", "")
+            val tcpHost = json.optString("tcp_host", "")
+            val tcpPort = json.optInt("tcp_port", 7633)
+            when (connectionMode) {
+                "ble" -> if (deviceName.isNotBlank()) "BLE · $deviceName" else "BLE"
+                "classic" -> if (deviceName.isNotBlank()) "Bluetooth · $deviceName" else "Bluetooth"
+                "tcp" -> if (tcpHost.isNotBlank()) "WiFi · $tcpHost:$tcpPort" else "WiFi"
+                "usb" -> "USB"
+                else -> ""
             }
         }
-        else -> typeLabel
+        "UDP" -> {
+            val listenIp = json.optString("listen_ip", "0.0.0.0")
+            val listenPort = json.optInt("listen_port", 4242)
+            "$listenIp:$listenPort"
+        }
+        "AndroidBLE" -> {
+            val deviceName = json.optString("device_name", "")
+            val maxConns = json.optInt("max_connections", 7)
+            if (deviceName.isNotBlank()) "'$deviceName' · max $maxConns" else "max $maxConns peers"
+        }
+        else -> ""
     }
 }
 


### PR DESCRIPTION
## Summary

Every non-TCPServer interface card had two sub-lines displaying the same string — e.g., `Bluetooth LE` / `Bluetooth LE`, `TCP Client` / `TCP Client`, `Auto Discovery` / `Auto Discovery`. Caught by manual eyeball during go-live testing.

Root cause: `getInterfaceDescription` was a stub that fell through to `typeLabel` for every type it didn't handle (only TCPServer had a real implementation showing the listen address). The two `Text()` calls in the card render site would then render identical strings.

## Fix

Two coordinated changes in one file:

1. **`getInterfaceDescription` now returns ONLY the per-type detail** — host:port, connection method, BLE/USB/WiFi mode, scope, device name, etc. — *without* redundantly prefixing the type label that the first sub-line already shows. Returns the empty string when there's no useful detail beyond the type label itself.

2. **Render site drops the second `Text()` entirely when the description is empty**, so types with no extra detail render as a cleaner two-line card (just icon + name + type label).

## Per-type detail content

| Type         | Second line |
|--------------|-------------|
| AutoInterface| `group_id` if set, else `"scope: $discovery_scope"` |
| TCPClient    | `target_host:target_port` |
| TCPServer    | unchanged — local ip:port, optional `Yggdrasil · ` prefix |
| RNode        | `BLE · DeviceName` / `Bluetooth · DeviceName` / `WiFi · host:port` / `USB` |
| UDP          | `listen_ip:listen_port` |
| AndroidBLE   | `max N peers` (+ `'device_name'` if set) |

All config-JSON keys confirmed snake_case by cross-checking existing parsers in `InterfaceStatsViewModel.kt`, `InterfaceRepository.kt`, `InterfaceManagementUtils.kt`.

## Test plan

- [x] Build passes
- [x] Installed on two phones and eyeballed all configured interface cards — each now shows distinct type-label + detail, no duplication
- [ ] Cards with missing configJson field gracefully fall back to empty description (skips second line)

🤖 Generated with [Claude Code](https://claude.com/claude-code)