### PR TITLE
Move Transport Node toggle to a new Advanced settings card

### DIFF
--- a/app/src/androidTest/java/network/columba/app/ui/screens/settings/cards/AdvancedCardTest.kt
+++ b/app/src/androidTest/java/network/columba/app/ui/screens/settings/cards/AdvancedCardTest.kt
@@ -1,0 +1,73 @@
+package network.columba.app.ui.screens.settings.cards
+
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.junit4.createAndroidComposeRule
+import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.performClick
+import network.columba.app.test.TestHostActivity
+import org.junit.Assert.assertTrue
+import org.junit.Rule
+import org.junit.Test
+
+/**
+ * UI tests for AdvancedCard composable.
+ *
+ * Mirrors the unit-level AdvancedCardTest in src/test/. This instrumented variant
+ * exercises the card in a real Android runtime to catch issues the Robolectric
+ * unit tests might miss (real Compose layout, actual Material3 Switch behavior).
+ */
+class AdvancedCardTest {
+    @get:Rule
+    val composeTestRule = createAndroidComposeRule<TestHostActivity>()
+
+    @Test
+    fun advancedCard_displaysHeader() {
+        composeTestRule.setContent {
+            AdvancedCard(isExpanded = true, onExpandedChange = {})
+        }
+        composeTestRule.waitForIdle()
+        composeTestRule.onNodeWithText("Advanced").assertIsDisplayed()
+    }
+
+    @Test
+    fun transportNodeToggle_defaultEnabled() {
+        composeTestRule.setContent {
+            AdvancedCard(
+                isExpanded = true,
+                onExpandedChange = {},
+                transportNodeEnabled = true,
+            )
+        }
+        composeTestRule.waitForIdle()
+        composeTestRule.onNodeWithText("Transport Node").assertIsDisplayed()
+    }
+
+    @Test
+    fun transportNodeToggle_callsCallback_whenToggled() {
+        var toggledValue: Boolean? = null
+        composeTestRule.setContent {
+            AdvancedCard(
+                isExpanded = true,
+                onExpandedChange = {},
+                transportNodeEnabled = true,
+                onTransportNodeToggle = { toggledValue = it },
+            )
+        }
+        composeTestRule.waitForIdle()
+        composeTestRule.onNodeWithText("Transport Node").performClick()
+        assertTrue("Toggle callback should be called", toggledValue != null)
+    }
+
+    @Test
+    fun transportNodeToggle_showsDisabledState() {
+        composeTestRule.setContent {
+            AdvancedCard(
+                isExpanded = true,
+                onExpandedChange = {},
+                transportNodeEnabled = false,
+            )
+        }
+        composeTestRule.waitForIdle()
+        composeTestRule.onNodeWithText("Transport Node").assertIsDisplayed()
+    }
+}

--- a/app/src/androidTest/java/network/columba/app/ui/screens/settings/cards/NetworkCardTest.kt
+++ b/app/src/androidTest/java/network/columba/app/ui/screens/settings/cards/NetworkCardTest.kt
@@ -81,70 +81,8 @@ class NetworkCardTest {
             ).assertIsDisplayed()
     }
 
-    // ========== Transport Node Toggle Tests ==========
-
-    @Test
-    fun transportNodeToggle_defaultEnabled() {
-        // When
-        composeTestRule.setContent {
-            NetworkCard(
-                isExpanded = true,
-                onExpandedChange = {},
-                onViewStatus = {},
-                onManageInterfaces = {},
-                transportNodeEnabled = true,
-            )
-        }
-        composeTestRule.waitForIdle()
-
-        // Then
-        composeTestRule.onNodeWithText("Transport Node").assertIsDisplayed()
-        // Switch should be checked when enabled
-    }
-
-    @Test
-    fun transportNodeToggle_displaysDescription() {
-        // When
-        composeTestRule.setContent {
-            NetworkCard(
-                isExpanded = true,
-                onExpandedChange = {},
-                onViewStatus = {},
-                onManageInterfaces = {},
-            )
-        }
-        composeTestRule.waitForIdle()
-
-        // Then
-        composeTestRule
-            .onNodeWithText(
-                "Forward traffic for the mesh network. When disabled, this device will only handle its own traffic and won't relay messages for other peers.",
-            ).assertIsDisplayed()
-    }
-
-    @Test
-    fun transportNodeToggle_callsCallback_whenToggled() {
-        // Given
-        var toggledValue: Boolean? = null
-        composeTestRule.setContent {
-            NetworkCard(
-                isExpanded = true,
-                onExpandedChange = {},
-                onViewStatus = {},
-                onManageInterfaces = {},
-                transportNodeEnabled = true,
-                onTransportNodeToggle = { toggledValue = it },
-            )
-        }
-        composeTestRule.waitForIdle()
-
-        // When - Click on the Transport Node row to toggle
-        composeTestRule.onNodeWithText("Transport Node").performClick()
-
-        // Then - Callback should be invoked
-        // Note: The exact value depends on Switch behavior; we verify callback was called
-        assertTrue("Toggle callback should be called", toggledValue != null)
-    }
+    // Transport Node tests moved to AdvancedCardTest (androidTest). The toggle now
+    // lives on the Advanced settings card between RNode Flasher and About.
 
     // ========== Button Tests ==========
 
