### PR TITLE
Bump reticulum-kt to v0.0.10

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -19,7 +19,7 @@ serialization = "1.10.0"
 coil = "2.7.0"
 
 # JitPack-published libraries (formerly git submodules)
-reticulumKt = "v0.0.9"
+reticulumKt = "v0.0.10"
 lxmfKt = "v0.0.4"
 lxstKt = "v0.0.3"
 


### PR DESCRIPTION
## Summary

Picks up two silent TCPServer bug fixes from [torlando-tech/reticulum-kt#47](https://github.com/torlando-tech/reticulum-kt/pull/47):

1. **Spawned TCPServer child interfaces register with `Transport.interfaces`** — matches Python's `Transport.interfaces.append(spawned_interface)` pattern at `TCPInterface.py:619`. Previously the spawned child was absent from the interface list, and any path response attached to it was silently dropped at `Transport.kt:3632-3658`.
2. **Spawned children inherit the parent's mode** — copies `parent.modeOverride ?: parent.mode` at spawn time. Previously defaulted to FULL regardless of parent configuration.

Both fixes matter for phone-as-server deployments: Yggdrasil gateway scenarios, rnsd-like setups, or any configuration using a TCPServer interface. A mis-moded or un-registered spawned child would silently misroute path-layer traffic — visible today only as a "paths sometimes don't work from peer X" symptom with no log trail.

Both bugs were discovered while building the [path-discovery conformance suite](https://github.com/torlando-tech/reticulum-conformance/pull/11) (filed tests that caught them).

## No Columba code changes required

Single-file bump. Verified CI fallback resolves v0.0.10 via JitPack (tagged + pushed, cache warming).

## Test plan

- [ ] CI Kotlin Tests / Module Tests / Instrumented Tests all green
- [ ] Install resulting APK and confirm existing functionality (TCPClient, BLE, RNode) unchanged
- [ ] If TCPServer is configured, confirm spawned peer count and interface mode reflect the parent's config

🤖 Generated with [Claude Code](https://claude.com/claude-code)