### PR TITLE
deps(reticulum-kt, LXMF-kt): bump v0.0.16 → v0.0.17, v0.0.11 → v0.0.12

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -19,8 +19,8 @@ serialization = "1.10.0"
 coil = "2.7.0"
 
 # JitPack-published libraries (formerly git submodules)
-reticulumKt = "v0.0.16"
-lxmfKt = "v0.0.11"
+reticulumKt = "v0.0.17"
+lxmfKt = "v0.0.12"
 lxstKt = "v0.0.3"
 
 [libraries]


### PR DESCRIPTION
## Summary

Pulls in the propagation-stamp perf fix and the identify-on-reused-link fix from the upstream port repos. Together these unblock PROPAGATED messages end-to-end on phones.

| repo | old | new | key fixes |
|---|---|---|---|
| reticulum-kt | v0.0.16 | v0.0.17 | [#66](https://github.com/torlando-tech/reticulum-kt/pull/66) Stamper perf rewrite (incremental SHA + bit-count); StamperTest 7 → 16 tests |
| LXMF-kt | v0.0.11 | v0.0.12 | [#31](https://github.com/torlando-tech/LXMF-kt/pull/31) identify on reused PN link before /get; [#24](https://github.com/torlando-tech/LXMF-kt/pull/24) LXMessage Nil-fields decode; [#28](https://github.com/torlando-tech/LXMF-kt/pull/28) conformance-bridge timestamp param; [#29](https://github.com/torlando-tech/LXMF-kt/pull/29) sealed LXMessageDelivery; [#30](https://github.com/torlando-tech/LXMF-kt/pull/30) conformance CI gate |

## Why this matters

Before these fixes:

- **Stamper** at lxmd's default cost=16 took ~21s on phones because each attempt re-hashed the 256KB workblock and allocated a new `BigInteger`. The propagation node's link-inactivity timer killed the link before the stamp was ready, so the LXMF Resource transfer advertised on a dead link and timed out.
- **LXMRouter** skipped `link.identify()` on the propagation-link reuse path, so lxmd returned `ERROR_NO_IDENTITY` (0xf0=240) on every `/get` after a delivery-link reuse. SYNC_PROP returned no messages even when lxmd held them.

After: stamp gen drops to ~400ms; /get returns queued messages; phone↔lxmd PROPAGATED round-trip completes in ~7s.

## Verification

End-to-end smoke test on a real phone (Pixel, USB-attached via adb):

```
SEND_PROP    msg_id=0a4a345…  →  state=PROPAGATED in <500ms
             stamp gen: workblock 130ms + stamp ~250ms (cost=16, value≥16)
             lxmd messagestore 0 → 1
SYNC_PROP    prop_sync_started → rx_msg roundtrip → rx_drain count=1
total: 6.3s scenario / 10s with init
```

`./gradlew :app:assembleNoSentryDebug` passes (94 actionable tasks, JitPack served both new pins).

## Note on LXMF-kt #29

PR #29 introduces a sealed `LXMessageDelivery` type for verified-vs-unverified delivery. This codebase consumes LXMF via the `messageReceivedFlow` SharedFlow contract, which is unchanged across the bump. No call-site updates needed in this PR.

## Test plan

- [ ] CI green (unit tests + lint)
- [ ] Manual install + DIRECT/OPP message test (PROPAGATED already verified above)
- [ ] No regression in existing message UI

🤖 Generated with [Claude Code](https://claude.com/claude-code)