### PR TITLE
fix(nomadnet): submit field defaults and pad form for IME (#917)

### DIFF
--- a/app/src/main/java/network/columba/app/ui/screens/NomadNetBrowserScreen.kt
+++ b/app/src/main/java/network/columba/app/ui/screens/NomadNetBrowserScreen.kt
@@ -16,6 +16,7 @@ import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.imePadding
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
@@ -441,10 +442,14 @@ fun NomadNetBrowserScreen(
                 PullToRefreshBox(
                     isRefreshing = isPullRefreshing,
                     onRefresh = { viewModel.refresh() },
+                    // imePadding required because MainActivity uses enableEdgeToEdge(),
+                    // which makes the manifest's adjustResize a no-op — without it the
+                    // soft keyboard slides up on top of focused micron form fields.
                     modifier =
                         Modifier
                             .fillMaxSize()
-                            .padding(paddingValues),
+                            .padding(paddingValues)
+                            .imePadding(),
                 ) {
                     if (renderingMode == RenderingMode.MONOSPACE_SCROLL) {
                         // BoxWithConstraints captures viewport width before

--- a/app/src/main/java/network/columba/app/viewmodel/NomadNetBrowserViewModel.kt
+++ b/app/src/main/java/network/columba/app/viewmodel/NomadNetBrowserViewModel.kt
@@ -15,6 +15,7 @@ import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
 import network.columba.app.micron.MicronDocument
+import network.columba.app.micron.MicronElement
 import network.columba.app.micron.MicronParser
 import network.columba.app.nomadnet.NomadNetPageCache
 import network.columba.app.nomadnet.PartialManager
@@ -558,6 +559,11 @@ class NomadNetBrowserViewModel
 
         /**
          * Emit a [BrowserState.PageLoaded] and trigger partial detection.
+         *
+         * Also seeds [_formFields] with parser-declared defaults for any text fields
+         * the user has not already populated. Required so unmodified pre-filled fields
+         * (e.g. a "display name" pre-filled with the user's nickname) are actually
+         * submitted instead of being sent as empty strings.
          */
         private fun emitPageLoaded(
             document: MicronDocument,
@@ -565,6 +571,7 @@ class NomadNetBrowserViewModel
             nodeHash: String,
         ) {
             _isPullRefreshing.value = false
+            _formFields.update { current -> seedFieldDefaults(document, current) }
             _browserState.value =
                 BrowserState.PageLoaded(
                     document = document,
@@ -572,6 +579,26 @@ class NomadNetBrowserViewModel
                     nodeHash = nodeHash,
                 )
             partialManager.detectAndLoad(document)
+        }
+
+        /**
+         * Return a copy of [current] with parser-declared text-field defaults filled
+         * in for any field name the user has not already typed into. User-typed values
+         * (including empty strings the user explicitly cleared) win over defaults.
+         */
+        private fun seedFieldDefaults(
+            document: MicronDocument,
+            current: Map<String, String>,
+        ): Map<String, String> {
+            val seeded = current.toMutableMap()
+            for (line in document.lines) {
+                for (element in line.elements) {
+                    if (element is MicronElement.Field && element.name !in seeded) {
+                        seeded[element.name] = element.defaultValue
+                    }
+                }
+            }
+            return seeded
         }
 
         private fun formatNomadnetStatus(status: String): String =

--- a/app/src/test/java/network/columba/app/viewmodel/NomadNetBrowserViewModelTest.kt
+++ b/app/src/test/java/network/columba/app/viewmodel/NomadNetBrowserViewModelTest.kt
@@ -11,6 +11,7 @@ import io.mockk.coVerify
 import io.mockk.every
 import io.mockk.just
 import io.mockk.mockk
+import io.mockk.slot
 import io.mockk.verify
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
@@ -220,6 +221,96 @@ class NomadNetBrowserViewModelTest {
             }
             Thread.sleep(100) // Wait for Dispatchers.IO coroutine
             assertTrue(viewModel.browserState.value is NomadNetBrowserViewModel.BrowserState.PageLoaded)
+        }
+
+    // Regression for #917: a page-author-supplied default (e.g. a "display name"
+    // pre-filled with the user's nickname) must be in _formFields after parse, so
+    // submission sends the default instead of an empty string when the user does
+    // not retype the field.
+    @Test
+    fun `loadPage seeds parser-declared field defaults into form state`() =
+        runTest(testDispatcher) {
+            val pageWithField = "`<|display_name`Alice>"
+            every { pageCache.get(any(), any()) } returns pageWithField
+
+            viewModel.loadPage(nodeHash)
+            advanceUntilIdle()
+
+            assertEquals("Alice", viewModel.formFields.value["display_name"])
+        }
+
+    @Test
+    fun `navigateToLink submits parser-declared default for unmodified field`() =
+        runTest(testDispatcher) {
+            // Forum-style page: display_name pre-filled, message empty.
+            // User types into message only — display_name must still go through.
+            val pageWithFields = "`<|display_name`Alice>\n`<|message`>"
+            every { pageCache.get(any(), any()) } returns pageWithFields
+            val formDataSlot = slot<String>()
+            coEvery {
+                protocol.requestNomadnetPage(any(), any(), capture(formDataSlot), any())
+            } returns Result.success(ReticulumProtocol.NomadnetPageResult(simplePage, "/page/result.mu"))
+
+            viewModel.loadPage(nodeHash)
+            advanceUntilIdle()
+
+            viewModel.updateField("message", "hello world")
+            viewModel.navigateToLink("/page/post.mu", listOf("display_name", "message"))
+            advanceUntilIdle()
+            Thread.sleep(100) // Wait for Dispatchers.IO coroutine
+
+            val submitted = org.json.JSONObject(formDataSlot.captured)
+            assertEquals("Alice", submitted.getString("display_name"))
+            assertEquals("hello world", submitted.getString("message"))
+        }
+
+    @Test
+    fun `navigateToLink user-typed value wins over field default`() =
+        runTest(testDispatcher) {
+            val pageWithField = "`<|display_name`Alice>"
+            every { pageCache.get(any(), any()) } returns pageWithField
+            val formDataSlot = slot<String>()
+            coEvery {
+                protocol.requestNomadnetPage(any(), any(), capture(formDataSlot), any())
+            } returns Result.success(ReticulumProtocol.NomadnetPageResult(simplePage, "/page/result.mu"))
+
+            viewModel.loadPage(nodeHash)
+            advanceUntilIdle()
+
+            viewModel.updateField("display_name", "Bob")
+            viewModel.navigateToLink("/page/post.mu", listOf("display_name"))
+            advanceUntilIdle()
+            Thread.sleep(100) // Wait for Dispatchers.IO coroutine
+
+            assertEquals(
+                "Bob",
+                org.json.JSONObject(formDataSlot.captured).getString("display_name"),
+            )
+        }
+
+    @Test
+    fun `navigateToLink user-cleared field submits empty string not default`() =
+        runTest(testDispatcher) {
+            val pageWithField = "`<|display_name`Alice>"
+            every { pageCache.get(any(), any()) } returns pageWithField
+            val formDataSlot = slot<String>()
+            coEvery {
+                protocol.requestNomadnetPage(any(), any(), capture(formDataSlot), any())
+            } returns Result.success(ReticulumProtocol.NomadnetPageResult(simplePage, "/page/result.mu"))
+
+            viewModel.loadPage(nodeHash)
+            advanceUntilIdle()
+
+            // User explicitly clears the pre-filled default to empty.
+            viewModel.updateField("display_name", "")
+            viewModel.navigateToLink("/page/post.mu", listOf("display_name"))
+            advanceUntilIdle()
+            Thread.sleep(100) // Wait for Dispatchers.IO coroutine
+
+            assertEquals(
+                "",
+                org.json.JSONObject(formDataSlot.captured).getString("display_name"),
+            )
         }
 
     @Test


### PR DESCRIPTION
## Summary
Closes #917. Two regressions on multi-field NomadNet forms (e.g. the fr33n0w recipes forum):

- **Field defaults silently dropped on submit.** A page-author default like `` `<|display_name`Alice> `` rendered as "Alice" but was submitted as `""` if the user didn't retype it. `_formFields` was only populated by `onValueChange`, so the lookup in `NomadNetBrowserViewModel.navigateToLink` (line 264) hit the `?: ""` fallback. Fix: seed defaults into `_formFields` in `emitPageLoaded`, leaving user-typed values (including explicit empty clears) untouched.
- **Soft keyboard covered focused form fields.** `MainActivity.enableEdgeToEdge()` neuters the manifest's `adjustResize`, and `NomadNetBrowserScreen` had no manual IME inset handling (every other text-entry screen uses `imePadding()` / `WindowInsets.ime`). Fix: add `Modifier.imePadding()` to the `PullToRefreshBox` that hosts the loaded page.

## Why this matches the reporter's symptom
The reporter wrote "message went through, display name did not". Message fields on these forms start empty (user types → `_formFields[message]` populated → submitted). Display-name fields come pre-filled with a nickname (user leaves it → `_formFields[display_name]` null → submitted as `""`). Exactly the bug above.

## Test plan
- [x] `:app:testNoSentryDebugUnitTest --tests NomadNetBrowserViewModelTest` — 4 new tests + 41 existing pass
  - `loadPage seeds parser-declared field defaults into form state`
  - `navigateToLink submits parser-declared default for unmodified field` (the #917 regression)
  - `navigateToLink user-typed value wins over field default`
  - `navigateToLink user-cleared field submits empty string not default` (preserves explicit clear)
- [x] `:app:detekt` clean
- [x] `NomadNetBrowserScreenTest`, `MicronPageContentSelectionTest` still pass
- [ ] Manual smoke on a real NomadNet form (e.g. fr33n0w recipes) — focus a text field, confirm keyboard slides the field up; submit with the default left untouched, confirm it lands on the server side

## Notes / out of scope
- Checkboxes and radios with `prechecked=true` have the same class of bug (visually checked but `_formFields` empty → not submitted). Left alone here because the report is text-field-specific and the multi-value semantics for checkboxes deserve their own change. Happy to follow up.