### PR TITLE
Plumb received-side RSSI/SNR/interface/hop fields to MessageEntity

### DIFF
--- a/data/src/main/java/network/columba/app/data/repository/ConversationRepository.kt
+++ b/data/src/main/java/network/columba/app/data/repository/ConversationRepository.kt
@@ -5,6 +5,11 @@ import androidx.paging.PagingConfig
 import androidx.paging.PagingData
 import androidx.paging.map
 import androidx.room.Transaction
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.emptyFlow
+import kotlinx.coroutines.flow.flatMapLatest
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.flow.map
 import network.columba.app.data.db.dao.ConversationDao
 import network.columba.app.data.db.dao.DraftDao
 import network.columba.app.data.db.dao.LocalIdentityDao
@@ -17,11 +22,6 @@ import network.columba.app.data.db.entity.PeerIdentityEntity
 import network.columba.app.data.model.EnrichedConversation
 import network.columba.app.data.storage.AttachmentStorageManager
 import network.columba.app.data.util.TextSanitizer
-import kotlinx.coroutines.flow.Flow
-import kotlinx.coroutines.flow.emptyFlow
-import kotlinx.coroutines.flow.flatMapLatest
-import kotlinx.coroutines.flow.flowOf
-import kotlinx.coroutines.flow.map
 import org.json.JSONArray
 import org.json.JSONObject
 import javax.inject.Inject
@@ -320,6 +320,14 @@ class ConversationRepository
                         deliveryMethod = message.deliveryMethod,
                         errorMessage = message.errorMessage,
                         replyToMessageId = message.replyToMessageId, // Reply reference
+                        // Received-side routing / signal metadata. Previously these
+                        // were dropped here, which meant the message-details screen
+                        // never rendered RSSI/SNR/hopcount/receiving-interface even
+                        // when the upstream producer populated them.
+                        receivedHopCount = message.receivedHopCount,
+                        receivedInterface = message.receivedInterface,
+                        receivedRssi = message.receivedRssi,
+                        receivedSnr = message.receivedSnr,
                         receivedAt = message.receivedAt,
                         sentInterface = message.sentInterface,
                     )


### PR DESCRIPTION
## Summary

`ConversationRepository.saveMessage` constructed `MessageEntity` from the input `Message` but silently dropped `receivedHopCount`, `receivedInterface`, `receivedRssi`, and `receivedSnr`. The fields exist on both sides (same names, same types) but weren't copied during the constructor call — classic field-omission drop introduced during the migration.

Consequence (what the user reported): message-details screen has UI for all four metrics (`MessageDetailScreen.kt:220-240`) but never rendered them because the persisted entity always held null.

## What this PR fixes

Only the repository → entity copy. That closes the secondary drop.

## What's still missing (upstream)

The upstream producer at `NativeReticulumProtocol.handleIncomingMessage` (`NativeReticulumProtocol.kt:826-836`) is also not populating these on the emitted `ReceivedMessage`. Root cause: LXMF-kt's `LXMessage` doesn't expose packet-level metadata on delivery — the `(LXMessage) -> Unit` delivery callback has no access to the Packet the message arrived on, and LXMessage itself carries no routing/signal fields. Tracked in [torlando-tech/LXMF-kt#9](https://github.com/torlando-tech/LXMF-kt/issues/9).

Once LXMF-kt ships the LXMessage annotation fix, a follow-up Columba PR adds two lines to `handleIncomingMessage` to copy the LXMessage fields into `ReceivedMessage`, and the full chain works end-to-end.

## Sequence after this PR + LXMF-kt#9 land

```
RNS Packet (rssi, snr, receivingInterfaceHash, hops) — already populated by RNodeInterface/BLE
  → LXMessage (NEW fields from LXMF-kt#9)
  → ReceivedMessage (Columba copies in handleIncomingMessage — follow-up PR)
  → data.Message (MessageCollector copies — already works)
  → MessageEntity (copies here — THIS PR)
  → MessageDetailScreen (UI already renders — works)
```

## Test plan

- [x] Build passes
- [ ] After merge + LXMF-kt#9 + follow-up: send a LoRa message to the phone, view message details, confirm RSSI + SNR render
- [ ] Same for BLE messages (RSSI only; SNR stays null — correct)
- [ ] TCP/Auto messages: all four stay null (correct; no radio metrics for IP interfaces)

🤖 Generated with [Claude Code](https://claude.com/claude-code)