### PR TITLE
Render Micron links on form lines in the NomadNet browser

### DIFF
--- a/app/src/main/java/network/columba/app/ui/components/MicronComposables.kt
+++ b/app/src/main/java/network/columba/app/ui/components/MicronComposables.kt
@@ -1,6 +1,7 @@
 package network.columba.app.ui.components
 
 import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
@@ -322,7 +323,27 @@ private fun MicronLineComposable(
                             )
                         }
                     }
-                    else -> { /* skip links/dividers/linebreaks in form line */ }
+                    is MicronElement.Link -> {
+                        // Render the link as a clickable Text that carries any form-field
+                        // names declared after the destination (e.g. `[Send Message`:/page`a|b]
+                        // where a & b name the fields to submit). Without this branch, links
+                        // on the same line as form fields were silently dropped — the canonical
+                        // "Send Message" affordance on pages like fr33n0w/thechatroom vanished.
+                        Text(
+                            text = element.label,
+                            color = Color(0xFF6699FF),
+                            fontFamily = fontFamily,
+                            textDecoration = TextDecoration.Underline,
+                            modifier =
+                                Modifier
+                                    .defaultMinSize(minHeight = MIN_LINK_HEIGHT_DP.dp)
+                                    .padding(vertical = 4.dp)
+                                    .clickable {
+                                        onLinkClick(element.destination, element.fieldNames)
+                                    },
+                        )
+                    }
+                    else -> { /* skip dividers/linebreaks/partials in form line */ }
                 }
             }
         }


### PR DESCRIPTION
## Summary

Fixes a renderer gap that silently drops the "Send Message" / "Set" / "Reload" buttons on multi-element form lines in the NomadNet browser. On pages like [fr33n0w/thechatroom](https://github.com/fr33n0w/thechatroom) — a MeshChat-style IRC room — the Micron markup looks like:

```
Nickname: `<20|username`JohnDoe> `[Set`:/page/nomadnet.mu`username]` Message: `<87|message`> `[Send Message`:/page/nomadnet.mu`username|message]` - `[Reload Page`:/page/nomadnet.mu`username]`
```

All three links sit inline with the input fields on a single Micron line. Columba's `MicronLineComposable` enters a "form line" branch when any `Field`/`Checkbox`/`Radio` is present, and inside that branch `when (element)` had an explicit catch-all:

```kotlin
else -> { /* skip links/dividers/linebreaks in form line */ }
```

`MicronElement.Link` fell into the `else`, so users saw the input fields but had no visible way to submit them. The message-submission plumbing in `NomadNetBrowserViewModel` (#838-era work) already handled `fieldNames` correctly — the renderer just never called it.

### The fix

Add a `MicronElement.Link` case in the form-line branch that renders the link as a clickable `Text` styled the same as the non-form branch (light-blue underlined, `Color(0xFF6699FF)`, `TextDecoration.Underline`) and wires `onLinkClick(destination, fieldNames)`. The parser already extracts `fieldNames` from the third backtick segment of `` `[label`:/page`f1|f2] `` (matches Python NomadNet's [`MicronParser.py:634-678`](https://github.com/markqvist/NomadNet/blob/master/nomadnet/ui/textui/MicronParser.py) canonical `link_components[2].split("|")`).

## Test plan

- [x] `./gradlew :app:compileNoSentryDebugKotlin` — clean.
- [ ] Manual verification on-device: visit fr33n0w/thechatroom's `nomadnet.mu` page, confirm Send Message / Set / Reload links are visible and submitting actually sends the field values.

🤖 Generated with [Claude Code](https://claude.com/claude-code)