### PR TITLE
Log loudly when RNode start drops due to null factory scope

### DIFF
--- a/reticulum/src/main/java/network/columba/app/reticulum/protocol/NativeInterfaceFactory.kt
+++ b/reticulum/src/main/java/network/columba/app/reticulum/protocol/NativeInterfaceFactory.kt
@@ -338,8 +338,19 @@ internal object NativeInterfaceFactory {
             }
 
             is InterfaceConfig.RNode -> {
-                scope?.launch(Dispatchers.IO) {
-                    startRNodeInterface(config)
+                // Explicit null-check mirrors the pattern in [startBleInterface]:
+                // a silent `scope?.launch` drops the RNode startup whenever the
+                // factory's scope hasn't been re-seated (e.g., across a service
+                // rebind), leaving the UI's "Sync complete: started 1" log
+                // misleading the user into thinking the interface is coming up
+                // when it never will.
+                val parentScope = scope
+                if (parentScope == null) {
+                    Log.e(TAG, "Cannot start RNode interface ${config.name}: factory scope not initialized")
+                } else {
+                    parentScope.launch(Dispatchers.IO) {
+                        startRNodeInterface(config)
+                    }
                 }
                 null
             }


### PR DESCRIPTION
## Summary

`NativeInterfaceFactory.createInterface`'s RNode branch used `scope?.launch(Dispatchers.IO) { startRNodeInterface(config) }`. The null-safe call silently no-ops if the factory's `scope` has been cleared — no exception, no log, but the surrounding `syncInterfaces` still reports `Sync complete: started 1`, lying to the UI about startup being in flight.

Mirrors the explicit-null-check pattern already in `startBleInterface` (line 171-177) so RNode failures are observable instead of mysterious.

## Symptom observed today

On .71: toggled a saved RNode interface to enabled; logcat showed only `Sync complete: started 1`; RNode device display stayed disconnected indefinitely; zero downstream activity from `RNodeConnectionHelper`, `BluetoothLeConnection`, or `RNodeInterface`. Force-stopping + reopening Columba brought the same interface up cleanly on first launch — confirming the scope was stale on the rebound state, not the config.

## Fix

```kotlin
val parentScope = scope
if (parentScope == null) {
    Log.e(TAG, "Cannot start RNode interface ${config.name}: factory scope not initialized")
} else {
    parentScope.launch(Dispatchers.IO) {
        startRNodeInterface(config)
    }
}
null
```

Same shape as the BLE path already uses. One-file, 13-line diff.

## Doesn't fix the root cause

The scope getting into a null/stale state is a separate service-lifecycle issue. This PR makes the failure mode *loud* so when it does happen, someone looking at logcat sees `Cannot start RNode interface …: factory scope not initialized` and can recover. Follow-up: audit why the factory scope can end up null, possibly make it non-nullable via eager init at service-bind time.

## Known out-of-scope: `syncInterfaces` started-count

`syncInterfaces` logs `Sync complete: started N` where `N = (desiredNames - runningNames).size` — computed synchronously, before any async coroutine (BLE or RNode) has actually completed startup. So even with this fix, a null-scope RNode start will still log both `started 1` and the new `Log.e`. The started-count has always been "intent to start", not "confirmed running"; that pre-existing semantic applies equally to the BLE path and is not introduced by this PR. Normalising that log line (or distinguishing intent vs. confirmed) is a follow-up.

## Test plan

- [x] Build passes, detekt clean
- [ ] Install on phone in an already-open Columba, toggle RNode interface — should work now as before (no regression)
- [ ] If the stale-scope state can be reliably reproduced, verify the `Log.e` fires instead of silent drop

🤖 Generated with [Claude Code](https://claude.com/claude-code)
