### PR TITLE
Dispatch MapViewModel.loadInterfaceMarkers to IO to avoid main-thread Room read

### DIFF
--- a/app/src/main/java/network/columba/app/viewmodel/MapViewModel.kt
+++ b/app/src/main/java/network/columba/app/viewmodel/MapViewModel.kt
@@ -6,6 +6,21 @@ import androidx.compose.runtime.Immutable
 import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
+import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.SharingStarted
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.combine
+import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.flow.stateIn
+import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.isActive
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
 import network.columba.app.data.db.dao.AnnounceDao
 import network.columba.app.data.db.dao.ReceivedLocationDao
 import network.columba.app.data.model.EnrichedContact
@@ -21,18 +36,6 @@ import network.columba.app.service.TelemetryCollectorManager
 import network.columba.app.ui.model.SharingDuration
 import network.columba.app.ui.util.InterfaceCategory
 import network.columba.app.ui.util.categorizeInterface
-import dagger.hilt.android.lifecycle.HiltViewModel
-import kotlinx.coroutines.delay
-import kotlinx.coroutines.flow.MutableStateFlow
-import kotlinx.coroutines.flow.SharingStarted
-import kotlinx.coroutines.flow.StateFlow
-import kotlinx.coroutines.flow.asStateFlow
-import kotlinx.coroutines.flow.combine
-import kotlinx.coroutines.flow.map
-import kotlinx.coroutines.flow.stateIn
-import kotlinx.coroutines.flow.update
-import kotlinx.coroutines.isActive
-import kotlinx.coroutines.launch
 import javax.inject.Inject
 
 /**
@@ -209,6 +212,16 @@ class MapViewModel
              * @suppress VisibleForTesting
              */
             internal var enablePeriodicRefresh = true
