### PR TITLE
Auto-populate IFAC network name on discovered interfaces (fixes #770)

### DIFF
--- a/app/src/main/java/com/lxmf/messenger/MainActivity.kt
+++ b/app/src/main/java/com/lxmf/messenger/MainActivity.kt
@@ -1573,10 +1573,12 @@ fun ColumbaNavigation(
                         composable("discovered_interfaces") {
                             DiscoveredInterfacesScreen(
                                 onNavigateBack = { navController.popBackStack() },
-                                onNavigateToTcpClientWizard = { host, port, name ->
+                                onNavigateToTcpClientWizard = { host, port, name, networkName, passphrase ->
                                     val encodedHost = Uri.encode(host)
                                     val encodedName = Uri.encode(name)
-                                    navController.navigate("tcp_client_wizard?host=$encodedHost&port=$port&name=$encodedName")
+                                    var encodedNetworkName = Uri.encode(networkName)
+                                    var encodedPassphrase = Uri.encode(passphrase)
+                                    navController.navigate("tcp_client_wizard?host=$encodedHost&port=$port&name=$encodedName&networkName=$encodedNetworkName&passphrase=$encodedPassphrase")
                                 },
                                 onNavigateToMapWithInterface = { details ->
                                     val encodedLabel = Uri.encode(details.name)
@@ -1607,7 +1609,7 @@ fun ColumbaNavigation(
                         }
 
                         composable(
-                            route = "tcp_client_wizard?interfaceId={interfaceId}&host={host}&port={port}&name={name}",
+                            route = "tcp_client_wizard?interfaceId={interfaceId}&host={host}&port={port}&name={name}&networkName={networkName}&passphrase={passphrase}",
                             arguments =
                                 listOf(
                                     navArgument("interfaceId") {
@@ -1626,12 +1628,22 @@ fun ColumbaNavigation(
                                         type = NavType.StringType
                                         defaultValue = ""
                                     },
+                                    navArgument("networkName") {
+                                        type = NavType.StringType
+                                        defaultValue = ""
+                                    },
+                                    navArgument("passphrase") {
+                                        type = NavType.StringType
+                                        defaultValue = ""
+                                    },
                                 ),
                         ) { backStackEntry ->
                             val interfaceId = backStackEntry.arguments?.getLong("interfaceId") ?: -1L
                             val host = backStackEntry.arguments?.getString("host") ?: ""
                             val port = backStackEntry.arguments?.getInt("port") ?: 0
                             val name = backStackEntry.arguments?.getString("name") ?: ""
+                            val networkName = backStackEntry.arguments?.getString("networkName") ?: ""
+                            val passphrase = backStackEntry.arguments?.getString("passphrase") ?: ""
                             TcpClientWizardScreen(
                                 onNavigateBack = { navController.popBackStack() },
                                 onComplete = {
@@ -1643,6 +1655,8 @@ fun ColumbaNavigation(
                                 initialHost = host.ifEmpty { null },
                                 initialPort = if (port > 0) port else null,
                                 initialName = name.ifEmpty { null },
+                                initialNetworkName = networkName.ifEmpty { null },
+                                initialPassphrase = passphrase.ifEmpty { null },
                             )
                         }
 

--- a/app/src/main/java/com/lxmf/messenger/MainActivity.kt
+++ b/app/src/main/java/com/lxmf/messenger/MainActivity.kt
@@ -1576,9 +1576,11 @@ fun ColumbaNavigation(
                                 onNavigateToTcpClientWizard = { host, port, name, networkName, passphrase ->
                                     val encodedHost = Uri.encode(host)
                                     val encodedName = Uri.encode(name)
-                                    var encodedNetworkName = Uri.encode(networkName)
-                                    var encodedPassphrase = Uri.encode(passphrase)
-                                    navController.navigate("tcp_client_wizard?host=$encodedHost&port=$port&name=$encodedName&networkName=$encodedNetworkName&passphrase=$encodedPassphrase")
+                                    val encodedNetworkName = Uri.encode(networkName)
+                                    val encodedPassphrase = Uri.encode(passphrase)
+                                    navController.navigate(
+                                        "tcp_client_wizard?host=$encodedHost&port=$port&name=$encodedName&networkName=$encodedNetworkName&passphrase=$encodedPassphrase",
+                                    )
                                 },
                                 onNavigateToMapWithInterface = { details ->
                                     val encodedLabel = Uri.encode(details.name)

--- a/app/src/main/java/com/lxmf/messenger/MainActivity.kt
+++ b/app/src/main/java/com/lxmf/messenger/MainActivity.kt
@@ -1576,8 +1576,8 @@ fun ColumbaNavigation(
                                 onNavigateToTcpClientWizard = { host, port, name, networkName, passphrase ->
                                     val encodedHost = Uri.encode(host)
                                     val encodedName = Uri.encode(name)
-                                    val encodedNetworkName = Uri.encode(networkName)
-                                    val encodedPassphrase = Uri.encode(passphrase)
+                                    val encodedNetworkName = Uri.encode(networkName.orEmpty())
+                                    val encodedPassphrase = Uri.encode(passphrase.orEmpty())
                                     navController.navigate(
                                         "tcp_client_wizard?host=$encodedHost&port=$port&name=$encodedName&networkName=$encodedNetworkName&passphrase=$encodedPassphrase",
                                     )

--- a/app/src/main/java/com/lxmf/messenger/ui/screens/DiscoveredInterfacesScreen.kt
+++ b/app/src/main/java/com/lxmf/messenger/ui/screens/DiscoveredInterfacesScreen.kt
@@ -861,6 +861,43 @@ internal fun DiscoveredInterfaceCard(
                 )
             }
 
+            // IFAC network name (when broadcast by the discovery announce).
+            // Note: only the network *name* is transmitted — the IFAC passphrase/key is
+            // never broadcast by Python RNS for security reasons, so users still need to
+            // obtain that out-of-band before connecting.
+            iface.networkName?.takeIf { it.isNotBlank() }?.let { networkName ->
+                val clipboardManager = LocalClipboardManager.current
+                val context = LocalContext.current
+                Row(
+                    verticalAlignment = Alignment.CenterVertically,
+                    horizontalArrangement = Arrangement.spacedBy(4.dp),
+                ) {
+                    Text(
+                        text = "network: $networkName",
+                        style = MaterialTheme.typography.bodySmall,
+                        fontFamily = FontFamily.Monospace,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                        modifier = Modifier.weight(1f, fill = false),
+                    )
+                    IconButton(
+                        onClick = {
+                            clipboardManager.setText(AnnotatedString(networkName))
+                            Toast
+                                .makeText(context, "Network name copied", Toast.LENGTH_SHORT)
+                                .show()
+                        },
+                        modifier = Modifier.size(24.dp),
+                    ) {
+                        Icon(
+                            imageVector = Icons.Default.ContentCopy,
+                            contentDescription = "Copy network name",
+                            modifier = Modifier.size(14.dp),
+                            tint = MaterialTheme.colorScheme.onSurfaceVariant,
+                        )
+                    }
+                }
+            }
+
             HorizontalDivider(
                 modifier = Modifier.padding(vertical = 8.dp),
                 color = MaterialTheme.colorScheme.outlineVariant,

--- a/app/src/main/java/com/lxmf/messenger/ui/screens/DiscoveredInterfacesScreen.kt
+++ b/app/src/main/java/com/lxmf/messenger/ui/screens/DiscoveredInterfacesScreen.kt
@@ -26,6 +26,8 @@ import androidx.compose.material.icons.filled.LocationOn
 import androidx.compose.material.icons.filled.Public
 import androidx.compose.material.icons.filled.Refresh
 import androidx.compose.material.icons.filled.Settings
+import androidx.compose.material.icons.filled.Visibility
+import androidx.compose.material.icons.filled.VisibilityOff
 import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.Button
 import androidx.compose.material3.ButtonDefaults
@@ -861,13 +863,18 @@ internal fun DiscoveredInterfaceCard(
                 )
             }
 
-            // IFAC network name (when broadcast by the discovery announce).
-            // Note: only the network *name* is transmitted — the IFAC passphrase/key is
-            // never broadcast by Python RNS for security reasons, so users still need to
-            // obtain that out-of-band before connecting.
+            // IFAC values broadcast by the discovery announce. Per RNS/Discovery.py:157-159,
+            // publishers opt in via `discovery_publish_ifac = true`, which causes BOTH the
+            // network name AND the passphrase (IFAC_NETKEY) to be included in the announce
+            // info dict. The announce can additionally be encrypted via `discovery_encrypt`
+            // + a shared network identity so only authorized receivers recover the payload.
+            //
+            // We display both when present. The passphrase is masked by default with a
+            // reveal toggle — it's a shared network secret and on-screen masking prevents
+            // shoulder-surfing leaks during the mere act of reviewing discovered networks.
+            val clipboardManager = LocalClipboardManager.current
+            val cardContext = LocalContext.current
             iface.networkName?.takeIf { it.isNotBlank() }?.let { networkName ->
-                val clipboardManager = LocalClipboardManager.current
-                val context = LocalContext.current
                 Row(
                     verticalAlignment = Alignment.CenterVertically,
                     horizontalArrangement = Arrangement.spacedBy(4.dp),
@@ -883,7 +890,7 @@ internal fun DiscoveredInterfaceCard(
                         onClick = {
                             clipboardManager.setText(AnnotatedString(networkName))
                             Toast
-                                .makeText(context, "Network name copied", Toast.LENGTH_SHORT)
+                                .makeText(cardContext, "Network name copied", Toast.LENGTH_SHORT)
                                 .show()
                         },
                         modifier = Modifier.size(24.dp),
@@ -891,6 +898,56 @@ internal fun DiscoveredInterfaceCard(
                         Icon(
                             imageVector = Icons.Default.ContentCopy,
                             contentDescription = "Copy network name",
+                            modifier = Modifier.size(14.dp),
+                            tint = MaterialTheme.colorScheme.onSurfaceVariant,
+                        )
+                    }
+                }
+            }
+            iface.passphrase?.takeIf { it.isNotBlank() }?.let { passphrase ->
+                var passphraseRevealed by remember(iface.transportId) { mutableStateOf(false) }
+                // A Bullet-char mask long enough to hide length info but short enough to fit.
+                val maskedDisplay = "•".repeat(passphrase.length.coerceAtMost(8))
+                Row(
+                    verticalAlignment = Alignment.CenterVertically,
+                    horizontalArrangement = Arrangement.spacedBy(4.dp),
+                ) {
+                    Text(
+                        text = "passphrase: ${if (passphraseRevealed) passphrase else maskedDisplay}",
+                        style = MaterialTheme.typography.bodySmall,
+                        fontFamily = FontFamily.Monospace,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                        modifier = Modifier.weight(1f, fill = false),
+                    )
+                    IconButton(
+                        onClick = { passphraseRevealed = !passphraseRevealed },
+                        modifier = Modifier.size(24.dp),
+                    ) {
+                        Icon(
+                            imageVector =
+                                if (passphraseRevealed) {
+                                    Icons.Default.VisibilityOff
+                                } else {
+                                    Icons.Default.Visibility
+                                },
+                            contentDescription =
+                                if (passphraseRevealed) "Hide passphrase" else "Reveal passphrase",
+                            modifier = Modifier.size(14.dp),
+                            tint = MaterialTheme.colorScheme.onSurfaceVariant,
+                        )
+                    }
+                    IconButton(
+                        onClick = {
+                            clipboardManager.setText(AnnotatedString(passphrase))
+                            Toast
+                                .makeText(cardContext, "Passphrase copied", Toast.LENGTH_SHORT)
+                                .show()
+                        },
+                        modifier = Modifier.size(24.dp),
+                    ) {
+                        Icon(
+                            imageVector = Icons.Default.ContentCopy,
+                            contentDescription = "Copy passphrase",
                             modifier = Modifier.size(14.dp),
                             tint = MaterialTheme.colorScheme.onSurfaceVariant,
                         )

--- a/app/src/main/java/com/lxmf/messenger/ui/screens/DiscoveredInterfacesScreen.kt
+++ b/app/src/main/java/com/lxmf/messenger/ui/screens/DiscoveredInterfacesScreen.kt
@@ -98,7 +98,7 @@ private val MdiFont = FontFamily(Font(R.font.materialdesignicons))
 @Composable
 fun DiscoveredInterfacesScreen(
     onNavigateBack: () -> Unit,
-    onNavigateToTcpClientWizard: (host: String, port: Int, name: String) -> Unit = { _, _, _ -> },
+    onNavigateToTcpClientWizard: (host: String, port: Int, name: String, networkName: String?, passphrase: String?) -> Unit = { _, _, _, _, _ -> },
     onNavigateToMapWithInterface: (details: FocusInterfaceDetails) -> Unit = { _ -> },
     onNavigateToRNodeWizardWithParams: (
         frequency: Long?,
@@ -246,6 +246,8 @@ fun DiscoveredInterfacesScreen(
                                                 reachableHost,
                                                 iface.port ?: 4242,
                                                 iface.name,
+                                                iface.networkName ?: "",
+                                                iface.passphrase ?: "",
                                             )
                                         } else {
                                             Toast

--- a/app/src/main/java/com/lxmf/messenger/ui/screens/tcpclient/ReviewConfigureStep.kt
+++ b/app/src/main/java/com/lxmf/messenger/ui/screens/tcpclient/ReviewConfigureStep.kt
@@ -28,6 +28,7 @@ import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.text.input.KeyboardType
+import androidx.compose.ui.text.input.PasswordVisualTransformation
 import androidx.compose.ui.unit.dp
 import com.lxmf.messenger.viewmodel.TcpClientWizardViewModel
 
@@ -131,13 +132,15 @@ fun ReviewConfigureStep(viewModel: TcpClientWizardViewModel) {
 
         Spacer(Modifier.height(16.dp))
 
-        // IFAC Passphrase
+        // IFAC Passphrase — masked; shared network secret
         OutlinedTextField(
             value = state.passphrase,
             onValueChange = { viewModel.updatePassphrase(it) },
             label = { Text("IFAC Passphrase") },
             modifier = Modifier.fillMaxWidth(),
             singleLine = true,
+            visualTransformation = PasswordVisualTransformation(),
+            keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Password),
         )
 
         Spacer(Modifier.height(24.dp))

--- a/app/src/main/java/com/lxmf/messenger/ui/screens/tcpclient/ReviewConfigureStep.kt
+++ b/app/src/main/java/com/lxmf/messenger/ui/screens/tcpclient/ReviewConfigureStep.kt
@@ -118,6 +118,28 @@ fun ReviewConfigureStep(viewModel: TcpClientWizardViewModel) {
             keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Number),
         )
 
+        Spacer(Modifier.height(16.dp))
+
+        // IFAC Network Name
+        OutlinedTextField(
+            value = state.networkName,
+            onValueChange = { viewModel.updateNetworkName(it) },
+            label = { Text("IFAC Network Name") },
+            modifier = Modifier.fillMaxWidth(),
+            singleLine = true,
+        )
+
+        Spacer(Modifier.height(16.dp))
+
+        // IFAC Passphrase
+        OutlinedTextField(
+            value = state.passphrase,
+            onValueChange = { viewModel.updatePassphrase(it) },
+            label = { Text("IFAC Passphrase") },
+            modifier = Modifier.fillMaxWidth(),
+            singleLine = true,
+        )
+
         Spacer(Modifier.height(24.dp))
 
         // Bootstrap interface toggle (RNS 1.1.x feature)

--- a/app/src/main/java/com/lxmf/messenger/ui/screens/tcpclient/TcpClientWizardScreen.kt
+++ b/app/src/main/java/com/lxmf/messenger/ui/screens/tcpclient/TcpClientWizardScreen.kt
@@ -38,6 +38,8 @@ fun TcpClientWizardScreen(
     initialHost: String? = null,
     initialPort: Int? = null,
     initialName: String? = null,
+    initialNetworkName: String? = null,
+    initialPassphrase: String? = null,
     viewModel: TcpClientWizardViewModel = hiltViewModel(),
 ) {
     val state by viewModel.state.collectAsState()
@@ -51,6 +53,8 @@ fun TcpClientWizardScreen(
                 host = initialHost,
                 port = initialPort ?: 4242,
                 name = initialName ?: "TCP Connection",
+                networkName = initialNetworkName ?: "",
+                passphrase = initialPassphrase ?: "",
             )
         }
     }

--- a/app/src/main/java/com/lxmf/messenger/viewmodel/TcpClientWizardViewModel.kt
+++ b/app/src/main/java/com/lxmf/messenger/viewmodel/TcpClientWizardViewModel.kt
@@ -127,8 +127,8 @@ class TcpClientWizardViewModel
             host: String,
             port: Int,
             name: String,
-            networkName: String,
-            passphrase: String,
+            networkName: String = "",
+            passphrase: String = "",
         ) {
             // Check if this matches a community server
             val matchingServer =

--- a/app/src/main/java/com/lxmf/messenger/viewmodel/TcpClientWizardViewModel.kt
+++ b/app/src/main/java/com/lxmf/messenger/viewmodel/TcpClientWizardViewModel.kt
@@ -237,14 +237,14 @@ class TcpClientWizardViewModel
         }
 
         /**
-         * Update interface name field.
+         * Update IFAC network name field.
          */
         fun updateNetworkName(value: String) {
             _state.update { it.copy(networkName = value) }
         }
 
         /**
-         * Update interface name field.
+         * Update IFAC passphrase field.
          */
         fun updatePassphrase(value: String) {
             _state.update { it.copy(passphrase = value) }
@@ -358,8 +358,8 @@ class TcpClientWizardViewModel
                             enabled = true,
                             targetHost = currentState.targetHost.trim(),
                             targetPort = currentState.targetPort.toIntOrNull() ?: 4242,
-                            networkName = currentState.networkName,
-                            passphrase = currentState.passphrase,
+                            networkName = currentState.networkName.trim().ifEmpty { null },
+                            passphrase = currentState.passphrase.ifEmpty { null },
                             kissFraming = false,
                             mode = "full",
                             bootstrapOnly = currentState.bootstrapOnly,

--- a/app/src/main/java/com/lxmf/messenger/viewmodel/TcpClientWizardViewModel.kt
+++ b/app/src/main/java/com/lxmf/messenger/viewmodel/TcpClientWizardViewModel.kt
@@ -43,6 +43,8 @@ data class TcpClientWizardState(
     val interfaceName: String = "",
     val targetHost: String = "",
     val targetPort: String = "",
+    val networkName: String = "",
+    val passphrase: String = "",
     // RNS 1.1.x Bootstrap Interface option
     val bootstrapOnly: Boolean = false,
     // SOCKS5 proxy (Tor/Orbot) settings
@@ -102,6 +104,8 @@ class TcpClientWizardViewModel
                             interfaceName = config.name,
                             targetHost = config.targetHost,
                             targetPort = config.targetPort.toString(),
+                            networkName = config.networkName ?: "",
+                            passphrase = config.passphrase ?: "",
                             bootstrapOnly = config.bootstrapOnly,
                             socksProxyEnabled = config.socksProxyEnabled,
                             socksProxyHost = config.socksProxyHost,
@@ -123,6 +127,8 @@ class TcpClientWizardViewModel
             host: String,
             port: Int,
             name: String,
+            networkName: String,
+            passphrase: String,
         ) {
             // Check if this matches a community server
             val matchingServer =
@@ -138,6 +144,8 @@ class TcpClientWizardViewModel
                     interfaceName = name,
                     targetHost = host,
                     targetPort = port.toString(),
+                    networkName = networkName,
+                    passphrase = passphrase,
                     bootstrapOnly = matchingServer?.isBootstrap ?: false,
                     // Auto-enable SOCKS proxy for .onion addresses
                     socksProxyEnabled = isOnion,
@@ -226,6 +234,20 @@ class TcpClientWizardViewModel
          */
         fun updateTargetPort(value: String) {
             _state.update { it.copy(targetPort = value) }
+        }
+
+        /**
+         * Update interface name field.
+         */
+        fun updateNetworkName(value: String) {
+            _state.update { it.copy(networkName = value) }
+        }
+
+        /**
+         * Update interface name field.
+         */
+        fun updatePassphrase(value: String) {
+            _state.update { it.copy(passphrase = value) }
         }
 
         /**
@@ -336,6 +358,8 @@ class TcpClientWizardViewModel
                             enabled = true,
                             targetHost = currentState.targetHost.trim(),
                             targetPort = currentState.targetPort.toIntOrNull() ?: 4242,
+                            networkName = currentState.networkName,
+                            passphrase = currentState.passphrase,
                             kissFraming = false,
                             mode = "full",
                             bootstrapOnly = currentState.bootstrapOnly,

--- a/python/reticulum_wrapper.py
+++ b/python/reticulum_wrapper.py
@@ -7057,6 +7057,8 @@ class ReticulumWrapper:
                             'type': iface_info.get('type', 'Unknown'),
                             'transport_id': transport_id,
                             'network_id': network_id,
+                            'network_name': iface_info.get('ifac_netname'),
+                            'passphrase': iface_info.get('ifac_netkey'),
 
                             # Status information
                             'status': iface_info.get('status', 'unknown'),

--- a/reticulum/src/main/java/com/lxmf/messenger/reticulum/protocol/ReticulumProtocol.kt
+++ b/reticulum/src/main/java/com/lxmf/messenger/reticulum/protocol/ReticulumProtocol.kt
@@ -628,6 +628,9 @@ data class DiscoveredInterface(
     val latitude: Double?,
     val longitude: Double?,
     val height: Double?, // Altitude in meters
+    // IFAC fields
+    val networkName: String?, // IFAC network name
+    val passphrase: String?, // IFAC passphrase
 ) {
     /**
      * Returns true if this is a TCP-based interface.
@@ -671,6 +674,8 @@ data class DiscoveredInterface(
                 type = item.optString("type", "Unknown"),
                 transportId = item.optString("transport_id", "").ifEmpty { null },
                 networkId = item.optString("network_id", "").ifEmpty { null },
+                networkName = item.optString("network_name", "").ifEmpty { null },
+                passphrase = item.optString("passphrase", "").ifEmpty { null },
                 // Status information
                 status = item.optString("status", "unknown"),
                 statusCode = item.optInt("status_code", STATUS_UNKNOWN),

--- a/reticulum/src/main/java/com/lxmf/messenger/reticulum/protocol/ReticulumProtocol.kt
+++ b/reticulum/src/main/java/com/lxmf/messenger/reticulum/protocol/ReticulumProtocol.kt
@@ -628,9 +628,10 @@ data class DiscoveredInterface(
     val latitude: Double?,
     val longitude: Double?,
     val height: Double?, // Altitude in meters
-    // IFAC fields
-    val networkName: String?, // IFAC network name
-    val passphrase: String?, // IFAC passphrase
+    // IFAC fields (default null for backwards compatibility with existing test
+    // constructors that pre-date the IFAC discovery work in this PR)
+    val networkName: String? = null, // IFAC network name (broadcast by RNS when peer sets discovery_publish_ifac)
+    val passphrase: String? = null, // IFAC passphrase (broadcast alongside netname, per RNS/Discovery.py:159)
 ) {
     /**
      * Returns true if this is a TCP-based interface.


### PR DESCRIPTION
## Summary

Completes [#770](https://github.com/torlando-tech/columba/issues/770) end-to-end on the `release/v0.10.x` branch, building on K8's original work in #771.

When a peer running a Discoverable-mode TCP interface opts in to publishing its IFAC configuration (RNS's `discovery_publish_ifac = true`), Columba now:

1. **Captures the IFAC fields** — `reticulum_wrapper.get_discovered_interfaces()` passes both `ifac_netname` and `ifac_netkey` from the Python discovery dict through as `network_name` / `passphrase`.
2. **Surfaces them in Kotlin** — `DiscoveredInterface.networkName` / `.passphrase` are parsed from the Python JSON and threaded through the TCP-client-wizard navigation so both fields are pre-populated when a user taps Add on a discovered card.
3. **Displays them on the Discovered Interfaces list** — a compact `network: <name>` line and a `passphrase: ●●●●●●●●` line (masked by default, with a reveal toggle and copy icon) render beneath the transport ID on each card when the announce carried IFAC values. The passphrase reveal state is keyed on `transportId` so it doesn't leak across cards.

## Corrected: the passphrase *is* broadcast

An earlier version of this PR description claimed RNS never transmits `IFAC_NETKEY`. That's wrong, and K8 pointed it out. `RNS/Discovery.py:157-159` writes both `IFAC_NETNAME` and `IFAC_NETKEY` into the announce info dict whenever the publisher sets `discovery_publish_ifac = true`; the announce can optionally be encrypted via `discovery_encrypt` + a shared network identity so only authorized receivers can decrypt it. So the passphrase slot really does carry a value in normal operation, and this PR's UI renders it accordingly.

The root-cause fix for IFAC on autoconnected discovered interfaces (upstream `866e63f`) is pulled in via the RNS 1.1.9 bump in #845, which landed just before this rebase.

## Credits

- K8 — original PR #771 plumbing (Python passthrough, Kotlin model, TCP-client wizard prefill, navigation args), plus the upstream RNS IFAC autoconnect fix that makes the whole path work end-to-end.
- This PR adds the list-level display (both network name and passphrase-with-reveal) + copy affordances and rebases onto current `release/v0.10.x` (picks up #810, #742, and #845).

Closes #771.

## Test plan

- [x] `./gradlew :app:compileNoSentryDebugKotlin` — clean.
- [x] `./gradlew :app:compileNoSentryDebugUnitTestKotlin` — clean (fixed the constructor-compat break by defaulting new IFAC fields to `null`).
- [ ] Manual: pair two devices where one has a `Discoverable`-mode TCP interface with IFAC `network_name` + `passphrase` set and `discovery_publish_ifac = true`; confirm both values appear on the card, reveal/copy work, and tapping Add on the wizard pre-populates both fields.

—
_Posted by Claude (claude-opus-4-7) on behalf of @torlando-tech._