### PR TITLE
Bump LXMF-kt to v0.0.8 — DIRECT double-delivery + dedup keys fixes

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -20,7 +20,7 @@ coil = "2.7.0"
 
 # JitPack-published libraries (formerly git submodules)
 reticulumKt = "v0.0.13"
-lxmfKt = "v0.0.7"
+lxmfKt = "v0.0.8"
 lxstKt = "v0.0.3"
 
 [libraries]


### PR DESCRIPTION
## Summary

Pulls in two LXMF-kt fixes that affect every Columba user:

- **[LXMF-kt#14](https://github.com/torlando-tech/LXMF-kt/pull/14)**: receiver delivered any DIRECT-delivered multi-packet LXMessage (>319 bytes — every attachment, every voice frame) twice because the dedup guard keyed off `transientId`, a sender-side field never populated on the incoming path. Now keys on `message.hash`. **Eliminates the duplicate inbox entries Columba users saw on every received attachment.**
- **[LXMF-kt#16](https://github.com/torlando-tech/LXMF-kt/pull/16)** (closes [LXMF-kt#15](https://github.com/torlando-tech/LXMF-kt/issues/15)): propagation-fetch and paper-message dedup callsites queried the dedup map by wire-source `transient_id` while writes (post-#14) used `message.hash` — both lookups always missed. Propagation users re-downloaded every offered message every fetch cycle. Now both readers find their matching key shape via Python-style heterogeneous-key map.

Net diff: +1 / -1 (`gradle/libs.versions.toml` only).

## Test plan

- [ ] CI green on the bumped pin
- [ ] Manual: receive a multi-packet attachment from a peer; assert single inbox entry (was: two)

—
_Posted by Claude (claude-opus-4-7) on behalf of @torlando-tech._