### PR TITLE
Add Edit action to interface-card long-press menu

### DIFF
--- a/app/src/main/java/network/columba/app/MainActivity.kt
+++ b/app/src/main/java/network/columba/app/MainActivity.kt
@@ -1591,8 +1591,12 @@ fun ColumbaNavigation(
                                             navController.navigate("rnode_wizard")
                                         }
                                     },
-                                    onNavigateToTcpClientWizard = {
-                                        navController.navigate("tcp_client_wizard")
+                                    onNavigateToTcpClientWizard = { interfaceId ->
+                                        if (interfaceId != null) {
+                                            navController.navigate("tcp_client_wizard?interfaceId=$interfaceId")
+                                        } else {
+                                            navController.navigate("tcp_client_wizard")
+                                        }
                                     },
                                     onNavigateToInterfaceStats = { interfaceId ->
                                         navController.navigate("interface_stats/$interfaceId")

--- a/app/src/main/java/network/columba/app/ui/screens/InterfaceManagementScreen.kt
+++ b/app/src/main/java/network/columba/app/ui/screens/InterfaceManagementScreen.kt
@@ -35,6 +35,8 @@ import androidx.compose.material.icons.filled.ArrowBack
 import androidx.compose.material.icons.filled.Check
 import androidx.compose.material.icons.filled.CheckCircle
 import androidx.compose.material.icons.filled.Close
+import androidx.compose.material.icons.filled.Delete
+import androidx.compose.material.icons.filled.Edit
 import androidx.compose.material.icons.filled.Info
 import androidx.compose.material.icons.filled.Settings
 import androidx.compose.material.icons.filled.Warning
@@ -44,8 +46,11 @@ import androidx.compose.material3.ButtonDefaults
 import androidx.compose.material3.Card
 import androidx.compose.material3.CardDefaults
 import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.DropdownMenu
+import androidx.compose.material3.DropdownMenuItem
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.FloatingActionButton
+import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
@@ -89,7 +94,7 @@ import network.columba.app.viewmodel.InterfaceManagementViewModel
 fun InterfaceManagementScreen(
     onNavigateBack: () -> Unit,
     onNavigateToRNodeWizard: (interfaceId: Long?) -> Unit = {},
-    onNavigateToTcpClientWizard: () -> Unit = {},
+    onNavigateToTcpClientWizard: (interfaceId: Long?) -> Unit = {},
     onNavigateToInterfaceStats: (interfaceId: Long) -> Unit = {},
     onNavigateToDiscoveredInterfaces: () -> Unit = {},
     viewModel: InterfaceManagementViewModel = hiltViewModel(),
@@ -100,6 +105,9 @@ fun InterfaceManagementScreen(
 
     // State for delete confirmation dialog
     var interfaceToDelete by remember { mutableStateOf<InterfaceEntity?>(null) }
+
+    // State for long-press context menu (Edit / Delete)
+    var contextMenuInterface by remember { mutableStateOf<InterfaceEntity?>(null) }
 
     // State for error dialog
     var errorDialogInterface by remember { mutableStateOf<InterfaceEntity?>(null) }
@@ -282,28 +290,47 @@ fun InterfaceManagementScreen(
                                     }
 
                                 item(key = "iface_${iface.id}") {
-                                    InterfaceCard(
-                                        interfaceEntity = iface,
-                                        onClick = { onNavigateToInterfaceStats(iface.id) },
-                                        onClickLabel = stringResource(R.string.view_interface_details),
-                                        onLongClick = { interfaceToDelete = iface },
-                                        onLongClickLabel = stringResource(R.string.delete_interface),
-                                        onToggle = { enabled ->
-                                            val hasPermissions = BlePermissionManager.hasAllPermissions(context)
-                                            viewModel.toggleInterface(iface.id, enabled, hasPermissions)
-                                        },
-                                        bluetoothState = state.bluetoothState,
-                                        blePermissionsGranted = state.blePermissionsGranted,
-                                        isOnline = isOnline,
-                                        peerCount = spawnedPeers.size,
-                                        onErrorClick = { errorDialogInterface = iface },
-                                        onRequestPermissions =
-                                            if (iface.isBleInterface()) {
-                                                { permissionLauncher.launch(BlePermissionManager.getRequiredPermissions().toTypedArray()) }
-                                            } else {
-                                                null
+                                    Box(modifier = Modifier.fillMaxWidth()) {
+                                        InterfaceCard(
+                                            interfaceEntity = iface,
+                                            onClick = { onNavigateToInterfaceStats(iface.id) },
+                                            onClickLabel = stringResource(R.string.view_interface_details),
+                                            onLongClick = { contextMenuInterface = iface },
+                                            onLongClickLabel = stringResource(R.string.interface_actions),
+                                            onToggle = { enabled ->
+                                                val hasPermissions = BlePermissionManager.hasAllPermissions(context)
+                                                viewModel.toggleInterface(iface.id, enabled, hasPermissions)
                                             },
-                                    )
+                                            bluetoothState = state.bluetoothState,
+                                            blePermissionsGranted = state.blePermissionsGranted,
+                                            isOnline = isOnline,
+                                            peerCount = spawnedPeers.size,
+                                            onErrorClick = { errorDialogInterface = iface },
+                                            onRequestPermissions =
+                                                if (iface.isBleInterface()) {
+                                                    { permissionLauncher.launch(BlePermissionManager.getRequiredPermissions().toTypedArray()) }
+                                                } else {
+                                                    null
+                                                },
+                                        )
+                                        InterfaceCardContextMenu(
+                                            expanded = contextMenuInterface?.id == iface.id,
+                                            onDismiss = { contextMenuInterface = null },
+                                            onEdit = {
+                                                val target = iface
+                                                contextMenuInterface = null
+                                                when (target.type) {
+                                                    "RNode" -> onNavigateToRNodeWizard(target.id)
+                                                    "TCPClient" -> onNavigateToTcpClientWizard(target.id)
+                                                    else -> viewModel.showEditDialog(target)
+                                                }
+                                            },
+                                            onDelete = {
+                                                interfaceToDelete = iface
+                                                contextMenuInterface = null
+                                            },
+                                        )
+                                    }
                                 }
 
                                 // Spawned sub-interfaces indented below parent
@@ -443,7 +470,7 @@ fun InterfaceManagementScreen(
                 showTypeSelector = false
                 when (type) {
                     "RNode" -> onNavigateToRNodeWizard(null)
-                    "TCPClient" -> onNavigateToTcpClientWizard()
+                    "TCPClient" -> onNavigateToTcpClientWizard(null)
                     "TCPServer" -> {
                         viewModel.showAddDialog()
                         viewModel.updateConfigState {
@@ -691,6 +718,55 @@ fun EmptyInterfacesView() {
                 color = MaterialTheme.colorScheme.onSurfaceVariant,
             )
         }
+    }
+}
+
+/**
+ * DropdownMenu shown on long-press of an [InterfaceCard], offering Edit / Delete.
+ * Anchored to the card via its parent Box; the caller controls [expanded].
+ */
+@Composable
+fun InterfaceCardContextMenu(
+    expanded: Boolean,
+    onDismiss: () -> Unit,
+    onEdit: () -> Unit,
+    onDelete: () -> Unit,
+) {
+    DropdownMenu(
+        expanded = expanded,
+        onDismissRequest = onDismiss,
+        shape = RoundedCornerShape(12.dp),
+        tonalElevation = 3.dp,
+    ) {
+        DropdownMenuItem(
+            leadingIcon = {
+                Icon(
+                    imageVector = Icons.Default.Edit,
+                    contentDescription = null,
+                )
+            },
+            text = { Text(stringResource(R.string.edit_interface)) },
+            onClick = onEdit,
+        )
+
+        HorizontalDivider()
+
+        DropdownMenuItem(
+            leadingIcon = {
+                Icon(
+                    imageVector = Icons.Default.Delete,
+                    contentDescription = null,
+                    tint = MaterialTheme.colorScheme.error,
+                )
+            },
+            text = {
+                Text(
+                    text = stringResource(R.string.delete_interface),
+                    color = MaterialTheme.colorScheme.error,
+                )
+            },
+            onClick = onDelete,
+        )
     }
 }
 

--- a/app/src/main/java/network/columba/app/ui/screens/InterfaceManagementScreen.kt
+++ b/app/src/main/java/network/columba/app/ui/screens/InterfaceManagementScreen.kt
@@ -317,12 +317,11 @@ fun InterfaceManagementScreen(
                                             expanded = contextMenuInterface?.id == iface.id,
                                             onDismiss = { contextMenuInterface = null },
                                             onEdit = {
-                                                val target = iface
                                                 contextMenuInterface = null
-                                                when (target.type) {
-                                                    "RNode" -> onNavigateToRNodeWizard(target.id)
-                                                    "TCPClient" -> onNavigateToTcpClientWizard(target.id)
-                                                    else -> viewModel.showEditDialog(target)
+                                                when (iface.type) {
+                                                    "RNode" -> onNavigateToRNodeWizard(iface.id)
+                                                    "TCPClient" -> onNavigateToTcpClientWizard(iface.id)
+                                                    else -> viewModel.showEditDialog(iface)
                                                 }
                                             },
                                             onDelete = {

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -26,4 +26,6 @@
     <!-- Network Interfaces screen -->
     <string name="delete_interface">Delete interface</string>
     <string name="view_interface_details">View interface details</string>
+    <string name="interface_actions">Interface actions</string>
+    <string name="edit_interface">Edit interface</string>
 </resources>


### PR DESCRIPTION
## Summary

Follow-up to #812. That PR restored long-press → confirm-delete on the interface card but regressed classic Columba's per-card Edit affordance (which used to sit next to Delete). User flagged that the long-press menu should expose both actions.

Long-press now opens a Material 3 `DropdownMenu` anchored to the card with **Edit** and **Delete** items. Delete preserves the existing confirmation-dialog path untouched — same `interfaceToDelete` state, same `DeleteConfirmationDialog`, same `viewModel.deleteInterface(iface.id)` call. Edit routes by interface type:

- **RNode** → `RNodeWizardScreen` in edit mode (reuses existing `editingInterfaceId` param; the wizard's `isEditMode` branches are already there)
- **TCPClient** → `TcpClientWizardScreen` in edit mode (reuses existing `interfaceId` nav arg on the `tcp_client_wizard` route)
- **AutoInterface / AndroidBLE / TCPServer** → existing `InterfaceConfigDialog` via `InterfaceManagementViewModel.showEditDialog`, which already populated `editingInterface` + pre-filled `configState` and branches save → update in `saveInterface()`

Matches the `ContactsScreen` long-press → DropdownMenu pattern already used elsewhere in the app. No new pattern introduced.

## Files touched

- `InterfaceManagementScreen.kt` — new `InterfaceCardContextMenu` composable; `Box` wrapper around each `InterfaceCard` so the menu can anchor; long-click handler toggles `contextMenuInterface` state; `onLongClickLabel` swaps from "Delete interface" to "Interface actions"; `onNavigateToTcpClientWizard` signature gains a nullable `interfaceId`.
- `MainActivity.kt` — `onNavigateToTcpClientWizard` callsite now passes `interfaceId` through to the existing `tcp_client_wizard?interfaceId=N` route (bare creation still works via the route's `defaultValue = -1L` on the `interfaceId` nav arg).
- `strings.xml` — two new strings: `interface_actions` (onLongClickLabel for a11y), `edit_interface` (menu item). `delete_interface` remains the menu item label.

## Test plan

- [x] `:app:compileNoSentryDebugKotlin` — green
- [x] `:app:ktlintCheck` — green (no new violations in touched files)
- [x] `:app:detekt` — green
- [x] `:app:testNoSentryDebugUnitTest` — 83 tasks, no regressions
- [x] On device: long-press an RNode card → menu shows Edit + Delete → tap Edit → RNode wizard opens in edit mode seeded with the current device/region/preset
- [x] Long-press a TCP Client card → tap Edit → TCP wizard opens in edit mode seeded with host/port/IFAC fields
- [x] Long-press an AutoInterface/BLE/TCPServer card → tap Edit → existing config dialog opens with fields pre-filled; Save writes the update
- [x] Tap Delete from the menu → existing confirmation dialog appears → confirm → interface removed (regression check on #812)
- [x] Dismiss the menu (tap outside) without choosing → state resets, nothing happens

🤖 Generated with [Claude Code](https://claude.com/claude-code)