@@ -323,44 +261,6 @@ class NetworkCardTest {
         composeTestRule.onNodeWithText("View Network Status").assertIsEnabled()
     }
 
-    // ========== Transport Node State Tests ==========
-
-    @Test
-    fun transportNodeToggle_showsEnabledState() {
-        // When
-        composeTestRule.setContent {
-            NetworkCard(
-                isExpanded = true,
-                onExpandedChange = {},
-                onViewStatus = {},
-                onManageInterfaces = {},
-                transportNodeEnabled = true,
-            )
-        }
-        composeTestRule.waitForIdle()
-
-        // Then - Transport Node label should be visible
-        composeTestRule.onNodeWithText("Transport Node").assertIsDisplayed()
-    }
-
-    @Test
-    fun transportNodeToggle_showsDisabledState() {
-        // When
-        composeTestRule.setContent {
-            NetworkCard(
-                isExpanded = true,
-                onExpandedChange = {},
-                onViewStatus = {},
-                onManageInterfaces = {},
-                transportNodeEnabled = false,
-            )
-        }
-        composeTestRule.waitForIdle()
-
-        // Then - Transport Node label should still be visible
-        composeTestRule.onNodeWithText("Transport Node").assertIsDisplayed()
-    }
-
     @Test
     fun networkCard_withAllDefaultValues_displaysCorrectly() {
         // When - Use all defaults
@@ -374,9 +274,9 @@ class NetworkCardTest {
         }
         composeTestRule.waitForIdle()
 
-        // Then - All key elements should be displayed
+        // Then - All key elements should be displayed (Transport Node is no longer
+        // on this card — see AdvancedCardTest).
         composeTestRule.onNodeWithText("Network").assertIsDisplayed()
-        composeTestRule.onNodeWithText("Transport Node").assertIsDisplayed()
         composeTestRule.onNodeWithText("View Network Status").assertIsDisplayed()
         composeTestRule.onNodeWithText("Manage Interfaces").assertIsDisplayed()
     }

--- a/app/src/main/java/network/columba/app/ui/screens/SettingsScreen.kt
+++ b/app/src/main/java/network/columba/app/ui/screens/SettingsScreen.kt
@@ -49,10 +49,12 @@ import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.LifecycleEventObserver
 import androidx.lifecycle.compose.LocalLifecycleOwner
+import kotlinx.coroutines.launch
 import network.columba.app.ui.components.BackgroundLocationPermissionBottomSheet
 import network.columba.app.ui.components.LocationPermissionBottomSheet
 import network.columba.app.ui.components.ServiceRestartBanner
 import network.columba.app.ui.screens.settings.cards.AboutCard
+import network.columba.app.ui.screens.settings.cards.AdvancedCard
 import network.columba.app.ui.screens.settings.cards.AutoAnnounceCard
 import network.columba.app.ui.screens.settings.cards.BatteryOptimizationCard
 import network.columba.app.ui.screens.settings.cards.DataMigrationCard
@@ -81,7 +83,6 @@ import network.columba.app.viewmodel.BlockedUsersViewModel
 import network.columba.app.viewmodel.DebugViewModel
 import network.columba.app.viewmodel.SettingsCardId
 import network.columba.app.viewmodel.SettingsViewModel
