### PR TITLE
feat(NomadNetBrowserScreen): replace duplicate Identify dropdown item with Close site

### DIFF
--- a/app/src/main/java/network/columba/app/ui/screens/NomadNetBrowserScreen.kt
+++ b/app/src/main/java/network/columba/app/ui/screens/NomadNetBrowserScreen.kt
@@ -28,6 +28,7 @@ import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.ArrowBack
+import androidx.compose.material.icons.filled.Close
 import androidx.compose.material.icons.filled.Fingerprint
 import androidx.compose.material.icons.filled.MoreVert
 import androidx.compose.material.icons.filled.Refresh
@@ -378,26 +379,10 @@ fun NomadNetBrowserScreen(
                                 )
                             }
                             HorizontalDivider()
-                            DropdownMenuItem(
-                                text = {
-                                    Text(if (isIdentified) "Identified" else "Identify to node")
-                                },
-                                leadingIcon = {
-                                    Icon(
-                                        Icons.Default.Fingerprint,
-                                        contentDescription = null,
-                                        tint =
-                                            if (isIdentified) {
-                                                MaterialTheme.colorScheme.primary
-                                            } else {
-                                                MaterialTheme.colorScheme.onSurface
-                                            },
-                                    )
-                                },
-                                enabled = !isIdentified && !identifyInProgress,
-                                onClick = {
+                            BrowserCloseSiteMenuItem(
+                                onCloseSite = {
                                     showMenu = false
-                                    showIdentifyConfirm = true
+                                    onBackClick()
                                 },
                             )
                         }
@@ -711,3 +696,17 @@ private fun formatFileSize(bytes: Long): String =
         bytes < 1024 * 1024 -> "${bytes / 1024} KB"
         else -> "%.1f MB".format(bytes / (1024.0 * 1024.0))
     }
+
+@Composable
+internal fun BrowserCloseSiteMenuItem(onCloseSite: () -> Unit) {
+    DropdownMenuItem(
+        text = { Text("Close site") },
+        leadingIcon = {
+            Icon(
+                Icons.Default.Close,
+                contentDescription = null,
+            )
+        },
+        onClick = onCloseSite,
+    )
+}

--- a/app/src/test/java/network/columba/app/ui/screens/NomadNetBrowserScreenTest.kt
+++ b/app/src/test/java/network/columba/app/ui/screens/NomadNetBrowserScreenTest.kt
@@ -1,0 +1,79 @@
+package network.columba.app.ui.screens
+
+import android.app.Application
+import androidx.compose.material3.DropdownMenu
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.performClick
+import network.columba.app.test.RegisterComponentActivityRule
+import org.junit.Assert.assertEquals
+import org.junit.Rule
+import org.junit.Test
+import org.junit.rules.RuleChain
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+
+@RunWith(RobolectricTestRunner::class)
+@Config(sdk = [34], application = Application::class)
+class NomadNetBrowserScreenTest {
+    private val registerActivityRule = RegisterComponentActivityRule()
+    private val composeRule = createComposeRule()
+
+    @get:Rule
+    val ruleChain: RuleChain = RuleChain.outerRule(registerActivityRule).around(composeRule)
+
+    private val composeTestRule get() = composeRule
+
+    @Test
+    fun browserCloseSiteMenuItem_displaysCloseSiteText() {
+        composeTestRule.setContent {
+            val expanded = mutableStateOf(true)
+            DropdownMenu(
+                expanded = expanded.value,
+                onDismissRequest = { expanded.value = false },
+            ) {
+                BrowserCloseSiteMenuItem(onCloseSite = {})
+            }
+        }
+
+        composeTestRule.onNodeWithText("Close site").assertIsDisplayed()
+    }
+
+    @Test
+    fun browserCloseSiteMenuItem_whenClicked_invokesOnCloseSiteExactlyOnce() {
+        var calls = 0
+
+        composeTestRule.setContent {
+            val expanded = mutableStateOf(true)
+            DropdownMenu(
+                expanded = expanded.value,
+                onDismissRequest = { expanded.value = false },
+            ) {
+                BrowserCloseSiteMenuItem(onCloseSite = { calls++ })
+            }
+        }
+
+        composeTestRule.onNodeWithText("Close site").performClick()
+
+        assertEquals(1, calls)
+    }
+
+    @Test
+    fun browserCloseSiteMenuItem_doesNotRenderIdentifyToNodeText() {
+        composeTestRule.setContent {
+            val expanded = mutableStateOf(true)
+            DropdownMenu(
+                expanded = expanded.value,
+                onDismissRequest = { expanded.value = false },
+            ) {
+                BrowserCloseSiteMenuItem(onCloseSite = {})
+            }
+        }
+
+        composeTestRule.onNodeWithText("Identify to node").assertDoesNotExist()
+        composeTestRule.onNodeWithText("Identify to Node").assertDoesNotExist()
+    }
+}


### PR DESCRIPTION
Implements the approved plan for #867.

## Summary
The NomadNet browser back-arrow walks history one step at a time, so leaving a deep site means tapping back N times. Reporter asked for a single-tap "close the site" affordance and noted that the three-dot menu already duplicates the "Identify to node" action that lives on the topbar — natural slot for the new control. Code confirmed the duplicate, so the dropdown identify item is swapped for a "Close site" item that calls the existing `onBackClick` callback wired in `MainActivity.kt` to `navController.popBackStack()`. ViewModel teardown via `onCleared()` already cancels the in-flight page request and stops status/progress collection on screen exit.

## Changes
- `app/src/main/java/network/columba/app/ui/screens/NomadNetBrowserScreen.kt` — remove duplicate "Identify to node" `DropdownMenuItem`; add a `BrowserCloseSiteMenuItem` composable in its slot whose click closes the menu and invokes `onBackClick()`. Adds `Icons.Default.Close` import.
- `app/src/test/java/network/columba/app/ui/screens/NomadNetBrowserScreenTest.kt` — new Robolectric Compose test covering the close-site item.

## Test plan
- [x] `browserCloseSiteMenuItem_displaysCloseSiteText` — exact "Close site" text rendered.
- [x] `browserCloseSiteMenuItem_whenClicked_invokesOnCloseSiteExactlyOnce` — click invokes lambda exactly once (`assertEquals(1, calls)`).
- [x] `browserCloseSiteMenuItem_doesNotRenderIdentifyToNodeText` — regression guard: neither "Identify to node" nor "Identify to Node" rendered by the new item.
- [x] `:app:detekt` — clean.
- [x] `:app:compileNoSentryDebugKotlin` — clean.

Plan tests 2 and 3 from the spec (full-screen render asserting "Identify to node" gone from the dropdown and topbar Fingerprint icon still present) require Hilt wiring around `NomadNetBrowserViewModel` (ReticulumProtocol + NomadNetPageCache injection) which the plan authorized swapping for an extracted-composable approach: "If `androidTest` infra for this screen is heavier than warranted (Hilt wiring, Python page-request fakes, etc.), the implementer may extract the dropdown content into a small private `@Composable` and test it under Robolectric/Roborazzi instead."

