### PR TITLE
Bump reticulum-kt to v0.0.11 (BLE per-packet RSSI) + local composite-build dev loop

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -19,7 +19,7 @@ serialization = "1.10.0"
 coil = "2.7.0"
 
 # JitPack-published libraries (formerly git submodules)
-reticulumKt = "v0.0.10"
+reticulumKt = "v0.0.11"
 lxmfKt = "v0.0.5"
 lxstKt = "v0.0.3"
 

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -16,6 +16,16 @@ dependencyResolutionManagement {
 }
 
 rootProject.name = "columba"
+
+// Opt-in composite-build override: point reticulum-kt/LXMF-kt/LXST-kt
+// at a local checkout for a tight edit-build-install loop. Enable with
+// e.g. `LOCAL_RETICULUM_KT=../reticulum-kt ./gradlew :app:installDebug`.
+// Not committed as always-on to avoid masking the published artifact from
+// CI / other developers.
+System.getenv("LOCAL_RETICULUM_KT")?.let { includeBuild(it) }
+System.getenv("LOCAL_LXMF_KT")?.let { includeBuild(it) }
+System.getenv("LOCAL_LXST_KT")?.let { includeBuild(it) }
+
 include(":app")
 include(":data")
 include(":domain")


### PR DESCRIPTION
## Summary

- **Bump reticulum-kt → v0.0.11**: adds BLE per-packet RSSI annotation. The GATT `readRemoteRssi` poll on central connections now mirrors its value into the base-class `rStatRssi`, so `Transport.inbound` annotates every received packet with it and LXMF-kt v0.0.5 surfaces it as `LXMessage.receivedRssi`. Upstream: [torlando-tech/reticulum-kt#48](https://github.com/torlando-tech/reticulum-kt/pull/48).
- **Env-gated composite-build pattern in `settings.gradle.kts`**: adds `includeBuild` lines gated on `LOCAL_RETICULUM_KT` / `LOCAL_LXMF_KT` / `LOCAL_LXST_KT`. Inert when unset, so CI and default workflows are unaffected. When set, it substitutes the Maven coordinates with a local checkout, skipping the JitPack round-trip (~2-10 min → ~2s per iteration).

## Observable user-facing change

Message-details screen on incoming BLE messages now shows RSSI in the direction where our phone is the central/outgoing side of the BLE connection. Peripheral-side RSSI stays blank because Android `BluetoothGatt` doesn't expose a peripheral-side read API — this is an Android limitation, not a bug.

## Test plan

- [x] Debug APK built against JitPack v0.0.11 (no composite override) — 140 Gradle tasks, confirms JitPack resolution
- [x] Installed on 10.0.0.71 and 10.0.0.249
- [ ] Manual: send BLE message central→peripheral and verify RSSI appears on recipient's message details
- [ ] Manual: reverse direction and verify it's blank (expected per Android limitation)

🤖 Generated with [Claude Code](https://claude.com/claude-code)