### PR TITLE
Bump reticulum-kt v0.0.14 + LXMF-kt v0.0.9 — multi-hop link race fixes + version alignment

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -19,7 +19,7 @@ serialization = "1.10.0"
 coil = "2.7.0"
 
 # JitPack-published libraries (formerly git submodules)
-reticulumKt = "v0.0.13"
+reticulumKt = "v0.0.14"
 lxmfKt = "v0.0.8"
 lxstKt = "v0.0.3"
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -20,7 +20,7 @@ coil = "2.7.0"
 
 # JitPack-published libraries (formerly git submodules)
 reticulumKt = "v0.0.14"
-lxmfKt = "v0.0.8"
+lxmfKt = "v0.0.9"
 lxstKt = "v0.0.3"
 
 [libraries]


### PR DESCRIPTION
## Summary

Two coordinated dep bumps that ship the multi-hop link race fix to Columba users:

### reticulumKt: v0.0.13 → v0.0.14

Pulls in critical Kotlin-side fixes that affect every Columba user of LXMF over a multi-hop topology (the standard phone ← rnsd hub ← phone path):

- **reticulum-kt[#52](https://github.com/torlando-tech/reticulum-kt/pull/52)** ([#46](https://github.com/torlando-tech/reticulum-kt/issues/46)): TCPServerInterface fan-out removed — closes cached-announce overwrite, path-request leakage to uninvolved peers, and the announce-mode-filter bypass that affected anyone running phone-as-transport.
- **reticulum-kt[#53](https://github.com/torlando-tech/reticulum-kt/pull/53) + [#54](https://github.com/torlando-tech/reticulum-kt/pull/54) + [#59](https://github.com/torlando-tech/reticulum-kt/pull/59)** ([#42](https://github.com/torlando-tech/reticulum-kt/issues/42), [#56](https://github.com/torlando-tech/reticulum-kt/issues/56)): complete multi-hop link race chain (sender, receiver, daemon-thread linkEstablished). **Verified zero flakes across 280 multihop conformance tests**; baseline pre-fix was 60% per-suite flake rate.

Plus reticulum-kt#50 (path expiry on link establishment failure for endpoint nodes) and #51 (BLEInterface incoming-handshake storm + blacklist race), both directly affecting Columba's mobile-radio code paths.

### lxmfKt: v0.0.8 → v0.0.9

Pure dep-alignment release on the LXMF-kt side — bumps its transitive rns-core/-interfaces/-test pins from v0.0.3 → v0.0.14 ([LXMF-kt#17](https://github.com/torlando-tech/LXMF-kt/pull/17)). No production-code changes between v0.0.8 and v0.0.9.

Without this, Gradle's highest-version-wins would resolve LXMF-kt's stale transitive `rns-core:v0.0.3` to Columba's direct `rns-core:v0.0.14` anyway. Bumping LXMF-kt's advertised metadata to match keeps the artifact graph consistent and lets LXMF-kt's own CI test against the same Reticulum bytecode users actually run.

### lxstKt: unchanged

LXST-kt has no reticulum-kt dependency — verified, zero `import network.reticulum.*` in the LXST-kt codebase. It's a pure audio/DSP library with a `NetworkTransport` interface that Columba wires up itself. No bump needed.

## User-visible

Messages on a fresh Link to a peer reachable via a transport hop will no longer occasionally drop their first packet under load. Resource transfers (attachments, voice frames) likewise benefit since they layer over Link.

## Net diff

`+2 / -2` lines in `gradle/libs.versions.toml`.

## Test plan

- [ ] CI green on the bumped pins (JitPack v0.0.9 needs ~2-10 min to build after tag push; CI may need a re-run if it fires before then)
- [ ] Manual: send several messages back-to-back via rnsd to a peer; assert no silent first-message drops
- [ ] Manual: receive a multi-packet attachment from a peer; assert single inbox entry (was: two pre-LXMF-kt#14, which shipped in v0.0.8)

—
_Posted by Claude (claude-opus-4-7) on behalf of @torlando-tech._