### PR TITLE
deps(LXMF-kt): bump v0.0.12 → v0.0.13 (Sideband stamp-drop fix)

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -20,7 +20,7 @@ coil = "2.7.0"
 
 # JitPack-published libraries (formerly git submodules)
 reticulumKt = "v0.0.17"
-lxmfKt = "v0.0.12"
+lxmfKt = "v0.0.13"
 lxstKt = "v0.0.3"
 
 [libraries]


### PR DESCRIPTION
## Summary

Ships the Columba→Sideband stamp-drop fix to release. Before v0.0.13, LXMF-kt's \`LXMRouter\` registered an announce handler for the \`lxmf.propagation\` aspect but **not** \`lxmf.delivery\` — peer announces never populated \`outboundStampCosts\` and every outbound DIRECT/OPPORTUNISTIC message to a stamp-enforcing receiver (Sideband with \`lxmf_require_stamps=True\`) shipped without a stamp slot. Receiver's \`enforce_stamps\` dropped them silently; sender saw a Reticulum-level delivery proof and assumed success.

Fix in [LXMF-kt#33](https://github.com/torlando-tech/LXMF-kt/pull/33) mirrors python \`LXMRouter\`'s \`LXMFDeliveryAnnounceHandler\` registration exactly.

### Other LXMF-kt v0.0.13 changes

* \`@Volatile\` on \`LXMessage.progress\` for cross-thread visibility ([LXMF-kt#34](https://github.com/torlando-tech/LXMF-kt/pull/34))
* \`:conformance-bridge\` implements \`lxmf_get_message_progress\` so the conformance check goes green ([LXMF-kt#34](https://github.com/torlando-tech/LXMF-kt/pull/34))
* python-bridge symlink retargeted (dev-loop only — [LXMF-kt#32](https://github.com/torlando-tech/LXMF-kt/pull/32))

### Cross-impl regression test

[lxmf-conformance#24](https://github.com/torlando-tech/lxmf-conformance/pull/24) added a test that runs the receiver-announces-cost / sender-auto-stamps contract across the \`(sender_impl, receiver_impl)\` matrix. Verified locally that the test fails against pre-#33 LXMF-kt JARs and passes against v0.0.13. Future regressions in any impl's announce-handler wiring or outbound stamp auto-config now surface there loudly.

### Dep pin notes

\`reticulumKt\` stays at v0.0.17. \`reticulum-kt\` v0.0.20 was tagged alongside LXMF-kt v0.0.13 but is test-infra only (bridge stamp-enforcement cmds + a \`Reticulum.clearPendingFactories()\` test-harness API). No runtime change Columba needs; bumping is optional follow-up.

## Test plan

- [x] JitPack resolved LXMF-kt v0.0.13 cleanly on first request (no build failures).
- [x] \`./gradlew :app:assembleNoSentryDebug --refresh-dependencies\` green.
- [x] \`./gradlew :app:dependencies --configuration noSentryDebugRuntimeClasspath\` confirms \`com.github.torlando-tech:LXMF-kt:v0.0.13\` is the resolved version.
- [x] On-device end-to-end manual verification before tagging — composite-build APK pinned at LXMF-kt fix branch successfully sent stamped messages to a stamp-enforcing Mac Echo Bot where pre-fix builds dropped silently.

🤖 Generated with [Claude Code](https://claude.com/claude-code)