### PR TITLE
Fix shutdown race that could close DB while Room writes are mid-transaction (Sentry COLUMBA-8R)

### DIFF
--- a/reticulum/src/main/java/network/columba/app/reticulum/protocol/NativeReticulumProtocol.kt
+++ b/reticulum/src/main/java/network/columba/app/reticulum/protocol/NativeReticulumProtocol.kt
@@ -434,11 +434,21 @@ class NativeReticulumProtocol(
                     }
                 }
             } catch (_: InterruptedException) {
-                // Best-effort: re-assert interrupt and abandon the wait. We still
-                // proceed to close — leaving a half-drained executor + open DB across
-                // shutdown is worse than losing the in-flight writes.
-                Thread.currentThread().interrupt()
+                // shutdownNow() signals workers but does not wait. We still need a
+                // brief drain before reticulumDatabase?.close() runs, otherwise a
+                // worker mid-endTransaction races the close (the very COLUMBA-8R
+                // bug this method exists to fix). Re-asserting Thread.interrupt()
+                // before awaitTermination would make it throw immediately and skip
+                // the drain — so wait first, then restore the flag.
                 executor.shutdownNow()
+                try {
+                    executor.awaitTermination(5, java.util.concurrent.TimeUnit.SECONDS)
+                } catch (_: InterruptedException) {
+                    // Give up entirely; we still proceed to close the DB below
+                    // because leaving a half-drained executor + open DB across
+                    // shutdown is worse than losing the in-flight writes.
+                }
+                Thread.currentThread().interrupt()
             }
         }
         reticulumDbWriteExecutor = null

