### PR TITLE
Implement TCPServer branch in NativeInterfaceFactory

### DIFF
--- a/app/src/main/java/network/columba/app/viewmodel/InterfaceManagementViewModel.kt
+++ b/app/src/main/java/network/columba/app/viewmodel/InterfaceManagementViewModel.kt
@@ -1014,18 +1014,32 @@ class InterfaceManagementViewModel
                         listenPort = state.listenPort.toIntOrNull() ?: 4242,
                         // `InterfaceConfigState.mode` defaults to "roaming" (shared
                         // BLE-biased default) while `InterfaceConfig.TCPServer.mode`
-                        // defaults to "full". The current dialog's InterfaceModeSelector
-                        // surfaces the picker so the user can correct it; `ifEmpty`
-                        // here only covers the case where a wizard clears the field
-                        // entirely.
+                        // defaults to "full". A forwarding server silently
+                        // advertising itself as roaming would mis-signal path
+                        // reachability to peers, which is the common failure mode
+                        // we're guarding against.
                         //
-                        // TODO(unified-ifac-ui): the upcoming TCPServer wizard must
-                        // either (a) initialise `InterfaceConfigState.mode` to "full"
-                        // when the selected type is TCPServer, or (b) always surface
-                        // the mode picker. A server silently defaulting to
-                        // "roaming" would advertise path reachability to peers in
-                        // a way that contradicts its forward-traffic role.
-                        mode = state.mode.ifEmpty { "full" },
+                        // Trade-off: coercing "roaming" → "full" here also
+                        // overrides a user who explicitly picks "roaming" in the
+                        // current dialog's mode dropdown. That's acceptable for
+                        // this PR because (a) TCPServer + roaming is a very
+                        // unusual combination — a server by definition has a
+                        // stable listen address — and (b) until the unified-ifac-ui
+                        // wizard lands, the current dialog surfaces "Roaming" as
+                        // the pre-selected default, so every new TCPServer would
+                        // otherwise be saved as roaming unless the user actively
+                        // opens the picker.
+                        //
+                        // TODO(unified-ifac-ui): once the wizard initialises
+                        // state.mode to "full" on TCPServer type-selection,
+                        // remove this coercion so power users can still pick
+                        // roaming semantics explicitly if they need them.
+                        mode =
+                            if (state.mode.isEmpty() || state.mode == "roaming") {
+                                "full"
+                            } else {
+                                state.mode
+                            },
                         networkName = state.networkName.trim().ifEmpty { null },
                         passphrase = state.passphrase.trim().ifEmpty { null },
                     )

--- a/app/src/main/java/network/columba/app/viewmodel/InterfaceManagementViewModel.kt
+++ b/app/src/main/java/network/columba/app/viewmodel/InterfaceManagementViewModel.kt
@@ -1012,7 +1012,16 @@ class InterfaceManagementViewModel
                         enabled = state.enabled,
                         listenIp = state.listenIp.trim(),
                         listenPort = state.listenPort.toIntOrNull() ?: 4242,
-                        mode = state.mode,
+                        // `InterfaceConfigState.mode` defaults to "roaming" (shared
+                        // BLE-biased default) while `InterfaceConfig.TCPServer.mode`
+                        // defaults to "full". The current dialog's InterfaceModeSelector
+                        // surfaces the picker so the user can correct it, but the
+                        // upcoming unified-ifac-ui wizard should be careful not to
+                        // silently hand "roaming" through to a server that is meant
+                        // to forward traffic. `ifEmpty { "full" }` is a belt-and-
+                        // braces guard for the case where the wizard clears the
+                        // field entirely rather than surfacing the picker.
+                        mode = state.mode.ifEmpty { "full" },
                         networkName = state.networkName.trim().ifEmpty { null },
                         passphrase = state.passphrase.trim().ifEmpty { null },
                     )

--- a/app/src/main/java/network/columba/app/viewmodel/InterfaceManagementViewModel.kt
+++ b/app/src/main/java/network/columba/app/viewmodel/InterfaceManagementViewModel.kt
@@ -1015,12 +1015,16 @@ class InterfaceManagementViewModel
                         // `InterfaceConfigState.mode` defaults to "roaming" (shared
                         // BLE-biased default) while `InterfaceConfig.TCPServer.mode`
                         // defaults to "full". The current dialog's InterfaceModeSelector