+
+            /**
+             * Dispatcher used for Room-backed calls reached via
+             * [ReticulumProtocol.getDiscoveredInterfaces] and the first-seen DAO.
+             *
+             * Made internal var to allow injecting a test dispatcher (same pattern as
+             * [DiscoveredInterfacesViewModel] and [InterfaceManagementViewModel]).
+             */
+            @Suppress("InjectDispatcher")
+            internal var ioDispatcher: CoroutineDispatcher = Dispatchers.IO
 
             /**
              * Parse appearance JSON from telemetry into icon fields.
@@ -655,56 +668,63 @@ class MapViewModel
                 }.stateIn(viewModelScope, SharingStarted.Eagerly, emptyList())
 
         private suspend fun loadInterfaceMarkers() {
+            // Dispatch to IO because ReticulumProtocol.getDiscoveredInterfaces() reaches
+            // Transport.listDiscoveredInterfaces() -> RoomDiscoveryStore.loadAllDiscovered(),
+            // which performs a synchronous (non-suspend) Room read and throws
+            // IllegalStateException if invoked on the main thread. The first-seen DAO
+            // calls below also hit Room, so we run the whole block off-main.
             try {
-                val discovered = reticulumProtocol.getDiscoveredInterfaces()
-                val withLocation = discovered.filter { it.hasLocation }
-
-                // Compute IDs once and persist first-seen timestamps
-                // (INSERT OR IGNORE preserves originals)
-                val now = System.currentTimeMillis() / 1000
-                val withId =
-                    withLocation.map { iface ->
-                        val id = "${iface.name}\u0000${iface.type}\u0000${iface.reachableOn ?: ""}"
-                        interfaceFirstSeenDao.insertIfNotExists(
-                            network.columba.app.data.db.entity
-                                .InterfaceFirstSeenEntity(id, now),
-                        )
-                        id to iface
-                    }
-
-                // Batch-fetch first-seen timestamps
-                val ids = withId.map { it.first }
-                val firstSeenMap =
-                    if (ids.isNotEmpty()) {
-                        interfaceFirstSeenDao
-                            .getFirstSeenBatch(ids)
-                            .associate { it.interfaceId to it.firstSeenTimestamp }
-                    } else {
-                        emptyMap()
-                    }
-
                 val markers =
-                    withId.map { (id, iface) ->
-                        InterfaceMarker(
-                            id = id,
-                            name = iface.name,
-                            type = iface.type,
-                            category = categorizeInterface(iface.type, iface.reachableOn),
-                            latitude = iface.latitude!!,
-                            longitude = iface.longitude!!,
-                            height = iface.height,
-                            frequency = iface.frequency,
-                            bandwidth = iface.bandwidth,
-                            spreadingFactor = iface.spreadingFactor,
-                            codingRate = iface.codingRate,
-                            modulation = iface.modulation,
-                            reachableOn = iface.reachableOn,
-                            port = iface.port,
-                            status = iface.status,
-                            lastHeard = iface.lastHeard,
-                            hops = iface.hops,
-                            firstSeen = firstSeenMap[id],
-                        )
+                    withContext(ioDispatcher) {
+                        val discovered = reticulumProtocol.getDiscoveredInterfaces()
+                        val withLocation = discovered.filter { it.hasLocation }
+
+                        // Compute IDs once and persist first-seen timestamps
+                        // (INSERT OR IGNORE preserves originals)
+                        val now = System.currentTimeMillis() / 1000
+                        val withId =
+                            withLocation.map { iface ->
+                                val id = "${iface.name}\u0000${iface.type}\u0000${iface.reachableOn ?: ""}"
+                                interfaceFirstSeenDao.insertIfNotExists(
+                                    network.columba.app.data.db.entity
+                                        .InterfaceFirstSeenEntity(id, now),
+                                )
+                                id to iface
+                            }
+
+                        // Batch-fetch first-seen timestamps
+                        val ids = withId.map { it.first }
+                        val firstSeenMap =
+                            if (ids.isNotEmpty()) {
+                                interfaceFirstSeenDao
+                                    .getFirstSeenBatch(ids)
+                                    .associate { it.interfaceId to it.firstSeenTimestamp }
+                            } else {
+                                emptyMap()
+                            }
+
+                        withId.map { (id, iface) ->
+                            InterfaceMarker(
+                                id = id,
+                                name = iface.name,
+                                type = iface.type,
+                                category = categorizeInterface(iface.type, iface.reachableOn),
+                                latitude = iface.latitude!!,
+                                longitude = iface.longitude!!,
+                                height = iface.height,
+                                frequency = iface.frequency,
+                                bandwidth = iface.bandwidth,
+                                spreadingFactor = iface.spreadingFactor,
+                                codingRate = iface.codingRate,
+                                modulation = iface.modulation,
+                                reachableOn = iface.reachableOn,
+                                port = iface.port,
+                                status = iface.status,
+                                lastHeard = iface.lastHeard,
+                                hops = iface.hops,
+                                firstSeen = firstSeenMap[id],
+                            )
+                        }
                     }
                 _state.update { it.copy(interfaceMarkers = markers) }
             } catch (e: Exception) {

--- a/app/src/test/java/network/columba/app/viewmodel/MapViewModelTest.kt
+++ b/app/src/test/java/network/columba/app/viewmodel/MapViewModelTest.kt
@@ -1,21 +1,11 @@
+@file:Suppress("InjectDispatcher")
+
 package network.columba.app.viewmodel
 
 import android.location.Location
 import androidx.arch.core.executor.testing.InstantTaskExecutorRule
 import androidx.lifecycle.SavedStateHandle
 import app.cash.turbine.test
-import network.columba.app.data.db.dao.AnnounceDao
-import network.columba.app.data.db.dao.ReceivedLocationDao
-import network.columba.app.data.db.entity.ReceivedLocationEntity
-import network.columba.app.data.model.MapAnnounceLookup
-import network.columba.app.data.repository.ContactRepository
-import network.columba.app.data.repository.OfflineMapRegionRepository
-import network.columba.app.map.MapStyleResult
-import network.columba.app.map.MapTileSourceManager
-import network.columba.app.repository.SettingsRepository
-import network.columba.app.service.LocationSharingManager
-import network.columba.app.service.TelemetryCollectorManager
-import network.columba.app.test.TestFactories
 import io.mockk.Runs
 import io.mockk.clearAllMocks
 import io.mockk.coEvery
@@ -32,6 +22,18 @@ import kotlinx.coroutines.test.UnconfinedTestDispatcher
 import kotlinx.coroutines.test.resetMain
 import kotlinx.coroutines.test.runTest
 import kotlinx.coroutines.test.setMain
+import network.columba.app.data.db.dao.AnnounceDao
+import network.columba.app.data.db.dao.ReceivedLocationDao
+import network.columba.app.data.db.entity.ReceivedLocationEntity
+import network.columba.app.data.model.MapAnnounceLookup
+import network.columba.app.data.repository.ContactRepository
+import network.columba.app.data.repository.OfflineMapRegionRepository
+import network.columba.app.map.MapStyleResult
+import network.columba.app.map.MapTileSourceManager
+import network.columba.app.repository.SettingsRepository
+import network.columba.app.service.LocationSharingManager
+import network.columba.app.service.TelemetryCollectorManager
+import network.columba.app.test.TestFactories
 import org.junit.After
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
@@ -77,6 +79,8 @@ class MapViewModelTest {
         Dispatchers.setMain(testDispatcher)
         // Disable periodic refresh to prevent infinite loops in tests
         MapViewModel.enablePeriodicRefresh = false
+        // Route IO-dispatched work to the test dispatcher so runTest can drive it
+        MapViewModel.ioDispatcher = testDispatcher
 
         savedStateHandle = SavedStateHandle()
         contactRepository = mockk()
@@ -123,6 +127,8 @@ class MapViewModelTest {
         Dispatchers.resetMain()
         // Re-enable periodic refresh for other tests
         MapViewModel.enablePeriodicRefresh = true
+        // Restore IO dispatcher for other tests
+        MapViewModel.ioDispatcher = Dispatchers.IO
         clearAllMocks()
     }
 


### PR DESCRIPTION
## Summary

Fixes a `IllegalStateException: Cannot access database on the main thread` that fires roughly every 30 seconds from `MapViewModel` on a real device:

```
W MapViewModel: Failed to load interface markers
W MapViewModel: java.lang.IllegalStateException: Cannot access database on the main thread since it may potentially lock the UI for a long period of time.
W MapViewModel:     at androidx.room.RoomDatabase.assertNotMainThread(RoomDatabase.android.kt:592)
W MapViewModel:     at androidx.room.RoomDatabase.query(RoomDatabase.android.kt:660)
W MapViewModel:     at androidx.room.util.DBUtil__DBUtil_androidKt.query(DBUtil.android.kt:183)
W MapViewModel:     at network.reticulum.android.db.dao.DiscoveredInterfaceDao_Impl.getAll(DiscoveredInterfaceDao_Impl.java:444)
W MapViewModel:     at network.reticulum.android.db.store.RoomDiscoveryStore.loadAllDiscovered(RoomDiscoveryStore.kt:51)
W MapViewModel:     at network.reticulum.discovery.InterfaceDiscovery.listDiscovered(InterfaceDiscovery.kt:147)
W MapViewModel:     at network.reticulum.transport.Transport.listDiscoveredInterfaces(Transport.kt:998)
W MapViewModel:     at network.columba.app.reticulum.protocol.NativeReticulumProtocol.getDiscoveredInterfaces(NativeReticulumProtocol.kt:1701)
W MapViewModel:     at network.columba.app.viewmodel.MapViewModel.loadInterfaceMarkers(MapViewModel.kt:659)
```

## Root cause

`MapViewModel` runs a periodic refresh every 30 s:

```kotlin
while (isActive) {
    delay(REFRESH_INTERVAL_MS)
    _refreshTrigger.value = System.currentTimeMillis()
    loadInterfaceMarkers()
}
```

`loadInterfaceMarkers` is a `suspend` function launched on `viewModelScope` (Main dispatcher). It calls `reticulumProtocol.getDiscoveredInterfaces()`, which on the native path is:

```kotlin
override suspend fun getDiscoveredInterfaces(): List<DiscoveredInterface> =
    Transport.listDiscoveredInterfaces().map { ... }
```

`Transport.listDiscoveredInterfaces()` is a non-suspend call that ultimately reaches `RoomDiscoveryStore.loadAllDiscovered()` -> the generated `DiscoveredInterfaceDao_Impl.getAll()` Room query. Because it's non-suspend, Room doesn't dispatch it onto its internal IO executor, and `assertNotMainThread` trips.

The offending DAO lives in `reticulum-kt` (not this repo), so we can't flip it to `suspend` from here -- the fix has to come from the caller.

Two other ViewModels that call the same `getDiscoveredInterfaces()` already dispatch to IO (`DiscoveredInterfacesViewModel`, `InterfaceManagementViewModel`); `MapViewModel` was the outlier.

## Fix

Wrap the full body of `MapViewModel.loadInterfaceMarkers` in `withContext(ioDispatcher)`. This covers both the reticulum-kt-backed `getDiscoveredInterfaces()` call and the local `InterfaceFirstSeenDao` writes/reads (which, while `suspend`, have no reason to hog Main).

`ioDispatcher` is exposed as an `internal var` on the companion object (defaulting to `Dispatchers.IO`) to mirror the exact pattern used by `DiscoveredInterfacesViewModel` and `InterfaceManagementViewModel`, which allows `MapViewModelTest` to swap in the test dispatcher.

## Test plan

- [x] `./gradlew :app:compileNoSentryDebugKotlin` passes
- [x] `./gradlew :app:ktlintCheck` passes (no new violations introduced)
- [x] `./gradlew :app:detekt` passes
- [x] `./gradlew :app:testNoSentryDebugUnitTest` passes (all 56 `MapViewModelTest` cases + full suite, zero failures)
- [ ] Verify on device that the warning no longer appears every 30 s in logcat from `MapViewModel`