### PR TITLE
Unify IFAC network-access UI across all interface wizards

### DIFF
--- a/app/src/main/java/network/columba/app/repository/InterfaceRepository.kt
+++ b/app/src/main/java/network/columba/app/repository/InterfaceRepository.kt
@@ -1,6 +1,8 @@
 package network.columba.app.repository
 
 import android.util.Log
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.map
 import network.columba.app.data.database.dao.InterfaceDao
 import network.columba.app.data.database.entity.InterfaceEntity
 import network.columba.app.reticulum.model.InterfaceConfig
@@ -8,8 +10,6 @@ import network.columba.app.reticulum.model.toJsonString
 import network.columba.app.reticulum.model.typeName
 import network.columba.app.util.validation.InputValidator
 import network.columba.app.util.validation.ValidationResult
-import kotlinx.coroutines.flow.Flow
-import kotlinx.coroutines.flow.map
 import org.json.JSONException
 import org.json.JSONObject
 import javax.inject.Inject
@@ -430,6 +430,8 @@ class InterfaceRepository
                             listenIp = listenIp,
                             listenPort = listenPort,
                             mode = json.optString("mode", "full"),
+                            networkName = json.optString("network_name", "").ifEmpty { null },
+                            passphrase = json.optString("passphrase", "").ifEmpty { null },
                         )
                     }
 

--- a/app/src/main/java/network/columba/app/ui/components/IfacConfigCard.kt
+++ b/app/src/main/java/network/columba/app/ui/components/IfacConfigCard.kt
@@ -7,6 +7,7 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Lock
 import androidx.compose.material.icons.filled.Visibility
@@ -21,6 +22,7 @@ import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.ui.text.input.PasswordVisualTransformation
 import androidx.compose.ui.text.input.VisualTransformation
 import androidx.compose.ui.unit.dp