-import kotlinx.coroutines.launch
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
@@ -266,8 +267,6 @@ fun SettingsScreen(
                     onManageInterfaces = onNavigateToInterfaces,
                     isSharedInstance = state.isSharedInstance,
                     sharedInstanceOnline = state.sharedInstanceOnline,
-                    transportNodeEnabled = state.transportNodeEnabled,
-                    onTransportNodeToggle = { viewModel.setTransportNodeEnabled(it) },
                 )
 
                 IdentityCard(
@@ -503,6 +502,13 @@ fun SettingsScreen(
                     isExpanded = state.cardExpansionStates[SettingsCardId.RNODE_FLASHER.name] ?: false,
                     onExpandedChange = { viewModel.toggleCardExpanded(SettingsCardId.RNODE_FLASHER, it) },
                     onOpenFlasher = onNavigateToFlasher,
+                )
+
+                AdvancedCard(
+                    isExpanded = state.cardExpansionStates[SettingsCardId.ADVANCED.name] ?: false,
+                    onExpandedChange = { viewModel.toggleCardExpanded(SettingsCardId.ADVANCED, it) },
+                    transportNodeEnabled = state.transportNodeEnabled,
+                    onTransportNodeToggle = { viewModel.setTransportNodeEnabled(it) },
                 )
 
                 // About section

--- a/app/src/main/java/network/columba/app/ui/screens/settings/cards/AdvancedCard.kt
+++ b/app/src/main/java/network/columba/app/ui/screens/settings/cards/AdvancedCard.kt
@@ -40,14 +40,6 @@ fun AdvancedCard(
         isExpanded = isExpanded,
         onExpandedChange = onExpandedChange,
     ) {
-        Text(
-            text =
-                "Power-user toggles. Leave these at their defaults unless you know what each " +
-                    "one does — changes here can affect how this device participates in the mesh.",
-            style = MaterialTheme.typography.bodyMedium,
-            color = MaterialTheme.colorScheme.onSurfaceVariant,
-        )
-
         // Transport Node toggle
         Row(
             modifier = Modifier.fillMaxWidth(),
@@ -77,7 +69,12 @@ fun AdvancedCard(
         Text(
             text =
                 "Forward traffic for the mesh network. When disabled, this device will only " +
-                    "handle its own traffic and won't relay messages for other peers.",
+                    "handle its own traffic and won't relay messages for other peers. " +
+                    "It's generally not recommended for mobile devices to be transport nodes. " +
+                    "They are less likely to maintain a fixed position in the network, and thus " +
+                    "can negatively impact multihop routing. Enabling this will increase data " +
+                    "usage and battery drain. However, in a BLE-only mesh, it's required for " +
+                    "multi-hop messaging.",
             style = MaterialTheme.typography.bodySmall,
             color = MaterialTheme.colorScheme.onSurfaceVariant,
         )

--- a/app/src/main/java/network/columba/app/ui/screens/settings/cards/AdvancedCard.kt
+++ b/app/src/main/java/network/columba/app/ui/screens/settings/cards/AdvancedCard.kt
@@ -1,0 +1,85 @@
+package network.columba.app.ui.screens.settings.cards
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Hub
+import androidx.compose.material.icons.filled.Tune
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Switch
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import network.columba.app.ui.components.CollapsibleSettingsCard
+
+/**
+ * Advanced settings card — houses power-user toggles and options that most users should
+ * leave alone. Sits between the RNode Flasher and About cards so it's findable but
+ * out of the way.
+ *
+ * @param isExpanded Whether the card is currently expanded
+ * @param onExpandedChange Callback when expansion state changes
+ * @param transportNodeEnabled Whether transport node mode is enabled (forwards mesh traffic)
+ * @param onTransportNodeToggle Callback when transport node toggle is changed
+ */
+@Composable
+fun AdvancedCard(
+    isExpanded: Boolean,
+    onExpandedChange: (Boolean) -> Unit,
+    transportNodeEnabled: Boolean = true,
+    onTransportNodeToggle: (Boolean) -> Unit = {},
+) {
+    CollapsibleSettingsCard(
+        title = "Advanced",
+        icon = Icons.Default.Tune,
+        isExpanded = isExpanded,
+        onExpandedChange = onExpandedChange,
+    ) {
+        Text(
+            text =
+                "Power-user toggles. Leave these at their defaults unless you know what each " +
+                    "one does — changes here can affect how this device participates in the mesh.",
+            style = MaterialTheme.typography.bodyMedium,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+        )
+
+        // Transport Node toggle
+        Row(
+            modifier = Modifier.fillMaxWidth(),
+            verticalAlignment = Alignment.CenterVertically,
+            horizontalArrangement = Arrangement.SpaceBetween,
+        ) {
+            Row(
+                verticalAlignment = Alignment.CenterVertically,
+                horizontalArrangement = Arrangement.spacedBy(8.dp),
+            ) {
+                Icon(
+                    imageVector = Icons.Default.Hub,
+                    contentDescription = null,
+                    tint = MaterialTheme.colorScheme.primary,
+                )
+                Text(
+                    text = "Transport Node",
+                    style = MaterialTheme.typography.bodyLarge,
+                    fontWeight = FontWeight.Medium,
+                )
+            }
+            Switch(
+                checked = transportNodeEnabled,
+                onCheckedChange = onTransportNodeToggle,
+            )
+        }
+        Text(
+            text =
+                "Forward traffic for the mesh network. When disabled, this device will only " +
+                    "handle its own traffic and won't relay messages for other peers.",
+            style = MaterialTheme.typography.bodySmall,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+        )
+    }
+}

--- a/app/src/main/java/network/columba/app/ui/screens/settings/cards/NetworkCard.kt
+++ b/app/src/main/java/network/columba/app/ui/screens/settings/cards/NetworkCard.kt
@@ -1,29 +1,21 @@
 package network.columba.app.ui.screens.settings.cards
 
-import androidx.compose.foundation.layout.Arrangement
-import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
 import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.filled.Hub
 import androidx.compose.material.icons.filled.Info
 import androidx.compose.material.icons.filled.Sensors
 import androidx.compose.material.icons.filled.Settings
 import androidx.compose.material3.Button
 import androidx.compose.material3.ButtonDefaults
-import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.OutlinedButton
-import androidx.compose.material3.Switch
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
-import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import network.columba.app.ui.components.CollapsibleSettingsCard
 
@@ -39,8 +31,6 @@ import network.columba.app.ui.components.CollapsibleSettingsCard
  * @param sharedInstanceOnline Whether the shared instance is currently reachable.
  *                             When false and isSharedInstance is true, Columba has
  *                             switched to its own instance and interfaces can be managed.
- * @param transportNodeEnabled Whether transport node mode is enabled (forwards mesh traffic)
- * @param onTransportNodeToggle Callback when transport node toggle is changed
  */
 @Composable
 fun NetworkCard(
@@ -50,8 +40,6 @@ fun NetworkCard(
     onManageInterfaces: () -> Unit,
     isSharedInstance: Boolean = false,
     sharedInstanceOnline: Boolean = true,
-    transportNodeEnabled: Boolean = true,
-    onTransportNodeToggle: (Boolean) -> Unit = {},
 ) {
     // Interface management is only disabled when actively using a shared instance
     // If shared instance went offline, we're now using our own instance
@@ -85,45 +73,6 @@ fun NetworkCard(
                 } else {
                     MaterialTheme.colorScheme.onSurfaceVariant
                 },
-        )
-
-        // Transport Node toggle row
-        Row(
-            modifier = Modifier.fillMaxWidth(),
-            verticalAlignment = Alignment.CenterVertically,
-            horizontalArrangement = Arrangement.SpaceBetween,
-        ) {
-            Row(
-                verticalAlignment = Alignment.CenterVertically,
-                horizontalArrangement = Arrangement.spacedBy(8.dp),
-            ) {
-                Icon(
-                    imageVector = Icons.Default.Hub,
-                    contentDescription = null,
-                    tint = MaterialTheme.colorScheme.primary,
-                )
-                Text(
-                    text = "Transport Node",
-                    style = MaterialTheme.typography.bodyLarge,
-                    fontWeight = FontWeight.Medium,
-                )
-            }
-            Switch(
-                checked = transportNodeEnabled,
-                onCheckedChange = onTransportNodeToggle,
-            )
-        }
-        Text(
-            text =
-                "Forward traffic for the mesh network. When disabled, this device will only " +
-                    "handle its own traffic and won't relay messages for other peers.",
-            style = MaterialTheme.typography.bodySmall,
-            color = MaterialTheme.colorScheme.onSurfaceVariant,
-        )
-
-        HorizontalDivider(
-            modifier = Modifier.padding(vertical = 4.dp),
-            color = MaterialTheme.colorScheme.outlineVariant,
         )
 
         // Primary action - View Network Status (always enabled)

--- a/app/src/main/java/network/columba/app/viewmodel/SettingsViewModel.kt
+++ b/app/src/main/java/network/columba/app/viewmodel/SettingsViewModel.kt
@@ -57,6 +57,7 @@ enum class SettingsCardId {
     DATA_MIGRATION,
     RNODE_FLASHER,
     SHARE_COLUMBA,
+    ADVANCED,
     ABOUT,
     SHARED_INSTANCE_BANNER,
 }

--- a/app/src/test/java/network/columba/app/ui/screens/settings/cards/AdvancedCardTest.kt
+++ b/app/src/test/java/network/columba/app/ui/screens/settings/cards/AdvancedCardTest.kt
@@ -62,7 +62,13 @@ class AdvancedCardTest {
         }
         composeTestRule
             .onNodeWithText(
-                "Forward traffic for the mesh network. When disabled, this device will only handle its own traffic and won't relay messages for other peers.",
+                "Forward traffic for the mesh network. When disabled, this device will only " +
+                    "handle its own traffic and won't relay messages for other peers. " +
+                    "It's generally not recommended for mobile devices to be transport nodes. " +
+                    "They are less likely to maintain a fixed position in the network, and thus " +
+                    "can negatively impact multihop routing. Enabling this will increase data " +
+                    "usage and battery drain. However, in a BLE-only mesh, it's required for " +
+                    "multi-hop messaging.",
             ).assertIsDisplayed()
     }
 

--- a/app/src/test/java/network/columba/app/ui/screens/settings/cards/AdvancedCardTest.kt
+++ b/app/src/test/java/network/columba/app/ui/screens/settings/cards/AdvancedCardTest.kt
@@ -1,0 +1,137 @@
+package network.columba.app.ui.screens.settings.cards
+
+import android.app.Application
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.assertIsOff
+import androidx.compose.ui.test.assertIsOn
+import androidx.compose.ui.test.isToggleable
+import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.performClick
+import network.columba.app.test.RegisterComponentActivityRule
+import org.junit.Assert.assertEquals
+import org.junit.Rule
+import org.junit.Test
+import org.junit.rules.RuleChain
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+
+/**
+ * Unit tests for AdvancedCard composable using Robolectric.
+ *
+ * Tests the Transport Node toggle that was relocated here from NetworkCard — the
+ * card lives between RNode Flasher and About on the Settings page so it's out of
+ * the way for typical users but findable for power users.
+ */
+@RunWith(RobolectricTestRunner::class)
+@Config(sdk = [34], application = Application::class)
+class AdvancedCardTest {
+    private val registerActivityRule = RegisterComponentActivityRule()
+    private val composeRule = createComposeRule()
+
+    @get:Rule
+    val ruleChain: RuleChain = RuleChain.outerRule(registerActivityRule).around(composeRule)
+
+    val composeTestRule get() = composeRule
+
+    // ========== Header and Content Tests ==========
+
+    @Test
+    fun advancedCard_displaysHeader() {
+        composeTestRule.setContent {
+            AdvancedCard(isExpanded = true, onExpandedChange = {})
+        }
+        composeTestRule.onNodeWithText("Advanced").assertIsDisplayed()
+    }
+
+    // ========== Transport Node Toggle Tests ==========
+
+    @Test
+    fun transportNodeToggle_displaysLabel() {
+        composeTestRule.setContent {
+            AdvancedCard(isExpanded = true, onExpandedChange = {})
+        }
+        composeTestRule.onNodeWithText("Transport Node").assertIsDisplayed()
+    }
+
+    @Test
+    fun transportNodeToggle_displaysDescription() {
+        composeTestRule.setContent {
+            AdvancedCard(isExpanded = true, onExpandedChange = {})
+        }
+        composeTestRule
+            .onNodeWithText(
+                "Forward traffic for the mesh network. When disabled, this device will only handle its own traffic and won't relay messages for other peers.",
+            ).assertIsDisplayed()
+    }
+
+    @Test
+    fun transportNodeToggle_isOn_whenEnabled() {
+        composeTestRule.setContent {
+            AdvancedCard(
+                isExpanded = true,
+                onExpandedChange = {},
+                transportNodeEnabled = true,
+            )
+        }
+        composeTestRule.onNode(isToggleable()).assertIsOn()
+    }
+
+    @Test
+    fun transportNodeToggle_isOff_whenDisabled() {
+        composeTestRule.setContent {
+            AdvancedCard(
+                isExpanded = true,
+                onExpandedChange = {},
+                transportNodeEnabled = false,
+            )
+        }
+        composeTestRule.onNode(isToggleable()).assertIsOff()
+    }
+
+    @Test
+    fun transportNodeToggle_callsCallback_withFalse_whenTurningOff() {
+        var receivedValue: Boolean? = null
+        composeTestRule.setContent {
+            AdvancedCard(
+                isExpanded = true,
+                onExpandedChange = {},
+                transportNodeEnabled = true,
+                onTransportNodeToggle = { receivedValue = it },
+            )
+        }
+        composeTestRule.onNode(isToggleable()).performClick()
+        assertEquals(false, receivedValue)
+    }
+
+    @Test
+    fun transportNodeToggle_callsCallback_withTrue_whenTurningOn() {
+        var receivedValue: Boolean? = null
+        composeTestRule.setContent {
+            AdvancedCard(
+                isExpanded = true,
+                onExpandedChange = {},
+                transportNodeEnabled = false,
+                onTransportNodeToggle = { receivedValue = it },
+            )
+        }
+        composeTestRule.onNode(isToggleable()).performClick()
+        assertEquals(true, receivedValue)
+    }
+
+    @Test
+    fun transportNodeToggle_callbackCalledOnce() {
+        var callCount = 0
+        composeTestRule.setContent {
+            AdvancedCard(
+                isExpanded = true,
+                onExpandedChange = {},
+                transportNodeEnabled = true,
+                onTransportNodeToggle = { callCount++ },
+            )
+        }
+        composeTestRule.onNode(isToggleable()).performClick()
+        assertEquals("Callback should be called exactly once", 1, callCount)
+    }
+}

--- a/app/src/test/java/network/columba/app/ui/screens/settings/cards/NetworkCardTest.kt
+++ b/app/src/test/java/network/columba/app/ui/screens/settings/cards/NetworkCardTest.kt
@@ -4,9 +4,6 @@ import android.app.Application
 import androidx.compose.ui.test.assertIsDisplayed
 import androidx.compose.ui.test.assertIsEnabled
 import androidx.compose.ui.test.assertIsNotEnabled
-import androidx.compose.ui.test.assertIsOff
-import androidx.compose.ui.test.assertIsOn
-import androidx.compose.ui.test.isToggleable
 import androidx.compose.ui.test.junit4.createComposeRule
 import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.performClick
@@ -66,9 +63,10 @@ class NetworkCardTest {
         }
 
         // Then
-        composeTestRule.onNodeWithText(
-            "Monitor your Reticulum network status, active interfaces, BLE connections, and connection diagnostics.",
-        ).assertIsDisplayed()
+        composeTestRule
+            .onNodeWithText(
+                "Monitor your Reticulum network status, active interfaces, BLE connections, and connection diagnostics.",
+            ).assertIsDisplayed()
     }
 
     @Test
@@ -85,125 +83,15 @@ class NetworkCardTest {
         }
 
         // Then
-        composeTestRule.onNodeWithText(
-            "Configure how your device connects to the Reticulum network. " +
-                "Add TCP connections, auto-discovery, LoRa (via RNode), or BLE interfaces.",
-        ).assertIsDisplayed()
+        composeTestRule
+            .onNodeWithText(
+                "Configure how your device connects to the Reticulum network. " +
+                    "Add TCP connections, auto-discovery, LoRa (via RNode), or BLE interfaces.",
+            ).assertIsDisplayed()
     }
 
-    // ========== Transport Node Toggle Tests ==========
-
-    @Test
-    fun transportNodeToggle_displaysLabel() {
-        // When
-        composeTestRule.setContent {
-            NetworkCard(
-                isExpanded = true,
-                onExpandedChange = {},
-                onViewStatus = {},
-                onManageInterfaces = {},
-            )
-        }
-
-        // Then
-        composeTestRule.onNodeWithText("Transport Node").assertIsDisplayed()
-    }
-
-    @Test
-    fun transportNodeToggle_displaysDescription() {
-        // When
-        composeTestRule.setContent {
-            NetworkCard(
-                isExpanded = true,
-                onExpandedChange = {},
-                onViewStatus = {},
-                onManageInterfaces = {},
-            )
-        }
-
-        // Then
-        composeTestRule.onNodeWithText(
-            "Forward traffic for the mesh network. When disabled, this device will only handle its own traffic and won't relay messages for other peers.",
-        ).assertIsDisplayed()
-    }
-
-    @Test
-    fun transportNodeToggle_isOn_whenEnabled() {
-        // When
-        composeTestRule.setContent {
-            NetworkCard(
-                isExpanded = true,
-                onExpandedChange = {},
-                onViewStatus = {},
-                onManageInterfaces = {},
-                transportNodeEnabled = true,
-            )
-        }
-
-        // Then - Switch should be checked
-        composeTestRule.onNode(isToggleable()).assertIsOn()
-    }
-
-    @Test
-    fun transportNodeToggle_isOff_whenDisabled() {
-        // When
-        composeTestRule.setContent {
-            NetworkCard(
-                isExpanded = true,
-                onExpandedChange = {},
-                onViewStatus = {},
-                onManageInterfaces = {},
-                transportNodeEnabled = false,
-            )
-        }
-
-        // Then - Switch should be unchecked
-        composeTestRule.onNode(isToggleable()).assertIsOff()
-    }
-
-    @Test
-    fun transportNodeToggle_callsCallback_withFalse_whenTurningOff() {
-        // Given
-        var receivedValue: Boolean? = null
-        composeTestRule.setContent {
-            NetworkCard(
-                isExpanded = true,
-                onExpandedChange = {},
-                onViewStatus = {},
-                onManageInterfaces = {},
-                transportNodeEnabled = true,
-                onTransportNodeToggle = { receivedValue = it },
-            )
-        }
-
-        // When - Click the switch to turn it off
-        composeTestRule.onNode(isToggleable()).performClick()
-
-        // Then - Callback should receive false
-        assertEquals(false, receivedValue)
-    }
-
-    @Test
-    fun transportNodeToggle_callsCallback_withTrue_whenTurningOn() {
-        // Given
-        var receivedValue: Boolean? = null
-        composeTestRule.setContent {
-            NetworkCard(
-                isExpanded = true,
-                onExpandedChange = {},
-                onViewStatus = {},
-                onManageInterfaces = {},
-                transportNodeEnabled = false,
-                onTransportNodeToggle = { receivedValue = it },
-            )
-        }
-
-        // When - Click the switch to turn it on
-        composeTestRule.onNode(isToggleable()).performClick()
-
-        // Then - Callback should receive true
-        assertEquals(true, receivedValue)
-    }
+    // Transport Node toggle tests moved to AdvancedCardTest — the toggle now lives
+    // on the Advanced settings card between RNode Flasher and About.
 
     // ========== View Network Status Button Tests ==========
 
@@ -385,9 +273,10 @@ class NetworkCardTest {
         }
 
         // Then - Should display disabled message
-        composeTestRule.onNodeWithText(
-            "Interface management is disabled while using a shared system instance.",
-        ).assertIsDisplayed()
+        composeTestRule
+            .onNodeWithText(
+                "Interface management is disabled while using a shared system instance.",
+            ).assertIsDisplayed()
     }
 
     @Test
@@ -405,10 +294,11 @@ class NetworkCardTest {
         }
 
         // Then - Should display normal interface description
-        composeTestRule.onNodeWithText(
-            "Configure how your device connects to the Reticulum network. " +
-                "Add TCP connections, auto-discovery, LoRa (via RNode), or BLE interfaces.",
-        ).assertIsDisplayed()
+        composeTestRule
+            .onNodeWithText(
+                "Configure how your device connects to the Reticulum network. " +
+                    "Add TCP connections, auto-discovery, LoRa (via RNode), or BLE interfaces.",
+            ).assertIsDisplayed()
     }
 
     @Test
