### PR TITLE
deps(reticulum-kt): bump v0.0.17 → v0.0.20

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -19,7 +19,7 @@ serialization = "1.10.0"
 coil = "2.7.0"
 
 # JitPack-published libraries (formerly git submodules)
-reticulumKt = "v0.0.17"
+reticulumKt = "v0.0.20"
 lxmfKt = "v0.0.13"
 lxstKt = "v0.0.3"
 


### PR DESCRIPTION
## Summary

Picks up the **`rns-android` shared-instance auto-attach fix** landed in v0.0.19 (torlando-tech/reticulum-kt#68). Before that fix, `ReticulumService` logged \"Connected to shared instance\" but silently dropped every packet because the `LocalClientInterface` factory + interface registrar were never wired before \`Reticulum.start\`. Affects anyone running Columba alongside Sideband on the same Android device with \`standalone=false\` in the Reticulum config — the silent-drop is invisible to the user and looks like generic non-delivery. The reticulum-kt v0.0.19 tag body explicitly calls out: \"Eridanus, Caelum, Carina, and any app on top of rns-android should bump to this version\".

## What else lands in this bump

| Tag | Highlight | Columba impact |
|---|---|---|
| **v0.0.18** | `link_id` divergence fix in shared-instance master forwarding (#67) | Columba isn't a master, so harmless either way — comes along for the ride |
| **v0.0.19** | rns-android shared-instance auto-attach (#68) — the headline fix | Real, fixes silent-drop for shared-instance users |
| **v0.0.20** | Bridge stamp-enforcement test cmds (#73) + `Reticulum.clearPendingFactories()` test-harness helper (#70) | Test infra only; no runtime change for Columba |

## Test plan

- [x] JitPack resolved rns-core / rns-interfaces / rns-android v0.0.20 cleanly on first request (no build failures from the artifact server).
- [x] `./gradlew :app:assembleNoSentryDebug --refresh-dependencies` green.
- [x] `./gradlew :app:dependencies --configuration noSentryDebugRuntimeClasspath` confirms all three rns-* artifacts pinned at v0.0.20.

🤖 Generated with [Claude Code](https://claude.com/claude-code)