### PR TITLE
Bump LXMF-kt to v0.0.6 (send-hang fix) + dependencySubstitution for JitPack-collapsed libs

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -20,7 +20,7 @@ coil = "2.7.0"
 
 # JitPack-published libraries (formerly git submodules)
 reticulumKt = "v0.0.12"
-lxmfKt = "v0.0.5"
+lxmfKt = "v0.0.6"
 lxstKt = "v0.0.3"
 
 [libraries]

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -23,8 +23,31 @@ rootProject.name = "columba"
 // Not committed as always-on to avoid masking the published artifact from
 // CI / other developers.
 System.getenv("LOCAL_RETICULUM_KT")?.let { includeBuild(it) }
-System.getenv("LOCAL_LXMF_KT")?.let { includeBuild(it) }
-System.getenv("LOCAL_LXST_KT")?.let { includeBuild(it) }
+// LXMF-kt + LXST-kt are published on JitPack with its single-module
+// root-coord collapse: the Maven coord is `<user>:<repo>`, but the
+// actual Gradle module is a subproject (lxmf-core / lxst-core). A
+// plain `includeBuild` won't auto-substitute because the project
+// group (`com.github.torlando-tech.LXMF-kt`) and artifact
+// (`lxmf-core`) don't match the consumer-side coord
+// (`com.github.torlando-tech:LXMF-kt`). We add an explicit
+// dependencySubstitution to map the collapsed coord to the real
+// subproject.
+System.getenv("LOCAL_LXMF_KT")?.let {
+    includeBuild(it) {
+        dependencySubstitution {
+            substitute(module("com.github.torlando-tech:LXMF-kt"))
+                .using(project(":lxmf-core"))
+        }
+    }
+}
+System.getenv("LOCAL_LXST_KT")?.let {
+    includeBuild(it) {
+        dependencySubstitution {
+            substitute(module("com.github.torlando-tech:LXST-kt"))
+                .using(project(":lxst-core"))
+        }
+    }
+}
 
 include(":app")
 include(":data")


### PR DESCRIPTION
## Summary

- **LXMF-kt v0.0.5 → v0.0.6**: closes the deterministic send-spinner-hang reproduced on-device during today's multi-interface routing test. Contains [LXMF-kt#11](https://github.com/torlando-tech/LXMF-kt/pull/11) (`LXMRouter.processOutbound` releases `pendingOutboundMutex` before dispatching per-message delivery, so a single blocked interface write can't wedge subsequent `handleOutbound` callers) and [LXMF-kt#12](https://github.com/torlando-tech/LXMF-kt/pull/12) (first-ever CI on LXMF-kt, enforcing the regression test from #11).
- **`settings.gradle.kts` hardening**: the env-gated `LOCAL_LXMF_KT` / `LOCAL_LXST_KT` `includeBuild` blocks were silently no-ops because JitPack's single-module root-coord collapse puts those repos at `com.github.torlando-tech:LXMF-kt` while the local Gradle subproject has a different group+artifact (`com.github.torlando-tech.LXMF-kt:lxmf-core`). Adding explicit `dependencySubstitution { substitute(module(...)).using(project(...)) }` rules makes the local override actually kick in — verified today: task count goes 140 → 142 when the env var is set, and the rebuild picks up local LXMF-kt edits.

## User-facing impact

When a Columba user's phone has multiple interfaces and one goes into a blocking send state (common when peer disables an interface mid-send), the send-button spinner no longer hangs indefinitely. Previously every subsequent send would wedge; now each send queues independently, and blocked-interface timeouts propagate as packet failures that the LXMF layer handles via its normal retry / propagation fallback path.

## Test plan

- [x] Clean JitPack v0.0.6 resolve (140 Gradle tasks, no composite override in effect)
- [x] Installed on 10.0.0.71 and 10.0.0.249
- [ ] Manual: reproduce the 2026-04-20 multi-interface routing scenario and confirm no `handleOutbound` log chain stops at `pre-mutex` without a matching `mutex-acquired`
- [ ] Manual: toggle interfaces on one phone mid-send-burst, confirm the UI spinner clears on every send

🤖 Generated with [Claude Code](https://claude.com/claude-code)