@@ -447,28 +337,11 @@ class NetworkCardTest {
             )
         }
 
-        // Then - All key elements should be displayed
+        // Then - All key elements should be displayed (Transport Node was moved
+        // to AdvancedCard and its assertion lives in AdvancedCardTest now).
         composeTestRule.onNodeWithText("Network").assertIsDisplayed()
-        composeTestRule.onNodeWithText("Transport Node").assertIsDisplayed()
         composeTestRule.onNodeWithText("View Network Status").assertIsDisplayed()
         composeTestRule.onNodeWithText("Manage Interfaces").assertIsDisplayed()
-    }
-
-    @Test
-    fun networkCard_defaultTransportNodeEnabled_isTrue() {
-        // When - Default value
-        composeTestRule.setContent {
-            NetworkCard(
-                isExpanded = true,
-                onExpandedChange = {},
-                onViewStatus = {},
-                onManageInterfaces = {},
-                // transportNodeEnabled defaults to true
-            )
-        }
-
-        // Then - Switch should be on by default
-        composeTestRule.onNode(isToggleable()).assertIsOn()
     }
 
     // ========== Callback Invocation Count Tests ==========
@@ -511,27 +384,5 @@ class NetworkCardTest {
 
         // Then
         assertEquals("Callback should be called exactly once", 1, clickCount)
-    }
-
-    @Test
-    fun transportNodeToggle_callbackCalledOnce() {
-        // Given
-        var callCount = 0
-        composeTestRule.setContent {
-            NetworkCard(
-                isExpanded = true,
-                onExpandedChange = {},
-                onViewStatus = {},
-                onManageInterfaces = {},
-                transportNodeEnabled = true,
-                onTransportNodeToggle = { callCount++ },
-            )
-        }
-
-        // When
-        composeTestRule.onNode(isToggleable()).performClick()
-
-        // Then
-        assertEquals("Callback should be called exactly once", 1, callCount)
     }
 }