-                        // surfaces the picker so the user can correct it, but the
-                        // upcoming unified-ifac-ui wizard should be careful not to
-                        // silently hand "roaming" through to a server that is meant
-                        // to forward traffic. `ifEmpty { "full" }` is a belt-and-
-                        // braces guard for the case where the wizard clears the
-                        // field entirely rather than surfacing the picker.
+                        // surfaces the picker so the user can correct it; `ifEmpty`
+                        // here only covers the case where a wizard clears the field
+                        // entirely.
+                        //
+                        // TODO(unified-ifac-ui): the upcoming TCPServer wizard must
+                        // either (a) initialise `InterfaceConfigState.mode` to "full"
+                        // when the selected type is TCPServer, or (b) always surface
+                        // the mode picker. A server silently defaulting to
+                        // "roaming" would advertise path reachability to peers in
+                        // a way that contradicts its forward-traffic role.
                         mode = state.mode.ifEmpty { "full" },
                         networkName = state.networkName.trim().ifEmpty { null },
                         passphrase = state.passphrase.trim().ifEmpty { null },

--- a/app/src/test/java/network/columba/app/repository/InterfaceRepositoryTest.kt
+++ b/app/src/test/java/network/columba/app/repository/InterfaceRepositoryTest.kt
@@ -1,9 +1,6 @@
 package network.columba.app.repository
 
 import app.cash.turbine.test
-import network.columba.app.data.database.dao.InterfaceDao
-import network.columba.app.data.database.entity.InterfaceEntity
-import network.columba.app.reticulum.model.InterfaceConfig
 import io.mockk.clearAllMocks
 import io.mockk.every
 import io.mockk.mockk
@@ -14,6 +11,9 @@ import kotlinx.coroutines.test.StandardTestDispatcher
 import kotlinx.coroutines.test.resetMain
 import kotlinx.coroutines.test.runTest
 import kotlinx.coroutines.test.setMain
+import network.columba.app.data.database.dao.InterfaceDao
+import network.columba.app.data.database.entity.InterfaceEntity
+import network.columba.app.reticulum.model.InterfaceConfig
 import org.junit.After
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNull
@@ -944,6 +944,66 @@ class InterfaceRepositoryTest {
                 assertEquals("192.168.1.1", config.listenIp)
                 assertEquals(8080, config.listenPort)
                 assertEquals("gateway", config.mode)
+
+                cancelAndIgnoreRemainingEvents()
+            }
+        }
+
+    @Test
+    fun `enabledInterfaces deserializes TCPServer IFAC fields`() =
+        runTest {
+            val withIfac =
+                InterfaceEntity(
+                    id = 1,
+                    name = "IFAC Server",
+                    type = "TCPServer",
+                    enabled = true,
+                    configJson =
+                        """{"listen_ip":"0.0.0.0","listen_port":4242,"mode":"full",""" +
+                            """"network_name":"testnet","passphrase":"secret"}""",
+                    displayOrder = 0,
+                )
+
+            every { mockDao.getAllInterfaces() } returns flowOf(emptyList())
+            every { mockDao.getEnabledInterfaces() } returns flowOf(listOf(withIfac))
+            val repository = InterfaceRepository(mockDao)
+
+            repository.enabledInterfaces.test {
+                val interfaces = awaitItem()
+
+                assertEquals(1, interfaces.size)
+                val config = interfaces[0] as InterfaceConfig.TCPServer
+                assertEquals("testnet", config.networkName)
+                assertEquals("secret", config.passphrase)
+
+                cancelAndIgnoreRemainingEvents()
+            }
+        }
+
+    @Test
+    fun `enabledInterfaces reads null TCPServer IFAC fields when omitted`() =
+        runTest {
+            val withoutIfac =
+                InterfaceEntity(
+                    id = 1,
+                    name = "Plain Server",
+                    type = "TCPServer",
+                    enabled = true,
+                    configJson = """{"listen_ip":"0.0.0.0","listen_port":4242,"mode":"full"}""",
+                    displayOrder = 0,
+                )
+
+            every { mockDao.getAllInterfaces() } returns flowOf(emptyList())
+            every { mockDao.getEnabledInterfaces() } returns flowOf(listOf(withoutIfac))
+            val repository = InterfaceRepository(mockDao)
+
+            repository.enabledInterfaces.test {
+                val interfaces = awaitItem()
+
+                assertEquals(1, interfaces.size)
+                val config = interfaces[0] as InterfaceConfig.TCPServer
+                assertEquals(null, config.networkName)
+                assertEquals(null, config.passphrase)
 
                 cancelAndIgnoreRemainingEvents()
             }

--- a/reticulum/src/main/java/network/columba/app/reticulum/protocol/NativeInterfaceFactory.kt
+++ b/reticulum/src/main/java/network/columba/app/reticulum/protocol/NativeInterfaceFactory.kt
@@ -419,6 +419,12 @@ internal object NativeInterfaceFactory {
                             TAG,
                             "TCPServer ${config.name}: client connected (${spawnedChild.name})",
                         )
+                        // Parity with registerAndTrack: surface the new sub-interface
+                        // to the UI immediately instead of waiting for the next
+                        // debugInfoFlow poll. Without this the InterfaceList card
+                        // for a TCP server lags by a second or two on every client
+                        // connect/disconnect pair.
+                        notifyListeners()
                     }
                     // TCPServerInterface.clientDisconnected already deregisters
                     // via Transport; this callback is purely for surface-level