--- a/reticulum/src/main/java/network/columba/app/reticulum/protocol/NativeReticulumProtocol.kt
+++ b/reticulum/src/main/java/network/columba/app/reticulum/protocol/NativeReticulumProtocol.kt
@@ -411,16 +411,34 @@ class NativeReticulumProtocol(
         Transport.destinationRatchetStore = null
         network.reticulum.identity.Identity.identityStore = null
 
+        // Drain the DB writer before closing the database. Reticulum.stop()'s
+        // final flush calls packetHashStore.saveAll(), which posts a deleteByGeneration
+        // and N chunked insertAll(500) writes onto this single-thread executor. With a
+        // large hashlist those transactions can take well past 5s to drain. Previously
+        // we ignored awaitTermination's boolean — so on slow drains, reticulumDatabase
+        // .close() ran while a worker was mid-endTransaction, and Room's
+        // SQLiteClosable.acquireReference threw IllegalStateException
+        // ("attempt to re-open an already-closed object"). See Sentry COLUMBA-8R.
         reticulumDbWriteExecutor?.let { executor ->
             executor.shutdown()
             try {
-                // TODO(#857): the boolean return is being discarded. Fixed in PR #857
-                // (NativeReticulumProtocol shutdown race) — once that lands, this
-                // @Suppress can be removed (the call gets wrapped in `if (!...)`).
-                @Suppress("DiscardedConcurrencyReturn")
-                executor.awaitTermination(5, java.util.concurrent.TimeUnit.SECONDS)
+                if (!executor.awaitTermination(15, java.util.concurrent.TimeUnit.SECONDS)) {
+                    Log.w(
+                        TAG,
+                        "DB write executor did not drain within 15s; forcing shutdownNow. " +
+                            "Some persisted writes may be lost.",
+                    )
+                    executor.shutdownNow()
+                    if (!executor.awaitTermination(5, java.util.concurrent.TimeUnit.SECONDS)) {
+                        Log.e(TAG, "DB write executor still running after shutdownNow + 5s wait; closing DB anyway")
+                    }
+                }
             } catch (_: InterruptedException) {
+                // Best-effort: re-assert interrupt and abandon the wait. We still
+                // proceed to close — leaving a half-drained executor + open DB across
+                // shutdown is worse than losing the in-flight writes.
                 Thread.currentThread().interrupt()
+                executor.shutdownNow()
             }
         }
         reticulumDbWriteExecutor = null


### PR DESCRIPTION
## Summary

Fixes [Sentry COLUMBA-8R](https://sentry.io/organizations/-/issues/COLUMBA-8R/) — fatal `IllegalStateException: attempt to re-open an already-closed object: SQLiteDatabase reticulum.db` on shutdown.

## Stack trace

\`\`\`
java.lang.IllegalStateException: attempt to re-open an already-closed object:
    SQLiteDatabase: /data/user/0/network.columba.app/databases/reticulum.db
  at SQLiteClosable.acquireReference(SQLiteClosable.java:58)
  at SQLiteDatabase.endTransaction(SQLiteDatabase.java:756)
  at RoomDatabase.internalEndTransaction(RoomDatabase.android.kt:717)
  at PacketHashDao_Impl.insertAll(PacketHashDao_Impl.java:75)
  at RoomPacketHashStore.saveAll$lambda$1(RoomPacketHashStore.kt:21)
  at [NativeReticulumDB-write executor]
\`\`\`

## Root cause

Race during \`NativeReticulumProtocol.shutdown()\`:

1. \`Reticulum.stop()\`'s final flush calls \`packetHashStore.saveAll(...)\` which posts a \`deleteByGeneration\` plus N chunked \`insertAll(500)\` writes onto the single-thread \`NativeReticulumDB-write\` executor (RoomPacketHashStore.kt:17-23).
2. \`closePersistentStores()\` then runs \`executor.shutdown()\` followed by \`awaitTermination(5, SECONDS)\` — **but the boolean return value was ignored**.
3. With a large packet hashlist, the chunked-insert transactions don't drain in 5s. \`awaitTermination\` returns \`false\`; code proceeds anyway.
4. \`reticulumDatabase?.close()\` runs at line 424 while a worker thread is mid-\`endTransaction()\`. Room's \`endTransaction()\` then calls \`acquireReference()\` on the now-closed \`SQLiteDatabase\` → \`IllegalStateException\`.

## Fix

\`NativeReticulumProtocol.kt:closePersistentStores()\`:
- Capture \`awaitTermination\`'s return value.
- On timeout (15s), escalate via \`shutdownNow()\` + a 5s second wait, then proceed regardless (logged at WARN/ERROR).
- On \`InterruptedException\`, also escalate to \`shutdownNow()\` rather than silently leaving in-flight writes pending.
- Only \`reticulumDatabase?.close()\` after the executor has had its drain attempts.

\`\`\`kotlin
reticulumDbWriteExecutor?.let { executor ->
    executor.shutdown()
    try {
        if (!executor.awaitTermination(15, TimeUnit.SECONDS)) {
            Log.w(TAG, "DB write executor did not drain within 15s; forcing shutdownNow...")
            executor.shutdownNow()
            if (!executor.awaitTermination(5, TimeUnit.SECONDS)) {
                Log.e(TAG, "DB write executor still running after shutdownNow + 5s wait; closing DB anyway")
            }
        }
    } catch (_: InterruptedException) {
        Thread.currentThread().interrupt()
        executor.shutdownNow()
    }
}
\`\`\`

## Trade-offs

- **15s wait extends graceful shutdown by up to 10s** vs the previous 5s, in the rare case the executor is mid-drain. Acceptable: graceful shutdown is best-effort and doesn't block app exit (Reticulum service teardown isn't on the UI thread).
- **\`shutdownNow()\` interrupts in-flight writes**, which can leak partial transaction state. Better than silently corrupting Room's \`endTransaction()\` callback, which is what the bug currently produces.
- **The same anti-pattern exists upstream in reticulum-kt's \`ReticulumService.onDestroy\` (lines 257-274)**. This PR fixes the parallel \`NativeReticulumProtocol\` path that Columba uses; an upstream parallel fix would benefit every other reticulum-kt consumer too.

## Test plan

- [x] \`./gradlew :app:assembleNoSentryDebug\` builds clean (BUILD SUCCESSFUL in 45s)
- [ ] Manual: shutdown the app while a large message-burst is in flight; confirm no IllegalStateException in logcat
- [ ] Sentry COLUMBA-8R event count drops to zero on subsequent releases

## Notes

The Sentry frequency is currently 1 occurrence / 1 user, but that likely reflects 1.0's small early-adopter pool. The bug is structural — every shutdown with a non-trivial packet hashlist is at risk — so frequency will scale with adoption.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Also fixes COLUMBA-8X (filed 2026-04-28)

[Sentry COLUMBA-8X](https://torlando-tech.sentry.io/issues/COLUMBA-8X) — `IllegalStateException: Cannot perform this operation because the connection pool has been closed.` Same race as 8R, just one stack frame earlier — the queued `insertAll` had not yet started its transaction when the DB closed, so it threw at `beginTransaction → throwIfClosedLocked` instead of `endTransaction → acquireReference`. Same fix applies (drain executor before `database.close()`).