### PR TITLE
Propagate LXMessage packet metadata through the receive pipeline

### DIFF
--- a/app/src/main/java/network/columba/app/service/MessageCollector.kt
+++ b/app/src/main/java/network/columba/app/service/MessageCollector.kt
@@ -1,6 +1,12 @@
 package network.columba.app.service
 
 import android.util.Log
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.launch
 import network.columba.app.data.db.dao.PeerIconDao
 import network.columba.app.data.db.entity.ContactStatus
 import network.columba.app.data.db.entity.PeerIconEntity
@@ -12,12 +18,6 @@ import network.columba.app.data.repository.IdentityRepository
 import network.columba.app.notifications.NotificationHelper
 import network.columba.app.reticulum.protocol.ReticulumProtocol
 import network.columba.app.service.util.PeerNameResolver
-import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.SupervisorJob
-import kotlinx.coroutines.flow.MutableStateFlow
-import kotlinx.coroutines.flow.StateFlow
-import kotlinx.coroutines.launch
 import java.util.concurrent.ConcurrentHashMap
 import javax.inject.Inject
 import javax.inject.Singleton
@@ -217,6 +217,9 @@ class MessageCollector
                                 // Routing info (hop count and receiving interface)
                                 receivedHopCount = receivedMessage.receivedHopCount,
                                 receivedInterface = receivedMessage.receivedInterface,
+                                // Signal quality metrics (RNode/BLE; null on TCP/Auto/propagated)
+                                receivedRssi = receivedMessage.receivedRssi,
+                                receivedSnr = receivedMessage.receivedSnr,
                                 // Local reception time for sort ordering
                                 receivedAt = now,
                             )

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -20,7 +20,7 @@ coil = "2.7.0"
 
 # JitPack-published libraries (formerly git submodules)
 reticulumKt = "v0.0.10"
-lxmfKt = "v0.0.4"
+lxmfKt = "v0.0.5"
 lxstKt = "v0.0.3"
 
 [libraries]

--- a/reticulum/src/main/java/network/columba/app/reticulum/protocol/NativeReticulumProtocol.kt
+++ b/reticulum/src/main/java/network/columba/app/reticulum/protocol/NativeReticulumProtocol.kt
@@ -823,35 +823,51 @@ class NativeReticulumProtocol(
                 return@launch
             }
 
-            // Resolve the receiving interface hash (annotated by LXMF-kt v0.0.5+
-            // on the delivering packet) to a human-readable interface name
-            // via the Transport's interface table. Falls back to null when
-            // the interface is gone (e.g., was removed mid-delivery) or for
-            // propagation-fetched messages (LXMF-kt intentionally leaves it
-            // null on those — see LXMF-kt#9).
-            val receivingInterfaceName =
-                message.receivingInterfaceHash?.let { hash ->
-                    Transport.getInterfaces().firstOrNull { it.hash.contentEquals(hash) }?.name
-                }
-
-            val received =
-                ReceivedMessage(
-                    messageHash = message.hash?.let { it.joinToString("") { b -> "%02x".format(b) } } ?: "",
+            _messages.tryEmit(
+                buildReceivedMessage(
+                    message = message,
                     content = content,
                     sourceHash = sourceHash,
-                    destinationHash = destHash,
+                    destHash = destHash,
                     timestamp = timestamp,
                     fieldsJson = fieldsJson,
-                    publicKey = null, // Will be populated by recall if needed
                     iconAppearance = iconAppearance,
-                    receivedHopCount = message.receivedHopCount,
-                    receivedInterface = receivingInterfaceName,
-                    receivedRssi = message.receivedRssi,
-                    receivedSnr = message.receivedSnr,
-                )
-
-            _messages.tryEmit(received)
+                ),
+            )
         }
+    }
+
+    private fun buildReceivedMessage(
+        message: LXMessage,
+        content: String,
+        sourceHash: ByteArray,
+        destHash: ByteArray,
+        timestamp: Long,
+        fieldsJson: String?,
+        iconAppearance: IconAppearance?,
+    ): ReceivedMessage {
+        // Resolve the receiving interface hash (annotated by LXMF-kt v0.0.5+ on the
+        // delivering packet) to a human-readable interface name via the Transport's
+        // interface table. Falls back to null when the interface is gone or for
+        // propagation-fetched messages (LXMF-kt leaves it null there — see LXMF-kt#9).
+        val receivingInterfaceName =
+            message.receivingInterfaceHash?.let { hash ->
+                Transport.getInterfaces().firstOrNull { it.hash.contentEquals(hash) }?.name
+            }
+        return ReceivedMessage(
+            messageHash = message.hash?.let { it.joinToString("") { b -> "%02x".format(b) } } ?: "",
+            content = content,
+            sourceHash = sourceHash,
+            destinationHash = destHash,
+            timestamp = timestamp,
+            fieldsJson = fieldsJson,
+            publicKey = null,
+            iconAppearance = iconAppearance,
+            receivedHopCount = message.receivedHopCount,
+            receivedInterface = receivingInterfaceName,
+            receivedRssi = message.receivedRssi,
+            receivedSnr = message.receivedSnr,
+        )
     }
 
     override val locationTelemetryFlow = _locationTelemetryFlow.asSharedFlow()

