### PR TITLE
Move map interface filters behind a layers icon

### DIFF
--- a/app/src/main/java/network/columba/app/ui/screens/MapScreen.kt
+++ b/app/src/main/java/network/columba/app/ui/screens/MapScreen.kt
@@ -13,6 +13,8 @@ import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.ExperimentalLayoutApi
+import androidx.compose.foundation.layout.FlowRow
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxHeight
@@ -77,6 +79,7 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.platform.LocalLifecycleOwner
+import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
@@ -98,6 +101,7 @@ import network.columba.app.ui.components.ContactLocationBottomSheet
 import network.columba.app.ui.components.LocationPermissionBottomSheet
 import network.columba.app.ui.components.ShareLocationBottomSheet
 import network.columba.app.ui.components.SharingStatusChip
+import network.columba.app.ui.util.InterfaceCategory
 import network.columba.app.ui.util.MarkerBitmapFactory
 import network.columba.app.ui.util.ScreenMarker
 import network.columba.app.ui.util.ScreenToLatLng
@@ -1253,7 +1257,7 @@ fun MapScreen(
         // TopAppBar overlays map (transparent background)
         val availableCategories =
             remember(state.interfaceMarkers) {
-                network.columba.app.ui.util.InterfaceCategory.entries
+                InterfaceCategory.entries
                     .filter { cat -> state.interfaceMarkers.any { it.category == cat } }
             }
         val anyLayerHidden =
@@ -1313,19 +1317,25 @@ fun MapScreen(
         }
 
         // Layers bottom sheet — interface-type filter toggles
+        // Close the sheet if the underlying markers vanish so it doesn't reopen
+        // silently the next time a marker appears.
+        LaunchedEffect(availableCategories.isEmpty()) {
+            if (availableCategories.isEmpty() && showLayersSheet) {
+                showLayersSheet = false
+            }
+        }
         if (showLayersSheet && availableCategories.isNotEmpty()) {
             ModalBottomSheet(
                 onDismissRequest = { showLayersSheet = false },
                 sheetState = layersSheetState,
             ) {
+                // ModalBottomSheet already applies navigation-bar insets via its
+                // contentWindowInsets — don't double-pad the content here.
                 MapLayersSheetContent(
                     categories = availableCategories,
                     filterEnabled = state.interfaceFilterEnabled,
                     onToggle = { viewModel.toggleInterfaceFilter(it) },
-                    modifier =
-                        Modifier
-                            .navigationBarsPadding()
-                            .padding(horizontal = 24.dp, vertical = 8.dp),
+                    modifier = Modifier.padding(horizontal = 24.dp, vertical = 8.dp),
                 )
             }
         }
@@ -1660,11 +1670,12 @@ private fun FocusInterfaceBottomSheet(
  * Content for the map layers bottom sheet — interface-type filter toggles.
  * Extracted for testability since ModalBottomSheet is difficult to test in Robolectric.
  */
+@OptIn(ExperimentalLayoutApi::class)
 @Composable
 internal fun MapLayersSheetContent(
-    categories: List<network.columba.app.ui.util.InterfaceCategory>,
-    filterEnabled: Map<network.columba.app.ui.util.InterfaceCategory, Boolean>,
-    onToggle: (network.columba.app.ui.util.InterfaceCategory) -> Unit,
+    categories: List<InterfaceCategory>,
+    filterEnabled: Map<InterfaceCategory, Boolean>,
+    onToggle: (InterfaceCategory) -> Unit,
     modifier: Modifier = Modifier,
 ) {
     Column(modifier = modifier) {
@@ -1673,7 +1684,7 @@ internal fun MapLayersSheetContent(
             style = MaterialTheme.typography.titleMedium,
             modifier = Modifier.padding(bottom = 12.dp),
         )
-        androidx.compose.foundation.layout.FlowRow(
+        FlowRow(
             horizontalArrangement = Arrangement.spacedBy(8.dp),
             verticalArrangement = Arrangement.spacedBy(8.dp),
         ) {
@@ -1684,9 +1695,7 @@ internal fun MapLayersSheetContent(
                     label = { Text(category.defaultText) },
                     leadingIcon = {
                         Icon(
-                            painter =
-                                androidx.compose.ui.res
-                                    .painterResource(category.markerIconResId),
+                            painter = painterResource(category.markerIconResId),
                             contentDescription = null,
                             modifier = Modifier.size(18.dp),
                         )

--- a/app/src/main/java/network/columba/app/ui/screens/MapScreen.kt
+++ b/app/src/main/java/network/columba/app/ui/screens/MapScreen.kt
@@ -47,10 +47,12 @@ import androidx.compose.material3.CardDefaults
 import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.ExtendedFloatingActionButton
+import androidx.compose.material3.FilledIconButton
 import androidx.compose.material3.FilterChip
 import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
+import androidx.compose.material3.IconButtonDefaults
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.ModalBottomSheet
 import androidx.compose.material3.OutlinedButton
@@ -1260,7 +1262,15 @@ fun MapScreen(
             title = {},
             actions = {
                 if (availableCategories.isNotEmpty()) {
-                    IconButton(onClick = { showLayersSheet = true }) {
+                    FilledIconButton(
+                        onClick = { showLayersSheet = true },
+                        colors =
+                            IconButtonDefaults.filledIconButtonColors(
+                                containerColor = Color.Black.copy(alpha = 0.45f),
+                                contentColor = Color.White,
+                            ),
+                        modifier = Modifier.padding(end = 8.dp),
+                    ) {
                         BadgedBox(
                             badge = {
                                 if (anyLayerHidden) {
@@ -1273,7 +1283,6 @@ fun MapScreen(
                             Icon(
                                 imageVector = Icons.Default.Layers,
                                 contentDescription = "Map layers",
-                                tint = Color.White,
                             )
                         }
                     }

--- a/app/src/main/java/network/columba/app/ui/screens/MapScreen.kt
+++ b/app/src/main/java/network/columba/app/ui/screens/MapScreen.kt
@@ -30,6 +30,7 @@ import androidx.compose.material.icons.filled.Close
 import androidx.compose.material.icons.filled.CloudDownload
 import androidx.compose.material.icons.filled.ContentCopy
 import androidx.compose.material.icons.filled.Download
+import androidx.compose.material.icons.filled.Layers
 import androidx.compose.material.icons.filled.LocationOn
 import androidx.compose.material.icons.filled.MyLocation
 import androidx.compose.material.icons.filled.Radio
@@ -37,6 +38,8 @@ import androidx.compose.material.icons.filled.Send
 import androidx.compose.material.icons.filled.ShareLocation
 import androidx.compose.material.icons.filled.Stop
 import androidx.compose.material.icons.filled.WifiOff
+import androidx.compose.material3.Badge
+import androidx.compose.material3.BadgedBox
 import androidx.compose.material3.Button
 import androidx.compose.material3.ButtonDefaults
 import androidx.compose.material3.Card
@@ -226,6 +229,8 @@ fun MapScreen(
     val permissionSheetState = rememberModalBottomSheetState(skipPartiallyExpanded = true)
     val shareLocationSheetState = rememberModalBottomSheetState(skipPartiallyExpanded = true)
     val contactLocationSheetState = rememberModalBottomSheetState(skipPartiallyExpanded = true)
+    val layersSheetState = rememberModalBottomSheetState(skipPartiallyExpanded = true)
+    var showLayersSheet by remember { mutableStateOf(false) }
 
     // Map state
     var mapLibreMap by remember { mutableStateOf<MapLibreMap?>(null) }
@@ -1226,17 +1231,17 @@ fun MapScreen(
             Log.d("MapScreen", "Added focus marker at $focusLatitude, $focusLongitude for $focusLabel")
         }
 
-        // Gradient scrim behind TopAppBar for readability
+        // Gradient scrim behind TopAppBar actions for legibility against variable map backgrounds
         Box(
             modifier =
                 Modifier
                     .fillMaxWidth()
-                    .height(120.dp)
+                    .height(80.dp)
                     .background(
                         Brush.verticalGradient(
                             colors =
                                 listOf(
-                                    Color.Black.copy(alpha = 0.4f),
+                                    Color.Black.copy(alpha = 0.35f),
                                     Color.Transparent,
                                 ),
                         ),
@@ -1244,12 +1249,35 @@ fun MapScreen(
         )
 
         // TopAppBar overlays map (transparent background)
+        val availableCategories =
+            remember(state.interfaceMarkers) {
+                network.columba.app.ui.util.InterfaceCategory.entries
+                    .filter { cat -> state.interfaceMarkers.any { it.category == cat } }
+            }
+        val anyLayerHidden =
+            availableCategories.any { state.interfaceFilterEnabled[it] == false }
         TopAppBar(
-            title = {
-                Text(
-                    text = "Map",
-                    color = Color.White,
-                )
+            title = {},
+            actions = {
+                if (availableCategories.isNotEmpty()) {
+                    IconButton(onClick = { showLayersSheet = true }) {
+                        BadgedBox(
+                            badge = {
+                                if (anyLayerHidden) {
+                                    Badge(
+                                        containerColor = MaterialTheme.colorScheme.primary,
+                                    )
+                                }
+                            },
+                        ) {
+                            Icon(
+                                imageVector = Icons.Default.Layers,
+                                contentDescription = "Map layers",
+                                tint = Color.White,
+                            )
+                        }
+                    }
+                }
             },
             colors =
                 TopAppBarDefaults.topAppBarColors(
@@ -1275,40 +1303,21 @@ fun MapScreen(
             )
         }
 
-        // Interface type filter chips (shown when interface markers exist)
-        if (state.interfaceMarkers.isNotEmpty()) {
-            Row(
-                modifier =
-                    Modifier
-                        .align(Alignment.TopStart)
-                        .statusBarsPadding()
-                        .padding(top = 64.dp, start = 8.dp),
-                horizontalArrangement = Arrangement.spacedBy(4.dp),
+        // Layers bottom sheet — interface-type filter toggles
+        if (showLayersSheet && availableCategories.isNotEmpty()) {
+            ModalBottomSheet(
+                onDismissRequest = { showLayersSheet = false },
+                sheetState = layersSheetState,
             ) {
-                network.columba.app.ui.util.InterfaceCategory.entries
-                    .filter { cat -> state.interfaceMarkers.any { it.category == cat } }
-                    .forEach { category ->
-                        FilterChip(
-                            selected = state.interfaceFilterEnabled[category] ?: true,
-                            onClick = { viewModel.toggleInterfaceFilter(category) },
-                            label = {
-                                Text(
-                                    category.defaultText,
-                                    style = MaterialTheme.typography.labelSmall,
-                                )
-                            },
-                            leadingIcon = {
-                                Icon(
-                                    painter =
-                                        androidx.compose.ui.res
-                                            .painterResource(category.markerIconResId),
-                                    contentDescription = null,
-                                    modifier = Modifier.size(16.dp),
-                                )
-                            },
-                            modifier = Modifier.height(32.dp),
-                        )
-                    }
+                MapLayersSheetContent(
+                    categories = availableCategories,
+                    filterEnabled = state.interfaceFilterEnabled,
+                    onToggle = { viewModel.toggleInterfaceFilter(it) },
+                    modifier =
+                        Modifier
+                            .navigationBarsPadding()
+                            .padding(horizontal = 24.dp, vertical = 8.dp),
+                )
             }
         }
 
@@ -1635,6 +1644,47 @@ private fun FocusInterfaceBottomSheet(
             onCopyLoraParams = onCopyLoraParams,
             onUseForNewRNode = onUseForNewRNode,
         )
+    }
+}
+
+/**
+ * Content for the map layers bottom sheet — interface-type filter toggles.
+ * Extracted for testability since ModalBottomSheet is difficult to test in Robolectric.
+ */
+@Composable
+internal fun MapLayersSheetContent(
+    categories: List<network.columba.app.ui.util.InterfaceCategory>,
+    filterEnabled: Map<network.columba.app.ui.util.InterfaceCategory, Boolean>,
+    onToggle: (network.columba.app.ui.util.InterfaceCategory) -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    Column(modifier = modifier) {
+        Text(
+            text = "Show on map",
+            style = MaterialTheme.typography.titleMedium,
+            modifier = Modifier.padding(bottom = 12.dp),
+        )
+        androidx.compose.foundation.layout.FlowRow(
+            horizontalArrangement = Arrangement.spacedBy(8.dp),
+            verticalArrangement = Arrangement.spacedBy(8.dp),
+        ) {
+            categories.forEach { category ->
+                FilterChip(
+                    selected = filterEnabled[category] ?: true,
+                    onClick = { onToggle(category) },
+                    label = { Text(category.defaultText) },
+                    leadingIcon = {
+                        Icon(
+                            painter =
+                                androidx.compose.ui.res
+                                    .painterResource(category.markerIconResId),
+                            contentDescription = null,
+                            modifier = Modifier.size(18.dp),
+                        )
+                    },
+                )
+            }
+        }
     }
 }
 

--- a/app/src/test/java/network/columba/app/ui/screens/MapLayersSheetContentTest.kt
+++ b/app/src/test/java/network/columba/app/ui/screens/MapLayersSheetContentTest.kt
@@ -1,0 +1,101 @@
+package network.columba.app.ui.screens
+
+import android.app.Application
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.assertIsNotSelected
+import androidx.compose.ui.test.assertIsSelected
+import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.performClick
+import network.columba.app.test.RegisterComponentActivityRule
+import network.columba.app.ui.util.InterfaceCategory
+import org.junit.Assert.assertEquals
+import org.junit.Rule
+import org.junit.Test
+import org.junit.rules.RuleChain
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+
+@RunWith(RobolectricTestRunner::class)
+@Config(sdk = [34], application = Application::class)
+class MapLayersSheetContentTest {
+    private val registerActivityRule = RegisterComponentActivityRule()
+    private val composeRule = createComposeRule()
+
+    @get:Rule
+    val ruleChain: RuleChain = RuleChain.outerRule(registerActivityRule).around(composeRule)
+
+    @Test
+    fun rendersHeaderAndOneChipPerProvidedCategory() {
+        composeRule.setContent {
+            MapLayersSheetContent(
+                categories = listOf(InterfaceCategory.TCP, InterfaceCategory.BLUETOOTH, InterfaceCategory.LORA),
+                filterEnabled =
+                    mapOf(
+                        InterfaceCategory.TCP to true,
+                        InterfaceCategory.BLUETOOTH to true,
+                        InterfaceCategory.LORA to true,
+                    ),
+                onToggle = {},
+            )
+        }
+
+        composeRule.onNodeWithText("Show on map").assertIsDisplayed()
+        composeRule.onNodeWithText("TCP/IP").assertIsDisplayed()
+        composeRule.onNodeWithText("Bluetooth").assertIsDisplayed()
+        composeRule.onNodeWithText("LoRa Radio").assertIsDisplayed()
+    }
+
+    @Test
+    fun chipSelectedStateReflectsFilterEnabledMap() {
+        composeRule.setContent {
+            MapLayersSheetContent(
+                categories = listOf(InterfaceCategory.TCP, InterfaceCategory.BLUETOOTH),
+                filterEnabled =
+                    mapOf(
+                        InterfaceCategory.TCP to true,
+                        InterfaceCategory.BLUETOOTH to false,
+                    ),
+                onToggle = {},
+            )
+        }
+
+        composeRule.onNodeWithText("TCP/IP").assertIsSelected()
+        composeRule.onNodeWithText("Bluetooth").assertIsNotSelected()
+    }
+
+    @Test
+    fun categoryMissingFromMapDefaultsToSelected() {
+        composeRule.setContent {
+            MapLayersSheetContent(
+                categories = listOf(InterfaceCategory.TCP),
+                // Empty map — chip should still render as selected via ?: true fallback
+                filterEnabled = emptyMap(),
+                onToggle = {},
+            )
+        }
+
+        composeRule.onNodeWithText("TCP/IP").assertIsSelected()
+    }
+
+    @Test
+    fun clickingChipInvokesOnToggleWithThatCategory() {
+        val toggled = mutableListOf<InterfaceCategory>()
+        composeRule.setContent {
+            MapLayersSheetContent(
+                categories = listOf(InterfaceCategory.TCP, InterfaceCategory.LORA),
+                filterEnabled =
+                    mapOf(
+                        InterfaceCategory.TCP to true,
+                        InterfaceCategory.LORA to true,
+                    ),
+                onToggle = { toggled += it },
+            )
+        }
+
+        composeRule.onNodeWithText("LoRa Radio").performClick()
+
+        assertEquals(listOf(InterfaceCategory.LORA), toggled)
+    }
+}


### PR DESCRIPTION
## Summary

The inline `FilterChip` row across the top of the map was visually busy — particularly once users have peers discovered across 4+ interface types — and several users asked for an option to hide it. This PR moves the same filters behind a canonical Material 3 layers icon pattern.

**Behaviour changes:**

- **Layers IconButton** (`Icons.Default.Layers`) in the map's `TopAppBar` actions slot, gated on `state.interfaceMarkers.isNotEmpty()` (same condition as before — if there's nothing to filter, no icon).
- **ModalBottomSheet** titled *Show on map* opens on tap, hosting the same chips as before in a `FlowRow` so they wrap gracefully.
- **Badge dot** on the icon (`BadgedBox` + `Badge`) when any layer is toggled off, so filtered state is discoverable without opening the sheet.
- **Dropped the `Map` title** and shrunk the scrim from 120dp → 80dp, matching how Google Maps / Apple Maps treat primary map surfaces. Reclaims ~56dp of vertical real estate.

**Code organisation:**

- `MapLayersSheetContent` is extracted as an `internal @Composable`, mirroring the existing `FocusInterfaceContent` "extract for testability" pattern already used in this file.

## Test plan

- [x] New Robolectric test `MapLayersSheetContentTest` covers: render (header + one chip per category), selected-state reflection from the `filterEnabled` map, the `?: true` default fallback for missing categories, and click → onToggle callback wiring.
- [x] `./gradlew :app:testNoSentryDebugUnitTest --tests '*MapLayersSheetContent*'` passes locally.
- [x] Installed the debug APK on a real device: layers icon appears only when interface markers exist, badge dot appears when a chip is toggled off, bottom sheet toggles match the previous chip-row behaviour one-for-one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)