### PR TITLE
Enable Java 8+ API desugaring for API 24/25 support (Sentry COLUMBA-8M)

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -228,6 +228,10 @@ android {
     compileOptions {
         sourceCompatibility = JavaVersion.VERSION_17
         targetCompatibility = JavaVersion.VERSION_17
+        // Required because reticulum-kt's public API touches java.time.LocalDateTime,
+        // which only exists on API 26+. Our minSdk is 24, so devices on Android 7.x
+        // crash with NoClassDefFoundError without this. See Sentry COLUMBA-8M.
+        isCoreLibraryDesugaringEnabled = true
     }
 
     kotlin {
@@ -365,6 +369,9 @@ dependencies {
     implementation(libs.lxst.kt)
     implementation(project(":reticulum"))
     implementation(project(":micron"))
+
+    // Java 8+ API desugaring (java.time.*, etc.) — required for API 24/25 support.
+    coreLibraryDesugaring(libs.android.desugar.jdk.libs)
 
     // Core
     implementation(libs.core.ktx)

--- a/data/build.gradle.kts
+++ b/data/build.gradle.kts
@@ -16,6 +16,8 @@ android {
     compileOptions {
         sourceCompatibility = JavaVersion.VERSION_17
         targetCompatibility = JavaVersion.VERSION_17
+        // Required for API 24/25 support — see Sentry COLUMBA-8M.
+        isCoreLibraryDesugaringEnabled = true
     }
 
     kotlin {
@@ -33,6 +35,9 @@ android {
 
 dependencies {
     implementation(project(":domain"))
+
+    // Java 8+ API desugaring (java.time.*, etc.) — required for API 24/25 support.
+    coreLibraryDesugaring(libs.android.desugar.jdk.libs)
 
     // Hilt
     implementation(libs.hilt)

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -17,6 +17,7 @@ ktlint = "12.1.1"
 detekt = "1.23.7"
 serialization = "1.10.0"
 coil = "2.7.0"
+desugarJdkLibs = "2.1.5"
 
 # JitPack-published libraries (formerly git submodules)
 reticulumKt = "v0.0.16"
@@ -32,6 +33,12 @@ rns-interfaces = { module = "com.github.torlando-tech.reticulum-kt:rns-interface
 rns-android = { module = "com.github.torlando-tech.reticulum-kt:rns-android", version.ref = "reticulumKt" }
 lxmf-kt = { module = "com.github.torlando-tech:LXMF-kt", version.ref = "lxmfKt" }
 lxst-kt = { module = "com.github.torlando-tech:LXST-kt", version.ref = "lxstKt" }
+
+# Java 8+ API desugaring — required because reticulum-kt's public API references
+# java.time.LocalDateTime, which only exists on API 26+. Without this, any device
+# on API 24/25 (Android 7.x) crashes with NoClassDefFoundError the first time
+# Transport.registerDestination is reached. See Sentry COLUMBA-8M.
+android-desugar-jdk-libs = { module = "com.android.tools:desugar_jdk_libs", version.ref = "desugarJdkLibs" }
 
 # Compose
 compose-bom = { module = "androidx.compose:compose-bom", version.ref = "composeBom" }

--- a/reticulum/build.gradle.kts
+++ b/reticulum/build.gradle.kts
@@ -30,6 +30,11 @@ android {
     compileOptions {
         sourceCompatibility = JavaVersion.VERSION_17
         targetCompatibility = JavaVersion.VERSION_17
+        // reticulum-kt's public API references java.time.LocalDateTime (API 26+),
+        // but our minSdk is 24. Without desugaring, devices on Android 7.x crash
+        // with NoClassDefFoundError as soon as Transport.registerDestination runs.
+        // See Sentry COLUMBA-8M.
+        isCoreLibraryDesugaringEnabled = true
     }
 
     kotlin {
@@ -54,6 +59,9 @@ android {
 dependencies {
     // LXST module (telephony, codecs, audio pipeline)
     api(libs.lxst.kt)
+
+    // Java 8+ API desugaring (java.time.*, etc.) — required for API 24/25 support.
+    coreLibraryDesugaring(libs.android.desugar.jdk.libs)
 
     // Hilt
     implementation(libs.hilt)


### PR DESCRIPTION
## Summary

Fixes [Sentry COLUMBA-8M](https://sentry.io/organizations/-/issues/COLUMBA-8M/) — `NoClassDefFoundError: java.time.LocalDateTime` on Android 7.x devices (API 24/25).

Captured stack:
\`\`\`
java.lang.NoClassDefFoundError: Failed resolution of: Ljava/time/LocalDateTime;
  at network.reticulum.transport.Transport.log(Transport.kt:5697)
  at network.reticulum.transport.Transport.registerDestination(Transport.kt:874)
  at network.reticulum.destination.Destination$Companion.create(Destination.kt:845)
  at NativeReticulumProtocol.buildIdentityResult(NativeReticulumProtocol.kt:1018)
  at NativeReticulumProtocol\$importIdentityFile\$2.invokeSuspend(NativeReticulumProtocol.kt:983)
Caused by: ClassNotFoundException: java.time.LocalDateTime
\`\`\`
For the captured user this fired during identity import via the deep link \`/identity_manager?base32Key={...}\`, but any code path that registers a destination would crash identically.

## Root cause

Upstream \`reticulum-kt\`'s public API references \`java.time.LocalDateTime\` (verified by grepping the cached jars: 8 refs in \`rns-core-v0.0.12.jar\`, 20 in \`rns-interfaces-v0.0.12.jar\`). \`java.time.*\` was only added to the Android runtime in **API 26**.

Columba's \`minSdk\` is **24** in every Android module, but \`coreLibraryDesugaring\` was not configured anywhere — zero hits across all \`build.gradle.kts\` files. So on API 24/25 the class loader trips the moment \`Transport\` touches a \`LocalDateTime\`-bearing method.

## Fix

Enable Java 8+ API desugaring in the three Android modules (\`app\`, \`reticulum\`, \`data\`) and add \`desugar_jdk_libs\` 2.1.5 as a \`coreLibraryDesugaring\` dependency in each. The \`domain\` and \`micron\` modules are pure JVM (\`java-library\` / \`kotlin(\"jvm\")\`) and don't need it.

\`\`\`kotlin
compileOptions {
    sourceCompatibility = JavaVersion.VERSION_17
    targetCompatibility = JavaVersion.VERSION_17
    isCoreLibraryDesugaringEnabled = true
}
\`\`\`
\`\`\`kotlin
dependencies {
    coreLibraryDesugaring(libs.android.desugar.jdk.libs)
}
\`\`\`

## Affected scope

- Devices: Android 7.x (API 24/25) — roughly the bottom ~2% of active Android.
- Code paths: not just identity import — anything that touches \`Transport\` in reticulum-kt eventually hits a \`LocalDateTime\`-bearing method.

## Test plan

- [x] \`./gradlew :app:assembleNoSentryDebug\` builds clean (BUILD SUCCESSFUL in 2m 17s)
- [x] No new dependencies pulled into \`domain\` / \`micron\` (verified — they're pure JVM)
- [ ] Manual smoke on an API 24 emulator: install, import identity via deep link, confirm no NCDFE
- [ ] Sentry COLUMBA-8M event count drops to zero on subsequent releases

## Notes

- An upstream fix in \`reticulum-kt\` to avoid \`java.time.*\` in public API would also resolve this without consumer-side desugaring, but that's a larger change. Desugaring is the safe, mechanical fix and is the standard solution for this exact scenario.
- \`desugar_jdk_libs\` 2.1.5 is the current stable release; works with AGP 8.x and Kotlin 2.x.

🤖 Generated with [Claude Code](https://claude.com/claude-code)