@@ -118,6 +120,12 @@ fun IfacConfigCard(
                 singleLine = true,
                 isError = passphraseError != null,
                 supportingText = passphraseError?.let { { Text(it) } },
+                // Credential-field IME hint: suppress autocomplete, word
+                // prediction, and keyboard history for the passphrase. The
+                // PasswordVisualTransformation below only masks the glyphs —
+                // without KeyboardType.Password the IME can still offer
+                // suggestions and retain the value in learned-words history.
+                keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Password),
                 visualTransformation =
                     if (passphraseVisible) {
                         VisualTransformation.None

--- a/app/src/main/java/network/columba/app/ui/components/IfacConfigCard.kt
+++ b/app/src/main/java/network/columba/app/ui/components/IfacConfigCard.kt
@@ -1,0 +1,148 @@
+package network.columba.app.ui.components
+
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.width
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Lock
+import androidx.compose.material.icons.filled.Visibility
+import androidx.compose.material.icons.filled.VisibilityOff
+import androidx.compose.material3.Card
+import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.input.PasswordVisualTransformation
+import androidx.compose.ui.text.input.VisualTransformation
+import androidx.compose.ui.unit.dp
+
+/**
+ * Default explanation shown inside the IFAC card. Used when the caller does
+ * not supply its own [IfacConfigCard.description].
+ */
+internal const val DEFAULT_IFAC_DESCRIPTION: String =
+    "Leave blank unless the remote interface requires an IFAC network " +
+        "name and passphrase. Auto-filled when adding from a discovered interface."
+
+/**
+ * Reusable Material card that renders the two IFAC (network access) fields —
+ * network name and passphrase — with consistent copy, spacing, and the
+ * password-visibility eye icon used across the TCP Client wizard, the RNode
+ * wizard, and the shared interface-config dialog.
+ *
+ * State is fully hoisted: the caller owns [networkName], [passphrase], and
+ * [passphraseVisible] and handles changes via the corresponding callbacks.
+ *
+ * @param networkName Current value of the IFAC network name field.
+ * @param passphrase Current value of the IFAC passphrase field.
+ * @param passphraseVisible Whether the passphrase should be rendered as
+ *   plaintext ([VisualTransformation.None]) or masked
+ *   ([PasswordVisualTransformation]).
+ * @param onNetworkNameChange Invoked when the network name text changes.
+ * @param onPassphraseChange Invoked when the passphrase text changes.
+ * @param onPassphraseVisibilityToggle Invoked when the user taps the eye icon.
+ * @param modifier Applied to the outer [Card].
+ * @param description Explanatory body text rendered under the header; defaults
+ *   to [DEFAULT_IFAC_DESCRIPTION]. Pass a wizard-specific string when the
+ *   guidance needs tweaking (e.g. "Only interfaces with matching credentials
+ *   can communicate").
+ * @param networkNameError Optional error message surfaced beneath the network
+ *   name field via [OutlinedTextField.supportingText] / [OutlinedTextField.isError].
+ * @param passphraseError Optional error message surfaced beneath the
+ *   passphrase field.
+ */
+@Composable
+fun IfacConfigCard(
+    networkName: String,
+    passphrase: String,
+    passphraseVisible: Boolean,
+    onNetworkNameChange: (String) -> Unit,
+    onPassphraseChange: (String) -> Unit,
+    onPassphraseVisibilityToggle: () -> Unit,
+    modifier: Modifier = Modifier,
+    description: String = DEFAULT_IFAC_DESCRIPTION,
+    networkNameError: String? = null,
+    passphraseError: String? = null,
+) {
+    Card(
+        colors =
+            CardDefaults.cardColors(
+                containerColor = MaterialTheme.colorScheme.surfaceVariant,
+            ),
+        modifier = modifier.fillMaxWidth(),
+    ) {
+        Column(modifier = Modifier.padding(16.dp)) {
+            Row(verticalAlignment = Alignment.CenterVertically) {
+                Icon(
+                    Icons.Default.Lock,
+                    contentDescription = null,
+                    tint = MaterialTheme.colorScheme.onSurfaceVariant,
+                )
+                Spacer(Modifier.width(8.dp))
+                Text(
+                    "IFAC (Network Access)",
+                    style = MaterialTheme.typography.titleSmall,
+                )
+            }
+            Spacer(Modifier.height(4.dp))
+            Text(
+                description,
+                style = MaterialTheme.typography.bodySmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
+            Spacer(Modifier.height(12.dp))
+            OutlinedTextField(
+                value = networkName,
+                onValueChange = onNetworkNameChange,
+                label = { Text("Network Name") },
+                modifier = Modifier.fillMaxWidth(),
+                singleLine = true,
+                isError = networkNameError != null,
+                supportingText = networkNameError?.let { { Text(it) } },
+            )
+            Spacer(Modifier.height(8.dp))
+            OutlinedTextField(
+                value = passphrase,
+                onValueChange = onPassphraseChange,
+                label = { Text("Passphrase") },
+                modifier = Modifier.fillMaxWidth(),
+                singleLine = true,
+                isError = passphraseError != null,
+                supportingText = passphraseError?.let { { Text(it) } },
+                visualTransformation =
+                    if (passphraseVisible) {
+                        VisualTransformation.None
+                    } else {
+                        PasswordVisualTransformation()
+                    },
+                trailingIcon = {
+                    IconButton(onClick = onPassphraseVisibilityToggle) {
+                        Icon(
+                            imageVector =
+                                if (passphraseVisible) {
+                                    Icons.Default.VisibilityOff
+                                } else {
+                                    Icons.Default.Visibility
+                                },
+                            contentDescription =
+                                if (passphraseVisible) {
+                                    "Hide passphrase"
+                                } else {
+                                    "Show passphrase"
+                                },
+                        )
+                    }
+                },
+            )
+        }
+    }
+}

--- a/app/src/main/java/network/columba/app/ui/components/InterfaceConfigDialog.kt
+++ b/app/src/main/java/network/columba/app/ui/components/InterfaceConfigDialog.kt
@@ -14,8 +14,6 @@ import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.KeyboardArrowDown
 import androidx.compose.material.icons.filled.KeyboardArrowUp
-import androidx.compose.material.icons.filled.Visibility
-import androidx.compose.material.icons.filled.VisibilityOff
 import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.Button
 import androidx.compose.material3.Divider
@@ -24,7 +22,6 @@ import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.ExposedDropdownMenuBox
 import androidx.compose.material3.ExposedDropdownMenuDefaults
 import androidx.compose.material3.Icon
-import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.OutlinedButton
 import androidx.compose.material3.OutlinedTextField
@@ -42,13 +39,11 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.text.input.PasswordVisualTransformation
-import androidx.compose.ui.text.input.VisualTransformation
 import androidx.compose.ui.unit.dp
+import kotlinx.coroutines.launch
 import network.columba.app.reticulum.ble.model.BlePowerPreset
 import network.columba.app.util.validation.ValidationConstants
 import network.columba.app.viewmodel.InterfaceConfigState
-import kotlinx.coroutines.launch
 
 /**
  * Dialog for adding or editing a Reticulum network interface configuration.
@@ -318,7 +313,16 @@ fun TCPClientFields(
         supportingText = configState.targetPortError?.let { { Text(it) } },
     )
 
-    IfacFields(configState, onConfigUpdate)
+    IfacConfigCard(
+        networkName = configState.networkName,
+        passphrase = configState.passphrase,
+        passphraseVisible = configState.passphraseVisible,
+        onNetworkNameChange = { onConfigUpdate(configState.copy(networkName = it)) },
+        onPassphraseChange = { onConfigUpdate(configState.copy(passphrase = it)) },
+        onPassphraseVisibilityToggle = {
+            onConfigUpdate(configState.copy(passphraseVisible = !configState.passphraseVisible))
+        },
+    )
 
     Divider()
 
@@ -395,93 +399,28 @@ fun TCPClientFields(
     }
 }
 
-/**
- * Shared IFAC (Interface Access Code) fields for network_name and passphrase.
- * Used by both TCP Client and RNode interface configurations.
- */
-@Composable
-fun IfacFields(
-    configState: InterfaceConfigState,
-    onConfigUpdate: (InterfaceConfigState) -> Unit,
-) {
-    // Network Name (IFAC)
-    OutlinedTextField(
-        value = configState.networkName,
-        onValueChange = { onConfigUpdate(configState.copy(networkName = it)) },
-        label = { Text("Network Name") },
-        placeholder = { Text("Optional") },
-        modifier = Modifier.fillMaxWidth(),
-        singleLine = true,
-        supportingText = {
-            Text(
-                "Optional: Sets the virtual network name for this segment. " +
-                    "This allows multiple separate networks to exist on the same " +
-                    "physical channel or medium.",
-                style = MaterialTheme.typography.bodySmall,
-                color = MaterialTheme.colorScheme.onSurfaceVariant,
-            )
-        },
-    )
-
-    // Passphrase (IFAC)
-    OutlinedTextField(
-        value = configState.passphrase,
-        onValueChange = { onConfigUpdate(configState.copy(passphrase = it)) },
-        label = { Text("Passphrase") },
-        placeholder = { Text("Optional") },
-        modifier = Modifier.fillMaxWidth(),
-        singleLine = true,
-        visualTransformation =
-            if (configState.passphraseVisible) {
-                VisualTransformation.None
-            } else {
-                PasswordVisualTransformation()
-            },
-        trailingIcon = {
-            IconButton(
-                onClick = {
-                    onConfigUpdate(configState.copy(passphraseVisible = !configState.passphraseVisible))
-                },
-            ) {
-                Icon(
-                    imageVector =
-                        if (configState.passphraseVisible) {
-                            Icons.Default.VisibilityOff
-                        } else {
-                            Icons.Default.Visibility
-                        },
-                    contentDescription =
-                        if (configState.passphraseVisible) {
-                            "Hide passphrase"
-                        } else {
-                            "Show passphrase"
-                        },
-                )
-            }
-        },
-        supportingText = {
-            Text(
-                "Optional: Sets an authentication passphrase on the interface. " +
-                    "This can be used in conjunction with Network Name, or alone.",
-                style = MaterialTheme.typography.bodySmall,
-                color = MaterialTheme.colorScheme.onSurfaceVariant,
-            )
-        },
-    )
-}
-
 @Composable
 fun RNodeFields(
     configState: InterfaceConfigState,
     onConfigUpdate: (InterfaceConfigState) -> Unit,
 ) {
-    Text(
-        "RNode IFAC Authentication",
-        style = MaterialTheme.typography.titleSmall,
-        color = MaterialTheme.colorScheme.primary,
+    // RNode dialog has no per-interface settings beyond IFAC (radio config
+    // lives in the full RNode wizard); the shared IFAC card already owns its
+    // own header and explanation so we let it stand alone here.
+    IfacConfigCard(
+        networkName = configState.networkName,
+        passphrase = configState.passphrase,
+        passphraseVisible = configState.passphraseVisible,
+        onNetworkNameChange = { onConfigUpdate(configState.copy(networkName = it)) },
+        onPassphraseChange = { onConfigUpdate(configState.copy(passphrase = it)) },
+        onPassphraseVisibilityToggle = {
+            onConfigUpdate(configState.copy(passphraseVisible = !configState.passphraseVisible))
+        },
+        description =
+            "Leave blank unless the RNode network requires an IFAC " +
+                "network name and passphrase. Only interfaces with " +
+                "matching credentials can communicate.",
     )
-
-    IfacFields(configState, onConfigUpdate)
 }
 
 @OptIn(ExperimentalMaterial3Api::class)
@@ -850,5 +789,20 @@ fun TCPServerFields(
                 )
             }
         },
+    )
+
+    IfacConfigCard(
+        networkName = configState.networkName,
+        passphrase = configState.passphrase,
+        passphraseVisible = configState.passphraseVisible,
+        onNetworkNameChange = { onConfigUpdate(configState.copy(networkName = it)) },
+        onPassphraseChange = { onConfigUpdate(configState.copy(passphrase = it)) },
+        onPassphraseVisibilityToggle = {
+            onConfigUpdate(configState.copy(passphraseVisible = !configState.passphraseVisible))
+        },
+        description =
+            "Leave blank unless inbound clients must authenticate with an " +
+                "IFAC network name and passphrase. Only clients with matching " +
+                "credentials will be able to connect.",
     )
 }

