### PR TITLE
fix: unblock LXMF send path on RNS 1.1.9 (known_destinations + path API + stamp callback)

### DIFF
--- a/app/src/main/java/com/lxmf/messenger/service/manager/PythonWrapperManager.kt
+++ b/app/src/main/java/com/lxmf/messenger/service/manager/PythonWrapperManager.kt
@@ -655,8 +655,15 @@ class PythonWrapperManager(
         stampGeneratorInstance = stampGenerator
         withWrapper { wrapper ->
             try {
-                // Pass static method reference to avoid lambda type erasure issues with R8
-                wrapper.callAttr("set_stamp_generator_callback", ::generateStampForPython)
+                // Wrap as java.util.function.BiFunction to expose a single SAM to Chaquopy.
+                // A Kotlin bound method reference implements Function2 + KotlinGenericDeclaration
+                // (+ KFunction, KCallable, ...), and Chaquopy's get_sam aborts with
+                // "implements multiple functional interfaces" when Python invokes it.
+                val callback =
+                    java.util.function.BiFunction<ByteArray, Int, PyObject> { workblock, stampCost ->
+                        generateStampForPython(workblock, stampCost)
+                    }
+                wrapper.callAttr("set_stamp_generator_callback", callback)
                 Log.d(TAG, "Native stamp generator callback registered with Python")
             } catch (e: Exception) {
                 Log.e(TAG, "Failed to set stamp generator callback: ${e.message}", e)

--- a/app/src/main/java/com/lxmf/messenger/service/manager/PythonWrapperManager.kt
+++ b/app/src/main/java/com/lxmf/messenger/service/manager/PythonWrapperManager.kt
@@ -574,9 +574,18 @@ class PythonWrapperManager(
                     callBridge = callBridge,
                 )
 
-            // Set up Python -> Kotlin callback for state events
+            // Set up Python -> Kotlin callback for state events.
+            // Wrap as java.util.function.BiConsumer to expose a single SAM to Chaquopy.
+            // Bare Kotlin method references implement Function2 + KotlinGenericDeclaration
+            // (+ KFunction, KCallable), and Chaquopy's get_sam aborts with
+            // "implements multiple functional interfaces" when Python invokes them —
+            // same trap fixed in setStampGeneratorCallback.
             try {
-                callManager.callAttr("set_kotlin_telephone_callback", ::handlePythonTelephoneEvent)
+                val telephoneCallback =
+                    java.util.function.BiConsumer<String, Map<String, Any?>> { event, data ->
+                        handlePythonTelephoneEvent(event, data)
+                    }
+                callManager.callAttr("set_kotlin_telephone_callback", telephoneCallback)
             } catch (e: Exception) {
                 Log.w(TAG, "Failed to set Kotlin telephone callback: ${e.message}")
                 // Non-fatal - Telephone can still work without this callback

--- a/python/requirements.txt
+++ b/python/requirements.txt
@@ -14,7 +14,7 @@
 # Bumping from 1.1.3 → 1.1.9 also pulls in 49 upstream commits including
 # the K8-authored IFAC autoconnect fix (866e63f) that's relevant to #844's
 # discovered-interface passphrase plumbing.
-rns @ git+https://github.com/torlando-tech/Reticulum@fix/known-destinations-migration
+rns @ git+https://github.com/torlando-tech/Reticulum@99c42fce06bc8afe8cfd0107acd990d8de428013
 
 # LXMF from fork with external stamp generator + receiving interface capture
 # Patches:

--- a/python/requirements.txt
+++ b/python/requirements.txt
@@ -1,15 +1,20 @@
 # Python dependencies for Reticulum integration
 # These will be installed by Chaquopy when building the Android app
 
-# RNS 1.1.9 with the same two fork patches rebased cleanly:
+# RNS 1.1.9 with the four fork patches stacked on top:
 # - TCPInterface/BackboneInterface: Close socket on connection failure
 #   to prevent resource leak (~780 leaked sockets/hour during reconnects)
 # - Link.py: Catch exceptions in __update_phy_stats() to prevent crashes
 #   when connecting to shared instance with mismatched RPC keys
+# - Identity.py / log: use context managers for ratchet file I/O and log writes
+# - Identity.py: migrate legacy 4-element known_destinations entries on the
+#   recombine path (b5658c4 grew entries from 4→5 elements; only the load
+#   path was migrated upstream, leaving recombine-imported legacy entries to
+#   crash _used_destination_data with IndexError on every recall)
 # Bumping from 1.1.3 → 1.1.9 also pulls in 49 upstream commits including
 # the K8-authored IFAC autoconnect fix (866e63f) that's relevant to #844's
 # discovered-interface passphrase plumbing.
-rns @ git+https://github.com/torlando-tech/Reticulum@fix/socket-leak-1.1.9
+rns @ git+https://github.com/torlando-tech/Reticulum@fix/known-destinations-migration
 
 # LXMF from fork with external stamp generator + receiving interface capture
 # Patches:

--- a/python/reticulum_wrapper.py
+++ b/python/reticulum_wrapper.py
@@ -5830,12 +5830,15 @@ class ReticulumWrapper:
                         continue
 
                     # Directly populate Identity.known_destinations
-                    # Format: [timestamp, packet_hash, public_key, app_data]
+                    # Format: [timestamp, packet_hash, public_key, app_data, last_used]
+                    # last_used field added in RNS b5658c4 (1.1.9+); access at [4]
+                    # raises IndexError if omitted.
                     RNS.Identity.known_destinations[dest_hash] = [
                         time.time(),  # timestamp
                         None,         # packet_hash (not needed for recall)
                         public_key,   # public key bytes
-                        None          # app_data
+                        None,         # app_data
+                        0             # last_used (0 = never used)
                     ]
 
                     # Also store in local identities cache for wrapper lookups
@@ -5924,12 +5927,15 @@ class ReticulumWrapper:
                     dest_hash = RNS.Identity.full_hash(addr_hash_material)[:RNS.Reticulum.TRUNCATED_HASHLENGTH // 8]
 
                     # Directly populate Identity.known_destinations
-                    # Format: [timestamp, packet_hash, public_key, app_data]
+                    # Format: [timestamp, packet_hash, public_key, app_data, last_used]
+                    # last_used field added in RNS b5658c4 (1.1.9+); access at [4]
+                    # raises IndexError if omitted.
                     RNS.Identity.known_destinations[dest_hash] = [
                         time.time(),  # timestamp
                         None,         # packet_hash (not needed for recall)
                         public_key,   # public key bytes
-                        None          # app_data
+                        None,         # app_data
+                        0             # last_used (0 = never used)
                     ]
 
                     # Also store in local identities cache for wrapper lookups

--- a/python/reticulum_wrapper.py
+++ b/python/reticulum_wrapper.py
@@ -6155,6 +6155,11 @@ class ReticulumWrapper:
         if not RETICULUM_AVAILABLE or not self.reticulum:
             return True  # Mock mode
 
+        # Chaquopy hands Java byte arrays to Python as jarray('B'), which is
+        # unhashable. RNS.Transport.has_path uses dest_hash as a dict key.
+        if hasattr(dest_hash, '__iter__') and not isinstance(dest_hash, (bytes, bytearray)):
+            dest_hash = bytes(dest_hash)
+
         return RNS.Transport.has_path(dest_hash)
 
     def _request_path_if_needed(self, dest_hash: bytes) -> bool:
@@ -6166,6 +6171,9 @@ class ReticulumWrapper:
         """
         if not RETICULUM_AVAILABLE or not self.reticulum:
             return True
+
+        if hasattr(dest_hash, '__iter__') and not isinstance(dest_hash, (bytes, bytearray)):
+            dest_hash = bytes(dest_hash)
 
         if RNS.Transport.has_path(dest_hash):
             return True
@@ -6186,6 +6194,9 @@ class ReticulumWrapper:
         """
         if not RETICULUM_AVAILABLE:
             return {"success": True}
+
+        if hasattr(dest_hash, '__iter__') and not isinstance(dest_hash, (bytes, bytearray)):
+            dest_hash = bytes(dest_hash)
 
         self._request_path_if_needed(dest_hash)
         return {"success": True}

--- a/python/reticulum_wrapper.py
+++ b/python/reticulum_wrapper.py
@@ -6217,6 +6217,9 @@ class ReticulumWrapper:
         if not RETICULUM_AVAILABLE or not self.reticulum:
             return 3  # Mock value
 
+        if hasattr(dest_hash, '__iter__') and not isinstance(dest_hash, (bytes, bytearray)):
+            dest_hash = bytes(dest_hash)
+
         try:
             if RNS.Transport.has_path(dest_hash):
                 return RNS.Transport.hops_to(dest_hash)

--- a/python/test_wrapper_peer_identity.py
+++ b/python/test_wrapper_peer_identity.py
@@ -1100,10 +1100,14 @@ class TestBulkRestoreAnnounceIdentities(unittest.TestCase):
         dest_hash_1 = bytes.fromhex("aabbccdd" * 4)
         self.assertIn(dest_hash_1, mock_rns.Identity.known_destinations)
         entry = mock_rns.Identity.known_destinations[dest_hash_1]
-        self.assertEqual(len(entry), 4)  # [time, packet_hash, public_key, app_data]
+        # 5-element format: [time, packet_hash, public_key, app_data, last_used]
+        # last_used (index 4) added by RNS b5658c4 (1.1.9+); a 4-element entry
+        # would crash _used_destination_data with IndexError on every recall.
+        self.assertEqual(len(entry), 5)
         self.assertEqual(entry[2], public_key_1)  # public key at index 2
         self.assertIsNone(entry[1])  # packet_hash is None
         self.assertIsNone(entry[3])  # app_data is None
+        self.assertEqual(entry[4], 0)  # last_used = 0 (never used)
 
     @patch('reticulum_wrapper.RNS')
     @patch('reticulum_wrapper.RETICULUM_AVAILABLE', True)
@@ -1665,11 +1669,13 @@ class TestBulkRestoreEquivalence(unittest.TestCase):
         dest_hash = bytes.fromhex("aabbccdd" * 4)
         entry = mock_rns.Identity.known_destinations[dest_hash]
 
-        # Format should be: [timestamp, packet_hash, public_key, app_data]
+        # Format should be: [timestamp, packet_hash, public_key, app_data, last_used]
+        self.assertEqual(len(entry), 5)
         self.assertIsInstance(entry[0], float)  # timestamp
         self.assertIsNone(entry[1])  # packet_hash
         self.assertEqual(entry[2], public_key)  # public_key
         self.assertIsNone(entry[3])  # app_data
+        self.assertEqual(entry[4], 0)  # last_used = 0 (never used)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
## Summary

Three independent regressions were stacking up to make outbound LXMF messages hang on `release/v0.10.x`. Reported as "messages over rnode to Sideband just sit pending"; the user reported a 4-element-list `IndexError` and another user hit an `IndexError` opening NomadNet pages — same root cause.

Each fix is its own commit; together they restore end-to-end delivery (verified `sent → delivered` on device against Sideband over BLE-RNode + propagation-node fallback).

### 1. `known_destinations` 4-element entries → IndexError

Upstream RNS commit `b5658c4` (April 20, 2026, on the 1.1.9 fork) grew `Identity.known_destinations` entries from 4 to 5 elements (added a "last used" timestamp at index `[4]`) and rewired `recall()` / `recall_app_data()` to call `_used_destination_data(destination_hash)` before returning. Two of `bulk_restore_peer_identities_v2`'s direct writes still used the pre-`b5658c4` 4-element format, so every subsequent `recall()` for those entries → `IndexError: list index out of range`.

Manifested as:
- LXMF deferred propagation stamp generation crash-loop every ~4s (`LXMRouter.get_outbound_propagation_cost → recall_app_data`)
- NomadNet page opens crashing (`Identity.recall`)

Fix: write the 5th `last_used: 0` field at both sites in `python/reticulum_wrapper.py`.

Bumps `rns` to `fix/known-destinations-migration` on our fork, which adds a defensive `_with_use_field` helper applied on the recombine_known_destinations path. Upstream's `b5658c4` only migrates 4→5 on the load path; the recombine path re-imports raw entries from disk without migration, so legacy 4-element entries can leak in. The new branch carries all four prior socket-leak-1.1.9 patches plus this one — see updated comment block in `requirements.txt`.

### 2. `RNS.Transport.has_path(jarray('B'))` → unhashable

Kotlin `RoutingManager.hasPath` / `requestPath` pass a `ByteArray` straight through to `wrapper.callAttr("has_path", destHash)`. Chaquopy hands that to Python as `jarray('B')`, which is unhashable; `RNS.Transport.has_path` uses `dest_hash` as a dict key:

```
TypeError: unhashable type: 'jarray('B')'
  at <python>.RNS.Transport.has_path
  at <python>.reticulum_wrapper.has_path / request_path
```

Fix: defensively coerce to `bytes` at the wrapper boundary in `has_path`, `_request_path_if_needed`, and `request_path`, matching the existing pattern used elsewhere in the same file (e.g. lines 2677-2678, 3461-3462).

### 3. Stamp generator callback "implements multiple functional interfaces"

`PythonWrapperManager.setStampGeneratorCallback` passed `::generateStampForPython` (a Kotlin bound method reference). Method references implement `Function2` + `KotlinGenericDeclaration` (+ `KFunction`, `KCallable`, …), so when Python invoked the callback Chaquopy's `get_sam` aborted with:

```
TypeError: PythonWrapperManager$setStampGeneratorCallback$1$1 implements multiple
functional interfaces (kotlin.jvm.functions.Function2,
kotlin.jvm.internal.KotlinGenericDeclaration): use cast() to select one
```

Fired at every `external_generator()` call from `LXStamper.generate_stamp`, so opportunistic stamp generation never returned and the message stalled until the 30s timeout escalated to propagation. Combined with #1 above, propagation also crashed, leaving messages permanently pending.

Fix: wrap the callback in `java.util.function.BiFunction<ByteArray, Int, PyObject>` so only one SAM is exposed. The original "avoid lambda type erasure issues with R8" comment doesn't apply — `BiFunction` is a Java functional interface with a stable JVM contract.

## Test plan

- [x] Build `:app:installNoSentryDebug` succeeds with bumped RNS branch
- [x] App startup loads `known_destinations` without IndexError
- [x] Send to Sideband over BLE-RNode: opportunistic times out (recipient unreachable directly), automatic propagation fallback, message reaches `delivered` state
- [x] No `TypeError: unhashable type: 'jarray('B')'` in logs after RoutingManager calls
- [x] No `implements multiple functional interfaces` in logs during `external_generator(...)` invocation
- [ ] Reproduce on a second device with a stale `known_destinations` file from pre-`b5658c4` install (defensive recombine migration path)
- [ ] NomadNet page open no longer crashes with `IndexError` (requires reproducing the second user's report)

## Related upstream

Reticulum fork branch: `torlando-tech/Reticulum#fix/known-destinations-migration` (already pushed, referenced by `requirements.txt`).