### PR TITLE
Bump reticulum-kt to v0.0.12 (expire path on link establishment failure)

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -19,7 +19,7 @@ serialization = "1.10.0"
 coil = "2.7.0"
 
 # JitPack-published libraries (formerly git submodules)
-reticulumKt = "v0.0.11"
+reticulumKt = "v0.0.12"
 lxmfKt = "v0.0.5"
 lxstKt = "v0.0.3"
 


### PR DESCRIPTION
## Summary

Upgrade reticulum-kt v0.0.11 → v0.0.12. The sole change in v0.0.12 is [torlando-tech/reticulum-kt#50](https://github.com/torlando-tech/reticulum-kt/pull/50), which closes the endpoint-side path-invalidation gap discovered during multi-interface routing testing (2026-04-20).

## Observable impact for Columba users

When a phone's cached path for its peer goes stale (e.g. the peer disables the interface that learned that path), the next LXMF direct-link attempt over the stale path now triggers path rediscovery within one establishment-timeout; the subsequent message uses the fresh path automatically. Before v0.0.12, the RNS layer left the stale path intact, so every retry failed the same way — only Columba's `tryPropagationOnFail` application-layer fallback could deliver.

## Test plan

- [x] Clean Gradle build against JitPack v0.0.12 (140 tasks, no composite override)
- [x] Installed on 10.0.0.71 and 10.0.0.249
- [ ] Manual: reproduce the 2026-04-20 multi-interface scenario — two phones on IFAC+BLE, disable IFAC on one, send from the other — and verify the *next* message's direct link uses BLE (not falling back to propagation) within ~1s of the initial establishment timeout.

🤖 Generated with [Claude Code](https://claude.com/claude-code)