### PR TITLE
Give interface cards the same semantic icon mapping as announce cards

### DIFF
--- a/app/src/main/java/network/columba/app/ui/components/PeerCard.kt
+++ b/app/src/main/java/network/columba/app/ui/components/PeerCard.kt
@@ -263,6 +263,36 @@ fun SignalStrengthIndicator(
 }
 
 /**
+ * Icon + accessibility label pair for an interface type. Returned by [interfaceTypeIconData]
+ * so callers that need full control over Icon sizing/tinting can render their own Icon composable.
+ */
+data class InterfaceTypeIconData(
+    val imageVector: ImageVector,
+    val contentDescription: String,
+)
+
+/**
+ * Canonical mapping from [InterfaceType] to icon + accessibility label. This is the single
+ * source of truth for "interface type → icon" used by both the announce overlay ([InterfaceTypeIcon])
+ * and the Interface Management screen. Returns `null` for [InterfaceType.UNKNOWN] so announce-card
+ * callers can short-circuit; screens that must always render an icon should fall back to a neutral
+ * glyph when they see `null`.
+ */
+@Composable
+fun interfaceTypeIconData(type: InterfaceType): InterfaceTypeIconData? =
+    when (type) {
+        InterfaceType.AUTO_INTERFACE -> InterfaceTypeIconData(Icons.Default.Wifi, "WiFi")
+        InterfaceType.TCP_CLIENT -> InterfaceTypeIconData(Icons.Default.Public, "Internet")
+        InterfaceType.ANDROID_BLE -> InterfaceTypeIconData(Icons.Default.Bluetooth, "Bluetooth")
+        InterfaceType.RNODE ->
+            InterfaceTypeIconData(
+                ImageVector.vectorResource(com.composables.icons.lucide.R.drawable.lucide_ic_antenna),
+                "LoRa/RNode",
+            )
+        InterfaceType.UNKNOWN -> null
+    }
+
+/**
  * Displays an icon representing the network interface type through which an announce was received.
  * Returns early (renders nothing) for unknown or null interface types.
  */
@@ -276,20 +306,11 @@ fun InterfaceTypeIcon(
             runCatching { InterfaceType.valueOf(it) }.getOrNull()
         } ?: return
 
-    if (type == InterfaceType.UNKNOWN) return
-
-    val (icon, contentDescription) =
-        when (type) {
-            InterfaceType.AUTO_INTERFACE -> Icons.Default.Wifi to "WiFi"
-            InterfaceType.TCP_CLIENT -> Icons.Default.Public to "Internet"
-            InterfaceType.ANDROID_BLE -> Icons.Default.Bluetooth to "Bluetooth"
-            InterfaceType.RNODE -> ImageVector.vectorResource(com.composables.icons.lucide.R.drawable.lucide_ic_antenna) to "LoRa/RNode"
-            InterfaceType.UNKNOWN -> return
-        }
+    val data = interfaceTypeIconData(type) ?: return
 
     Icon(
-        imageVector = icon,
-        contentDescription = contentDescription,
+        imageVector = data.imageVector,
+        contentDescription = data.contentDescription,
         modifier = modifier.size(18.dp),
         tint = MaterialTheme.colorScheme.onSurfaceVariant,
     )

--- a/app/src/main/java/network/columba/app/ui/screens/InterfaceManagementScreen.kt
+++ b/app/src/main/java/network/columba/app/ui/screens/InterfaceManagementScreen.kt
@@ -37,6 +37,7 @@ import androidx.compose.material.icons.filled.CheckCircle
 import androidx.compose.material.icons.filled.Close
 import androidx.compose.material.icons.filled.Info
 import androidx.compose.material.icons.filled.Settings
+import androidx.compose.material.icons.filled.SettingsInputAntenna
 import androidx.compose.material.icons.filled.Warning
 import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.Button
@@ -76,9 +77,11 @@ import androidx.hilt.navigation.compose.hiltViewModel
 import kotlinx.coroutines.delay
 import network.columba.app.R
 import network.columba.app.data.database.entity.InterfaceEntity
+import network.columba.app.data.model.InterfaceType
 import network.columba.app.reticulum.ble.util.BlePermissionManager
 import network.columba.app.ui.components.BlePermissionBottomSheet
 import network.columba.app.ui.components.InterfaceConfigDialog