### PR DESCRIPTION
## Summary

The **Transport Node** toggle was nestled inside the Network card, which conflated "here's how to configure interfaces" with a power-user decision about whether this device relays mesh traffic for other peers. Users who just wanted to add a TCP interface got prompted to consider a routing decision they probably shouldn't touch.

Moves the toggle to a new dedicated **Advanced** settings card between **RNode Flasher** and **About** — findable for power users, out of the way for everyone else. Same wiring (`SettingsViewModel.transportNodeEnabled` / `setTransportNodeEnabled`), so behavior and persisted state are unchanged.

## Changes

- Added `SettingsCardId.ADVANCED` between `SHARE_COLUMBA` and `ABOUT` in the enum.
- Created `AdvancedCard` composable mirroring the layout pattern of the other settings cards, with the Transport Node toggle and description moved verbatim.
- Removed the Transport Node row + associated props (`transportNodeEnabled`, `onTransportNodeToggle`) from `NetworkCard`. It now only concerns Network Status and Manage Interfaces.
- Moved the 7 transport-node unit tests from `NetworkCardTest` to a new `AdvancedCardTest`. Adjusted the Network-card default-values test to drop its Transport Node assertion.
- Wired `AdvancedCard` into `SettingsScreen` between `RNodeFlasherCard` and `AboutCard` with the same viewModel state/callbacks.

## Visual

Settings page card order now reads: Network → Identity → Privacy → Notifications → ... → Share Columba → RNode Flasher → **Advanced** → About.

## Test plan

- [x] `./gradlew :app:testNoSentryDebugUnitTest --tests '*.settings.cards.AdvancedCardTest' --tests '*.settings.cards.NetworkCardTest'` — all green.
- [ ] CI passes on the broader test matrix.
- [ ] Manual: open Settings, confirm Transport Node is no longer visible inside Network and is present in the new Advanced card just above About.

—
_Posted by Claude (claude-opus-4-7) on behalf of @torlando-tech._