### PR TITLE
Bump reticulum-kt to v0.0.13 (BLE handshake concurrency fix)

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -19,7 +19,7 @@ serialization = "1.10.0"
 coil = "2.7.0"
 
 # JitPack-published libraries (formerly git submodules)
-reticulumKt = "v0.0.12"
+reticulumKt = "v0.0.13"
 lxmfKt = "v0.0.6"
 lxstKt = "v0.0.3"
 


### PR DESCRIPTION
## Summary

Pulls in [reticulum-kt PR #51](https://github.com/torlando-tech/reticulum-kt/pull/51) via the new `v0.0.13` JitPack tag.

The reticulum-kt fix resolves three concurrency bugs in the custom BLE Interface (Stack A — p2p between Columba phones, not RNode-over-BT) that together caused a ~50x idle battery drain when a nearby peer repeatedly retried a failed identity handshake:

- **Single-flight guard**: a `ConcurrentHashMap.newKeySet<String>()` tracks handshakes already in flight per MAC, so simultaneous GATT connections from the same peripheral don't each spawn a fresh handshake coroutine.
- **Blacklist check on incoming path**: previously the blacklist was only consulted when we initiated a connection, so a throttled peer could keep reconnecting into us and still be accepted. Now incoming connections from blacklisted MACs are rejected immediately.
- **Atomic backoff updates**: `blacklist.compute(address) { ... }` replaces a read-modify-write that let two threads each extend the backoff window past what either saw, masking the real throttle duration.
- **Connection-scoped disconnect on reject**: uses `connection.close()` rather than `driver.disconnect(address)` so rejecting one stale connection doesn't also tear down a concurrent healthy handshake from the same MAC.

## Test plan

- [x] reticulum-kt PR #51 shipped with `BLEInterfaceIncomingHandshakeTest` (Robolectric, 299 lines) covering all three race paths
- [x] JitPack build verified for v0.0.13 across all three modules (`rns-core`, `rns-interfaces`, `rns-android`) — all return 200
- [ ] On-device smoke test on .71 (idle battery drop from 50% → stable after 12h under BLE-peer proximity)

🤖 Generated with [Claude Code](https://claude.com/claude-code)