@@ -429,6 +435,7 @@ internal object NativeInterfaceFactory {
                             TAG,
                             "TCPServer ${config.name}: client disconnected (${spawnedChild.name})",
                         )
+                        notifyListeners()
                     }
                 }
 

--- a/reticulum/src/main/java/network/columba/app/reticulum/protocol/NativeInterfaceFactory.kt
+++ b/reticulum/src/main/java/network/columba/app/reticulum/protocol/NativeInterfaceFactory.kt
@@ -13,6 +13,7 @@ import kotlinx.coroutines.launch
 import network.columba.app.reticulum.model.InterfaceConfig
 import network.reticulum.interfaces.auto.AutoInterface
 import network.reticulum.interfaces.tcp.TCPClientInterface
+import network.reticulum.interfaces.tcp.TCPServerInterface
 import network.reticulum.interfaces.udp.UDPInterface
 import network.reticulum.transport.Transport
 
@@ -383,15 +384,53 @@ internal object NativeInterfaceFactory {
                     forwardPort = config.forwardPort,
                 )
 
-            is InterfaceConfig.TCPServer -> {
-                // TCPServerInterface exists in reticulum-kt and accepts ifacNetname /
-                // ifacNetkey, but Columba's native factory does not yet wire TCPServer
-                // end-to-end (no tests, no lifecycle integration). The UI still
-                // captures IFAC credentials on TCPServer configs so they survive a
-                // round-trip through the DB when native support lands.
-                Log.w(TAG, "TCPServer not yet supported in native stack")
-                null
-            }
+            is InterfaceConfig.TCPServer ->
+                TCPServerInterface(
+                    name = config.name,
+                    bindAddress = config.listenIp,
+                    bindPort = config.listenPort,
+                    ifacNetname = config.networkName,
+                    ifacNetkey = config.passphrase,
+                ).apply {
+                    // Register each spawned child interface with Transport BEFORE
+                    // start() opens the accept loop, so the first incoming
+                    // connection can't race us into a silent-drop: Python RNS
+                    // does the same at RNS/Interfaces/TCPInterface.py:623
+                    // (Transport.interfaces.append(spawned_interface)), and
+                    // reticulum-kt PR #47 spawned-without-register bug
+                    // manifested as path responses dropped in
+                    // Transport.kt:3632-3658. See also: the conformance-bridge
+                    // reference implementation in WireTcp.kt:198-210.
+                    onClientConnected = { spawnedChild ->
+                        runCatching {
+                            Transport.registerInterface(
+                                network.reticulum.interfaces.InterfaceAdapter
+                                    .getOrCreate(spawnedChild),
+                            )
+                        }.onFailure { e ->
+                            Log.e(
+                                TAG,
+                                "Failed to register spawned client ${spawnedChild.name} " +
+                                    "for server ${config.name}: ${e.message}",
+                                e,
+                            )
+                        }
+                        Log.i(
+                            TAG,
+                            "TCPServer ${config.name}: client connected (${spawnedChild.name})",
+                        )
+                    }
+                    // TCPServerInterface.clientDisconnected already deregisters
+                    // via Transport; this callback is purely for surface-level
+                    // logging so a silent child-leak doesn't masquerade as
+                    // "server healthy" in the UI.
+                    onClientDisconnected = { spawnedChild ->
+                        Log.i(
+                            TAG,
+                            "TCPServer ${config.name}: client disconnected (${spawnedChild.name})",
+                        )
+                    }
+                }
 
             is InterfaceConfig.RNode -> {
                 scope.launch(Dispatchers.IO) {


### PR DESCRIPTION
## Summary

- Replaces the `InterfaceConfig.TCPServer` stub in `NativeInterfaceFactory.createInterface` (which returned `null` and only logged a warning) with a real `TCPServerInterface` construction, so a TCP Server configured in the app actually binds and goes online instead of sitting "Offline" forever after enable.
- Wires `onClientConnected` to register each spawned child interface with `Transport` (mirroring `RNS/Interfaces/TCPInterface.py:623` and the conformance-bridge reference at `reticulum-kt/conformance-bridge/src/main/kotlin/WireTcp.kt:154+`). Registration failures are surfaced via `runCatching { ... }.onFailure { Log.e(...) }` instead of the silent-drop anti-pattern that bit reticulum-kt PR #47.
- Plumbs optional IFAC parameters (`networkName` / `passphrase`) end-to-end: `InterfaceConfig.TCPServer` data class, `InterfaceConfigExt` serialisation, `InterfaceRepository` deserialisation, `InterfaceManagementViewModel` state round-trip, and the `TCPServerInterface` constructor. The wizard UI work lives in the parallel `feat/unified-ifac-ui` scope and will just populate the fields this PR made persistable.
- Adds targeted round-trip unit tests for the new IFAC serialisation path (omit-when-null, include-when-set) and repository deserialisation.

Follow-up to the TCPServer stub introduced when `NativeInterfaceFactory` was first written; unblocks the user's 2026-04-21 first-test observation.

## Notable details

- `InterfaceEntity` uses a JSON `configJson` blob rather than per-field columns, so no Room schema migration was needed for the new IFAC fields — only `toJsonString` / `entityToConfig` changes.
- `onClientDisconnected` currently only logs; `TCPServerInterface.clientDisconnected` (in reticulum-kt) already calls `Transport.deregisterInterface(client.toRef())` internally, so the Columba-side callback would be a duplicate deregister. Keeping the hook present for operator-visible logging.
- The `syncInterfaces` "started N" counter still tracks attempts rather than successful registrations. With this fix the TCPServer case is accurate because `createInterface` no longer returns `null` on that branch; broadening the counter across the async BLE/RNode paths is a separate follow-up.
- No changes to `settings.gradle.kts` (the env-gated `LOCAL_RETICULUM_KT` composite-build lines are untouched) and no changes to `NativeMessageSender.kt`. Stayed clear of UI wizards and the IFAC UI composable extraction per the parallel subagent coordination.

## Test plan

- [x] `:app:compileNoSentryDebugKotlin` green
- [x] `:reticulum:compileDebugKotlin` green
- [x] `:app:ktlintCheck` / `:reticulum:ktlintCheck` green
- [x] `:app:detekt` / `:reticulum:detekt` green
- [x] `:app:testNoSentryDebugUnitTest` green (incl. new `enabledInterfaces deserializes TCPServer IFAC fields` / `... reads null ... when omitted`)
- [x] `:reticulum:testDebugUnitTest` green (incl. new `TCPServer toJsonString includes IFAC fields when set` / `... omits null ...`)
- [ ] On-device smoke (deferred to device verification): `adb shell dumpsys activity services network.columba.app` shows the foreground service, logcat shows `NativeInterfaceFactory: Started interface: <server name> (online=true)` when a TCPServer is enabled, and `TCPServer <name>: client connected (<client-name>)` when a peer connects.

🤖 Generated with [Claude Code](https://claude.com/claude-code)