+import network.columba.app.ui.components.interfaceTypeIconData
 import network.columba.app.viewmodel.InterfaceManagementViewModel
 
 /**
@@ -514,18 +517,14 @@ fun InterfaceCard(
             modifier = Modifier.fillMaxWidth().padding(16.dp),
             verticalAlignment = Alignment.CenterVertically,
         ) {
-            // Type icon with online status color
+            // Type icon with online status color. Reuses the canonical
+            // interface-type → icon mapping shared with announce cards
+            // (see PeerCard.interfaceTypeIconData) so there's one source of truth.
+            val typeLabel = getInterfaceTypeLabel(interfaceEntity.type)
+            val iconData = interfaceTypeIconData(InterfaceType.fromInterfaceName(interfaceEntity.type))
             Icon(
-                imageVector =
-                    when (interfaceEntity.type) {
-                        "AutoInterface" -> Icons.Default.Settings
-                        "TCPClient" -> Icons.Default.CheckCircle
-                        "TCPServer" -> Icons.Default.CheckCircle
-                        "RNode" -> Icons.Default.Settings
-                        "AndroidBLE" -> Icons.Default.Settings
-                        else -> Icons.Default.Settings
-                    },
-                contentDescription = null,
+                imageVector = iconData?.imageVector ?: Icons.Default.SettingsInputAntenna,
+                contentDescription = "$typeLabel interface",
                 tint = statusColor,
                 modifier = Modifier.size(32.dp),
             )
@@ -540,7 +539,7 @@ fun InterfaceCard(
                     fontWeight = FontWeight.Bold,
                 )
                 Text(
-                    text = getInterfaceTypeLabel(interfaceEntity.type),
+                    text = typeLabel,
                     style = MaterialTheme.typography.bodySmall,
                     color = MaterialTheme.colorScheme.onSurfaceVariant,
                 )


### PR DESCRIPTION
## Summary

- Interface Management was showing an arbitrary `CheckCircle` / `Settings` icon split for interface cards (CheckCircle for TCPClient/TCPServer, Settings gear for AutoInterface/RNode/AndroidBLE). The split carried no semantic meaning.
- Announce/peer cards already use a well-vetted per-transport icon set (`Icons.Default.Wifi` for AutoInterface, `Icons.Default.Public` for TCP, `Icons.Default.Bluetooth` for BLE, Lucide antenna for RNode). This PR extracts that mapping from `PeerCard.InterfaceTypeIcon` into a public `interfaceTypeIconData()` helper and consumes it from `InterfaceManagementScreen.InterfaceCard`, so both screens share one source of truth.
- Also upgrades the icon's `contentDescription` from `null` to `"<Type Label> interface"` so screen readers announce the card.

## Icon choices

| Interface type | Icon | Notes |
|---|---|---|
| `AutoInterface` | `Icons.Default.Wifi` | From canonical announce mapping |
| `TCPClient` | `Icons.Default.Public` | From canonical announce mapping |
| `TCPServer` | `Icons.Default.Public` | Reuses `TCP_CLIENT` via `InterfaceType.fromInterfaceName`, matching `DiscoveredInterfacesScreen.InterfaceTypeIcon` which treats TCP server/client identically |
| `RNode` | `com.composables.icons.lucide.R.drawable.lucide_ic_antenna` | From canonical announce mapping |
| `AndroidBLE` | `Icons.Default.Bluetooth` | From canonical announce mapping |
| Unknown / fallback | `Icons.Default.SettingsInputAntenna` | Matches `InterfaceInfo`'s existing unknown glyph |

The `tint = statusColor` (online/offline green/grey) and `Modifier.size(32.dp)` are preserved — only the icon vector changes.

## Why not reuse `InterfaceFormattingUtils.getConnectionIcon`

`getConnectionIcon` uses `Icons.Default.Wifi` for TCP and `Icons.Default.SignalCellularAlt` for AutoInterface, which disagrees with the announce/peer card palette that the user wants parity with. The announce-card mapping is the intended canonical set, so this PR factors that one out instead.

## Test plan

- [x] `./gradlew :app:compileNoSentryDebugKotlin :app:detekt` — green
- [x] `./gradlew :app:testNoSentryDebugUnitTest` — all passing (no regressions)
- [x] `./gradlew :data:testDebugUnitTest` — all passing (`InterfaceTypeTest` still covers the `fromInterfaceName` mapping this PR depends on)
- [ ] Visual check on device: AutoInterface shows Wifi, TCPClient/TCPServer show Public (globe), RNode shows antenna, AndroidBLE shows Bluetooth. Online interfaces tint green, offline grey.
- [ ] TalkBack reads "AutoInterface: Auto Discovery interface" (or similar) instead of skipping the card

🤖 Generated with [Claude Code](https://claude.com/claude-code)