--- a/app/src/main/java/network/columba/app/ui/screens/rnode/ReviewConfigStep.kt
+++ b/app/src/main/java/network/columba/app/ui/screens/rnode/ReviewConfigStep.kt
@@ -23,8 +23,6 @@ import androidx.compose.material.icons.filled.Radio
 import androidx.compose.material.icons.filled.SignalCellularAlt
 import androidx.compose.material.icons.filled.Speed
 import androidx.compose.material.icons.filled.Usb
-import androidx.compose.material.icons.filled.Visibility
-import androidx.compose.material.icons.filled.VisibilityOff
 import androidx.compose.material.icons.filled.Warning
 import androidx.compose.material.icons.filled.Wifi
 import androidx.compose.material3.Card
@@ -34,7 +32,6 @@ import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.ExposedDropdownMenuBox
 import androidx.compose.material3.ExposedDropdownMenuDefaults
 import androidx.compose.material3.Icon
-import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.MenuAnchorType
 import androidx.compose.material3.OutlinedButton
@@ -50,10 +47,9 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.text.input.KeyboardType
-import androidx.compose.ui.text.input.PasswordVisualTransformation
-import androidx.compose.ui.text.input.VisualTransformation
 import androidx.compose.ui.unit.dp
 import network.columba.app.data.model.FrequencySlotCalculator
