### PR TITLE
NativeInterfaceFactory owns its own coroutine scope

### DIFF
--- a/reticulum/src/main/java/network/columba/app/reticulum/protocol/NativeInterfaceFactory.kt
+++ b/reticulum/src/main/java/network/columba/app/reticulum/protocol/NativeInterfaceFactory.kt
@@ -5,6 +5,7 @@ import android.util.Log
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
+import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.flow.drop
 import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.onEach
@@ -42,8 +43,25 @@ internal object NativeInterfaceFactory {
     /** App context for BLE driver construction. */
     var appContext: Context? = null
 
-    /** Coroutine scope for async interface startup (BLE, RNode). */
-    var scope: CoroutineScope? = null
+    /**
+     * Process-lifetime coroutine scope for async interface startup (BLE,
+     * RNode) and per-interface online-state observers. Owned by the factory
+     * itself — not assigned externally — so the scope never ends up in a
+     * null-or-cancelled state between protocol init cycles.
+     *
+     * Previously this was a nullable `var` assigned by
+     * [NativeReticulumProtocol.initialize]; if the protocol was shut down
+     * (which cancels the protocol's scope) without clearing this reference,
+     * subsequent interface-toggle attempts would silently no-op because
+     * `cancelledScope.launch(...)` returns a pre-cancelled Job. The
+     * concrete symptom: user toggles a saved RNode interface, factory
+     * logs "Sync complete: started 1", but nothing downstream ever runs.
+     *
+     * `SupervisorJob` ensures a single interface's startup failure doesn't
+     * cancel siblings. No callsite cancels this scope; per-interface
+     * cleanup flows through each interface's own stop() method.
+     */
+    val scope: CoroutineScope = CoroutineScope(SupervisorJob() + Dispatchers.Default)
 
     /**
      * Diff-based sync: compare running interfaces with desired config.
@@ -145,7 +163,6 @@ internal object NativeInterfaceFactory {
         name: String,
         iface: network.reticulum.interfaces.Interface,
     ) {
-        val collectorScope = scope ?: return
         // Atomically replace any previous collector under the same key.
         // runningInterfaces is the source of truth for "this interface is
         // currently managed"; stopInterface() removes it BEFORE
@@ -163,19 +180,18 @@ internal object NativeInterfaceFactory {
                 .onEach { online ->
                     Log.d(TAG, "Interface $name online → $online")
                     notifyListeners()
-                }.launchIn(collectorScope)
+                }.launchIn(scope)
         }
     }
 
     @Suppress("TooGenericExceptionCaught")
     private fun startBleInterface(config: InterfaceConfig.AndroidBLE) {
         val ctx = appContext
-        val parentScope = scope
-        if (ctx == null || parentScope == null) {
-            Log.e(TAG, "Cannot start BLE interface: appContext or scope not set")
+        if (ctx == null) {
+            Log.e(TAG, "Cannot start BLE interface: appContext not set")
             return
         }
-        parentScope.launch(Dispatchers.IO) {
+        scope.launch(Dispatchers.IO) {
             try {
                 val identityHash =
                     Transport.identity?.hash
@@ -189,7 +205,7 @@ internal object NativeInterfaceFactory {
                     network.reticulum.android.ble.AndroidBLEDriver(
                         context = ctx,
                         bluetoothManager = bluetoothManager,
-                        scope = parentScope,
+                        scope = scope,
                     )
                 driver.setTransportIdentity(identityHash)
 
@@ -338,7 +354,7 @@ internal object NativeInterfaceFactory {
             }
 
             is InterfaceConfig.RNode -> {
-                scope?.launch(Dispatchers.IO) {
+                scope.launch(Dispatchers.IO) {
                     startRNodeInterface(config)
                 }
                 null

--- a/reticulum/src/main/java/network/columba/app/reticulum/protocol/NativeInterfaceFactory.kt
+++ b/reticulum/src/main/java/network/columba/app/reticulum/protocol/NativeInterfaceFactory.kt
@@ -6,6 +6,7 @@ import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.cancel
 import kotlinx.coroutines.flow.drop
 import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.onEach
@@ -192,6 +193,16 @@ internal object NativeInterfaceFactory {
             return
         }
         scope.launch(Dispatchers.IO) {
+            // Give the driver its own scope rather than the factory's.
+            // BLEInterface.detach() calls driver.shutdown(), which internally
+            // cancels whatever scope it was constructed with. Sharing the
+            // factory's process-lifetime scope here would let a single BLE
+            // interface stop nuke the factory's ability to start any future
+            // interface — the cancelled-scope bug this PR set out to
+            // eliminate. Declared outside the try so a thrown exception can
+            // still cancel it and release the driver's aggregator coroutines.
+            val driverScope =
+                CoroutineScope(SupervisorJob() + Dispatchers.Default)
             try {
                 val identityHash =
                     Transport.identity?.hash
@@ -201,13 +212,6 @@ internal object NativeInterfaceFactory {
                     ctx.getSystemService(Context.BLUETOOTH_SERVICE)
                         as android.bluetooth.BluetoothManager
 
-                // Give the driver its own scope rather than the factory's. BLEInterface.detach()
-                // calls driver.shutdown(), which internally cancels whatever scope it was
-                // constructed with. Sharing the factory's process-lifetime scope here would let
-                // a single BLE interface stop nuke the factory's ability to start any future
-                // interface — exactly the cancelled-scope bug this PR set out to eliminate.
-                val driverScope =
-                    CoroutineScope(SupervisorJob() + Dispatchers.Default)
                 val driver =
                     network.reticulum.android.ble.AndroidBLEDriver(
                         context = ctx,
@@ -233,6 +237,12 @@ internal object NativeInterfaceFactory {
                 registerAndTrack(config.name, iface)
             } catch (e: Exception) {
                 Log.e(TAG, "Failed to start BLE interface ${config.name}: ${e.message}", e)
+                // AndroidBLEDriver launches event-aggregator coroutines from
+                // its init{} block, so the scope holds live work as soon as
+                // the driver is constructed. Cancel it on the failure path to
+                // avoid orphaning those jobs when stopInterface won't run
+                // (nothing is tracked in runningInterfaces).
+                driverScope.cancel()
             }
         }
     }

--- a/reticulum/src/main/java/network/columba/app/reticulum/protocol/NativeInterfaceFactory.kt
+++ b/reticulum/src/main/java/network/columba/app/reticulum/protocol/NativeInterfaceFactory.kt
@@ -61,7 +61,7 @@ internal object NativeInterfaceFactory {
      * cancel siblings. No callsite cancels this scope; per-interface
      * cleanup flows through each interface's own stop() method.
      */
-    val scope: CoroutineScope = CoroutineScope(SupervisorJob() + Dispatchers.Default)
+    private val scope: CoroutineScope = CoroutineScope(SupervisorJob() + Dispatchers.Default)
 
     /**
      * Diff-based sync: compare running interfaces with desired config.
@@ -201,11 +201,18 @@ internal object NativeInterfaceFactory {
                     ctx.getSystemService(Context.BLUETOOTH_SERVICE)
                         as android.bluetooth.BluetoothManager
 
+                // Give the driver its own scope rather than the factory's. BLEInterface.detach()
+                // calls driver.shutdown(), which internally cancels whatever scope it was
+                // constructed with. Sharing the factory's process-lifetime scope here would let
+                // a single BLE interface stop nuke the factory's ability to start any future
+                // interface — exactly the cancelled-scope bug this PR set out to eliminate.
+                val driverScope =
+                    CoroutineScope(SupervisorJob() + Dispatchers.Default)
                 val driver =
                     network.reticulum.android.ble.AndroidBLEDriver(
                         context = ctx,
                         bluetoothManager = bluetoothManager,
-                        scope = scope,
+                        scope = driverScope,
                     )
                 driver.setTransportIdentity(identityHash)
 

--- a/reticulum/src/main/java/network/columba/app/reticulum/protocol/NativeReticulumProtocol.kt
+++ b/reticulum/src/main/java/network/columba/app/reticulum/protocol/NativeReticulumProtocol.kt
@@ -462,9 +462,12 @@ class NativeReticulumProtocol(
                 // session. Shortens the in-memory lifetime of the raw key material.
                 lastConfig = lastConfig?.copy(deliveryIdentityKey = null)
 
-                // Create and register network interfaces from config
+                // Create and register network interfaces from config.
+                // The factory owns its own process-lifetime scope internally;
+                // we no longer assign one here (previously led to a stale
+                // cancelled scope between shutdown → next initialize cycles,
+                // silently dropping subsequent interface-toggle attempts).
                 NativeInterfaceFactory.appContext = appContext
-                NativeInterfaceFactory.scope = scope
                 NativeInterfaceFactory.addListener(interfaceFactoryListener)
                 NativeInterfaceFactory.syncInterfaces(config.enabledInterfaces)
 

--- a/reticulum/src/main/java/network/columba/app/reticulum/protocol/RNodeConnectionHelper.kt
+++ b/reticulum/src/main/java/network/columba/app/reticulum/protocol/RNodeConnectionHelper.kt
@@ -13,7 +13,7 @@ internal object RNodeConnectionHelper {
     suspend fun startRNodeInterface(
         config: InterfaceConfig.RNode,
         appContext: Context?,
-        scope: CoroutineScope?,
+        scope: CoroutineScope,
         onRegisterAndTrack: (String, network.reticulum.interfaces.Interface) -> Unit,
         onMonitorLifecycle: (InterfaceConfig.RNode, network.reticulum.interfaces.rnode.RNodeInterface) -> Unit,
         onEnsureRecovery: (InterfaceConfig.RNode) -> Unit,

--- a/reticulum/src/main/java/network/columba/app/reticulum/protocol/RNodeConnectionHelper.kt
+++ b/reticulum/src/main/java/network/columba/app/reticulum/protocol/RNodeConnectionHelper.kt
@@ -49,6 +49,12 @@ internal object RNodeConnectionHelper {
                     activityKeepaliveMs = if (config.connectionMode == "tcp") 3_500L else null,
                     framebufferLineDelayMs = if (config.connectionMode == "tcp") 15L else 0L,
                     framebufferEnableDelayMs = if (config.connectionMode == "tcp") 50L else 0L,
+                    // Safe to pass the factory's process-lifetime scope directly (unlike
+                    // AndroidBLEDriver, which cancels its scope in shutdown()). RNodeInterface
+                    // derives an internal ioScope with a child SupervisorJob tied to this
+                    // parent, and its detach() cancels only that ioScope — the factory's root
+                    // scope is never touched. If that invariant ever changes upstream, wrap
+                    // this in a dedicated child scope the way startBleInterface does.
                     parentScope = scope,
                     displayImageData =
                         if (config.enableFramebuffer) {

--- a/reticulum/src/main/java/network/columba/app/reticulum/protocol/RNodeRecoveryHelper.kt
+++ b/reticulum/src/main/java/network/columba/app/reticulum/protocol/RNodeRecoveryHelper.kt
@@ -16,13 +16,12 @@ internal object RNodeRecoveryHelper {
     fun monitorLifecycle(
         config: InterfaceConfig.RNode,
         iface: network.reticulum.interfaces.rnode.RNodeInterface,
-        scope: CoroutineScope?,
+        scope: CoroutineScope,
         runningInterfaces: java.util.concurrent.ConcurrentHashMap<String, network.reticulum.interfaces.Interface>,
         onNotifyListeners: () -> Unit,
         onEnsureRecovery: (InterfaceConfig.RNode) -> Unit,
     ) {
-        val parentScope = scope ?: return
-        parentScope.launch(Dispatchers.IO) {
+        scope.launch(Dispatchers.IO) {
             var wasOnline = false
             while (isActive) {
                 if (runningInterfaces[config.name] !== iface || iface.detached.get()) return@launch
@@ -43,18 +42,17 @@ internal object RNodeRecoveryHelper {
 
     fun ensureRecovery(
         config: InterfaceConfig.RNode,
-        scope: CoroutineScope?,
+        scope: CoroutineScope,
         rnodeRecoveryJobs: java.util.concurrent.ConcurrentHashMap<String, kotlinx.coroutines.Job>,
         runningInterfaces: java.util.concurrent.ConcurrentHashMap<String, network.reticulum.interfaces.Interface>,
         onStopInterface: (String) -> Unit,
         onStartInterface: (InterfaceConfig) -> Unit,
     ) {
-        val parentScope = scope ?: return
         val existing = rnodeRecoveryJobs[config.name]
         if (existing != null && existing.isActive) return
 
         val job =
-            parentScope.launch(Dispatchers.IO) {
+            scope.launch(Dispatchers.IO) {
                 try {
                     while (isActive) {
                         val current = runningInterfaces[config.name]


### PR DESCRIPTION
## Summary

Replaces the previous external-set `var scope: CoroutineScope? = null` on `NativeInterfaceFactory` with an internally-owned, non-null, process-lifetime `val`. Eliminates the null-or-cancelled-scope class of bug entirely rather than patching around it.

Supersedes the closed [#817](https://github.com/torlando-tech/columba/pull/817), which added a loud log on the guard site but left the underlying lifecycle bug intact.

## Bug

On .71 today: user toggled a saved RNode interface to enabled. Factory logged `Sync complete: started 1`. RNode device display stayed disconnected. Zero downstream activity from `RNodeConnectionHelper`, `BluetoothLeConnection`, or `RNodeInterface`. Force-stopping and reopening Columba made the same interface come up cleanly on first launch.

## Root cause

`NativeInterfaceFactory.scope` was a nullable `var` assigned by `NativeReticulumProtocol.initialize()`. On protocol `shutdown()` the protocol cancelled its own scope (`NativeReticulumProtocol.kt:586`) but did NOT clear the factory's reference. Same stale state after a failed `initialize()` (`NativeReticulumProtocol.kt:539`). Between one shutdown-or-failed-init and the next successful `initialize()`, the factory held a **cancelled** scope. `cancelledScope.launch(...)` returns a pre-cancelled `Job` that never runs, silently dropping startup. Same pattern applied to `observeOnlineState` (null-returned early) and `startBleInterface` (explicit null guard worked but scope could still be cancelled).

## Fix

Factory owns its own scope:

```kotlin
val scope: CoroutineScope = CoroutineScope(SupervisorJob() + Dispatchers.Default)
```

Since `NativeInterfaceFactory` is an `object` (one instance per process), the scope's lifetime is coextensive with the process — cannot become null, cannot be cancelled across init cycles. `SupervisorJob` ensures one interface's startup failure doesn't cancel siblings.

Removed:
- The nullable-`var` declaration and all its null checks
- The `collectorScope = scope ?: return` in `observeOnlineState`
- The `val parentScope = scope; if (null) return` in `startBleInterface`
- The `scope?.launch` in the RNode branch of `createInterface`
- The `NativeInterfaceFactory.scope = scope` assignment at `NativeReticulumProtocol.kt:467`

## Safety

Per-interface cleanup continues through each interface's own `stop()` method (unchanged). The factory's scope sits idle when no interfaces are running — it holds no per-interface state. No callsite cancels this scope; it's a singleton scope tied to the process.

## Test plan

- [x] `./gradlew :reticulum:testDebugUnitTest` — PASSED
- [x] `./gradlew :reticulum:detekt` — PASSED
- [x] Build clean
- [ ] Install on phone, toggle RNode / BLE / TCPClient interfaces repeatedly across service-restart cycles, confirm each toggle starts cleanly
- [ ] Specifically reproduce the closed-#817 scenario: start Columba, background it long enough that the service re-binds (doze transition, app-switching), then toggle an interface; confirm it starts vs. the pre-fix silent drop

🤖 Generated with [Claude Code](https://claude.com/claude-code)