### PR TITLE
feat: LXST call privacy gates (contacts-only + master toggle) for dual-build

### DIFF
--- a/app/src/main/java/network/columba/app/repository/SettingsRepository.kt
+++ b/app/src/main/java/network/columba/app/repository/SettingsRepository.kt
@@ -134,6 +134,8 @@ class SettingsRepository
 
             // Privacy preferences
             val BLOCK_UNKNOWN_SENDERS = booleanPreferencesKey("block_unknown_senders")
+            val ALLOW_CALLS_FROM_CONTACTS_ONLY = booleanPreferencesKey("allow_calls_from_contacts_only")
+            val ALLOW_VOICE_CALLS = booleanPreferencesKey("allow_voice_calls")
 
             // Telemetry collector preferences
             val TELEMETRY_COLLECTOR_ADDRESS = stringPreferencesKey("telemetry_collector_address")
@@ -1692,6 +1694,8 @@ class SettingsRepository
             // Cross-process SharedPreferences keys (for settings read by the service)
             const val CROSS_PROCESS_PREFS_NAME = "cross_process_settings"
             const val KEY_BLOCK_UNKNOWN_SENDERS = "block_unknown_senders"
+            const val KEY_ALLOW_CALLS_FROM_CONTACTS_ONLY = "allow_calls_from_contacts_only"
+            const val KEY_ALLOW_VOICE_CALLS = "allow_voice_calls"
 
             /** Default telemetry send interval: 5 minutes */
             const val DEFAULT_TELEMETRY_SEND_INTERVAL_SECONDS = 300
@@ -1887,6 +1891,94 @@ class SettingsRepository
                 .getSharedPreferences(CROSS_PROCESS_PREFS_NAME, Context.MODE_MULTI_PROCESS)
                 .edit()
                 .putBoolean(KEY_BLOCK_UNKNOWN_SENDERS, enabled)
+                .apply()
+        }
+
+        /**
+         * Flow of the calls-from-contacts-only setting.
+         *
+         * When enabled, inbound LXST link requests whose source identity is not in the
+         * user's contacts list are silently dropped after identification (no STATUS_RINGING
+         * to the originator, no UI surface on this device).
+         *
+         * Defaults to false (allow calls from anyone — preserves existing behaviour).
+         */
+        val allowCallsFromContactsOnlyFlow: Flow<Boolean> =
+            context.dataStore.data
+                .map { preferences ->
+                    preferences[PreferencesKeys.ALLOW_CALLS_FROM_CONTACTS_ONLY] ?: false
+                }.distinctUntilChanged()
+
+        /** Get the calls-from-contacts-only setting (non-flow). */
+        suspend fun getAllowCallsFromContactsOnly(): Boolean =
+            context.dataStore.data
+                .map { preferences ->
+                    preferences[PreferencesKeys.ALLOW_CALLS_FROM_CONTACTS_ONLY] ?: false
+                }.first()
+
+        /**
+         * Save the calls-from-contacts-only setting.
+         *
+         * Dual-writes DataStore (UI-side flow) + MODE_MULTI_PROCESS SharedPreferences
+         * (service-side reads each inbound link). No runtime signal is needed because the
+         * `:reticulum` call manager reads the SharedPreferences value on every
+         * `onCallerIdentified` — same pattern as [saveBlockUnknownSenders].
+         */
+        @Suppress("DEPRECATION") // MODE_MULTI_PROCESS needed for cross-process reads
+        suspend fun saveAllowCallsFromContactsOnly(enabled: Boolean) {
+            context.dataStore.edit { preferences ->
+                preferences[PreferencesKeys.ALLOW_CALLS_FROM_CONTACTS_ONLY] = enabled
+            }
+            context
+                .getSharedPreferences(CROSS_PROCESS_PREFS_NAME, Context.MODE_MULTI_PROCESS)
+                .edit()
+                .putBoolean(KEY_ALLOW_CALLS_FROM_CONTACTS_ONLY, enabled)
+                .apply()
+        }
+
+        /**
+         * Flow of the master "Allow voice calls" setting.
+         *
+         * When false, the `lxst.telephony` Destination is deregistered from the network
+         * (peers cannot reach it; new link requests fail at Transport with no application
+         * code running on this side). Outbound calls remain functional regardless — only
+         * the inbound destination is affected.
+         *
+         * Defaults to true (incoming voice calls accepted — preserves existing behaviour).
+         */
+        val allowVoiceCallsFlow: Flow<Boolean> =
+            context.dataStore.data
+                .map { preferences ->
+                    preferences[PreferencesKeys.ALLOW_VOICE_CALLS] ?: true
+                }.distinctUntilChanged()
+
+        /** Get the master allow-voice-calls setting (non-flow). */
+        suspend fun getAllowVoiceCalls(): Boolean =
+            context.dataStore.data
+                .map { preferences ->
+                    preferences[PreferencesKeys.ALLOW_VOICE_CALLS] ?: true
+                }.first()
+
+        /**
+         * Save the master allow-voice-calls setting.
+         *
+         * Dual-writes DataStore + MODE_MULTI_PROCESS SharedPreferences. The
+         * SharedPreferences value is what `:reticulum` reads at cold-start (post
+         * START_STICKY restart) to apply the persisted state before the first announce.
+         * Runtime delivery to the live `:reticulum` process happens via the AIDL
+         * `RnsTelephony.setIncomingEnabled(boolean)` call from the ViewModel — not from
+         * here — because `SharedPreferences.OnSharedPreferenceChangeListener` does not
+         * fire across processes (a v0.10.x port lesson).
+         */
+        @Suppress("DEPRECATION") // MODE_MULTI_PROCESS needed for cross-process reads
+        suspend fun saveAllowVoiceCalls(enabled: Boolean) {
+            context.dataStore.edit { preferences ->
+                preferences[PreferencesKeys.ALLOW_VOICE_CALLS] = enabled
+            }
+            context
+                .getSharedPreferences(CROSS_PROCESS_PREFS_NAME, Context.MODE_MULTI_PROCESS)
+                .edit()
+                .putBoolean(KEY_ALLOW_VOICE_CALLS, enabled)
                 .apply()
         }
 

--- a/app/src/main/java/network/columba/app/ui/screens/SettingsScreen.kt
+++ b/app/src/main/java/network/columba/app/ui/screens/SettingsScreen.kt
@@ -281,6 +281,8 @@ fun SettingsScreen(
                     onExpandedChange = { viewModel.toggleCardExpanded(SettingsCardId.PRIVACY, it) },
                     blockUnknownSenders = state.blockUnknownSenders,
                     onBlockUnknownSendersChange = { viewModel.setBlockUnknownSenders(it) },
+                    allowCallsFromContactsOnly = state.allowCallsFromContactsOnly,
+                    onAllowCallsFromContactsOnlyChange = { viewModel.setAllowCallsFromContactsOnly(it) },
                     blockedPeerCount = blockedPeerCount,
                     onNavigateToBlockedUsers = onNavigateToBlockedUsers,
                 )