+import network.columba.app.ui.components.IfacConfigCard
 import network.columba.app.viewmodel.RNodeWizardViewModel
 
 @OptIn(ExperimentalMaterial3Api::class)
@@ -520,66 +516,20 @@ fun ReviewConfigStep(viewModel: RNodeWizardViewModel) {
 
                     Spacer(Modifier.height(16.dp))
 
-                    // IFAC Authentication header
-                    Text(
-                        "IFAC Authentication",
-                        style = MaterialTheme.typography.labelMedium,
-                        color = MaterialTheme.colorScheme.onSurfaceVariant,
-                    )
-                    Spacer(Modifier.height(8.dp))
-
-                    OutlinedTextField(
-                        value = state.networkName,
-                        onValueChange = { viewModel.updateNetworkName(it) },
-                        label = { Text("Network Name") },
-                        placeholder = { Text("Optional") },
-                        modifier = Modifier.fillMaxWidth(),
-                        singleLine = true,
-                        supportingText = {
-                            Text(
-                                "Sets the virtual network name for this segment. " +
-                                    "Only interfaces with matching credentials can communicate.",
-                                style = MaterialTheme.typography.bodySmall,
-                                color = MaterialTheme.colorScheme.onSurfaceVariant,
-                            )
-                        },
-                    )
-
-                    OutlinedTextField(
-                        value = state.passphrase,
-                        onValueChange = { viewModel.updatePassphrase(it) },
-                        label = { Text("Passphrase") },
-                        placeholder = { Text("Optional") },
-                        modifier = Modifier.fillMaxWidth(),
-                        singleLine = true,
-                        visualTransformation =
-                            if (state.passphraseVisible) {
-                                VisualTransformation.None
-                            } else {
-                                PasswordVisualTransformation()
-                            },
-                        trailingIcon = {
-                            IconButton(onClick = { viewModel.togglePassphraseVisible() }) {
-                                Icon(
-                                    imageVector =
-                                        if (state.passphraseVisible) {
-                                            Icons.Default.VisibilityOff
-                                        } else {
-                                            Icons.Default.Visibility
-                                        },
-                                    contentDescription =
-                                        if (state.passphraseVisible) "Hide passphrase" else "Show passphrase",
-                                )
-                            }
-                        },
-                        supportingText = {
-                            Text(
-                                "Sets an authentication passphrase. " +
-                                    "Can be used with Network Name, or alone.",
-                                style = MaterialTheme.typography.bodySmall,
-                                color = MaterialTheme.colorScheme.onSurfaceVariant,
-                            )
-                        },
+                    // IFAC (network_name + passphrase). Shared card matches the
+                    // TCP Client wizard and interface-config dialog for a
+                    // consistent "enter network access credentials" UI.
+                    IfacConfigCard(
+                        networkName = state.networkName,
+                        passphrase = state.passphrase,
+                        passphraseVisible = state.passphraseVisible,
+                        onNetworkNameChange = { viewModel.updateNetworkName(it) },
+                        onPassphraseChange = { viewModel.updatePassphrase(it) },
+                        onPassphraseVisibilityToggle = { viewModel.togglePassphraseVisible() },
+                        description =
+                            "Leave blank unless the RNode network requires an IFAC " +
+                                "network name and passphrase. Only interfaces with " +
+                                "matching credentials can communicate.",
                     )
 
                     Spacer(Modifier.height(16.dp))

--- a/app/src/main/java/network/columba/app/ui/screens/tcpclient/ReviewConfigureStep.kt
+++ b/app/src/main/java/network/columba/app/ui/screens/tcpclient/ReviewConfigureStep.kt
@@ -14,13 +14,9 @@ import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Cloud
-import androidx.compose.material.icons.filled.Lock
-import androidx.compose.material.icons.filled.Visibility
-import androidx.compose.material.icons.filled.VisibilityOff
 import androidx.compose.material3.Card
 import androidx.compose.material3.CardDefaults
 import androidx.compose.material3.Icon
-import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.Switch
@@ -31,9 +27,8 @@ import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.text.input.KeyboardType
-import androidx.compose.ui.text.input.PasswordVisualTransformation
-import androidx.compose.ui.text.input.VisualTransformation
 import androidx.compose.ui.unit.dp
+import network.columba.app.ui.components.IfacConfigCard
 import network.columba.app.viewmodel.TcpClientWizardViewModel
 
 /**
@@ -126,63 +121,14 @@ fun ReviewConfigureStep(viewModel: TcpClientWizardViewModel) {
 
         // IFAC (network_name + passphrase). Auto-filled when reached from a
         // discovered interface that published IFAC; otherwise optional user input.
-        Card(
-            colors =
-                CardDefaults.cardColors(
-                    containerColor = MaterialTheme.colorScheme.surfaceVariant,
-                ),
-            modifier = Modifier.fillMaxWidth(),
-        ) {
-            Column(modifier = Modifier.padding(16.dp)) {
-                Row(verticalAlignment = Alignment.CenterVertically) {
-                    Icon(
-                        Icons.Default.Lock,
-                        contentDescription = null,
-                        tint = MaterialTheme.colorScheme.onSurfaceVariant,
-                    )
-                    Spacer(Modifier.width(8.dp))
-                    Text(
-                        "IFAC (Network Access)",
-                        style = MaterialTheme.typography.titleSmall,
-                    )
-                }
-                Spacer(Modifier.height(4.dp))
-                Text(
-                    "Leave blank unless the remote interface requires an IFAC network " +
-                        "name and passphrase. Auto-filled when adding from a discovered interface.",
-                    style = MaterialTheme.typography.bodySmall,
-                    color = MaterialTheme.colorScheme.onSurfaceVariant,
-                )
-                Spacer(Modifier.height(12.dp))
-                OutlinedTextField(
-                    value = state.networkName,
-                    onValueChange = { viewModel.setNetworkName(it) },
-                    label = { Text("Network Name") },
-                    modifier = Modifier.fillMaxWidth(),
-                    singleLine = true,
-                )
-                Spacer(Modifier.height(8.dp))
-                OutlinedTextField(
-                    value = state.passphrase,
-                    onValueChange = { viewModel.setPassphrase(it) },
-                    label = { Text("Passphrase") },
-                    modifier = Modifier.fillMaxWidth(),
-                    singleLine = true,
-                    visualTransformation =
-                        if (state.passphraseVisible) VisualTransformation.None else PasswordVisualTransformation(),
-                    trailingIcon = {
-                        IconButton(onClick = { viewModel.togglePassphraseVisibility() }) {
-                            Icon(
-                                imageVector =
-                                    if (state.passphraseVisible) Icons.Default.VisibilityOff else Icons.Default.Visibility,
-                                contentDescription =
-                                    if (state.passphraseVisible) "Hide passphrase" else "Show passphrase",
-                            )
-                        }
-                    },
-                )
-            }
-        }
+        IfacConfigCard(
+            networkName = state.networkName,
+            passphrase = state.passphrase,
+            passphraseVisible = state.passphraseVisible,
+            onNetworkNameChange = { viewModel.setNetworkName(it) },
+            onPassphraseChange = { viewModel.setPassphrase(it) },
+            onPassphraseVisibilityToggle = { viewModel.togglePassphraseVisibility() },
+        )
 
         Spacer(Modifier.height(16.dp))
 

--- a/app/src/main/java/network/columba/app/viewmodel/InterfaceManagementViewModel.kt
+++ b/app/src/main/java/network/columba/app/viewmodel/InterfaceManagementViewModel.kt
@@ -933,6 +933,8 @@ class InterfaceManagementViewModel
                         listenIp = config.listenIp,
                         listenPort = config.listenPort.toString(),
                         mode = config.mode,
+                        networkName = config.networkName.orEmpty(),
+                        passphrase = config.passphrase.orEmpty(),
                     )
 
                 else -> InterfaceConfigState() // Default for unsupported types
@@ -1011,6 +1013,8 @@ class InterfaceManagementViewModel
                         listenIp = state.listenIp.trim(),
                         listenPort = state.listenPort.toIntOrNull() ?: 4242,
                         mode = state.mode,
+                        networkName = state.networkName.trim().ifEmpty { null },
+                        passphrase = state.passphrase.trim().ifEmpty { null },
                     )
 
                 else -> throw IllegalArgumentException("Unsupported interface type: ${state.type}")

--- a/app/src/test/java/network/columba/app/ui/components/IfacConfigCardTest.kt
+++ b/app/src/test/java/network/columba/app/ui/components/IfacConfigCardTest.kt
@@ -1,0 +1,213 @@
+package network.columba.app.ui.components
+
+import android.app.Application
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.onNodeWithContentDescription
+import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.performClick
+import androidx.compose.ui.test.performTextInput
+import network.columba.app.test.RegisterComponentActivityRule
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Rule
+import org.junit.Test
+import org.junit.rules.RuleChain
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+
+/**
+ * UI tests for [IfacConfigCard], the reusable IFAC (network access) input card
+ * shared by every interface wizard + the interface-config dialog. Focus is on
+ * the contract: label text, state hoisting, and the eye-icon toggle.
+ */
+@RunWith(RobolectricTestRunner::class)
+@Config(sdk = [34], application = Application::class)
+class IfacConfigCardTest {
+    private val registerActivityRule = RegisterComponentActivityRule()
+    private val composeRule = createComposeRule()
+
+    @get:Rule
+    val ruleChain: RuleChain = RuleChain.outerRule(registerActivityRule).around(composeRule)
+
+    @Test
+    fun ifacConfigCard_rendersHeaderAndDefaultDescription() {
+        composeRule.setContent {
+            IfacConfigCard(
+                networkName = "",
+                passphrase = "",
+                passphraseVisible = false,
+                onNetworkNameChange = {},
+                onPassphraseChange = {},
+                onPassphraseVisibilityToggle = {},
+            )
+        }
+
+        composeRule.onNodeWithText("IFAC (Network Access)").assertIsDisplayed()
+        // Default description pinned by DEFAULT_IFAC_DESCRIPTION so every
+        // wizard gets the same guidance text unless it explicitly overrides.
+        composeRule.onNodeWithText(DEFAULT_IFAC_DESCRIPTION).assertIsDisplayed()
+        composeRule.onNodeWithText("Network Name").assertIsDisplayed()
+        composeRule.onNodeWithText("Passphrase").assertIsDisplayed()
+    }
+
+    @Test
+    fun ifacConfigCard_rendersCustomDescriptionWhenProvided() {
+        val custom = "Only matching credentials can connect."
+        composeRule.setContent {
+            IfacConfigCard(
+                networkName = "",
+                passphrase = "",
+                passphraseVisible = false,
+                onNetworkNameChange = {},
+                onPassphraseChange = {},
+                onPassphraseVisibilityToggle = {},
+                description = custom,
+            )
+        }
+
+        composeRule.onNodeWithText(custom).assertIsDisplayed()
+    }
+
+    @Test
+    fun ifacConfigCard_routesNetworkNameEditsToCallback() {
+        var captured = ""
+        composeRule.setContent {
+            IfacConfigCard(
+                networkName = "",
+                passphrase = "",
+                passphraseVisible = false,
+                onNetworkNameChange = { captured = it },
+                onPassphraseChange = {},
+                onPassphraseVisibilityToggle = {},
+            )
+        }
+
+        composeRule.onNodeWithText("Network Name").performTextInput("secret-net")
+
+        assertEquals("secret-net", captured)
+    }
+
+    @Test
+    fun ifacConfigCard_routesPassphraseEditsToCallback() {
+        var captured = ""
+        composeRule.setContent {
+            IfacConfigCard(
+                networkName = "",
+                passphrase = "",
+                passphraseVisible = true,
+                onNetworkNameChange = {},
+                onPassphraseChange = { captured = it },
+                onPassphraseVisibilityToggle = {},
+            )
+        }
+
+        composeRule.onNodeWithText("Passphrase").performTextInput("hunter2")
+
+        assertEquals("hunter2", captured)
+    }
+
+    @Test
+    fun ifacConfigCard_togglesPassphraseVisibilityViaEyeIcon() {
+        var toggled = false
+        composeRule.setContent {
+            IfacConfigCard(
+                networkName = "",
+                passphrase = "hunter2",
+                passphraseVisible = false,
+                onNetworkNameChange = {},
+                onPassphraseChange = {},
+                onPassphraseVisibilityToggle = { toggled = true },
+            )
+        }
+
+        // When masked, the trailing icon offers "Show passphrase" — click it and
+        // confirm the visibility-toggle callback fires.
+        composeRule.onNodeWithContentDescription("Show passphrase").performClick()
+
+        assertTrue(toggled)
+    }
+
+    @Test
+    fun ifacConfigCard_eyeIconReflectsVisibilityState() {
+        var visible by mutableStateOf(false)
+        composeRule.setContent {
+            IfacConfigCard(
+                networkName = "",
+                passphrase = "hunter2",
+                passphraseVisible = visible,
+                onNetworkNameChange = {},
+                onPassphraseChange = {},
+                onPassphraseVisibilityToggle = { visible = !visible },
+            )
+        }
+
+        // Masked → "Show passphrase"
+        composeRule.onNodeWithContentDescription("Show passphrase").assertIsDisplayed()
+
+        composeRule.onNodeWithContentDescription("Show passphrase").performClick()
+
+        // Flipped to plaintext → "Hide passphrase"
+        composeRule.onNodeWithContentDescription("Hide passphrase").assertIsDisplayed()
+    }
+
+    @Test
+    fun ifacConfigCard_surfacesNetworkNameError() {
+        val errorText = "Network name must be shorter"
+        composeRule.setContent {
+            IfacConfigCard(
+                networkName = "too-long-net-name",
+                passphrase = "",
+                passphraseVisible = false,
+                onNetworkNameChange = {},
+                onPassphraseChange = {},
+                onPassphraseVisibilityToggle = {},
+                networkNameError = errorText,
+            )
+        }
+
+        composeRule.onNodeWithText(errorText).assertIsDisplayed()
+    }
+
+    @Test
+    fun ifacConfigCard_surfacesPassphraseError() {
+        val errorText = "Passphrase too short"
+        composeRule.setContent {
+            IfacConfigCard(
+                networkName = "",
+                passphrase = "x",
+                passphraseVisible = false,
+                onNetworkNameChange = {},
+                onPassphraseChange = {},
+                onPassphraseVisibilityToggle = {},
+                passphraseError = errorText,
+            )
+        }
+
+        composeRule.onNodeWithText(errorText).assertIsDisplayed()
+    }
+
+    @Test
+    fun ifacConfigCard_rendersWhenNoErrorsProvided() {
+        composeRule.setContent {
+            IfacConfigCard(
+                networkName = "net",
+                passphrase = "pass",
+                passphraseVisible = false,
+                onNetworkNameChange = {},
+                onPassphraseChange = {},
+                onPassphraseVisibilityToggle = {},
+            )
+        }
+
+        // With null errors both fields are still rendered with their labels,
+        // and the passphrase row still exposes the eye-icon trailing affordance.
+        composeRule.onNodeWithText("Network Name").assertIsDisplayed()
+        composeRule.onNodeWithText("Passphrase").assertIsDisplayed()
+        composeRule.onNodeWithContentDescription("Show passphrase").assertIsDisplayed()
+    }
+}

--- a/reticulum/src/main/java/network/columba/app/reticulum/model/InterfaceConfigExt.kt
+++ b/reticulum/src/main/java/network/columba/app/reticulum/model/InterfaceConfigExt.kt
@@ -88,6 +88,8 @@ fun InterfaceConfig.toJsonString(): String =
                     put("listen_ip", listenIp)
                     put("listen_port", listenPort)
                     put("mode", mode)
+                    networkName?.let { put("network_name", it) }
+                    passphrase?.let { put("passphrase", it) }
                 }.toString()
     }
 

