### PR TITLE
chore: bump reticulum-kt v0.0.14 → v0.0.16, LXMF-kt v0.0.9 → v0.0.11

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -19,8 +19,8 @@ serialization = "1.10.0"
 coil = "2.7.0"
 
 # JitPack-published libraries (formerly git submodules)
-reticulumKt = "v0.0.14"
-lxmfKt = "v0.0.9"
+reticulumKt = "v0.0.16"
+lxmfKt = "v0.0.11"
 lxstKt = "v0.0.3"
 
 [libraries]


### PR DESCRIPTION
## Summary

Picks up the cross-impl conformance fixes shipped in:
- **reticulum-kt v0.0.16** (PR #64): Resource transfer reliability under load — `Transport.transmit()` releases `jobsLock` around blocking I/O, `TCPClientInterface.processOutgoing` uses `ReentrantLock.lockInterruptibly()`, `Resource.accept` dedups by advertisement hash, watchdog FAILED → `cancel()` clears the dedup cache, plus path/link table identity-CAS to prevent stale R-M-W races. Also: v0.0.15 (StoreLifecycle shutdown-race fix from earlier).
- **LXMF-kt v0.0.11** (PRs #21 + #23): kotlin LXMRouter no longer identifies on the propagation delivery link — restores parity with python LXMF (`LXMRouter.py:2700-2704` does NOT identify). The bug caused lxmd to run its peer-discovery branch unnecessarily on resource conclusion, slowing kotlin→python propagation ~2x on CI.

Both fixes interlock — the `port-deviations.md` registry in reticulum-kt documents the four kotlin/python divergences the port carries (with python file:line references). New `LinkResourceDedupTest` regression test enforces the dedup invariant.

## Verification

- `:reticulum:compileDebugKotlin` and `:app:compileNoSentryDebugKotlin` clean build against the new versions. No API breaks.

## Follow-up

[reticulum-kt#65](https://github.com/torlando-tech/reticulum-kt/issues/65) tracks the remaining kotlin Resource transfer perf gap (kotlin sender ~3-5x slower than python on 2-core hardware). Materially narrowed by the lock-release + no-identify fixes here, but not closed.

🤖 Generated with [Claude Opus 4.7 (1M context)](https://claude.com/claude-code)