@@ -296,6 +298,8 @@ fun SettingsScreen(
                 VoiceCallPermissionsCard(
                     isExpanded = state.cardExpansionStates[SettingsCardId.VOICE_CALL_PERMISSIONS.name] ?: false,
                     onExpandedChange = { viewModel.toggleCardExpanded(SettingsCardId.VOICE_CALL_PERMISSIONS, it) },
+                    allowVoiceCalls = state.allowVoiceCalls,
+                    onAllowVoiceCallsChange = { viewModel.setAllowVoiceCalls(it) },
                 )
 
                 AutoAnnounceCard(

--- a/app/src/main/java/network/columba/app/ui/screens/settings/cards/PrivacyCard.kt
+++ b/app/src/main/java/network/columba/app/ui/screens/settings/cards/PrivacyCard.kt
@@ -37,14 +37,29 @@ fun PrivacyCard(
         icon = Icons.Default.Security,
         isExpanded = isExpanded,
         onExpandedChange = onExpandedChange,
-        headerAction = {
+    ) {
+        // Messages-from-contacts-only toggle row. Moved out of the card header
+        // so it's visually equal-billed with the calls toggle below.
+        Row(
+            modifier =
+                Modifier
+                    .fillMaxWidth()
+                    .padding(vertical = 8.dp),
+            verticalAlignment = Alignment.CenterVertically,
+        ) {
+            Text(
+                text = "Messages from contacts only",
+                style = MaterialTheme.typography.bodyMedium,
+                modifier =
+                    Modifier
+                        .weight(1f)
+                        .padding(end = 12.dp),
+            )
             Switch(
                 checked = blockUnknownSenders,
                 onCheckedChange = onBlockUnknownSendersChange,
             )
-        },
-    ) {
-        // Description
+        }
         Text(
             text =
                 if (blockUnknownSenders) {
@@ -52,7 +67,7 @@ fun PrivacyCard(
                 } else {
                     "Anyone can send you messages, including unknown senders."
                 },
-            style = MaterialTheme.typography.bodyMedium,
+            style = MaterialTheme.typography.bodySmall,
             color = MaterialTheme.colorScheme.onSurfaceVariant,
         )
 

--- a/app/src/main/java/network/columba/app/ui/screens/settings/cards/PrivacyCard.kt
+++ b/app/src/main/java/network/columba/app/ui/screens/settings/cards/PrivacyCard.kt
@@ -27,6 +27,8 @@ fun PrivacyCard(
     onExpandedChange: (Boolean) -> Unit,
     blockUnknownSenders: Boolean,
     onBlockUnknownSendersChange: (Boolean) -> Unit,
+    allowCallsFromContactsOnly: Boolean,
+    onAllowCallsFromContactsOnlyChange: (Boolean) -> Unit,
     blockedPeerCount: Int = 0,
     onNavigateToBlockedUsers: () -> Unit = {},
 ) {
@@ -51,6 +53,40 @@ fun PrivacyCard(
                     "Anyone can send you messages, including unknown senders."
                 },
             style = MaterialTheme.typography.bodyMedium,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+        )
+
+        Spacer(modifier = Modifier.height(12.dp))
+
+        // Calls-from-contacts-only toggle row (independent of block_unknown_senders).
+        Row(
+            modifier =
+                Modifier
+                    .fillMaxWidth()
+                    .padding(vertical = 8.dp),
+            verticalAlignment = Alignment.CenterVertically,
+        ) {
+            Text(
+                text = "Calls from contacts only",
+                style = MaterialTheme.typography.bodyMedium,
+                modifier =
+                    Modifier
+                        .weight(1f)
+                        .padding(end = 12.dp),
+            )
+            Switch(
+                checked = allowCallsFromContactsOnly,
+                onCheckedChange = onAllowCallsFromContactsOnlyChange,
+            )
+        }
+        Text(
+            text =
+                if (allowCallsFromContactsOnly) {
+                    "Only contacts can call you. Other callers' link attempts are silently dropped."
+                } else {
+                    "Anyone can call you, including unknown callers."
+                },
+            style = MaterialTheme.typography.bodySmall,
             color = MaterialTheme.colorScheme.onSurfaceVariant,
         )
 

--- a/app/src/main/java/network/columba/app/ui/screens/settings/cards/VoiceCallPermissionsCard.kt
+++ b/app/src/main/java/network/columba/app/ui/screens/settings/cards/VoiceCallPermissionsCard.kt
@@ -31,6 +31,7 @@ import androidx.compose.material3.CardDefaults
 import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Switch
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
@@ -52,6 +53,8 @@ import kotlinx.coroutines.delay
 fun VoiceCallPermissionsCard(
     isExpanded: Boolean,
     onExpandedChange: (Boolean) -> Unit,
+    allowVoiceCalls: Boolean,
+    onAllowVoiceCallsChange: (Boolean) -> Unit,
 ) {
     // Not relevant below Android 10 — background activity launch restrictions
     // only became an issue starting with Q
@@ -145,6 +148,16 @@ fun VoiceCallPermissionsCard(
                     )
                 }
 
+                // Master "Allow voice calls" switch — placed to the left of
+                // the chevron so it stays visible whether the card is
+                // expanded or collapsed. When OFF, the inbound LXST
+                // destination is deregistered via the RnsTelephony AIDL
+                // surface; outbound calls still work.
+                Switch(
+                    checked = allowVoiceCalls,
+                    onCheckedChange = onAllowVoiceCallsChange,
+                )
+
                 Icon(
                     imageVector =
                         if (isExpanded) {
@@ -166,6 +179,17 @@ fun VoiceCallPermissionsCard(
                 Column(
                     verticalArrangement = Arrangement.spacedBy(12.dp),
                 ) {
+                    if (!allowVoiceCalls) {
+                        // Master toggle is OFF — let the user know inbound is
+                        // disabled before they see (and worry about) the
+                        // permission-status content below.
+                        Text(
+                            text = "Incoming voice calls are currently disabled. Outgoing calls still work.",
+                            style = MaterialTheme.typography.bodyMedium,
+                            fontWeight = FontWeight.Medium,
+                            color = contentColor,
+                        )
+                    }
                     if (isCheckingStatus) {
                         CircularProgressIndicator(modifier = Modifier.size(24.dp))
                     } else if (allGranted) {

--- a/app/src/main/java/network/columba/app/viewmodel/SettingsViewModel.kt
+++ b/app/src/main/java/network/columba/app/viewmodel/SettingsViewModel.kt
@@ -129,6 +129,8 @@ data class SettingsState(
     val notificationsEnabled: Boolean = true,
     // Privacy state
     val blockUnknownSenders: Boolean = false,
+    val allowCallsFromContactsOnly: Boolean = false,
+    val allowVoiceCalls: Boolean = true,
     // Incoming message size limit (default 1MB)
     val incomingMessageSizeLimitKb: Int = 1024,
     // Image compression state
@@ -186,6 +188,7 @@ class SettingsViewModel
         private val rnsCore: RnsCore,
         private val rnsLxmf: RnsLxmf,
         private val rnsTransportAdmin: RnsTransportAdmin,
+        private val rnsTelephony: network.columba.app.rns.api.RnsTelephony,
         private val interfaceConfigManager: network.columba.app.service.InterfaceConfigManager,
         private val propagationNodeManager: PropagationNodeManager,
         private val locationSharingManager: network.columba.app.service.LocationSharingManager,
@@ -470,6 +473,8 @@ class SettingsViewModel
                             notificationsEnabled = _state.value.notificationsEnabled,
                             // Preserve privacy state from loadPrivacySettings()
                             blockUnknownSenders = _state.value.blockUnknownSenders,
+                            allowCallsFromContactsOnly = _state.value.allowCallsFromContactsOnly,
+                            allowVoiceCalls = _state.value.allowVoiceCalls,
                             // Preserve message size limit from loadLocationSharingSettings()
                             incomingMessageSizeLimitKb = _state.value.incomingMessageSizeLimitKb,
                             // Preserve message sorting from loadLocationSharingSettings()
@@ -1520,6 +1525,16 @@ class SettingsViewModel
                     _state.update { it.copy(blockUnknownSenders = enabled) }
                 }
             }
+            viewModelScope.launch {
+                settingsRepository.allowCallsFromContactsOnlyFlow.collect { enabled ->
+                    _state.update { it.copy(allowCallsFromContactsOnly = enabled) }
+                }
+            }
+            viewModelScope.launch {
+                settingsRepository.allowVoiceCallsFlow.collect { enabled ->
+                    _state.update { it.copy(allowVoiceCalls = enabled) }
+                }
+            }
         }
 
         /**
@@ -1531,6 +1546,43 @@ class SettingsViewModel
                 settingsRepository.saveBlockUnknownSenders(enabled)
                 _state.update { it.copy(blockUnknownSenders = enabled) }
                 Log.d(TAG, "Block unknown senders ${if (enabled) "enabled" else "disabled"}")
+            }
+        }
+
+        /**
+         * Set the calls-from-contacts-only setting.
+         * When enabled, only contacts can establish incoming voice calls; non-contact
+         * callers' link attempts are silently dropped in `:reticulum` after caller
+         * identification. No runtime AIDL signal needed — the gate reads the cross-process
+         * SharedPreferences value per-call.
+         */
+        fun setAllowCallsFromContactsOnly(enabled: Boolean) {
+            viewModelScope.launch {
+                settingsRepository.saveAllowCallsFromContactsOnly(enabled)
+                _state.update { it.copy(allowCallsFromContactsOnly = enabled) }
+                Log.d(TAG, "Calls-from-contacts-only ${if (enabled) "enabled" else "disabled"}")
+            }
+        }
+
+        /**
+         * Set the master allow-voice-calls setting.
+         * When disabled, the inbound LXST telephony destination is deregistered in
+         * `:reticulum` and no announces are sent; peers see this device as unreachable
+         * for calls. Outbound calls are unaffected.
+         *
+         * Runtime delivery rides the new `RnsTelephony.setIncomingEnabled` AIDL call —
+         * the SharedPreferences write done by `saveAllowVoiceCalls` exists only for the
+         * cold-start path (`:reticulum` reads it after restart). If the AIDL call fails
+         * the cold-start path eventually applies the desired state, so failures are logged
+         * rather than surfaced.
+         */
+        fun setAllowVoiceCalls(enabled: Boolean) {
+            viewModelScope.launch {
+                settingsRepository.saveAllowVoiceCalls(enabled)
+                _state.update { it.copy(allowVoiceCalls = enabled) }
+                runCatching { rnsTelephony.setIncomingEnabled(enabled) }
+                    .onFailure { Log.w(TAG, "setIncomingEnabled($enabled) AIDL call failed", it) }
+                Log.d(TAG, "Allow voice calls ${if (enabled) "enabled" else "disabled"}")
             }
         }
 

--- a/app/src/test/java/network/columba/app/repository/SettingsRepositoryTest.kt
+++ b/app/src/test/java/network/columba/app/repository/SettingsRepositoryTest.kt
@@ -1100,6 +1100,73 @@ class SettingsRepositoryTest {
             assertTrue("Both should be true", methodValue)
         }
 
+    // ========== Allow Calls From Contacts Only Flow Tests ==========
+
+    @Test
+    fun allowCallsFromContactsOnlyFlow_emitsOnlyOnChange() =
+        runTest {
+            repository.allowCallsFromContactsOnlyFlow.test(timeout = 5.seconds) {
+                val initial = awaitItem()
+
+                // Save same value - should NOT emit
+                repository.saveAllowCallsFromContactsOnly(initial)
+                expectNoEvents()
+
+                // Save opposite value - should emit
+                repository.saveAllowCallsFromContactsOnly(!initial)
+                assertEquals(!initial, awaitItem())
+
+                cancelAndIgnoreRemainingEvents()
+            }
+        }
+
+    @Test
+    fun getAllowCallsFromContactsOnly_matchesFlow() =
+        runTest {
+            repository.saveAllowCallsFromContactsOnly(true)
+            testDispatcher.scheduler.advanceUntilIdle()
+
+            val flowValue = repository.allowCallsFromContactsOnlyFlow.first()
+            val methodValue = repository.getAllowCallsFromContactsOnly()
+
+            assertEquals("Flow and method should return same value", flowValue, methodValue)
+            assertTrue("Both should be true after save(true)", methodValue)
+        }
+
+    // ========== Allow Voice Calls (master) Flow Tests ==========
+
+    @Test
+    fun allowVoiceCallsFlow_emitsOnlyOnChange() =
+        runTest {
+            repository.allowVoiceCallsFlow.test(timeout = 5.seconds) {
+                val initial = awaitItem()
+
+                // Save same value - should NOT emit
+                repository.saveAllowVoiceCalls(initial)
+                expectNoEvents()
+
+                // Save opposite value - should emit
+                repository.saveAllowVoiceCalls(!initial)
+                assertEquals(!initial, awaitItem())
+
+                cancelAndIgnoreRemainingEvents()
+            }
+        }
+
+    @Test
+    fun getAllowVoiceCalls_matchesFlow() =
+        runTest {
+            // Default is true; flip to false then assert both sources agree.
+            repository.saveAllowVoiceCalls(false)
+            testDispatcher.scheduler.advanceUntilIdle()
+
+            val flowValue = repository.allowVoiceCallsFlow.first()
+            val methodValue = repository.getAllowVoiceCalls()
+
+            assertEquals("Flow and method should return same value", flowValue, methodValue)
+            assertFalse("Both should be false after save(false)", methodValue)
+        }
+
     // ========== Telemetry Collector Flow Tests ==========
 
     @Test

--- a/app/src/test/java/network/columba/app/ui/screens/settings/cards/PrivacyCardTest.kt
+++ b/app/src/test/java/network/columba/app/ui/screens/settings/cards/PrivacyCardTest.kt
@@ -36,10 +36,12 @@ class PrivacyCardTest {
     // ========== Callback Tracking Variables ==========
 
     private var blockUnknownSendersChanged: Boolean? = null
+    private var allowCallsFromContactsOnlyChanged: Boolean? = null
 
     @Before
     fun resetCallbackTrackers() {
         blockUnknownSendersChanged = null
+        allowCallsFromContactsOnlyChanged = null
     }
 
     // ========== Setup Helper ==========
@@ -47,6 +49,7 @@ class PrivacyCardTest {
     private fun setUpCard(
         isExpanded: Boolean = true,
         blockUnknownSenders: Boolean = false,
+        allowCallsFromContactsOnly: Boolean = false,
     ) {
         composeTestRule.setContent {
             Column(modifier = Modifier.verticalScroll(rememberScrollState())) {
@@ -55,6 +58,8 @@ class PrivacyCardTest {
                     onExpandedChange = {},
                     blockUnknownSenders = blockUnknownSenders,
                     onBlockUnknownSendersChange = { blockUnknownSendersChanged = it },
+                    allowCallsFromContactsOnly = allowCallsFromContactsOnly,
+                    onAllowCallsFromContactsOnlyChange = { allowCallsFromContactsOnlyChanged = it },
                 )
             }
         }

--- a/app/src/test/java/network/columba/app/ui/screens/settings/cards/PrivacyCardTest.kt
+++ b/app/src/test/java/network/columba/app/ui/screens/settings/cards/PrivacyCardTest.kt
@@ -125,4 +125,33 @@ class PrivacyCardTest {
             "Anyone can send you messages, including unknown senders.",
         ).assertIsDisplayed()
     }
+
+    @Test
+    fun privacyCard_displaysMessagesFromContactsOnly_rowLabel() {
+        // The block-unknown-senders toggle was moved out of the card header into
+        // the body so it's equal-billed with the calls toggle. Verify the row
+        // label renders alongside the existing description text.
+        setUpCard(isExpanded = true)
+
+        composeTestRule.onNodeWithText("Messages from contacts only").assertIsDisplayed()
+    }
+
+    @Test
+    fun privacyCard_displaysCallsFromContactsOnly_rowLabelAndOffDescription() {
+        setUpCard(isExpanded = true, allowCallsFromContactsOnly = false)
+
+        composeTestRule.onNodeWithText("Calls from contacts only").assertIsDisplayed()
+        composeTestRule.onNodeWithText(
+            "Anyone can call you, including unknown callers.",
+        ).assertIsDisplayed()
+    }
+
+    @Test
+    fun privacyCard_displaysCallsFromContactsOnly_onDescription() {
+        setUpCard(isExpanded = true, allowCallsFromContactsOnly = true)
+
+        composeTestRule.onNodeWithText(
+            "Only contacts can call you. Other callers' link attempts are silently dropped.",
+        ).assertIsDisplayed()
+    }
 }

--- a/app/src/test/java/network/columba/app/viewmodel/SettingsViewModelIncomingMessageLimitTest.kt
+++ b/app/src/test/java/network/columba/app/viewmodel/SettingsViewModelIncomingMessageLimitTest.kt
@@ -65,6 +65,7 @@ class SettingsViewModelIncomingMessageLimitTest {
     private lateinit var rnsCore: RnsCore
     private lateinit var rnsLxmf: RnsLxmf
     private lateinit var rnsTransportAdmin: RnsTransportAdmin
+    private lateinit var rnsTelephony: network.columba.app.rns.api.RnsTelephony
     private lateinit var interfaceConfigManager: InterfaceConfigManager
     private lateinit var propagationNodeManager: PropagationNodeManager
     private lateinit var locationSharingManager: LocationSharingManager
@@ -107,6 +108,7 @@ class SettingsViewModelIncomingMessageLimitTest {
         rnsCore = mockk()
         rnsLxmf = mockk()
         rnsTransportAdmin = mockk()
+        rnsTelephony = mockk(relaxed = true)
         interfaceConfigManager = mockk()
         propagationNodeManager = mockk()
         locationSharingManager = mockk()
@@ -186,6 +188,8 @@ class SettingsViewModelIncomingMessageLimitTest {
 
         // Privacy settings flows
         every { settingsRepository.blockUnknownSendersFlow } returns MutableStateFlow(false)
+        every { settingsRepository.allowCallsFromContactsOnlyFlow } returns MutableStateFlow(false)
+        every { settingsRepository.allowVoiceCallsFlow } returns MutableStateFlow(true)
 
         // Telemetry request settings flows
         every { settingsRepository.telemetryRequestEnabledFlow } returns MutableStateFlow(false)
@@ -236,6 +240,7 @@ class SettingsViewModelIncomingMessageLimitTest {
             rnsCore = rnsCore,
             rnsLxmf = rnsLxmf,
             rnsTransportAdmin = rnsTransportAdmin,
+            rnsTelephony = rnsTelephony,
             interfaceConfigManager = interfaceConfigManager,
             propagationNodeManager = propagationNodeManager,
             locationSharingManager = locationSharingManager,

--- a/app/src/test/java/network/columba/app/viewmodel/SettingsViewModelTest.kt
+++ b/app/src/test/java/network/columba/app/viewmodel/SettingsViewModelTest.kt
@@ -68,6 +68,7 @@ class SettingsViewModelTest {
     private lateinit var rnsCore: RnsCore
     private lateinit var rnsLxmf: RnsLxmf
     private lateinit var rnsTransportAdmin: RnsTransportAdmin
+    private lateinit var rnsTelephony: network.columba.app.rns.api.RnsTelephony
     private lateinit var interfaceConfigManager: InterfaceConfigManager
     private lateinit var propagationNodeManager: PropagationNodeManager
     private lateinit var locationSharingManager: LocationSharingManager
@@ -112,6 +113,7 @@ class SettingsViewModelTest {
         rnsCore = mockk()
         rnsLxmf = mockk()
         rnsTransportAdmin = mockk()
+        rnsTelephony = mockk(relaxed = true) // setAllowVoiceCalls fires setIncomingEnabled
         interfaceConfigManager = mockk()
         propagationNodeManager = mockk()
         locationSharingManager = mockk()
@@ -180,6 +182,8 @@ class SettingsViewModelTest {
         every { settingsRepository.incomingMessageSizeLimitKbFlow } returns flowOf(500)
         every { settingsRepository.notificationsEnabledFlow } returns flowOf(true)
         every { settingsRepository.blockUnknownSendersFlow } returns flowOf(false)
+        every { settingsRepository.allowCallsFromContactsOnlyFlow } returns flowOf(false)
+        every { settingsRepository.allowVoiceCallsFlow } returns flowOf(true)
         every { settingsRepository.telemetryCollectorEnabledFlow } returns flowOf(false)
         every { settingsRepository.telemetryCollectorAddressFlow } returns flowOf(null)
         every { settingsRepository.telemetrySendIntervalSecondsFlow } returns flowOf(60)
@@ -272,6 +276,7 @@ class SettingsViewModelTest {
             rnsCore = rnsCore,
             rnsLxmf = rnsLxmf,
             rnsTransportAdmin = rnsTransportAdmin,
+            rnsTelephony = rnsTelephony,
             interfaceConfigManager = interfaceConfigManager,
             propagationNodeManager = propagationNodeManager,
             locationSharingManager = locationSharingManager,
@@ -1600,6 +1605,7 @@ class SettingsViewModelTest {
                     rnsCore = serviceRnsCore,
                     rnsLxmf = rnsLxmf,
                     rnsTransportAdmin = rnsTransportAdmin,
+                    rnsTelephony = rnsTelephony,
                     interfaceConfigManager = interfaceConfigManager,
                     propagationNodeManager = propagationNodeManager,
                     locationSharingManager = locationSharingManager,
@@ -1651,6 +1657,7 @@ class SettingsViewModelTest {
                     rnsCore = serviceRnsCore,
                     rnsLxmf = rnsLxmf,
                     rnsTransportAdmin = rnsTransportAdmin,
+                    rnsTelephony = rnsTelephony,
                     interfaceConfigManager = interfaceConfigManager,
                     propagationNodeManager = propagationNodeManager,
                     locationSharingManager = locationSharingManager,
@@ -2280,6 +2287,7 @@ class SettingsViewModelTest {
                     rnsCore = serviceRnsCore,
                     rnsLxmf = rnsLxmf,
                     rnsTransportAdmin = serviceRnsTransportAdmin,
+                    rnsTelephony = rnsTelephony,
                     interfaceConfigManager = interfaceConfigManager,
                     propagationNodeManager = propagationNodeManager,
                     locationSharingManager = locationSharingManager,
@@ -2328,6 +2336,7 @@ class SettingsViewModelTest {
                     rnsCore = serviceRnsCore,
                     rnsLxmf = rnsLxmf,
                     rnsTransportAdmin = rnsTransportAdmin,
+                    rnsTelephony = rnsTelephony,
                     interfaceConfigManager = interfaceConfigManager,
                     propagationNodeManager = propagationNodeManager,
                     locationSharingManager = locationSharingManager,

--- a/rns-api/src/main/aidl/network/columba/app/rns/ipc/IRnsTelephony.aidl
+++ b/rns-api/src/main/aidl/network/columba/app/rns/ipc/IRnsTelephony.aidl
@@ -1,8 +1,9 @@
 // AIDL surface mirroring the Kotlin RnsTelephony interface (LXST voice).
 //
 // Bundle key conventions for IRnsResultCallback payloads:
-//   - getCallState   → "state": VoiceCallState
-//   - Result<Unit>   → Bundle.EMPTY
+//   - getCallState      → "state": VoiceCallState
+//   - setIncomingEnabled→ Bundle.EMPTY
+//   - Result<Unit>      → Bundle.EMPTY
 //
 // profileCode is a nullable int — represented as (value, hasValue) for AIDL
 // since boxed Int isn't supported. Pass hasValue=false to mean null.
@@ -79,4 +80,15 @@ oneway interface IRnsTelephony {
     void setSpeakerLocally(boolean enabled, in IRnsResultCallback cb);
     void setPttModeLocally(boolean enabled, in IRnsResultCallback cb);
     void setPttActiveLocally(boolean active, in IRnsResultCallback cb);
+
+    // ==================== Master incoming-calls toggle ====================
+    //
+    // setIncomingEnabled(false) deregisters the lxst.telephony destination
+    // in :reticulum so peers cannot reach this device for inbound calls
+    // (outbound is unaffected — outbound creates an ephemeral OUT
+    // destination per call). setIncomingEnabled(true) re-registers and
+    // re-announces. Idempotent on both sides.
+    //
+    // Mirrors RnsTelephony.setIncomingEnabled on the Kotlin side.
+    void setIncomingEnabled(boolean enabled, in IRnsResultCallback cb);
 }

--- a/rns-api/src/main/java/network/columba/app/rns/api/RnsTelephony.kt
+++ b/rns-api/src/main/java/network/columba/app/rns/api/RnsTelephony.kt
@@ -153,6 +153,28 @@ interface RnsTelephony {
     suspend fun setPttActiveLocally(active: Boolean)
 
     /**
+     * Master toggle for inbound voice-call reachability.
+     *
+     * `false` → the backend deregisters the `lxst.telephony` destination
+     * (python: `Transport.deregister_destination(dest)` via Chaquopy;
+     * kotlin: [Transport.deregisterDestination] on reticulum-kt) and hangs
+     * up any active call. Subsequent peer call attempts time out without
+     * reaching this device. Outbound calls continue to work — they
+     * construct an ephemeral OUT destination per call.
+     *
+     * `true` → the backend re-registers the destination, re-announces it,
+     * and resumes accepting inbound link requests.
+     *
+     * Both states are persisted via `ServiceSettingsAccessor.getAllowVoiceCalls`
+     * so the desired state survives `:reticulum` restarts. This AIDL call
+     * is the runtime delivery path; the SharedPreferences write done by
+     * the UI handles the cold-start path.
+     *
+     * Idempotent — applying the same state twice is a no-op.
+     */
+    suspend fun setIncomingEnabled(enabled: Boolean)
+
+    /**
      * True when [callState] is currently in any non-terminal phase
      * (Connecting / Ringing / Incoming / Active). Derived from
      * [callState] — does not cross the AIDL boundary on every call.

--- a/rns-backend-kt/src/main/kotlin/network/columba/app/rns/backend/kt/HostBridges.kt
+++ b/rns-backend-kt/src/main/kotlin/network/columba/app/rns/backend/kt/HostBridges.kt
@@ -62,3 +62,33 @@ interface RNodeHostBridge {
      */
     fun rnodeFramebufferData(): ByteArray?
 }
+
+/**
+ * Tiny bridge into `:rns-host`-side privacy state for the LXST inbound-call
+ * path. Mirrors [RNodeHostBridge] in shape — `:rns-backend-kt` cannot
+ * import `:rns-host` (would cycle the Gradle dep graph), so this interface
+ * lives here and the adapter implementing it lives in
+ * `:rns-host/src/kotlinBackend/.../HostBackendModule.kt`, wrapping
+ * `CallsFromContactsGate` + `ServiceSettingsAccessor`.
+ *
+ * Both methods are called from the reticulum-kt callback thread on every
+ * inbound link / caller-identified event. They must be fast + safe to call
+ * synchronously — the gate uses `runBlocking(Dispatchers.IO)` internally,
+ * marked `// THREADING: allowed` per the audit-script convention.
+ */
+interface CallPrivacyBridge {
+    /**
+     * @return `true` → silently tear down the inbound link (no signal back
+     * to the originator, no UI surface on this device). `false` → let the
+     * call ring through. Reads the `allow_calls_from_contacts_only` toggle
+     * on every call so live UI toggles take effect immediately.
+     */
+    fun shouldSilentlyDrop(identityHashHex: String): Boolean
+
+    /**
+     * @return current persisted value of `allow_voice_calls` (default true).
+     * Read at `NativeCallManager.setup()` to apply the master toggle's
+     * last value before the first announce goes out.
+     */
+    fun getAllowVoiceCalls(): Boolean
+}

--- a/rns-backend-kt/src/main/kotlin/network/columba/app/rns/backend/kt/NativeCallManager.kt
+++ b/rns-backend-kt/src/main/kotlin/network/columba/app/rns/backend/kt/NativeCallManager.kt
@@ -17,6 +17,7 @@ import network.reticulum.common.DestinationType
 import network.reticulum.destination.Destination
 import network.reticulum.identity.Identity
 import network.reticulum.link.Link
+import network.reticulum.transport.Transport
 import tech.torlando.lxst.audio.Signalling
 import tech.torlando.lxst.core.AudioDevice
 import tech.torlando.lxst.core.AudioPacketHandler
@@ -63,6 +64,7 @@ class NativeCallManager(
     private val context: Context,
     private val deliveryIdentity: Identity,
     val transport: NativeNetworkTransport,
+    private val callPrivacyBridge: CallPrivacyBridge? = null,
 ) : CallController {
     companion object {
         private const val TAG = "NativeCallManager"
@@ -88,6 +90,18 @@ class NativeCallManager(
      * Held to prevent GC and to allow cleanup on [shutdown].
      */
     private var telephonyDestination: Destination? = null
+
+    /**
+     * Master incoming-calls toggle state. Mirrors `:rns-host/pythonBackend`'s
+     * sibling. Read by [onInboundLinkEstablished] as a TOCTOU guard against
+     * an inbound link that crossed the wire just before [disableIncoming]
+     * ran; written only inside [incomingLock].
+     */
+    @Volatile
+    private var incomingDisabled: Boolean = false
+
+    /** Serialises [disableIncoming] / [enableIncoming] transitions. */
+    private val incomingLock = Any()
 
     // ===== Initialization =====
 
@@ -135,6 +149,15 @@ class NativeCallManager(
         // Announce immediately so peers can resolve a path to our telephony destination
         // even before the next coupled LXMF auto-announce fires.
         announce()
+
+        // Cold-start application of the persisted master toggle. If the user
+        // turned voice calls OFF before the last process tear-down (or before
+        // this fresh-start), apply that now — register+immediately-deregister
+        // is marginally wasteful but lets re-enable share one helper.
+        if (callPrivacyBridge?.getAllowVoiceCalls() == false) {
+            Log.i(TAG, "Cold-start: Allow voice calls = false, deregistering destination")
+            disableIncoming()
+        }
 
         Log.i(TAG, "Native telephony stack ready")
     }
@@ -198,6 +221,17 @@ class NativeCallManager(
     private fun onInboundLinkEstablished(link: Link) {
         Log.i(TAG, "Inbound call link arrived")
 
+        // Defense-in-depth TOCTOU guard: an inbound link may have been
+        // admitted by reticulum-kt's Transport in the brief window before
+        // deregisterDestination returned. Drop it silently — STATUS_AVAILABLE
+        // has not yet been sent, so the caller sees the same "remote went
+        // away" timeout as the toggle-off path below.
+        if (incomingDisabled) {
+            Log.d(TAG, "Inbound link but incoming disabled, silently tearing down")
+            link.teardown()
+            return
+        }
+
         if (telephone.isCallActive()) {
             Log.w(TAG, "Line busy — signalling busy and rejecting inbound link")
             link.send(packSignal(Signalling.STATUS_BUSY))
@@ -247,6 +281,18 @@ class NativeCallManager(
     ) {
         val identityHash = identity.hexHash
         Log.i(TAG, "Caller identified: ${identityHash.take(16)}")
+
+        // Calls-from-contacts-only gate. Fires BEFORE STATUS_RINGING and
+        // BEFORE Telephone.onIncomingCall, so the originator only sees a
+        // wait-time timeout (no STATUS_BUSY / STATUS_REJECTED) and this
+        // device shows no UI / no ringtone. Sibling of the same gate in
+        // PythonCallManager; both share the same CallsFromContactsGate
+        // singleton via the CallPrivacyBridge adapter.
+        if (callPrivacyBridge?.shouldSilentlyDrop(identityHash) == true) {
+            Log.i(TAG, "Calls-only-from-contacts: dropping ${identityHash.take(16)}")
+            link.teardown()
+            return
+        }
 
         if (telephone.isCallActive()) {
             Log.w(TAG, "Line became busy after identify — signalling busy")
@@ -308,6 +354,53 @@ class NativeCallManager(
 
     override fun setSpeaker(enabled: Boolean) {
         audioBridge.setSpeakerphoneOn(enabled)
+    }
+
+    // ===== Master incoming-calls toggle =====
+
+    /**
+     * Apply [setIncomingEnabled] for this manager.
+     *
+     * Invoked by [NativeRnsBackendImpl.setIncomingEnabledHook] (wired in
+     * [NativeRnsBackendImpl.setupNativeTelephone] once this manager is
+     * constructed) when the UI calls `RnsTelephony.setIncomingEnabled(...)`
+     * across the AIDL boundary.
+     *
+     * Idempotent — applying the same state twice is a no-op.
+     */
+    fun setIncomingEnabled(enabled: Boolean) {
+        if (enabled) enableIncoming() else disableIncoming()
+    }
+
+    private fun disableIncoming() = synchronized(incomingLock) {
+        if (incomingDisabled) return@synchronized
+        incomingDisabled = true
+        telephonyDestination?.let { dest ->
+            try {
+                Transport.deregisterDestination(dest)
+                Log.i(TAG, "lxst.telephony destination deregistered")
+            } catch (e: Exception) {
+                Log.w(TAG, "deregisterDestination failed", e)
+            }
+        }
+        telephonyDestination = null
+        if (::telephone.isInitialized && telephone.isCallActive()) {
+            // Hang up before the link's transport state goes away so the
+            // remote sees a clean drop (hangup signal sent over the active
+            // call link, not the destination).
+            try {
+                telephone.hangup()
+            } catch (e: Exception) {
+                Log.w(TAG, "Ignored hangup error during disableIncoming: ${e.message}")
+            }
+        }
+    }
+
+    private fun enableIncoming() = synchronized(incomingLock) {
+        if (!incomingDisabled && telephonyDestination != null) return@synchronized
+        incomingDisabled = false
+        registerTelephonyDestination()
+        announce()
     }
 
     // ===== Lifecycle =====

--- a/rns-backend-kt/src/main/kotlin/network/columba/app/rns/backend/kt/NativeRnsBackend.kt
+++ b/rns-backend-kt/src/main/kotlin/network/columba/app/rns/backend/kt/NativeRnsBackend.kt
@@ -34,6 +34,7 @@ import network.columba.app.rns.api.RnsTransportAdmin
 class NativeRnsBackend(
     appContext: Context? = null,
     rnodeHostBridge: RNodeHostBridge? = null,
+    callPrivacyBridge: CallPrivacyBridge? = null,
 ) : RnsBackend {
     init {
         // Defense-in-depth A.10 assertion: this constructor MUST only run in
@@ -68,6 +69,7 @@ class NativeRnsBackend(
     val impl: NativeRnsBackendImpl = NativeRnsBackendImpl(
         appContext = appContext,
         rnodeHostBridge = rnodeHostBridge,
+        callPrivacyBridge = callPrivacyBridge,
     )
 
     override val core: RnsCore = impl

--- a/rns-backend-kt/src/main/kotlin/network/columba/app/rns/backend/kt/NativeRnsBackendImpl.kt
+++ b/rns-backend-kt/src/main/kotlin/network/columba/app/rns/backend/kt/NativeRnsBackendImpl.kt
@@ -92,6 +92,13 @@ class NativeRnsBackendImpl(
      * May be null in unit-test mode.
      */
     private val rnodeHostBridge: RNodeHostBridge? = null,
+    /**
+     * Bridge into `:rns-host`-side privacy state for inbound voice calls.
+     * Supplied by the kotlinBackend Hilt module wrapping `CallsFromContactsGate`
+     * + `ServiceSettingsAccessor`. Null in unit-test mode → all calls are
+     * allowed through (preserves the pre-feature behaviour).
+     */
+    private val callPrivacyBridge: CallPrivacyBridge? = null,
 ) : network.columba.app.rns.api.RnsCore,
     network.columba.app.rns.api.RnsLxmf,
     network.columba.app.rns.api.RnsTelephony,
@@ -2017,9 +2024,20 @@ class NativeRnsBackendImpl(
 
     private fun setupNativeTelephone(identity: NativeIdentity) {
         val ctx = appContext ?: return
-        val manager = NativeCallManager(ctx, identity, callTransport)
+        val manager = NativeCallManager(
+            context = ctx,
+            deliveryIdentity = identity,
+            transport = callTransport,
+            callPrivacyBridge = callPrivacyBridge,
+        )
         manager.setup()
         callManager = manager
+        // Wire the AIDL master-toggle hook now that the manager exists.
+        // Until this point setIncomingEnabledHook is null and the stub on
+        // this class logs + returns. The Hilt eager-init path constructs
+        // NativeRnsBackend at app start, but setupNativeTelephone runs
+        // later inside initialize() after Reticulum + identity are ready.
+        setIncomingEnabledHook = manager::setIncomingEnabled
         Log.i(TAG, "📞 Native Telephone ready")
     }
 

--- a/rns-backend-kt/src/main/kotlin/network/columba/app/rns/backend/kt/NativeRnsBackendImpl.kt
+++ b/rns-backend-kt/src/main/kotlin/network/columba/app/rns/backend/kt/NativeRnsBackendImpl.kt
@@ -2108,6 +2108,24 @@ class NativeRnsBackendImpl(
         callCoordinator.setPttActiveLocally(active)
     }
 
+    /**
+     * Master incoming-calls toggle. Wired to [NativeCallManager] in
+     * `setupNativeTelephone` once the call manager is constructed
+     * (commit 5). Until then this is a no-op log so the AIDL boundary
+     * compiles end-to-end.
+     */
+    @Volatile
+    var setIncomingEnabledHook: ((Boolean) -> Unit)? = null
+
+    override suspend fun setIncomingEnabled(enabled: Boolean) {
+        val hook = setIncomingEnabledHook
+        if (hook == null) {
+            Log.w(TAG, "setIncomingEnabled($enabled) before NativeCallManager wired hook")
+        } else {
+            hook(enabled)
+        }
+    }
+
     override suspend fun getCallState(): Result<VoiceCallState> =
         runCatching {
             val coordinator =

--- a/rns-backend-py/src/main/kotlin/network/columba/app/rns/backend/py/PythonRnsTelephony.kt
+++ b/rns-backend-py/src/main/kotlin/network/columba/app/rns/backend/py/PythonRnsTelephony.kt
@@ -186,6 +186,29 @@ class PythonRnsTelephony(
         callCoordinator.setPttActiveLocally(active)
     }
 
+    /**
+     * Wired by `PythonCallManager`'s init block so the manager can react to
+     * the toggle without `PythonRnsTelephony` itself needing to know about
+     * Chaquopy / `Transport.deregister_destination`. Same single-listener
+     * shape used by every other `*Hook` on this class — the manager owns the
+     * destination lifecycle, this class owns the AIDL contract.
+     *
+     * Null between class construction and PythonCallManager init — the
+     * implementation logs and treats the call as a no-op rather than
+     * crashing the binder thread.
+     */
+    @Volatile
+    var setIncomingEnabledHook: ((Boolean) -> Unit)? = null
+
+    override suspend fun setIncomingEnabled(enabled: Boolean) {
+        val hook = setIncomingEnabledHook
+        if (hook == null) {
+            Log.w(TAG, "setIncomingEnabled($enabled) before PythonCallManager wired hook")
+        } else {
+            hook(enabled)
+        }
+    }
+
     // ==================== One-shot snapshot ====================
 
     override suspend fun getCallState(): Result<VoiceCallState> =

--- a/rns-host/src/kotlinBackend/kotlin/network/columba/app/rns/host/HostBackendModule.kt
+++ b/rns-host/src/kotlinBackend/kotlin/network/columba/app/rns/host/HostBackendModule.kt
@@ -8,11 +8,14 @@ import dagger.hilt.InstallIn
 import dagger.hilt.android.qualifiers.ApplicationContext
 import dagger.hilt.components.SingletonComponent
 import network.columba.app.rns.api.RnsBackend
+import network.columba.app.rns.backend.kt.CallPrivacyBridge
 import network.columba.app.rns.backend.kt.NativeRnsBackend
 import network.columba.app.rns.backend.kt.RNodeHostBridge
 import network.columba.app.rns.host.call.rnode.BluetoothLeConnection
 import network.columba.app.rns.host.call.rnode.ColumbaLogo
 import network.columba.app.rns.host.di.LocalBackend
+import network.columba.app.rns.host.persistence.CallsFromContactsGate
+import network.columba.app.rns.host.persistence.ServiceSettingsAccessor
 import network.columba.app.rns.host.usb.KotlinUSBBridge
 import java.io.InputStream
 import java.io.OutputStream
@@ -47,12 +50,38 @@ object HostBackendModule {
     fun provideRNodeHostBridge(@ApplicationContext context: Context): RNodeHostBridge =
         AndroidRNodeHostBridge(context)
 
+    /**
+     * Bridge adapter wrapping the shared [CallsFromContactsGate] +
+     * [ServiceSettingsAccessor] (provided by [network.columba.app.rns.host.di.PersistenceModule])
+     * behind the [CallPrivacyBridge] interface that `:rns-backend-kt`
+     * declares. `:rns-backend-kt` cannot import these classes directly
+     * (Gradle dep graph would cycle), so we adapt here.
+     */
+    @Provides
+    @Singleton
+    fun provideCallPrivacyBridge(
+        contactsGate: CallsFromContactsGate,
+        settingsAccessor: ServiceSettingsAccessor,
+    ): CallPrivacyBridge =
+        object : CallPrivacyBridge {
+            override fun shouldSilentlyDrop(identityHashHex: String): Boolean =
+                contactsGate.shouldSilentlyDrop(identityHashHex)
+
+            override fun getAllowVoiceCalls(): Boolean = settingsAccessor.getAllowVoiceCalls()
+        }
+
     @Provides
     @Singleton
     fun provideNativeRnsBackend(
         @ApplicationContext context: Context,
         bridge: RNodeHostBridge,
-    ): NativeRnsBackend = NativeRnsBackend(appContext = context, rnodeHostBridge = bridge)
+        callPrivacyBridge: CallPrivacyBridge,
+    ): NativeRnsBackend =
+        NativeRnsBackend(
+            appContext = context,
+            rnodeHostBridge = bridge,
+            callPrivacyBridge = callPrivacyBridge,
+        )
 
     /**
      * Flavor-local [RnsBackend] view of [NativeRnsBackend]. [LocalBackend]

--- a/rns-host/src/main/kotlin/network/columba/app/rns/host/di/PersistenceModule.kt
+++ b/rns-host/src/main/kotlin/network/columba/app/rns/host/di/PersistenceModule.kt
@@ -1,0 +1,46 @@
+package network.columba.app.rns.host.di
+
+import android.content.Context
+import dagger.Module
+import dagger.Provides
+import dagger.hilt.InstallIn
+import dagger.hilt.android.qualifiers.ApplicationContext
+import dagger.hilt.components.SingletonComponent
+import network.columba.app.rns.host.persistence.CallsFromContactsGate
+import network.columba.app.rns.host.persistence.ServiceSettingsAccessor
+import javax.inject.Singleton
+
+/**
+ * Hilt wiring for `:reticulum`-side persistence helpers that need to be
+ * injected into flavor-specific call managers.
+ *
+ * Both [ServiceSettingsAccessor] and [CallsFromContactsGate] are
+ * flavor-independent (no `pythonBackend` / `kotlinBackend` references) so
+ * they live in `:rns-host/src/main/` rather than being duplicated in both
+ * flavor `HostBackendModule.kt`s.
+ *
+ * Note that [ServiceSettingsAccessor] is also constructed manually inside
+ * [network.columba.app.rns.host.di.ServiceModule.createManagers] for the
+ * UI-process binder path. That path predates Hilt being available to
+ * `:reticulum` (it explicitly notes "Hilt doesn't work across process
+ * boundaries"). Both constructions are cheap — the class is stateless above
+ * `SharedPreferences` — so the duplicate is acceptable. Consumers that go
+ * through Hilt (the call managers + the contacts gate) all share the
+ * `@Singleton`-scoped instance provided here.
+ */
+@Module
+@InstallIn(SingletonComponent::class)
+object PersistenceModule {
+    @Provides
+    @Singleton
+    fun provideServiceSettingsAccessor(
+        @ApplicationContext context: Context,
+    ): ServiceSettingsAccessor = ServiceSettingsAccessor(context)
+
+    @Provides
+    @Singleton
+    fun provideCallsFromContactsGate(
+        @ApplicationContext context: Context,
+        settingsAccessor: ServiceSettingsAccessor,
+    ): CallsFromContactsGate = CallsFromContactsGate(context, settingsAccessor)
+}

--- a/rns-host/src/main/kotlin/network/columba/app/rns/host/ipc/BoundRnsTelephony.kt
+++ b/rns-host/src/main/kotlin/network/columba/app/rns/host/ipc/BoundRnsTelephony.kt
@@ -116,4 +116,8 @@ internal class BoundRnsTelephony(
     override suspend fun setPttActiveLocally(active: Boolean) {
         awaitBound().telephony.setPttActiveLocally(active)
     }
+
+    override suspend fun setIncomingEnabled(enabled: Boolean) {
+        awaitBound().telephony.setIncomingEnabled(enabled)
+    }
 }

--- a/rns-host/src/main/kotlin/network/columba/app/rns/host/persistence/CallsFromContactsGate.kt
+++ b/rns-host/src/main/kotlin/network/columba/app/rns/host/persistence/CallsFromContactsGate.kt
@@ -1,0 +1,98 @@
+package network.columba.app.rns.host.persistence
+
+import android.content.Context
+import android.util.Log
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.runBlocking
+import network.columba.app.data.db.ColumbaDatabase
+import network.columba.app.rns.host.di.ServiceDatabaseProvider
+
+/**
+ * Decides whether an inbound LXST link request should be silently dropped
+ * because the caller is not in the user's contacts list.
+ *
+ * Both `PythonCallManager` and `NativeCallManager` invoke
+ * [shouldSilentlyDrop] from their `onCallerIdentified` callback BEFORE
+ * sending `STATUS_RINGING` and BEFORE notifying `Telephone.onIncomingCall`.
+ * If this returns `true`, the call manager tears down the link without any
+ * signal, leaving the originator with a wait-time timeout that's
+ * indistinguishable from "remote went away" — no `STATUS_BUSY`, no
+ * `STATUS_REJECTED`, no notification on this device.
+ *
+ * The lookup walks the same two indices used elsewhere in the persistence
+ * layer (see [ServicePersistenceManager.shouldBlockUnknownSender]):
+ *
+ *   1. `announceDao.getAnnounceByIdentityHash(identityHashHex)` to translate
+ *      the inbound RNS identity hash into the destination hash the contacts
+ *      table is keyed on. No announce → treat as unknown (drop).
+ *   2. `localIdentityDao.getActiveIdentitySync()` to find the current
+ *      active local identity. Missing → fail open (allow).
+ *   3. `contactDao.contactExists(announce.destinationHash, active.identityHash)`
+ *      to confirm the (destination, owner) pair is in the contacts table.
+ *
+ * Any other exception inside the gate logs and returns `false` (allow). This
+ * mirrors the fail-open semantics of `block_unknown_senders` for messages so
+ * the toggle can never accidentally brick all inbound calls if a DAO query
+ * fails.
+ *
+ * Hilt-provided as a `@Singleton` in both flavor `HostBackendModule.kt`s.
+ */
+class CallsFromContactsGate(
+    private val context: Context,
+    private val settingsAccessor: ServiceSettingsAccessor,
+) {
+    private companion object {
+        const val TAG = "CallsFromContactsGate"
+    }
+
+    private val database: ColumbaDatabase by lazy { ServiceDatabaseProvider.getDatabase(context) }
+    private val announceDao by lazy { database.announceDao() }
+    private val contactDao by lazy { database.contactDao() }
+    private val localIdentityDao by lazy { database.localIdentityDao() }
+
+    /**
+     * @return `true` → silently tear down the inbound link (don't surface the
+     * call to UI, don't send any signal back to the originator).
+     * `false` → let the call ring normally.
+     *
+     * Reads `getAllowCallsFromContactsOnly()` on every call so live UI
+     * toggles take effect immediately without requiring any IPC.
+     */
+    fun shouldSilentlyDrop(identityHashHex: String): Boolean =
+        try {
+            if (!settingsAccessor.getAllowCallsFromContactsOnly()) {
+                false
+            } else {
+                // RNS reactor / Chaquopy callback thread expects a synchronous
+                // decision before STATUS_RINGING or STATUS_AVAILABLE can be
+                // sent. Matches the message-side block_unknown_senders gate's
+                // sync-on-receive shape.
+                runBlocking(Dispatchers.IO) { // THREADING: allowed — inbound-link callback requires synchronous gate decision
+                    val normalised = identityHashHex.lowercase()
+                    val announce = announceDao.getAnnounceByIdentityHash(normalised)
+                    if (announce == null) {
+                        Log.d(TAG, "Drop: no announce for $normalised")
+                        true
+                    } else {
+                        val active = localIdentityDao.getActiveIdentitySync()
+                        if (active == null) {
+                            // No active local identity — fail open. We can't
+                            // meaningfully check contacts without an owner.
+                            Log.w(TAG, "Allow: no active local identity, contacts check skipped")
+                            false
+                        } else {
+                            val known = contactDao.contactExists(announce.destinationHash, active.identityHash)
+                            if (!known) {
+                                Log.d(TAG, "Drop: ${announce.destinationHash.take(16)} not a contact of ${active.identityHash.take(16)}")
+                            }
+                            !known
+                        }
+                    }
+                }
+            }
+        } catch (e: Exception) {
+            // Fail open — a DAO blowup should not stop all inbound calls.
+            Log.w(TAG, "Contact gate failed, allowing call: ${e.message}", e)
+            false
+        }
+}

--- a/rns-host/src/main/kotlin/network/columba/app/rns/host/persistence/ServiceSettingsAccessor.kt
+++ b/rns-host/src/main/kotlin/network/columba/app/rns/host/persistence/ServiceSettingsAccessor.kt
@@ -21,6 +21,8 @@ class ServiceSettingsAccessor(
 
         // Keys for cross-process settings
         const val KEY_BLOCK_UNKNOWN_SENDERS = "block_unknown_senders"
+        const val KEY_ALLOW_CALLS_FROM_CONTACTS_ONLY = "allow_calls_from_contacts_only"
+        const val KEY_ALLOW_VOICE_CALLS = "allow_voice_calls"
         const val KEY_NETWORK_CHANGE_ANNOUNCE_TIME = "network_change_announce_time"
         const val KEY_LAST_AUTO_ANNOUNCE_TIME = "last_auto_announce_time"
         const val KEY_LAST_NETWORK_STATUS = "last_network_status"
@@ -66,6 +68,28 @@ class ServiceSettingsAccessor(
      * @return true if unknown senders should be blocked, false otherwise (default)
      */
     fun getBlockUnknownSenders(): Boolean = getCrossProcessPrefs().getBoolean(KEY_BLOCK_UNKNOWN_SENDERS, false)
+
+    /**
+     * Get the calls-from-contacts-only setting.
+     * When enabled, inbound LXST link requests from non-contacts are silently dropped
+     * after caller identification (no STATUS_RINGING to the originator, no UI surface).
+     *
+     * @return true if non-contact callers should be silently dropped, false (default) otherwise
+     */
+    fun getAllowCallsFromContactsOnly(): Boolean =
+        getCrossProcessPrefs().getBoolean(KEY_ALLOW_CALLS_FROM_CONTACTS_ONLY, false)
+
+    /**
+     * Get the master allow-voice-calls setting.
+     * When false, the `lxst.telephony` Destination should be deregistered so peers
+     * cannot reach it. Outbound calls remain functional regardless (they construct
+     * a fresh OUT destination per call). Defaults to true so a fresh install can
+     * receive calls without onboarding past this toggle.
+     *
+     * @return true (default) if incoming voice calls should be accepted, false otherwise
+     */
+    fun getAllowVoiceCalls(): Boolean =
+        getCrossProcessPrefs().getBoolean(KEY_ALLOW_VOICE_CALLS, true)
 
     /**
      * Persist the app process's current network-status string so the service process can

--- a/rns-host/src/pythonBackend/kotlin/network/columba/app/rns/host/HostBackendModule.kt
+++ b/rns-host/src/pythonBackend/kotlin/network/columba/app/rns/host/HostBackendModule.kt
@@ -10,6 +10,8 @@ import network.columba.app.rns.api.RnsBackend
 import network.columba.app.rns.backend.py.ChaquopyRnsBackend
 import network.columba.app.rns.host.ble.bridge.KotlinBLEBridge
 import network.columba.app.rns.host.di.LocalBackend
+import network.columba.app.rns.host.persistence.CallsFromContactsGate
+import network.columba.app.rns.host.persistence.ServiceSettingsAccessor
 import tech.torlando.lxst.core.CallCoordinator
 import javax.inject.Singleton
 
@@ -78,12 +80,16 @@ object HostBackendModule {
         backend: ChaquopyRnsBackend,
         transport: PythonNetworkTransport,
         callCoordinator: CallCoordinator,
+        settingsAccessor: ServiceSettingsAccessor,
+        contactsGate: CallsFromContactsGate,
     ): PythonCallManager =
         PythonCallManager(
             context = context,
             backend = backend,
             transport = transport,
             callCoordinator = callCoordinator,
+            settingsAccessor = settingsAccessor,
+            contactsGate = contactsGate,
         )
 
     /**

--- a/rns-host/src/pythonBackend/kotlin/network/columba/app/rns/host/PythonCallManager.kt
+++ b/rns-host/src/pythonBackend/kotlin/network/columba/app/rns/host/PythonCallManager.kt
@@ -16,6 +16,8 @@ import network.columba.app.rns.backend.py.ChaquopyRnsBackend
 import network.columba.app.rns.backend.py.PyEventCallback
 import network.columba.app.rns.backend.py.PyTwoArgCallback
 import network.columba.app.rns.backend.py.PythonRnsRuntime
+import network.columba.app.rns.host.persistence.CallsFromContactsGate
+import network.columba.app.rns.host.persistence.ServiceSettingsAccessor
 import tech.torlando.lxst.audio.Signalling
 import tech.torlando.lxst.core.AudioDevice
 import tech.torlando.lxst.core.AudioPacketHandler
@@ -41,6 +43,8 @@ class PythonCallManager(
     private val backend: ChaquopyRnsBackend,
     private val transport: PythonNetworkTransport,
     private val callCoordinator: CallCoordinator,
+    private val settingsAccessor: ServiceSettingsAccessor,
+    private val contactsGate: CallsFromContactsGate,
 ) : CallController {
     private val runtime: PythonRnsRuntime = backend.runtime
     private val backendStatusFlow: StateFlow<NetworkStatus> = backend.core.networkStatus
@@ -60,13 +64,26 @@ class PythonCallManager(
     @Volatile
     private var setupRan: Boolean = false
 
+    /**
+     * Master incoming-calls toggle state. Mirrors `:rns-backend-kt`'s
+     * sibling. Read by [onInboundLinkEstablished] as a TOCTOU guard
+     * against a link that crossed the wire just before
+     * [disableIncoming] ran; written only inside [incomingLock].
+     */
+    @Volatile
+    private var incomingDisabled: Boolean = false
+
+    /** Serialises [disableIncoming] / [enableIncoming] transitions. */
+    private val incomingLock = Any()
+
     init {
         // Auto-run setup() at backend READY (:rns-backend-py can't reach
         // here, so observe its status flow instead of being called inline
         // like NativeRnsBackendImpl.setupNativeTelephone). Also install
         // the profile-aware call hook so PythonRnsTelephony.initiateCall
         // can pass the codec profile through (default CallCoordinator
-        // path drops it).
+        // path drops it), and the setIncomingEnabled hook so the master
+        // AIDL toggle reaches this manager from the UI process.
         scope.launch {
             backendStatusFlow.filter { it == NetworkStatus.READY }.first()
             if (!setupRan) {
@@ -77,6 +94,7 @@ class PythonCallManager(
             backend.telephonyImpl.profileAwareCallHook = { destHex, profileCode ->
                 call(destHex, profileCode)
             }
+            backend.telephonyImpl.setIncomingEnabledHook = ::setIncomingEnabled
         }
     }
 
@@ -131,6 +149,17 @@ class PythonCallManager(
         callCoordinator.setCallManager(this)
         registerTelephonyDestination(localIdentity)
         announce()
+
+        // Cold-start application of the persisted master toggle. If the
+        // user turned voice calls OFF before the last :reticulum tear-down
+        // (or before this fresh-start), apply that now — we register +
+        // immediately deregister rather than skipping registration, so the
+        // re-enable path uses the same single helper. Marginally wasteful
+        // (~ms of work) but correct + minimal-conditional.
+        if (!settingsAccessor.getAllowVoiceCalls()) {
+            Log.i(TAG, "Cold-start: Allow voice calls = false, deregistering destination")
+            disableIncoming()
+        }
 
         Log.i(TAG, "Python telephony stack ready")
     }
@@ -202,6 +231,17 @@ class PythonCallManager(
     private fun onInboundLinkEstablished(link: PyObject) {
         Log.i(TAG, "Inbound call link arrived")
 
+        // Defense-in-depth TOCTOU guard: an inbound link may have been
+        // admitted by RNS in the brief window before
+        // Transport.deregister_destination returned. Drop it silently —
+        // STATUS_AVAILABLE has not yet been sent, so the caller sees the
+        // same "remote went away" timeout as the toggle-off path below.
+        if (incomingDisabled) {
+            Log.d(TAG, "Inbound link but incoming disabled, silently tearing down")
+            runCatching { link.callAttr("teardown") }
+            return
+        }
+
         if (telephone.isCallActive()) {
             Log.w(TAG, "Line busy — signalling busy and rejecting inbound link")
             sendSignalOnLink(link, Signalling.STATUS_BUSY)
@@ -239,6 +279,18 @@ class PythonCallManager(
             ?.joinToString("") { "%02x".format(it) }
             .orEmpty()
         Log.i(TAG, "Caller identified: ${identityHash.take(16)}")
+
+        // Calls-from-contacts-only gate. Fires BEFORE STATUS_RINGING and
+        // BEFORE Telephone.onIncomingCall, so the originator only sees a
+        // wait-time timeout (no STATUS_BUSY / STATUS_REJECTED) and this
+        // device shows no UI / no ringtone. Same fail-open semantics as
+        // ServicePersistenceManager.shouldBlockUnknownSender on the
+        // message side.
+        if (contactsGate.shouldSilentlyDrop(identityHash)) {
+            Log.i(TAG, "Calls-only-from-contacts: dropping ${identityHash.take(16)}")
+            runCatching { link.callAttr("teardown") }
+            return
+        }
 
         if (telephone.isCallActive()) {
             Log.w(TAG, "Line became busy after identify — signalling busy")
@@ -304,6 +356,56 @@ class PythonCallManager(
 
     override fun setSpeaker(enabled: Boolean) {
         audioBridge.setSpeakerphoneOn(enabled)
+    }
+
+    // ===== Master incoming-calls toggle =====
+
+    /**
+     * Apply [setIncomingEnabled] for this manager.
+     *
+     * Invoked by [network.columba.app.rns.backend.py.PythonRnsTelephony]'s
+     * `setIncomingEnabledHook` (wired in [init]) when the UI calls
+     * `RnsTelephony.setIncomingEnabled(...)` across the AIDL boundary.
+     *
+     * Idempotent — applying the same state twice is a no-op.
+     */
+    fun setIncomingEnabled(enabled: Boolean) {
+        if (enabled) enableIncoming() else disableIncoming()
+    }
+
+    private fun disableIncoming() = synchronized(incomingLock) {
+        if (incomingDisabled) return@synchronized
+        incomingDisabled = true
+        telephonyDestination?.let { dest ->
+            runCatching {
+                runtime.rnsModule["Transport"]!!.callAttr("deregister_destination", dest)
+                Log.i(TAG, "lxst.telephony destination deregistered")
+            }.onFailure { Log.w(TAG, "deregister_destination failed", it) }
+        }
+        telephonyDestination = null
+        if (::telephone.isInitialized && telephone.isCallActive()) {
+            // Hang up active call so the remote sees a clean drop rather
+            // than dead air. Hangup signal must travel BEFORE the
+            // destination is gone, but we've already nulled it above —
+            // that's fine because outgoing audio uses transport.activeLink
+            // (set on accept) not the destination.
+            runCatching { telephone.hangup() }
+                .onFailure { Log.w(TAG, "Ignored hangup error during disableIncoming", it) }
+        }
+    }
+
+    private fun enableIncoming() = synchronized(incomingLock) {
+        if (!incomingDisabled && telephonyDestination != null) return@synchronized
+        incomingDisabled = false
+        val ident = runtime.localIdentity
+        if (ident == null) {
+            // setup() hasn't run yet (cold-start before backend READY).
+            // The flag is now `false`; setup() will register normally.
+            Log.d(TAG, "enableIncoming: localIdentity not ready, will register at setup")
+            return@synchronized
+        }
+        registerTelephonyDestination(ident)
+        announce()
     }
 
     /** Tear down the telephony stack. Mirrors `NativeCallManager.shutdown()`. */

--- a/rns-host/src/test/kotlin/network/columba/app/rns/host/ipc/BoundRnsBackendTest.kt
+++ b/rns-host/src/test/kotlin/network/columba/app/rns/host/ipc/BoundRnsBackendTest.kt
@@ -290,6 +290,7 @@ class BoundRnsBackendTest {
         override suspend fun setSpeakerLocally(enabled: Boolean) {}
         override suspend fun setPttModeLocally(enabled: Boolean) {}
         override suspend fun setPttActiveLocally(active: Boolean) {}
+        override suspend fun setIncomingEnabled(enabled: Boolean) {}
     }
 
     private class FakeRnsTransportAdmin : RnsTransportAdmin {

--- a/rns-host/src/test/kotlin/network/columba/app/rns/host/persistence/CallsFromContactsGateTest.kt
+++ b/rns-host/src/test/kotlin/network/columba/app/rns/host/persistence/CallsFromContactsGateTest.kt
@@ -1,0 +1,168 @@
+package network.columba.app.rns.host.persistence
+
+import android.content.Context
+import io.mockk.clearAllMocks
+import io.mockk.coEvery
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.mockkObject
+import io.mockk.unmockkObject
+import network.columba.app.data.db.ColumbaDatabase
+import network.columba.app.data.db.dao.AnnounceDao
+import network.columba.app.data.db.dao.ContactDao
+import network.columba.app.data.db.dao.LocalIdentityDao
+import network.columba.app.data.db.entity.AnnounceEntity
+import network.columba.app.data.db.entity.LocalIdentityEntity
+import network.columba.app.rns.host.di.ServiceDatabaseProvider
+import org.junit.After
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+
+/**
+ * Unit tests for CallsFromContactsGate.
+ *
+ * Covers the same shape ServicePersistenceManagerTest uses for
+ * shouldBlockUnknownSender — settings toggle, DAO mocks, fail-open on
+ * exception — so the inbound-call gate stays consistent with the
+ * inbound-message gate.
+ */
+class CallsFromContactsGateTest {
+    private lateinit var context: Context
+    private lateinit var database: ColumbaDatabase
+    private lateinit var announceDao: AnnounceDao
+    private lateinit var contactDao: ContactDao
+    private lateinit var localIdentityDao: LocalIdentityDao
+    private lateinit var settingsAccessor: ServiceSettingsAccessor
+    private lateinit var gate: CallsFromContactsGate
+
+    private val callerIdentityHash = "abcdef0123456789abcdef0123456789"
+    private val callerDestinationHash = "deadbeefcafef00ddeadbeefcafef00d"
+    private val ownerIdentityHash = "0011223344556677001122334455667700"
+
+    private val sampleAnnounce =
+        AnnounceEntity(
+            destinationHash = callerDestinationHash,
+            peerName = "Caller",
+            publicKey = ByteArray(32),
+            appData = null,
+            hops = 1,
+            lastSeenTimestamp = 0L,
+            nodeType = "LXMF_PEER",
+            receivingInterface = null,
+        )
+
+    private val sampleIdentity =
+        LocalIdentityEntity(
+            identityHash = ownerIdentityHash,
+            displayName = "Owner",
+            destinationHash = "deadbeefdeadbeefdeadbeefdeadbeef",
+            filePath = "/dev/null",
+            createdTimestamp = 0L,
+            lastUsedTimestamp = 0L,
+            isActive = true,
+        )
+
+    @Suppress("NoRelaxedMocks") // Android Context fixture — gate touches no Context methods directly
+    @Before
+    fun setup() {
+        context = mockk(relaxed = true)
+        database = mockk()
+        announceDao = mockk()
+        contactDao = mockk()
+        localIdentityDao = mockk()
+        settingsAccessor = mockk()
+
+        every { database.announceDao() } returns announceDao
+        every { database.contactDao() } returns contactDao
+        every { database.localIdentityDao() } returns localIdentityDao
+
+        mockkObject(ServiceDatabaseProvider)
+        every { ServiceDatabaseProvider.getDatabase(any()) } returns database
+
+        gate = CallsFromContactsGate(context, settingsAccessor)
+    }
+
+    @After
+    fun tearDown() {
+        unmockkObject(ServiceDatabaseProvider)
+        clearAllMocks()
+    }
+
+    @Test
+    fun `shouldSilentlyDrop returns false when toggle is off`() {
+        every { settingsAccessor.getAllowCallsFromContactsOnly() } returns false
+
+        assertFalse(gate.shouldSilentlyDrop(callerIdentityHash))
+    }
+
+    @Test
+    fun `shouldSilentlyDrop returns true when toggle on and no announce known`() {
+        every { settingsAccessor.getAllowCallsFromContactsOnly() } returns true
+        coEvery { announceDao.getAnnounceByIdentityHash(any()) } returns null
+
+        assertTrue(gate.shouldSilentlyDrop(callerIdentityHash))
+    }
+
+    @Test
+    fun `shouldSilentlyDrop returns false when caller is a known contact`() {
+        every { settingsAccessor.getAllowCallsFromContactsOnly() } returns true
+        coEvery { announceDao.getAnnounceByIdentityHash(callerIdentityHash) } returns sampleAnnounce
+        coEvery { localIdentityDao.getActiveIdentitySync() } returns sampleIdentity
+        coEvery { contactDao.contactExists(callerDestinationHash, ownerIdentityHash) } returns true
+
+        assertFalse(gate.shouldSilentlyDrop(callerIdentityHash))
+    }
+
+    @Test
+    fun `shouldSilentlyDrop returns true when announce exists but contact lookup misses`() {
+        every { settingsAccessor.getAllowCallsFromContactsOnly() } returns true
+        coEvery { announceDao.getAnnounceByIdentityHash(callerIdentityHash) } returns sampleAnnounce
+        coEvery { localIdentityDao.getActiveIdentitySync() } returns sampleIdentity
+        coEvery { contactDao.contactExists(callerDestinationHash, ownerIdentityHash) } returns false
+
+        assertTrue(gate.shouldSilentlyDrop(callerIdentityHash))
+    }
+
+    @Test
+    fun `shouldSilentlyDrop fails open when no active local identity exists`() {
+        // Without an owner identity we cannot meaningfully check contacts.
+        // Allowing the call through is safer than silently dropping every
+        // inbound during the first-launch / identity-rotation window.
+        every { settingsAccessor.getAllowCallsFromContactsOnly() } returns true
+        coEvery { announceDao.getAnnounceByIdentityHash(callerIdentityHash) } returns sampleAnnounce
+        coEvery { localIdentityDao.getActiveIdentitySync() } returns null
+
+        assertFalse(gate.shouldSilentlyDrop(callerIdentityHash))
+    }
+
+    @Test
+    fun `shouldSilentlyDrop normalises identity hash to lowercase before lookup`() {
+        every { settingsAccessor.getAllowCallsFromContactsOnly() } returns true
+        coEvery { announceDao.getAnnounceByIdentityHash(callerIdentityHash) } returns sampleAnnounce
+        coEvery { localIdentityDao.getActiveIdentitySync() } returns sampleIdentity
+        coEvery { contactDao.contactExists(callerDestinationHash, ownerIdentityHash) } returns true
+
+        // Uppercase + mixed-case inputs both reduce to the same lowercase lookup.
+        assertFalse(gate.shouldSilentlyDrop(callerIdentityHash.uppercase()))
+    }
+
+    @Test
+    fun `shouldSilentlyDrop fails open when announce DAO throws`() {
+        every { settingsAccessor.getAllowCallsFromContactsOnly() } returns true
+        coEvery { announceDao.getAnnounceByIdentityHash(any()) } throws RuntimeException("Room boom")
+
+        assertFalse(gate.shouldSilentlyDrop(callerIdentityHash))
+    }
+
+    @Test
+    fun `shouldSilentlyDrop fails open when contact DAO throws`() {
+        every { settingsAccessor.getAllowCallsFromContactsOnly() } returns true
+        coEvery { announceDao.getAnnounceByIdentityHash(callerIdentityHash) } returns sampleAnnounce
+        coEvery { localIdentityDao.getActiveIdentitySync() } returns sampleIdentity
+        coEvery { contactDao.contactExists(any(), any()) } throws RuntimeException("Room boom")
+
+        assertFalse(gate.shouldSilentlyDrop(callerIdentityHash))
+    }
+}

--- a/rns-host/src/test/kotlin/network/columba/app/rns/host/persistence/ServiceSettingsAccessorTest.kt
+++ b/rns-host/src/test/kotlin/network/columba/app/rns/host/persistence/ServiceSettingsAccessorTest.kt
@@ -136,6 +136,55 @@ class ServiceSettingsAccessorTest {
         assertTrue(accessor.getBlockUnknownSenders())
     }
 
+    // ========== getAllowCallsFromContactsOnly() Tests ==========
+
+    @Test
+    fun `getAllowCallsFromContactsOnly returns false by default`() {
+        assertFalse(accessor.getAllowCallsFromContactsOnly())
+    }
+
+    @Test
+    fun `getAllowCallsFromContactsOnly returns true when set`() {
+        prefs.edit().putBoolean(ServiceSettingsAccessor.KEY_ALLOW_CALLS_FROM_CONTACTS_ONLY, true).apply()
+
+        assertTrue(accessor.getAllowCallsFromContactsOnly())
+    }
+
+    @Test
+    fun `getAllowCallsFromContactsOnly reflects changes between calls`() {
+        assertFalse(accessor.getAllowCallsFromContactsOnly())
+
+        prefs.edit().putBoolean(ServiceSettingsAccessor.KEY_ALLOW_CALLS_FROM_CONTACTS_ONLY, true).apply()
+
+        assertTrue(accessor.getAllowCallsFromContactsOnly())
+    }
+
+    // ========== getAllowVoiceCalls() Tests ==========
+
+    @Test
+    fun `getAllowVoiceCalls returns true by default`() {
+        // Default is true so an upgrading user still receives calls without
+        // touching the toggle.
+        assertTrue(accessor.getAllowVoiceCalls())
+    }
+
+    @Test
+    fun `getAllowVoiceCalls returns false when explicitly set to false`() {
+        prefs.edit().putBoolean(ServiceSettingsAccessor.KEY_ALLOW_VOICE_CALLS, false).apply()
+
+        assertFalse(accessor.getAllowVoiceCalls())
+    }
+
+    @Test
+    fun `getAllowVoiceCalls reflects changes between calls`() {
+        // First call returns the true default
+        assertTrue(accessor.getAllowVoiceCalls())
+
+        prefs.edit().putBoolean(ServiceSettingsAccessor.KEY_ALLOW_VOICE_CALLS, false).apply()
+
+        assertFalse(accessor.getAllowVoiceCalls())
+    }
+
     // ========== Cross-process key constants Tests ==========
 
     @Test
@@ -146,6 +195,8 @@ class ServiceSettingsAccessorTest {
     @Test
     fun `companion object exposes correct key constants`() {
         assertEquals("block_unknown_senders", ServiceSettingsAccessor.KEY_BLOCK_UNKNOWN_SENDERS)
+        assertEquals("allow_calls_from_contacts_only", ServiceSettingsAccessor.KEY_ALLOW_CALLS_FROM_CONTACTS_ONLY)
+        assertEquals("allow_voice_calls", ServiceSettingsAccessor.KEY_ALLOW_VOICE_CALLS)
         assertEquals("network_change_announce_time", ServiceSettingsAccessor.KEY_NETWORK_CHANGE_ANNOUNCE_TIME)
         assertEquals("last_auto_announce_time", ServiceSettingsAccessor.KEY_LAST_AUTO_ANNOUNCE_TIME)
     }

--- a/rns-ipc/src/main/kotlin/network/columba/app/rns/ipc/client/ClientRnsTelephony.kt
+++ b/rns-ipc/src/main/kotlin/network/columba/app/rns/ipc/client/ClientRnsTelephony.kt
@@ -184,6 +184,10 @@ internal class ClientRnsTelephony(
     override suspend fun setPttActiveLocally(active: Boolean) {
         awaitResult { cb -> remote.setPttActiveLocally(active, cb) }
     }
+
+    override suspend fun setIncomingEnabled(enabled: Boolean) {
+        awaitResult { cb -> remote.setIncomingEnabled(enabled, cb) }
+    }
 }
 
 /** Snapshot read for the [CallState] StateFlow. */

--- a/rns-ipc/src/main/kotlin/network/columba/app/rns/ipc/server/ServerRnsTelephony.kt
+++ b/rns-ipc/src/main/kotlin/network/columba/app/rns/ipc/server/ServerRnsTelephony.kt
@@ -191,4 +191,9 @@ internal class ServerRnsTelephony(
         impl.setPttActiveLocally(active)
         Bundle.EMPTY
     }
+
+    override fun setIncomingEnabled(enabled: Boolean, cb: IRnsResultCallback) = dispatch(cb, scope) {
+        impl.setIncomingEnabled(enabled)
+        Bundle.EMPTY
+    }
 }

--- a/rns-ipc/src/test/java/network/columba/app/rns/ipc/RnsBackendIpcRoundTripTest.kt
+++ b/rns-ipc/src/test/java/network/columba/app/rns/ipc/RnsBackendIpcRoundTripTest.kt
@@ -201,6 +201,22 @@ class RnsBackendIpcRoundTripTest {
     }
 
     @Test
+    fun `setIncomingEnabled round-trips both true and false through the stub`() = runTest {
+        val (client, _) = buildClientAndServer()
+        advanceUntilIdle()
+
+        client.telephony.setIncomingEnabled(false)
+        advanceUntilIdle()
+        assertEquals(false, fake.telephony.incomingEnabled)
+
+        client.telephony.setIncomingEnabled(true)
+        advanceUntilIdle()
+        assertEquals(true, fake.telephony.incomingEnabled)
+
+        assertEquals(2, fake.telephony.setIncomingEnabledCalls)
+    }
+
+    @Test
     fun `capabilities observer pushes mutations into the client StateFlow`() = runTest {
         val (client, _) = buildClientAndServer()
         advanceUntilIdle()
@@ -263,6 +279,8 @@ private class FakeRnsTelephony : RnsTelephony {
     var nextAnswerResult: Result<Unit> = Result.success(Unit)
     var hangupCount = 0
     var declineCount = 0
+    var setIncomingEnabledCalls = 0
+    var incomingEnabled: Boolean? = null
     var nextCallState: Result<VoiceCallState> = Result.success(
         VoiceCallState("IDLE", isActive = false, isMuted = false, remoteIdentity = null, profile = null),
     )
@@ -308,6 +326,10 @@ private class FakeRnsTelephony : RnsTelephony {
     override suspend fun setSpeakerLocally(enabled: Boolean) { _isSpeakerOn.value = enabled }
     override suspend fun setPttModeLocally(enabled: Boolean) { _isPttMode.value = enabled }
     override suspend fun setPttActiveLocally(active: Boolean) { _isPttActive.value = active }
+    override suspend fun setIncomingEnabled(enabled: Boolean) {
+        setIncomingEnabledCalls++
+        incomingEnabled = enabled
+    }
 }
 
 private class FakeRnsLxmf : RnsLxmf {


### PR DESCRIPTION
## Summary

Ports the two LXST inbound-call privacy gates from PR #930 (`feat/lxst-call-privacy-gates-v0.10.x`) onto the dual-build line. Both python and kotlin backends ship both features in one PR.

- **Feature 1 — Privacy → "Calls from contacts only"**: silently drops inbound LXST link requests from non-contacts after caller identification, before STATUS_RINGING. No UI surface on this device, no signal back to the originator (they see a wait-time timeout). Default OFF.
- **Feature 2 — Voice Call Permissions → "Allow voice calls"**: master toggle that deregisters the `lxst.telephony` destination when OFF, hangs up any active call, stops accepting inbound link requests. Outbound calls keep working (separate ephemeral OUT destination). Default ON.

## Architecture (deviation from v0.10.x)

The v0.10.x port hit cross-process bugs with `SharedPreferences.OnSharedPreferenceChangeListener` (doesn't fire across processes) and shipped an Intent-action runtime delivery path as fix-forward. Dual-build avoids that bug class by using the existing `:reticulum` AIDL surface:

1. **New AIDL method** `RnsTelephony.setIncomingEnabled(boolean)` — runtime delivery for Feature 2 from UI process → `:reticulum`. Backpressure + error propagation via `IRnsResultCallback`.
2. **Cold-start path** — both call managers read `ServiceSettingsAccessor.getAllowVoiceCalls()` at the end of `setup()` and apply the persisted toggle so `:reticulum` restarts (Android OOM-kill, force-stop) self-recover even without UI being alive.
3. **Shared helper** — `CallsFromContactsGate` lives in `:rns-host/src/main/` and is injected via Hilt into both `PythonCallManager` (pythonBackend) and `NativeCallManager` (kotlinBackend). For kotlinBackend, a `CallPrivacyBridge` interface in `:rns-backend-kt` mirrors the existing `RNodeHostBridge` pattern — the adapter wrapping `CallsFromContactsGate` + `ServiceSettingsAccessor` lives in the kotlinBackend `HostBackendModule.kt`. (`:rns-backend-kt` cannot import `:rns-host` directly — would cycle the Gradle dep graph.)
4. **Both flavors ship Feature 2** — `reticulum-kt`'s `Transport.deregisterDestination` is public (verified via `javap` on `rns-core-0.1.0-SNAPSHOT.jar`). No upstream gap.

## Commit decomposition

Each commit is independently green:

1. `bd4d7dd8` — DataStore prefs + ServiceSettingsAccessor (plumbing only)
2. `9ff644c9` — `CallsFromContactsGate` helper + shared `PersistenceModule` Hilt providers
3. `90f758bf` — `RnsTelephony.setIncomingEnabled` AIDL surface (interface + server/client/bound forwarders + IPC round-trip test; stub backend impls via hook pattern)
4. `749369ca` — pythonBackend wiring (gate, TOCTOU guard, disable/enable, cold-start, hook)
5. `b6544818` — kotlinBackend wiring (mirror via `CallPrivacyBridge` interface)
6. `9101392e` — UI toggles in PrivacyCard + VoiceCallPermissionsCard + ViewModel
7. `780ce15b` — PrivacyCard refactor (block-unknown-senders header → body for equal billing)

## Test plan

### Unit tests (already green per-commit)

- [x] `./gradlew :rns-host:testPythonBackendDebugUnitTest`
- [x] `./gradlew :rns-host:testKotlinBackendDebugUnitTest`
- [x] `./gradlew :rns-backend-py:testDebugUnitTest`
- [x] `./gradlew :rns-backend-kt:testDebugUnitTest`
- [x] `./gradlew :rns-ipc:testDebugUnitTest`
- [x] `./gradlew :rns-api:testDebugUnitTest`
- [x] `./gradlew :app:testNoSentryPythonBackendDebugUnitTest`
- [x] `./audit-dispatchers.sh` — zero violations, new `runBlocking` carries the `// THREADING: allowed` marker

Pre-existing failure observed on `:app:testNoSentryKotlinBackendDebugUnitTest` in `BleStatusRepositoryTest` (MockK inline-function stubbing). Not introduced by this branch — `git log` shows no commits since the base touched that file and no BLE prod code changed here.

### On-device verification (two phones, per flavor)

After a fresh install, for each of pythonBackend and kotlinBackend:

- [ ] Feature 1 baseline — Toggle OFF. Non-contact peer calls → device rings normally.
- [ ] Feature 1 silent drop — Toggle ON. Non-contact peer calls → no UI, no ringtone, no notification. Logcat `:reticulum`: `Calls-only-from-contacts: dropping <hash>`. Caller's UI shows ringing until 70s timeout.
- [ ] Feature 1 contact allow — Add caller as contact, retry. Device rings.
- [ ] Feature 2 baseline — Toggle ON (default). Peer calls → device rings.
- [ ] Feature 2 master disable — Toggle OFF. Peer calls → no reach. Logcat: `lxst.telephony destination deregistered`. AIDL clean return.
- [ ] Feature 2 mid-call disable — Mid-ring, flip OFF. Caller sees clean drop within seconds.
- [ ] Feature 2 re-enable — Flip ON. Logcat: `lxst.telephony destination registered: <hash>` + announce. Next peer call rings.
- [ ] Outbound while master OFF — Outbound call places normally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)