--- a/reticulum/src/main/java/network/columba/app/reticulum/protocol/NativeReticulumProtocol.kt
+++ b/reticulum/src/main/java/network/columba/app/reticulum/protocol/NativeReticulumProtocol.kt
@@ -823,6 +823,17 @@ class NativeReticulumProtocol(
                 return@launch
             }
 
+            // Resolve the receiving interface hash (annotated by LXMF-kt v0.0.5+
+            // on the delivering packet) to a human-readable interface name
+            // via the Transport's interface table. Falls back to null when
+            // the interface is gone (e.g., was removed mid-delivery) or for
+            // propagation-fetched messages (LXMF-kt intentionally leaves it
+            // null on those — see LXMF-kt#9).
+            val receivingInterfaceName =
+                message.receivingInterfaceHash?.let { hash ->
+                    Transport.getInterfaces().firstOrNull { it.hash.contentEquals(hash) }?.name
+                }
+
             val received =
                 ReceivedMessage(
                     messageHash = message.hash?.let { it.joinToString("") { b -> "%02x".format(b) } } ?: "",
@@ -833,6 +844,10 @@ class NativeReticulumProtocol(
                     fieldsJson = fieldsJson,
                     publicKey = null, // Will be populated by recall if needed
                     iconAppearance = iconAppearance,
+                    receivedHopCount = message.receivedHopCount,
+                    receivedInterface = receivingInterfaceName,
+                    receivedRssi = message.receivedRssi,
+                    receivedSnr = message.receivedSnr,
                 )
 
             _messages.tryEmit(received)


### PR DESCRIPTION
## Summary

Completes the end-to-end RSSI / SNR / receiving-interface / hop-count flow to the message-details screen. Bumps LXMF-kt `v0.0.4` → `v0.0.5` (which ships the [LXMessage annotation](https://github.com/torlando-tech/LXMF-kt/pull/10) — closes LXMF-kt#9) and connects the new producer to the already-ready consumer chain.

## Data flow after this PR

```
RNS Packet (rssi, snr, receivingInterfaceHash, hops)
  └─ set by RNodeInterface, BLEPeerInterface per-packet on receive
  ▼
LXMessage (LXMF-kt v0.0.5 annotations)
  └─ populated in LXMRouter.processInboundDelivery (both packet + link branches)
  ▼
ReceivedMessage (THIS PR, NativeReticulumProtocol.handleIncomingMessage)
  └─ copies 4 LXMessage fields; resolves interface hash to name via Transport.getInterfaces()
  ▼
DataMessage (THIS PR, MessageCollector)
  └─ copies rssi + snr (hop + interface were already plumbed in a prior pass)
  ▼
MessageEntity (already in Columba PR #819)
  ▼
MessageDetailScreen (already rendered the fields; just saw null forever)
```

## Interface-name resolution

LXMessage exposes the receiving interface as a 16-byte hash. Rather than showing `5460428f58bae2d2a745eb4d...` in the UI, this PR resolves via `Transport.getInterfaces().firstOrNull { it.hash.contentEquals(hash) }?.name`, so users see "RNode E16A BLE" or "TCP Client" etc.

## Null semantics (all intentional)

| Scenario | rssi | snr | interface | hops |
|---|---|---|---|---|
| LoRa/RNode receive | ✓ | ✓ | ✓ | ✓ |
| BLE receive | ✓ | — | ✓ | ✓ |
| TCP / AutoInterface receive | — | — | ✓ | ✓ |
| Propagated-fetched | — | — | — | — |
| Outgoing | — | — | — | — |

Propagated messages are null because LXMF-kt#10 explicitly leaves them unset — the sync-link RSSI isn't meaningful for the original message. BLE SNR is null because BLE has no SNR concept.

## Test plan

- [x] `./gradlew :app:assembleNoSentryDebug` — PASSED locally
- [x] Installed on two phones for on-device smoke (pending your visual confirmation)
- [ ] Open message details on a received LoRa message — RSSI + SNR render
- [ ] Open message details on a BLE-received message — RSSI renders, SNR is "—"
- [ ] Message received via TCP — all four "—"
- [ ] Propagated-fetched message — all four "—"

🤖 Generated with [Claude Code](https://claude.com/claude-code)