--- a/reticulum/src/main/java/network/columba/app/reticulum/model/ReticulumConfig.kt
+++ b/reticulum/src/main/java/network/columba/app/reticulum/model/ReticulumConfig.kt
@@ -321,6 +321,8 @@ sealed class InterfaceConfig {
      * @param listenIp IP address to bind to (0.0.0.0 for all interfaces)
      * @param listenPort TCP port to listen on
      * @param mode Interface mode: "full", "gateway", "access_point", "roaming", "boundary"
+     * @param networkName Optional IFAC network name for cryptographic authentication
+     * @param passphrase Optional IFAC passphrase for cryptographic authentication
      */
     data class TCPServer(
         override val name: String = "TCP Server",
@@ -328,6 +330,8 @@ sealed class InterfaceConfig {
         val listenIp: String = "0.0.0.0",
         val listenPort: Int = 4242,
         val mode: String = "full",
+        val networkName: String? = null,
+        val passphrase: String? = null,
     ) : InterfaceConfig()
 }
 

--- a/reticulum/src/main/java/network/columba/app/reticulum/protocol/NativeInterfaceFactory.kt
+++ b/reticulum/src/main/java/network/columba/app/reticulum/protocol/NativeInterfaceFactory.kt
@@ -384,6 +384,11 @@ internal object NativeInterfaceFactory {
                 )
 
             is InterfaceConfig.TCPServer -> {
+                // TCPServerInterface exists in reticulum-kt and accepts ifacNetname /
+                // ifacNetkey, but Columba's native factory does not yet wire TCPServer
+                // end-to-end (no tests, no lifecycle integration). The UI still
+                // captures IFAC credentials on TCPServer configs so they survive a
+                // round-trip through the DB when native support lands.
                 Log.w(TAG, "TCPServer not yet supported in native stack")
                 null
             }

--- a/reticulum/src/test/java/network/columba/app/reticulum/model/InterfaceConfigExtTest.kt
+++ b/reticulum/src/test/java/network/columba/app/reticulum/model/InterfaceConfigExtTest.kt
@@ -280,6 +280,44 @@ class InterfaceConfigExtTest {
         assertEquals("full", json.getString("mode"))
     }
 
+    @Test
+    fun `TCPServer toJsonString includes IFAC fields when set`() {
+        val config =
+            InterfaceConfig.TCPServer(
+                name = "Secure Server",
+                enabled = true,
+                listenIp = "0.0.0.0",
+                listenPort = 4242,
+                mode = "full",
+                networkName = "my-net",
+                passphrase = "top-secret",
+            )
+
+        val json = JSONObject(config.toJsonString())
+
+        assertEquals("my-net", json.getString("network_name"))
+        assertEquals("top-secret", json.getString("passphrase"))
+    }
+
+    @Test
+    fun `TCPServer toJsonString omits null IFAC fields for backwards compat`() {
+        val config =
+            InterfaceConfig.TCPServer(
+                name = "Legacy Server",
+                enabled = true,
+                networkName = null,
+                passphrase = null,
+            )
+
+        val json = JSONObject(config.toJsonString())
+
+        // Existing entities persisted before IFAC was added must round-trip
+        // cleanly — they should neither emit null strings nor synthesise
+        // empty placeholders.
+        assertFalse(json.has("network_name"))
+        assertFalse(json.has("passphrase"))
+    }
+
     // ========== typeName Tests ==========
 
     @Test


### PR DESCRIPTION
## Summary

- Extracts the existing TCP Client IFAC card into a shared `IfacConfigCard` composable so "enter IFAC network name + passphrase" has one source of truth across the TCP Client wizard, the RNode wizard, and the interface-config dialog.
- Replaces the RNode wizard's inline OutlinedTextFields (no card, no eye icon) with the shared card; same fields, consistent visuals.
- Grows the interface-config dialog's TCPServer branch an IFAC card (was missing entirely) and adds `networkName` / `passphrase` fields to `InterfaceConfig.TCPServer`, round-tripping through JSON in the entity + viewmodel path.

## Before / after surfaces

| Surface | Before | After |
| --- | --- | --- |
| TCP Client wizard ReviewConfigureStep | Material card + eye-icon (good) | `IfacConfigCard` (identical copy) |
| RNode wizard ReviewConfigStep | Two inline fields under bare "IFAC Authentication" header | `IfacConfigCard` inside Advanced Settings |
| Interface-config dialog TCPClient | Two bare fields via `IfacFields` helper | `IfacConfigCard` |
| Interface-config dialog RNode | Two bare fields under bare header | `IfacConfigCard` |
| Interface-config dialog TCPServer | None | `IfacConfigCard` + new `InterfaceConfig.TCPServer` fields |
| Interface-config dialog AutoInterface / AndroidBLE | None | None (intentionally — see below) |

## Intentional omission: AutoInterface + AndroidBLE

`reticulum-kt v0.0.12`'s `AutoInterface` and `BLEInterface` constructors do not accept `ifacNetname` / `ifacNetkey`, while `TCPClientInterface` and `TCPServerInterface` do. I grepped the library and verified. Adding card UI on those types today would be a no-op surface that sets fields the native layer ignores. Holding them until reticulum-kt grows IFAC support on those interface types.

## Backwards compat

`InterfaceEntity` stores config as a JSON string, so the two new `TCPServer` fields are additive — **no Room migration needed**. Pre-existing TCPServer entities without `network_name` / `passphrase` keys parse cleanly as `networkName = null, passphrase = null` via `json.optString(..., "").ifEmpty { null }`.

## Tests

- New `IfacConfigCardTest` (Robolectric + Compose test) covers header/description, state hoisting for both fields, eye-icon visibility toggle, and error-text surfacing (9 tests, all pass).
- New JSON round-trip tests for `TCPServer` IFAC fields in `InterfaceConfigExtTest` (including legacy-entity path where both are null).
- Existing `InterfaceConfigDialogTest`, `TcpClientWizardViewModelTest`, `TcpClientWizardScreenTest`, and `RNodeWizardViewModel*Test` all still green.

## Related in-flight work

- Sibling UI-consistency PR #831 (interface-card edit action) — no overlap, different files.
- Concurrent icon mapping PR — no overlap, different files.

## Test plan

- [x] `./gradlew :app:compileNoSentryDebugKotlin :app:detekt` — green
- [x] `:app:testNoSentryDebugUnitTest --tests *IfacConfigCardTest*` — 9/9 pass
- [x] `:app:testNoSentryDebugUnitTest --tests *InterfaceConfigDialogTest*` — all pass
- [x] `:app:testNoSentryDebugUnitTest --tests *TcpClientWizardScreenTest*` — all pass
- [x] `:app:testNoSentryDebugUnitTest --tests *TcpClientWizardViewModelTest* --tests *RNodeWizardViewModel*` — all pass
- [x] `:reticulum:testDebugUnitTest --tests *InterfaceConfigExtTest*` — all pass (new TCPServer IFAC serialization tests included)
- [ ] Manual smoke on device: TCP Client wizard, RNode wizard, add-interface dialog (TCPClient / TCPServer / RNode types)

🤖 Generated with [Claude Code](https://claude.com/claude-code)