### PR TITLE
Bump LXMF-kt to v0.0.7 (processingScope silent-drop fix)

### DIFF
--- a/app/src/test/java/network/columba/app/viewmodel/MapViewModelTest.kt
+++ b/app/src/test/java/network/columba/app/viewmodel/MapViewModelTest.kt
@@ -106,6 +106,8 @@ class MapViewModelTest {
         every { locationSharingManager.stopSharing(any()) } just Runs
         every { settingsRepository.hasDismissedLocationPermissionSheetFlow } returns flowOf(false)
         every { settingsRepository.mapMarkerDeclutterEnabledFlow } returns flowOf(true)
+        every { settingsRepository.mapStylePreferenceFlow } returns
+            flowOf(network.columba.app.data.model.MapStylePreference.AUTO)
         every { settingsRepository.sortMessagesBySentTime } returns flowOf(false)
         coEvery { settingsRepository.markLocationPermissionSheetDismissed() } just Runs
         coEvery { settingsRepository.setHttpEnabledForDownload(any()) } just Runs

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -20,7 +20,7 @@ coil = "2.7.0"
 
 # JitPack-published libraries (formerly git submodules)
 reticulumKt = "v0.0.13"
-lxmfKt = "v0.0.6"
+lxmfKt = "v0.0.7"
 lxstKt = "v0.0.3"
 
 [libraries]

--- a/reticulum/src/main/java/network/columba/app/reticulum/protocol/NativeReticulumProtocol.kt
+++ b/reticulum/src/main/java/network/columba/app/reticulum/protocol/NativeReticulumProtocol.kt
@@ -574,6 +574,11 @@ class NativeReticulumProtocol(
                 NativeInterfaceFactory.shutdownAll()
                 Reticulum.stop()
                 closePersistentStores()
+                // stop() cancels only processingJob and deliberately keeps the
+                // process-lifetime SupervisorJob scope alive (LXMF-kt v0.0.7 fix
+                // for the processingScope silent-drop bug on restart). close()
+                // is the explicit teardown path for that scope on final shutdown.
+                router?.close()
                 router = null
                 reticulum = null
                 deliveryIdentity = null


### PR DESCRIPTION
## Summary

Bumps `lxmfKt` in the Gradle version catalog from `v0.0.6` → `v0.0.7`.

Pulls in [LXMF-kt PR #13](https://github.com/torlando-tech/LXMF-kt/pull/13), which fixes the `LXMRouter.processingScope` silent-drop bug:

- `processingScope` used to be `var CoroutineScope? = null`, assigned in `start()` and nulled in `stop()`. Outbound message launches used `processingScope?.launch { ... }` — so any launch during a restart window silently no-op'd, leaving outbound messages stuck `PENDING` with no error surface anywhere.
- Replaced with a process-lifetime `val` scope backed by `SupervisorJob`; `stop()` now cancels only `processingJob` and leaves the scope intact for the next start cycle. `LXMRouter` is now `AutoCloseable` to give the scope an explicit teardown path at process end.

This was validated on-device in the prior session after a local (uncommitted) bump — the fix resolved stuck-pending outbound messages that could appear after backgrounding + reopening the app. Main was missed during that session; opening this to land it formally before the 1.0 pre-release tag.

## Test plan

- [x] JitPack returns 200 for `v0.0.7` artifact (`https://jitpack.io/com/github/torlando-tech/LXMF-kt/v0.0.7/LXMF-kt-v0.0.7.pom`) — warmed.
- [x] Prior on-device validation in the previous session: messages sent during a restart window were delivered correctly.
- [ ] CI build + test shards pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)