### PR TITLE
feat: LXST call privacy gates + telemetry responder (dual-build)

### DIFF
--- a/app/src/main/java/network/columba/app/migration/MigrationImporter.kt
+++ b/app/src/main/java/network/columba/app/migration/MigrationImporter.kt
@@ -471,7 +471,7 @@ class MigrationImporter
                     // Derive interface type from receivingInterface if not present (backward compatibility)
                     val interfaceType =
                         announce.receivingInterfaceType
-                            ?: InterfaceType.fromInterfaceName(announce.receivingInterface).name
+                            ?: InterfaceType.fromName(announce.receivingInterface).storageName
 
                     val decodedPublicKey = Base64.decode(announce.publicKey, Base64.NO_WRAP)
                     AnnounceEntity(

--- a/app/src/main/java/network/columba/app/repository/SettingsRepository.kt
+++ b/app/src/main/java/network/columba/app/repository/SettingsRepository.kt
@@ -134,6 +134,8 @@ class SettingsRepository
 
             // Privacy preferences
             val BLOCK_UNKNOWN_SENDERS = booleanPreferencesKey("block_unknown_senders")
+            val ALLOW_CALLS_FROM_CONTACTS_ONLY = booleanPreferencesKey("allow_calls_from_contacts_only")
+            val ALLOW_VOICE_CALLS = booleanPreferencesKey("allow_voice_calls")
 
             // Telemetry collector preferences
             val TELEMETRY_COLLECTOR_ADDRESS = stringPreferencesKey("telemetry_collector_address")
@@ -1692,6 +1694,8 @@ class SettingsRepository
             // Cross-process SharedPreferences keys (for settings read by the service)
             const val CROSS_PROCESS_PREFS_NAME = "cross_process_settings"
             const val KEY_BLOCK_UNKNOWN_SENDERS = "block_unknown_senders"
+            const val KEY_ALLOW_CALLS_FROM_CONTACTS_ONLY = "allow_calls_from_contacts_only"
+            const val KEY_ALLOW_VOICE_CALLS = "allow_voice_calls"
 
             /** Default telemetry send interval: 5 minutes */
             const val DEFAULT_TELEMETRY_SEND_INTERVAL_SECONDS = 300
@@ -1887,6 +1891,94 @@ class SettingsRepository
                 .getSharedPreferences(CROSS_PROCESS_PREFS_NAME, Context.MODE_MULTI_PROCESS)
                 .edit()
                 .putBoolean(KEY_BLOCK_UNKNOWN_SENDERS, enabled)
+                .apply()
+        }
+
+        /**
+         * Flow of the calls-from-contacts-only setting.
+         *
+         * When enabled, inbound LXST link requests whose source identity is not in the
+         * user's contacts list are silently dropped after identification (no STATUS_RINGING
+         * to the originator, no UI surface on this device).
+         *
+         * Defaults to false (allow calls from anyone — preserves existing behaviour).
+         */
+        val allowCallsFromContactsOnlyFlow: Flow<Boolean> =
+            context.dataStore.data
+                .map { preferences ->
+                    preferences[PreferencesKeys.ALLOW_CALLS_FROM_CONTACTS_ONLY] ?: false
+                }.distinctUntilChanged()
+
+        /** Get the calls-from-contacts-only setting (non-flow). */
+        suspend fun getAllowCallsFromContactsOnly(): Boolean =
+            context.dataStore.data
+                .map { preferences ->
+                    preferences[PreferencesKeys.ALLOW_CALLS_FROM_CONTACTS_ONLY] ?: false
+                }.first()
+
+        /**
+         * Save the calls-from-contacts-only setting.
+         *
+         * Dual-writes DataStore (UI-side flow) + MODE_MULTI_PROCESS SharedPreferences
+         * (service-side reads each inbound link). No runtime signal is needed because the
+         * `:reticulum` call manager reads the SharedPreferences value on every
+         * `onCallerIdentified` — same pattern as [saveBlockUnknownSenders].
+         */
+        @Suppress("DEPRECATION") // MODE_MULTI_PROCESS needed for cross-process reads
+        suspend fun saveAllowCallsFromContactsOnly(enabled: Boolean) {
+            context.dataStore.edit { preferences ->
+                preferences[PreferencesKeys.ALLOW_CALLS_FROM_CONTACTS_ONLY] = enabled
+            }
+            context
+                .getSharedPreferences(CROSS_PROCESS_PREFS_NAME, Context.MODE_MULTI_PROCESS)
+                .edit()
+                .putBoolean(KEY_ALLOW_CALLS_FROM_CONTACTS_ONLY, enabled)
+                .apply()
+        }
+
+        /**
+         * Flow of the master "Allow voice calls" setting.
+         *
+         * When false, the `lxst.telephony` Destination is deregistered from the network
+         * (peers cannot reach it; new link requests fail at Transport with no application
+         * code running on this side). Outbound calls remain functional regardless — only
+         * the inbound destination is affected.
+         *
+         * Defaults to true (incoming voice calls accepted — preserves existing behaviour).
+         */
+        val allowVoiceCallsFlow: Flow<Boolean> =
+            context.dataStore.data
+                .map { preferences ->
+                    preferences[PreferencesKeys.ALLOW_VOICE_CALLS] ?: true
+                }.distinctUntilChanged()
+
+        /** Get the master allow-voice-calls setting (non-flow). */
+        suspend fun getAllowVoiceCalls(): Boolean =
+            context.dataStore.data
+                .map { preferences ->
+                    preferences[PreferencesKeys.ALLOW_VOICE_CALLS] ?: true
+                }.first()
+
+        /**
+         * Save the master allow-voice-calls setting.
+         *
+         * Dual-writes DataStore + MODE_MULTI_PROCESS SharedPreferences. The
+         * SharedPreferences value is what `:reticulum` reads at cold-start (post
+         * START_STICKY restart) to apply the persisted state before the first announce.
+         * Runtime delivery to the live `:reticulum` process happens via the AIDL
+         * `RnsTelephony.setIncomingEnabled(boolean)` call from the ViewModel — not from
+         * here — because `SharedPreferences.OnSharedPreferenceChangeListener` does not
+         * fire across processes (a v0.10.x port lesson).
+         */
+        @Suppress("DEPRECATION") // MODE_MULTI_PROCESS needed for cross-process reads
+        suspend fun saveAllowVoiceCalls(enabled: Boolean) {
+            context.dataStore.edit { preferences ->
+                preferences[PreferencesKeys.ALLOW_VOICE_CALLS] = enabled
+            }
+            context
+                .getSharedPreferences(CROSS_PROCESS_PREFS_NAME, Context.MODE_MULTI_PROCESS)
+                .edit()
+                .putBoolean(KEY_ALLOW_VOICE_CALLS, enabled)
                 .apply()
         }
 

--- a/app/src/main/java/network/columba/app/service/LocationSharingManager.kt
+++ b/app/src/main/java/network/columba/app/service/LocationSharingManager.kt
@@ -121,12 +121,30 @@ class LocationSharingManager
                 }
             }
 
+        // Master gate cache. `Settings → Location Sharing` is a hard
+        // kill-switch — when OFF, [startSharing] refuses and outbound
+        // telemetry pauses regardless of which call site triggered it.
+        // Cached as a volatile field so `startSharing` (non-suspend, called
+        // from synchronous UI handlers) can read it without blocking. The
+        // init collector below keeps it in sync with the persisted flag.
+        @Volatile
+        private var masterEnabled: Boolean = true
+
         init {
             // Start listening for incoming location telemetry
             startListeningForLocationTelemetry()
 
             // Start periodic cleanup of expired locations
             startMaintenanceLoop()
+
+            // Mirror the persisted master-gate flag into the cache. Default
+            // starts permissive (true) so a brand-new install lets the user
+            // share before this collector has emitted its first value.
+            scope.launch {
+                settingsRepository.locationSharingEnabledFlow.collect { enabled ->
+                    masterEnabled = enabled
+                }
+            }
         }
 
         /**
@@ -142,6 +160,16 @@ class LocationSharingManager
             displayNames: Map<String, String>,
             duration: SharingDuration,
         ) {
+            // Master gate. Refuse every outbound sharing attempt while the
+            // settings toggle is OFF — covers per-conversation, multi-contact,
+            // and any future call site. Emit a SharingEvent so UI can show
+            // a snackbar / toast instead of a silent no-op.
+            if (!masterEnabled) {
+                Log.w(TAG, "startSharing blocked: Location Sharing is OFF in Settings")
+                scope.launch { _sharingEvents.emit(SharingEvent.Blocked) }
+                return
+            }
+
             val startTime = System.currentTimeMillis()
             val endTime = duration.calculateEndTime(startTime)
 
@@ -326,10 +354,23 @@ class LocationSharingManager
                 scope.launch {
                     try {
                         if (useGms) {
+                            // Active location sharing implies the user wants
+                            // accuracy ("Precise" in the precision picker
+                            // means radius=0 and they expect a real GPS fix,
+                            // not a Wi-Fi/cell-tower-positioning fallback).
+                            // `PRIORITY_BALANCED_POWER_ACCURACY` was producing
+                            // 600m+ fixes indoors that drift kilometers
+                            // between colocated peers — the network-positioning
+                            // signal is too noisy for "share my location with
+                            // someone in the same room" to look right.
+                            // `PRIORITY_HIGH_ACCURACY` engages GPS, which is
+                            // the right power/accuracy trade for the lifetime
+                            // of an active share (foreground service is
+                            // already running, user is actively engaged).
                             val locationRequest =
                                 LocationRequest
                                     .Builder(
-                                        Priority.PRIORITY_BALANCED_POWER_ACCURACY,
+                                        Priority.PRIORITY_HIGH_ACCURACY,
                                         LOCATION_UPDATE_INTERVAL_MS,
                                     ).apply {
                                         setMinUpdateIntervalMillis(LOCATION_MIN_UPDATE_INTERVAL_MS)
@@ -634,4 +675,11 @@ sealed class SharingEvent {
     data class Error(
         val message: String,
     ) : SharingEvent()
+
+    /**
+     * Emitted when a [LocationSharingManager.startSharing] call is refused
+     * because the master `Settings → Location Sharing` toggle is OFF. UI
+     * can show a snackbar pointing the user back to Settings.
+     */
+    data object Blocked : SharingEvent()
 }

--- a/app/src/main/java/network/columba/app/service/MessageCollector.kt
+++ b/app/src/main/java/network/columba/app/service/MessageCollector.kt
@@ -222,6 +222,12 @@ class MessageCollector
                                 // Signal quality metrics (RNode/BLE; null on TCP/Auto/propagated)
                                 receivedRssi = receivedMessage.receivedRssi,
                                 receivedSnr = receivedMessage.receivedSnr,
+                                // LXMF delivery method ("opportunistic" / "direct" / "propagated"
+                                // / "paper"). Surfaced in MessageDetailScreen for received
+                                // messages — most of the path-info cards (hop count, interface,
+                                // RSSI/SNR) are null for propagation-fetched messages, so
+                                // without this the detail screen renders essentially empty.
+                                deliveryMethod = receivedMessage.deliveryMethod,
                                 // Local reception time for sort ordering
                                 receivedAt = now,
                             )
@@ -400,7 +406,7 @@ class MessageCollector
                                     timestamp = announce.timestamp,
                                     nodeType = announce.nodeType.name,
                                     receivingInterface = announce.receivingInterface,
-                                    receivingInterfaceType = InterfaceType.fromInterfaceName(announce.receivingInterface).name,
+                                    receivingInterfaceType = InterfaceType.fromName(announce.receivingInterface).storageName,
                                     aspect = announce.aspect,
                                     stampCost = announce.stampCost,
                                     stampCostFlexibility = announce.stampCostFlexibility,
@@ -433,7 +439,7 @@ class MessageCollector
                                     destinationHash = peerHash,
                                     peerName = peerName,
                                     hops = announce.hops,
-                                    interfaceType = InterfaceType.fromInterfaceName(announce.receivingInterface),
+                                    interfaceType = InterfaceType.fromName(announce.receivingInterface),
                                     receivingInterface = announce.receivingInterface,
                                 )
                                 Log.d(TAG, "Posted notification for announce")

--- a/app/src/main/java/network/columba/app/service/TelemetryCollectorManager.kt
+++ b/app/src/main/java/network/columba/app/service/TelemetryCollectorManager.kt
@@ -354,8 +354,17 @@ class TelemetryCollectorManager
 
         /**
          * Enable or disable automatic telemetry sending.
+         *
+         * Gated on the master `Settings → Location Sharing` toggle: when
+         * the master flag is OFF, enabling group-telemetry sending is
+         * refused and the persisted state stays false. Disabling is
+         * always allowed.
          */
         suspend fun setEnabled(enabled: Boolean) {
+            if (enabled && !settingsRepository.locationSharingEnabledFlow.first()) {
+                Log.w(TAG, "TelemetryCollector.setEnabled(true) refused: master location sharing is OFF")
+                return
+            }
             settingsRepository.saveTelemetryCollectorEnabled(enabled)
         }
 

--- a/app/src/main/java/network/columba/app/service/TelemetryCollectorManager.kt
+++ b/app/src/main/java/network/columba/app/service/TelemetryCollectorManager.kt
@@ -16,8 +16,11 @@ import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.delay
+import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.SharedFlow
 import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asSharedFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.flow.first
@@ -118,6 +121,16 @@ class TelemetryCollectorManager
 
         private val _isEnabled = MutableStateFlow(false)
         val isEnabled: StateFlow<Boolean> = _isEnabled.asStateFlow()
+
+        // Fires when [setEnabled] is called with `enabled = true` while the
+        // master `Settings → Location Sharing` toggle is OFF. UI subscribes
+        // and surfaces a Toast pointing the user back to the master gate.
+        // Currently the only refusal vector — the toggle row in the
+        // settings card is preemptively disabled when master is off, so
+        // this should only fire if some other code path manages to call
+        // setEnabled(true) through the gate.
+        private val _setEnabledRefused = MutableSharedFlow<Unit>(extraBufferCapacity = 4)
+        val setEnabledRefused: SharedFlow<Unit> = _setEnabledRefused.asSharedFlow()
 
         private val _sendIntervalSeconds = MutableStateFlow(SettingsRepository.DEFAULT_TELEMETRY_SEND_INTERVAL_SECONDS)
         val sendIntervalSeconds: StateFlow<Int> = _sendIntervalSeconds.asStateFlow()
@@ -363,6 +376,7 @@ class TelemetryCollectorManager
         suspend fun setEnabled(enabled: Boolean) {
             if (enabled && !settingsRepository.locationSharingEnabledFlow.first()) {
                 Log.w(TAG, "TelemetryCollector.setEnabled(true) refused: master location sharing is OFF")
+                _setEnabledRefused.tryEmit(Unit)
                 return
             }
             settingsRepository.saveTelemetryCollectorEnabled(enabled)

--- a/app/src/main/java/network/columba/app/ui/components/AnnounceFilterChips.kt
+++ b/app/src/main/java/network/columba/app/ui/components/AnnounceFilterChips.kt
@@ -29,9 +29,10 @@ private val ALL_ASPECTS = setOf(AspectChip.PEER, AspectChip.NODE, AspectChip.REL
 
 private val INTERFACE_OPTIONS: List<Pair<InterfaceType, String>> =
     listOf(
-        InterfaceType.AUTO_INTERFACE to "Local",
+        InterfaceType.AUTO to "Local",
         InterfaceType.TCP_CLIENT to "TCP",
-        InterfaceType.ANDROID_BLE to "Bluetooth",
+        InterfaceType.TCP_SERVER to "TCP Server",
+        InterfaceType.BLE to "Bluetooth",
         InterfaceType.RNODE to "RNode",
         InterfaceType.UNKNOWN to "Other",
     )

--- a/app/src/main/java/network/columba/app/ui/components/PeerCard.kt
+++ b/app/src/main/java/network/columba/app/ui/components/PeerCard.kt
@@ -281,9 +281,10 @@ data class InterfaceTypeIconData(
 @Composable
 fun interfaceTypeIconData(type: InterfaceType): InterfaceTypeIconData? =
     when (type) {
-        InterfaceType.AUTO_INTERFACE -> InterfaceTypeIconData(Icons.Default.Wifi, "WiFi")
+        InterfaceType.AUTO -> InterfaceTypeIconData(Icons.Default.Wifi, "WiFi")
         InterfaceType.TCP_CLIENT -> InterfaceTypeIconData(Icons.Default.Public, "Internet")
-        InterfaceType.ANDROID_BLE -> InterfaceTypeIconData(Icons.Default.Bluetooth, "Bluetooth")
+        InterfaceType.TCP_SERVER -> InterfaceTypeIconData(Icons.Default.Public, "Internet")
+        InterfaceType.BLE -> InterfaceTypeIconData(Icons.Default.Bluetooth, "Bluetooth")
         InterfaceType.RNODE ->
             InterfaceTypeIconData(
                 ImageVector.vectorResource(com.composables.icons.lucide.R.drawable.lucide_ic_antenna),

--- a/app/src/main/java/network/columba/app/ui/components/PeerCard.kt
+++ b/app/src/main/java/network/columba/app/ui/components/PeerCard.kt
@@ -302,11 +302,17 @@ fun InterfaceTypeIcon(
     interfaceType: String?,
     modifier: Modifier = Modifier,
 ) {
-    val type =
-        interfaceType?.let {
-            runCatching { InterfaceType.valueOf(it) }.getOrNull()
-        } ?: return
-
+    // `InterfaceType.fromName` handles every observed variant: new
+    // canonical storage values ("AUTO", "TCP_CLIENT", …), legacy storage
+    // values ("AUTO_INTERFACE", "ANDROID_BLE"), AND raw RNS interface
+    // toString output ("AutoInterfacePeer[wlan0/fe80::…]", …). Falls
+    // through to UNKNOWN for nulls / unrecognized strings, then
+    // `interfaceTypeIconData` returns null for UNKNOWN so the icon
+    // disappears gracefully without throwing. Previously this used
+    // `valueOf` which threw on every non-exact identifier match — every
+    // legacy-stored row + every raw runtime string hit the catch and
+    // the icon never rendered.
+    val type = InterfaceType.fromName(interfaceType)
     val data = interfaceTypeIconData(type) ?: return
 
     Icon(

--- a/app/src/main/java/network/columba/app/ui/screens/IdentityScreen.kt
+++ b/app/src/main/java/network/columba/app/ui/screens/IdentityScreen.kt
@@ -468,8 +468,13 @@ fun InterfacesCard(
                 )
             } else {
                 interfaces.forEach { iface ->
-                    // RNode interfaces are clickable to navigate to stats screen
-                    val isRNode = iface.type.contains("RNode", ignoreCase = true)
+                    // RNode interfaces are clickable to navigate to stats screen.
+                    // Use the canonical classifier so this captures every
+                    // observed RNode variant (RNodeInterface,
+                    // RNodeMultiInterface, ColumbaRNodeInterface, KISS-framed
+                    // RNode, ...) — see `InterfaceType.fromName`.
+                    val isRNode = network.columba.app.data.model.InterfaceType.fromName(iface.type) ==
+                        network.columba.app.data.model.InterfaceType.RNODE
                     InterfaceRow(
                         iface = iface,
                         onClick =

--- a/app/src/main/java/network/columba/app/ui/screens/InterfaceManagementScreen.kt
+++ b/app/src/main/java/network/columba/app/ui/screens/InterfaceManagementScreen.kt
@@ -597,7 +597,7 @@ fun InterfaceCard(
             // interface-type → icon mapping shared with announce cards
             // (see PeerCard.interfaceTypeIconData) so there's one source of truth.
             val typeLabel = getInterfaceTypeLabel(interfaceEntity.type)
-            val iconData = interfaceTypeIconData(InterfaceType.fromInterfaceName(interfaceEntity.type))
+            val iconData = interfaceTypeIconData(InterfaceType.fromName(interfaceEntity.type))
             Icon(
                 imageVector = iconData?.imageVector ?: Icons.Default.SettingsInputAntenna,
                 contentDescription = "$typeLabel interface",

--- a/app/src/main/java/network/columba/app/ui/screens/MapScreen.kt
+++ b/app/src/main/java/network/columba/app/ui/screens/MapScreen.kt
@@ -220,6 +220,15 @@ fun MapScreen(
     val state by viewModel.state.collectAsState()
     val contacts by viewModel.contacts.collectAsState()
 
+    // Observe location-sharing refusals (master-gate OFF) and show Toast.
+    // The actual sharing-start call was already refused inside
+    // LocationSharingManager; this is purely user feedback.
+    LaunchedEffect(Unit) {
+        viewModel.locationSharingMessage.collect { message ->
+            android.widget.Toast.makeText(context, message, android.widget.Toast.LENGTH_LONG).show()
+        }
+    }
+
     // Debug logging for permission state
     Log.d(
         "MapScreen",

--- a/app/src/main/java/network/columba/app/ui/screens/MessageDetailScreen.kt
+++ b/app/src/main/java/network/columba/app/ui/screens/MessageDetailScreen.kt
@@ -192,7 +192,21 @@ fun MessageDetailScreen(
                         )
                     }
                 } else {
-                    // Received message info: hop count and receiving interface
+                    // Received message info: delivery method, hop count, receiving interface.
+
+                    // Delivery method card. Especially important for propagation-fetched
+                    // messages — hop count / interface / signal metrics are all null for
+                    // those, so without this card the detail screen renders empty below
+                    // the two timestamps.
+                    msg.deliveryMethod?.let { method ->
+                        val methodInfo = getDeliveryMethodInfo(method)
+                        MessageInfoCard(
+                            icon = methodInfo.icon,
+                            title = "Delivery Method",
+                            content = methodInfo.text,
+                            subtitle = methodInfo.subtitle,
+                        )
+                    }
 
                     // Hop count card (only if available)
                     msg.receivedHopCount?.let { hops ->

--- a/app/src/main/java/network/columba/app/ui/screens/MessagingScreen.kt
+++ b/app/src/main/java/network/columba/app/ui/screens/MessagingScreen.kt
@@ -538,6 +538,16 @@ fun MessagingScreen(
         }
     }
 
+    // Observe location-sharing refusals (master-gate OFF) and show Toast
+    // pointing the user back to Settings. The actual `startSharing` call
+    // was already refused inside LocationSharingManager — this is purely
+    // user feedback so the tap doesn't feel silently dropped.
+    LaunchedEffect(Unit) {
+        viewModel.locationSharingMessage.collect { message ->
+            Toast.makeText(context, message, Toast.LENGTH_LONG).show()
+        }
+    }
+
     // Compose-level clock for refreshing relative timestamps ("Just now" → "5 min ago").
     // Reading this state in the item composable triggers recomposition of visible items only —
     // unlike the old _messagesRefreshTrigger / viewModel.refreshTimestamps() approach, this

--- a/app/src/main/java/network/columba/app/ui/screens/SettingsScreen.kt
+++ b/app/src/main/java/network/columba/app/ui/screens/SettingsScreen.kt
@@ -281,6 +281,8 @@ fun SettingsScreen(
                     onExpandedChange = { viewModel.toggleCardExpanded(SettingsCardId.PRIVACY, it) },
                     blockUnknownSenders = state.blockUnknownSenders,
                     onBlockUnknownSendersChange = { viewModel.setBlockUnknownSenders(it) },
+                    allowCallsFromContactsOnly = state.allowCallsFromContactsOnly,
+                    onAllowCallsFromContactsOnlyChange = { viewModel.setAllowCallsFromContactsOnly(it) },
                     blockedPeerCount = blockedPeerCount,
                     onNavigateToBlockedUsers = onNavigateToBlockedUsers,
                 )
@@ -296,6 +298,8 @@ fun SettingsScreen(
                 VoiceCallPermissionsCard(
                     isExpanded = state.cardExpansionStates[SettingsCardId.VOICE_CALL_PERMISSIONS.name] ?: false,
                     onExpandedChange = { viewModel.toggleCardExpanded(SettingsCardId.VOICE_CALL_PERMISSIONS, it) },
+                    allowVoiceCalls = state.allowVoiceCalls,
+                    onAllowVoiceCallsChange = { viewModel.setAllowVoiceCalls(it) },
                 )
 
                 AutoAnnounceCard(

--- a/app/src/main/java/network/columba/app/ui/screens/SettingsScreen.kt
+++ b/app/src/main/java/network/columba/app/ui/screens/SettingsScreen.kt
@@ -186,6 +186,16 @@ fun SettingsScreen(
         }
     }
 
+    // Observe master-gate refusals from TelemetryCollectorManager and
+    // surface as a Snackbar. The "Share with group" toggle is also
+    // preemptively disabled in the card UI when master is off; this is
+    // belt-and-suspenders for any other path that hits the gate.
+    LaunchedEffect(Unit) {
+        viewModel.telemetryCollectorMessage.collect { message ->
+            snackbarHostState.showSnackbar(message)
+        }
+    }
+
     // Show Snackbar when shared instance becomes available (ephemeral notification)
     LaunchedEffect(state.sharedInstanceAvailable) {
         if (state.sharedInstanceAvailable && !state.preferOwnInstance) {

--- a/app/src/main/java/network/columba/app/ui/screens/settings/cards/LocationSharingCard.kt
+++ b/app/src/main/java/network/columba/app/ui/screens/settings/cards/LocationSharingCard.kt
@@ -136,11 +136,17 @@ fun LocationSharingCard(
             )
         },
     ) {
-        // Description
+        // Description — communicates master-gate semantics:
+        //   ON  = sharing is allowed (you can share from conversations)
+        //   OFF = hard kill-switch (active sessions stop, future shares refused)
+        // The toggle does NOT auto-flip when you share from a conversation;
+        // it's a permission gate, not a status indicator. Active sharing is
+        // shown separately in the "Currently sharing with" section below.
         Text(
             text =
-                "Share your real-time location with contacts. " +
-                    "When disabled, all active sharing sessions will be stopped.",
+                "Allow this app to share your location. " +
+                    "When off, location sharing is blocked everywhere — including " +
+                    "active sessions, conversations, and the group tracker.",
             style = MaterialTheme.typography.bodyMedium,
             color = MaterialTheme.colorScheme.onSurfaceVariant,
         )

--- a/app/src/main/java/network/columba/app/ui/screens/settings/cards/LocationSharingCard.kt
+++ b/app/src/main/java/network/columba/app/ui/screens/settings/cards/LocationSharingCard.kt
@@ -239,6 +239,7 @@ fun LocationSharingCard(
         HorizontalDivider(modifier = Modifier.padding(vertical = 8.dp))
 
         TelemetryCollectorSection(
+            masterEnabled = enabled,
             enabled = telemetryCollectorEnabled,
             collectorAddress = telemetryCollectorAddress,
             sendIntervalSeconds = telemetrySendIntervalSeconds,
@@ -577,6 +578,7 @@ internal fun getPrecisionRadiusDisplayText(radiusMeters: Int): String =
 @OptIn(ExperimentalLayoutApi::class)
 @Composable
 private fun TelemetryCollectorSection(
+    masterEnabled: Boolean,
     enabled: Boolean,
     collectorAddress: String?,
     sendIntervalSeconds: Int,
@@ -654,7 +656,13 @@ private fun TelemetryCollectorSection(
             color = MaterialTheme.colorScheme.onSurfaceVariant,
         )
 
-        // Enable toggle
+        // Enable toggle. Disabled when the master location-sharing toggle
+        // (top of this card) is off — `LocationSharingManager` +
+        // `TelemetryCollectorManager` both gate outbound location data
+        // through that flag, so the share toggle here is non-functional
+        // and silently refuses. Disabling here keeps the user from tapping
+        // a toggle that "doesn't react" and surfaces a hint pointing them
+        // back to the master.
         Row(
             modifier =
                 Modifier
@@ -662,6 +670,7 @@ private fun TelemetryCollectorSection(
                     .clickable(
                         interactionSource = null,
                         indication = null,
+                        enabled = masterEnabled,
                     ) { onEnabledChange(!enabled) },
             verticalAlignment = Alignment.CenterVertically,
             horizontalArrangement = Arrangement.SpaceBetween,
@@ -671,16 +680,28 @@ private fun TelemetryCollectorSection(
                     text = "Share with group",
                     style = MaterialTheme.typography.bodyMedium,
                     fontWeight = FontWeight.Medium,
+                    color =
+                        if (masterEnabled) {
+                            MaterialTheme.colorScheme.onSurface
+                        } else {
+                            MaterialTheme.colorScheme.onSurfaceVariant
+                        },
                 )
                 Text(
-                    text = "Automatically share your location",
+                    text =
+                        if (masterEnabled) {
+                            "Automatically share your location"
+                        } else {
+                            "Enable Location Sharing above first"
+                        },
                     style = MaterialTheme.typography.bodySmall,
                     color = MaterialTheme.colorScheme.onSurfaceVariant,
                 )
             }
             Switch(
-                checked = enabled,
+                checked = enabled && masterEnabled,
                 onCheckedChange = null,
+                enabled = masterEnabled,
             )
         }
 

--- a/app/src/main/java/network/columba/app/ui/screens/settings/cards/PrivacyCard.kt
+++ b/app/src/main/java/network/columba/app/ui/screens/settings/cards/PrivacyCard.kt
@@ -37,14 +37,29 @@ fun PrivacyCard(
         icon = Icons.Default.Security,
         isExpanded = isExpanded,
         onExpandedChange = onExpandedChange,
-        headerAction = {
+    ) {
+        // Messages-from-contacts-only toggle row. Moved out of the card header
+        // so it's visually equal-billed with the calls toggle below.
+        Row(
+            modifier =
+                Modifier
+                    .fillMaxWidth()
+                    .padding(vertical = 8.dp),
+            verticalAlignment = Alignment.CenterVertically,
+        ) {
+            Text(
+                text = "Messages from contacts only",
+                style = MaterialTheme.typography.bodyMedium,
+                modifier =
+                    Modifier
+                        .weight(1f)
+                        .padding(end = 12.dp),
+            )
             Switch(
                 checked = blockUnknownSenders,
                 onCheckedChange = onBlockUnknownSendersChange,
             )
-        },
-    ) {
-        // Description
+        }
         Text(
             text =
                 if (blockUnknownSenders) {
@@ -52,7 +67,7 @@ fun PrivacyCard(
                 } else {
                     "Anyone can send you messages, including unknown senders."
                 },
-            style = MaterialTheme.typography.bodyMedium,
+            style = MaterialTheme.typography.bodySmall,
             color = MaterialTheme.colorScheme.onSurfaceVariant,
         )
 

--- a/app/src/main/java/network/columba/app/ui/screens/settings/cards/PrivacyCard.kt
+++ b/app/src/main/java/network/columba/app/ui/screens/settings/cards/PrivacyCard.kt
@@ -27,6 +27,8 @@ fun PrivacyCard(
     onExpandedChange: (Boolean) -> Unit,
     blockUnknownSenders: Boolean,
     onBlockUnknownSendersChange: (Boolean) -> Unit,
+    allowCallsFromContactsOnly: Boolean,
+    onAllowCallsFromContactsOnlyChange: (Boolean) -> Unit,
     blockedPeerCount: Int = 0,
     onNavigateToBlockedUsers: () -> Unit = {},
 ) {
@@ -51,6 +53,40 @@ fun PrivacyCard(
                     "Anyone can send you messages, including unknown senders."
                 },
             style = MaterialTheme.typography.bodyMedium,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+        )
+
+        Spacer(modifier = Modifier.height(12.dp))
+
+        // Calls-from-contacts-only toggle row (independent of block_unknown_senders).
+        Row(
+            modifier =
+                Modifier
+                    .fillMaxWidth()
+                    .padding(vertical = 8.dp),
+            verticalAlignment = Alignment.CenterVertically,
+        ) {
+            Text(
+                text = "Calls from contacts only",
+                style = MaterialTheme.typography.bodyMedium,
+                modifier =
+                    Modifier
+                        .weight(1f)
+                        .padding(end = 12.dp),
+            )
+            Switch(
+                checked = allowCallsFromContactsOnly,
+                onCheckedChange = onAllowCallsFromContactsOnlyChange,
+            )
+        }
+        Text(
+            text =
+                if (allowCallsFromContactsOnly) {
+                    "Only contacts can call you. Other callers' link attempts are silently dropped."
+                } else {
+                    "Anyone can call you, including unknown callers."
+                },
+            style = MaterialTheme.typography.bodySmall,
             color = MaterialTheme.colorScheme.onSurfaceVariant,
         )
 

--- a/app/src/main/java/network/columba/app/ui/screens/settings/cards/VoiceCallPermissionsCard.kt
+++ b/app/src/main/java/network/columba/app/ui/screens/settings/cards/VoiceCallPermissionsCard.kt
@@ -31,6 +31,7 @@ import androidx.compose.material3.CardDefaults
 import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Switch
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
@@ -52,6 +53,8 @@ import kotlinx.coroutines.delay
 fun VoiceCallPermissionsCard(
     isExpanded: Boolean,
     onExpandedChange: (Boolean) -> Unit,
+    allowVoiceCalls: Boolean,
+    onAllowVoiceCallsChange: (Boolean) -> Unit,
 ) {
     // Not relevant below Android 10 — background activity launch restrictions
     // only became an issue starting with Q
@@ -145,6 +148,16 @@ fun VoiceCallPermissionsCard(
                     )
                 }
 
+                // Master "Allow voice calls" switch — placed to the left of
+                // the chevron so it stays visible whether the card is
+                // expanded or collapsed. When OFF, the inbound LXST
+                // destination is deregistered via the RnsTelephony AIDL
+                // surface; outbound calls still work.
+                Switch(
+                    checked = allowVoiceCalls,
+                    onCheckedChange = onAllowVoiceCallsChange,
+                )
+
                 Icon(
                     imageVector =
                         if (isExpanded) {
@@ -166,6 +179,17 @@ fun VoiceCallPermissionsCard(
                 Column(
                     verticalArrangement = Arrangement.spacedBy(12.dp),
                 ) {
+                    if (!allowVoiceCalls) {
+                        // Master toggle is OFF — let the user know inbound is
+                        // disabled before they see (and worry about) the
+                        // permission-status content below.
+                        Text(
+                            text = "Incoming voice calls are currently disabled. Outgoing calls still work.",
+                            style = MaterialTheme.typography.bodyMedium,
+                            fontWeight = FontWeight.Medium,
+                            color = contentColor,
+                        )
+                    }
                     if (isCheckingStatus) {
                         CircularProgressIndicator(modifier = Modifier.size(24.dp))
                     } else if (allGranted) {

--- a/app/src/main/java/network/columba/app/ui/screens/settings/cards/VoiceCallPermissionsCard.kt
+++ b/app/src/main/java/network/columba/app/ui/screens/settings/cards/VoiceCallPermissionsCard.kt
@@ -30,6 +30,7 @@ import androidx.compose.material3.Card
 import androidx.compose.material3.CardDefaults
 import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Switch
 import androidx.compose.material3.Text
@@ -148,26 +149,37 @@ fun VoiceCallPermissionsCard(
                     )
                 }
 
-                // Master "Allow voice calls" switch — placed to the left of
-                // the chevron so it stays visible whether the card is
-                // expanded or collapsed. When OFF, the inbound LXST
-                // destination is deregistered via the RnsTelephony AIDL
-                // surface; outbound calls still work.
-                Switch(
-                    checked = allowVoiceCalls,
-                    onCheckedChange = onAllowVoiceCallsChange,
-                )
-
-                Icon(
-                    imageVector =
-                        if (isExpanded) {
-                            Icons.Default.KeyboardArrowUp
-                        } else {
-                            Icons.Default.KeyboardArrowDown
-                        },
-                    contentDescription = if (isExpanded) "Collapse" else "Expand",
-                    tint = contentColor,
-                )
+                // Right-side controls: Switch + chevron. Wrapped in a
+                // nested Row that mirrors CollapsibleSettingsCard's layout
+                // (used by Notifications + Auto Announce + Privacy) so the
+                // toggle visually lines up with theirs — without this the
+                // outer SpaceBetween row distributes space between every
+                // pair and the Switch ends up floating mid-row. The chevron
+                // also goes through an IconButton for matching ~12dp inset
+                // padding, otherwise the bare Icon hugs the card's right
+                // edge and reads as misaligned next to the other cards'
+                // chevrons.
+                Row(
+                    verticalAlignment = Alignment.CenterVertically,
+                    horizontalArrangement = Arrangement.spacedBy(8.dp),
+                ) {
+                    Switch(
+                        checked = allowVoiceCalls,
+                        onCheckedChange = onAllowVoiceCallsChange,
+                    )
+                    IconButton(onClick = { onExpandedChange(!isExpanded) }) {
+                        Icon(
+                            imageVector =
+                                if (isExpanded) {
+                                    Icons.Default.KeyboardArrowUp
+                                } else {
+                                    Icons.Default.KeyboardArrowDown
+                                },
+                            contentDescription = if (isExpanded) "Collapse" else "Expand",
+                            tint = contentColor,
+                        )
+                    }
+                }
             }
 
             // Expanded content with animation

--- a/app/src/main/java/network/columba/app/ui/util/InterfaceInfo.kt
+++ b/app/src/main/java/network/columba/app/ui/util/InterfaceInfo.kt
@@ -8,6 +8,7 @@ import androidx.compose.material.icons.filled.Public
 import androidx.compose.material.icons.filled.SettingsInputAntenna
 import androidx.compose.material.icons.filled.Wifi
 import androidx.compose.ui.graphics.vector.ImageVector
+import network.columba.app.data.model.InterfaceType
 
 data class InterfaceInfo(
     val icon: ImageVector,
@@ -75,30 +76,40 @@ private fun extractInterfaceType(interfaceName: String): String = interfaceName.
 internal fun categorizeInterface(interfaceName: String): InterfaceCategory = categorizeInterface(interfaceName, host = null)
 
 /**
- * Determine the interface category based on the interface name and optional host.
- * The host is used to distinguish Yggdrasil TCP interfaces from regular TCP.
+ * Determine the interface category for UI display purposes (icon, color,
+ * marker style) based on the interface name and optional host.
+ *
+ * Sources the transport classification from the canonical
+ * [InterfaceType] (single source of truth — see
+ * `network.columba.app.data.model.InterfaceType.fromName`), then layers
+ * on UI-only sub-categories ([InterfaceCategory.YGGDRASIL] from host
+ * inspection, [InterfaceCategory.I2P] / [InterfaceCategory.SERIAL] from
+ * legacy substring matches that don't map to a configurable
+ * [InterfaceType]).
+ *
+ * `host` is used to distinguish Yggdrasil TCP traffic (IPv6 in 0200::/7)
+ * from regular TCP for the map-pin coloring.
  */
 internal fun categorizeInterface(
     interfaceName: String,
     host: String?,
 ): InterfaceCategory {
     val lowerName = interfaceName.lowercase()
-    return when {
-        lowerName.contains("autointerface") ||
-            lowerName.contains("auto discovery") ||
-            lowerName.startsWith("auto") -> InterfaceCategory.AUTO
-        lowerName.contains("i2p") -> InterfaceCategory.I2P
-        lowerName.contains("rnode") ||
-            lowerName.contains("lora") ||
-            lowerName.contains("weave") ||
-            lowerName.contains("kiss") -> InterfaceCategory.LORA
-        lowerName.contains("ble") ||
-            lowerName.contains("bluetooth") ||
-            lowerName.contains("androidble") -> InterfaceCategory.BLUETOOTH
-        lowerName.contains("tcp") || lowerName.contains("backbone") ->
-            if (isYggdrasilHost(host)) InterfaceCategory.YGGDRASIL else InterfaceCategory.TCP
-        lowerName.contains("serial") -> InterfaceCategory.SERIAL
-        else -> InterfaceCategory.UNKNOWN
+
+    // UI-only sub-categories not represented in the canonical enum.
+    // Checked first because their substrings can also match the broader
+    // TCP / BLE rules below (e.g. "i2p" interfaces are TCP under the hood).
+    if (lowerName.contains("i2p")) return InterfaceCategory.I2P
+    if (lowerName.contains("serial")) return InterfaceCategory.SERIAL
+
+    return when (InterfaceType.fromName(interfaceName)) {
+        InterfaceType.AUTO -> InterfaceCategory.AUTO
+        InterfaceType.TCP_CLIENT,
+        InterfaceType.TCP_SERVER,
+        -> if (isYggdrasilHost(host)) InterfaceCategory.YGGDRASIL else InterfaceCategory.TCP
+        InterfaceType.BLE -> InterfaceCategory.BLUETOOTH
+        InterfaceType.RNODE -> InterfaceCategory.LORA
+        InterfaceType.UNKNOWN -> InterfaceCategory.UNKNOWN
     }
 }
 

--- a/app/src/main/java/network/columba/app/viewmodel/AnnounceStreamViewModel.kt
+++ b/app/src/main/java/network/columba/app/viewmodel/AnnounceStreamViewModel.kt
@@ -147,7 +147,7 @@ class AnnounceStreamViewModel
                                 val matchesInterface =
                                     selectedInterfaces.isEmpty() ||
                                         selectedInterfaces.contains(
-                                            InterfaceType.fromInterfaceName(announce.receivingInterface),
+                                            InterfaceType.fromName(announce.receivingInterface),
                                         )
 
                                 matchesTypeOrAudio && matchesInterface
@@ -316,7 +316,7 @@ class AnnounceStreamViewModel
                             timestamp = announce.timestamp,
                             nodeType = announce.nodeType.name,
                             receivingInterface = announce.receivingInterface,
-                            receivingInterfaceType = InterfaceType.fromInterfaceName(announce.receivingInterface).name,
+                            receivingInterfaceType = InterfaceType.fromName(announce.receivingInterface).storageName,
                             aspect = announce.aspect,
                             stampCost = announce.stampCost,
                             stampCostFlexibility = announce.stampCostFlexibility,

--- a/app/src/main/java/network/columba/app/viewmodel/MapViewModel.kt
+++ b/app/src/main/java/network/columba/app/viewmodel/MapViewModel.kt
@@ -10,9 +10,12 @@ import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.delay
+import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.SharedFlow
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asSharedFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.map
@@ -319,7 +322,28 @@ class MapViewModel
                     initialValue = emptyList(),
                 )
 
+        // User-facing feedback from location-sharing actions. Fires when
+        // `LocationSharingManager` refuses an outbound share (master-gate
+        // off). MapScreen collects this and shows a Snackbar pointing back
+        // to Settings.
+        private val _locationSharingMessage = MutableSharedFlow<String>(extraBufferCapacity = 4)
+        val locationSharingMessage: SharedFlow<String> = _locationSharingMessage.asSharedFlow()
+
         init {
+            // Translate LocationSharingManager events into user-visible
+            // messages. Currently only `Blocked` (master-gate refused).
+            viewModelScope.launch {
+                locationSharingManager.sharingEvents.collect { event ->
+                    when (event) {
+                        is network.columba.app.service.SharingEvent.Blocked ->
+                            _locationSharingMessage.emit(
+                                "Location sharing is off. Enable it in Settings → Location Sharing.",
+                            )
+                        else -> Unit
+                    }
+                }
+            }
+
             // Resolve initial map style (with null location)
             resolveMapStyle(null, null)
 

--- a/app/src/main/java/network/columba/app/viewmodel/MessagingViewModel.kt
+++ b/app/src/main/java/network/columba/app/viewmodel/MessagingViewModel.kt
@@ -225,6 +225,13 @@ class MessagingViewModel
         private val _sharedImageError = MutableSharedFlow<String>()
         val sharedImageError: SharedFlow<String> = _sharedImageError.asSharedFlow()
 
+        // User-facing feedback from location-sharing actions. Fires when
+        // `LocationSharingManager` refuses an outbound share (master-gate
+        // off, currently the only Blocked source). MessagingScreen
+        // collects this and shows a Snackbar pointing back to Settings.
+        private val _locationSharingMessage = MutableSharedFlow<String>(extraBufferCapacity = 4)
+        val locationSharingMessage: SharedFlow<String> = _locationSharingMessage.asSharedFlow()
+
         // Image quality selection dialog state
         private val _qualitySelectionState = MutableStateFlow<QualitySelectionState?>(null)
         val qualitySelectionState: StateFlow<QualitySelectionState?> = _qualitySelectionState.asStateFlow()
@@ -738,6 +745,23 @@ class MessagingViewModel
                     _isTransportEnabled.value = rnsCore.isTransportEnabled()
                 } catch (e: Exception) {
                     Log.w(TAG, "Failed to check transport status", e)
+                }
+            }
+
+            // Translate LocationSharingManager events into user-visible
+            // messages. `Blocked` is the only one MessagingScreen needs
+            // today (master-gate refused a share); other events
+            // (Started/Stopped/Error/SessionsExpired) are surfaced
+            // elsewhere or don't need explicit UI in this context.
+            viewModelScope.launch {
+                locationSharingManager.sharingEvents.collect { event ->
+                    when (event) {
+                        is network.columba.app.service.SharingEvent.Blocked ->
+                            _locationSharingMessage.emit(
+                                "Location sharing is off. Enable it in Settings → Location Sharing.",
+                            )
+                        else -> Unit
+                    }
                 }
             }
 

--- a/app/src/main/java/network/columba/app/viewmodel/MessagingViewModel.kt
+++ b/app/src/main/java/network/columba/app/viewmodel/MessagingViewModel.kt
@@ -887,11 +887,13 @@ class MessagingViewModel
                         conversationLinkManager.recordPeerActivity(message.conversationHash, update.timestamp)
                     }
 
-                    // Enrich sentInterface on delivery — only on successful delivery,
-                    // where the routing table still reflects the actual send path.
-                    // Other statuses (failed, retrying_propagated) carry too much
-                    // routing ambiguity to produce accurate interface data.
-                    if (update.status == "delivered") {
+                    // Enrich sentInterface on a terminal-success state — the
+                    // routing table still reflects the actual send path. For
+                    // DIRECT/OPPORTUNISTIC this fires on "delivered"; for
+                    // PROPAGATED on "propagated" (the propagation-node-accepted
+                    // analogue). Failed / retrying paths carry too much routing
+                    // ambiguity to produce accurate interface data.
+                    if (update.status == "delivered" || update.status == "propagated") {
                         enrichSentInterfaceOnDelivery(message, update.messageHash)
                     }
 
@@ -905,23 +907,34 @@ class MessagingViewModel
         }
 
         /**
-         * Enrich sentInterface on delivery if it wasn't captured at send time.
-         * Skips propagated messages: they route through the propagation node
-         * (a different hash than conversationHash), so querying conversationHash
-         * would return the wrong interface or null.
+         * Enrich sentInterface on a terminal-success status if it wasn't
+         * captured at send time. For PROPAGATED messages the recipient hash
+         * has no direct next-hop — the message physically went over the
+         * interface reaching the propagation node — so we query the
+         * configured outbound propagation node hash instead. Other delivery
+         * methods query the recipient (conversationHash) as usual.
          */
         private suspend fun enrichSentInterfaceOnDelivery(
             message: network.columba.app.data.db.entity.MessageEntity,
             messageHash: String,
         ) {
-            if (!message.isFromMe || message.sentInterface != null || message.deliveryMethod == "propagated") return
+            if (!message.isFromMe || message.sentInterface != null) return
             try {
-                val destHashBytes =
-                    message.conversationHash
-                        .chunked(2)
-                        .map { it.toInt(16).toByte() }
-                        .toByteArray()
-                val sentInterface = rnsCore.getNextHopInterfaceName(destHashBytes)
+                val lookupHash =
+                    if (message.deliveryMethod == "propagated") {
+                        runCatching { rnsLxmf.getOutboundPropagationNode().getOrNull() }
+                            .getOrNull()
+                            ?.chunked(2)
+                            ?.map { it.toInt(16).toByte() }
+                            ?.toByteArray()
+                            ?: return // no propagation node configured → nothing useful to query
+                    } else {
+                        message.conversationHash
+                            .chunked(2)
+                            .map { it.toInt(16).toByte() }
+                            .toByteArray()
+                    }
+                val sentInterface = rnsCore.getNextHopInterfaceName(lookupHash)
                 if (sentInterface != null) {
                     conversationRepository.updateMessageSentInterface(messageHash, sentInterface)
                 }
@@ -1256,10 +1269,33 @@ class MessagingViewModel
             val actualDestHash = resolveActualDestHash(receipt, destinationHash)
             Log.d(TAG, "Original dest hash: $destinationHash, Actual LXMF dest hash: $actualDestHash")
 
-            // Query outbound interface immediately after send (best-effort)
+            // Query outbound interface immediately after send (best-effort).
+            // For PROPAGATED sends the recipient hash has no direct next-hop
+            // — the message physically went over whatever interface reaches
+            // the propagation node. Query that hash instead so the detail
+            // screen shows a meaningful "Sent Via" for propagation messages
+            // too. Falls back to the recipient hash for direct/opportunistic.
+            val lookupHashForInterface =
+                if (deliveryMethodString == "propagated") {
+                    val propHash = runCatching { rnsLxmf.getOutboundPropagationNode().getOrNull() }
+                        .getOrNull()
+                    Log.i(TAG, "sendSuccess: propagated path, outboundPropagationNode=$propHash")
+                    propHash
+                        ?.chunked(2)
+                        ?.map { it.toInt(16).toByte() }
+                        ?.toByteArray()
+                        ?: receipt.destinationHash
+                } else {
+                    receipt.destinationHash
+                }
             val sentInterface =
                 try {
-                    rnsCore.getNextHopInterfaceName(receipt.destinationHash)
+                    val r = rnsCore.getNextHopInterfaceName(lookupHashForInterface)
+                    Log.i(
+                        TAG,
+                        "sendSuccess: getNextHopInterfaceName(${lookupHashForInterface.joinToString("") { "%02x".format(it) }.take(16)}) = $r (method=$deliveryMethodString)",
+                    )
+                    r
                 } catch (e: Exception) {
                     Log.w(TAG, "Failed to query sent interface: ${e.message}")
                     null

--- a/app/src/main/java/network/columba/app/viewmodel/SettingsViewModel.kt
+++ b/app/src/main/java/network/columba/app/viewmodel/SettingsViewModel.kt
@@ -129,6 +129,8 @@ data class SettingsState(
     val notificationsEnabled: Boolean = true,
     // Privacy state
     val blockUnknownSenders: Boolean = false,
+    val allowCallsFromContactsOnly: Boolean = false,
+    val allowVoiceCalls: Boolean = true,
     // Incoming message size limit (default 1MB)
     val incomingMessageSizeLimitKb: Int = 1024,
     // Image compression state
@@ -186,6 +188,7 @@ class SettingsViewModel
         private val rnsCore: RnsCore,
         private val rnsLxmf: RnsLxmf,
         private val rnsTransportAdmin: RnsTransportAdmin,
+        private val rnsTelephony: network.columba.app.rns.api.RnsTelephony,
         private val interfaceConfigManager: network.columba.app.service.InterfaceConfigManager,
         private val propagationNodeManager: PropagationNodeManager,
         private val locationSharingManager: network.columba.app.service.LocationSharingManager,
@@ -470,6 +473,8 @@ class SettingsViewModel
                             notificationsEnabled = _state.value.notificationsEnabled,
                             // Preserve privacy state from loadPrivacySettings()
                             blockUnknownSenders = _state.value.blockUnknownSenders,
+                            allowCallsFromContactsOnly = _state.value.allowCallsFromContactsOnly,
+                            allowVoiceCalls = _state.value.allowVoiceCalls,
                             // Preserve message size limit from loadLocationSharingSettings()
                             incomingMessageSizeLimitKb = _state.value.incomingMessageSizeLimitKb,
                             // Preserve message sorting from loadLocationSharingSettings()
@@ -1520,6 +1525,16 @@ class SettingsViewModel
                     _state.update { it.copy(blockUnknownSenders = enabled) }
                 }
             }
+            viewModelScope.launch {
+                settingsRepository.allowCallsFromContactsOnlyFlow.collect { enabled ->
+                    _state.update { it.copy(allowCallsFromContactsOnly = enabled) }
+                }
+            }
+            viewModelScope.launch {
+                settingsRepository.allowVoiceCallsFlow.collect { enabled ->
+                    _state.update { it.copy(allowVoiceCalls = enabled) }
+                }
+            }
         }
 
         /**
@@ -1531,6 +1546,43 @@ class SettingsViewModel
                 settingsRepository.saveBlockUnknownSenders(enabled)
                 _state.update { it.copy(blockUnknownSenders = enabled) }
                 Log.d(TAG, "Block unknown senders ${if (enabled) "enabled" else "disabled"}")
+            }
+        }
+
+        /**
+         * Set the calls-from-contacts-only setting.
+         * When enabled, only contacts can establish incoming voice calls; non-contact
+         * callers' link attempts are silently dropped in `:reticulum` after caller
+         * identification. No runtime AIDL signal needed — the gate reads the cross-process
+         * SharedPreferences value per-call.
+         */
+        fun setAllowCallsFromContactsOnly(enabled: Boolean) {
+            viewModelScope.launch {
+                settingsRepository.saveAllowCallsFromContactsOnly(enabled)
+                _state.update { it.copy(allowCallsFromContactsOnly = enabled) }
+                Log.d(TAG, "Calls-from-contacts-only ${if (enabled) "enabled" else "disabled"}")
+            }
+        }
+
+        /**
+         * Set the master allow-voice-calls setting.
+         * When disabled, the inbound LXST telephony destination is deregistered in
+         * `:reticulum` and no announces are sent; peers see this device as unreachable
+         * for calls. Outbound calls are unaffected.
+         *
+         * Runtime delivery rides the new `RnsTelephony.setIncomingEnabled` AIDL call —
+         * the SharedPreferences write done by `saveAllowVoiceCalls` exists only for the
+         * cold-start path (`:reticulum` reads it after restart). If the AIDL call fails
+         * the cold-start path eventually applies the desired state, so failures are logged
+         * rather than surfaced.
+         */
+        fun setAllowVoiceCalls(enabled: Boolean) {
+            viewModelScope.launch {
+                settingsRepository.saveAllowVoiceCalls(enabled)
+                _state.update { it.copy(allowVoiceCalls = enabled) }
+                runCatching { rnsTelephony.setIncomingEnabled(enabled) }
+                    .onFailure { Log.w(TAG, "setIncomingEnabled($enabled) AIDL call failed", it) }
+                Log.d(TAG, "Allow voice calls ${if (enabled) "enabled" else "disabled"}")
             }
         }
 

--- a/app/src/main/java/network/columba/app/viewmodel/SettingsViewModel.kt
+++ b/app/src/main/java/network/columba/app/viewmodel/SettingsViewModel.kt
@@ -232,9 +232,6 @@ class SettingsViewModel
         val capabilities: StateFlow<network.columba.app.rns.api.BackendCapabilities> =
             rnsBackend.capabilities
 
-        // Track group telemetry state before toggle-off so we can restore it on toggle-on
-        private var groupTelemetryWasEnabled = false
-
         // Track when we first noticed shared instance disconnected
         private var sharedInstanceDisconnectedTime: Long? = null
         private var sharedInstanceMonitorJob: Job? = null
@@ -1631,15 +1628,18 @@ class SettingsViewModel
          * Called unconditionally to ensure settings persist across navigation.
          */
         private fun loadLocationSharingSettings() {
-            // Location sharing toggle reflects EITHER individual sharing OR group telemetry send
+            // Master gate: this toggle is a hard kill-switch for ANY outbound
+            // location data — per-conversation sharing AND group-telemetry
+            // sends. The toggle's display state mirrors the persisted user
+            // preference (`locationSharingEnabledFlow`) directly, NOT a
+            // computed status of "is something currently sharing". Per-call
+            // sharing actions consult this flag at start-time and refuse when
+            // it's off (see LocationSharingManager.startSharing). Active
+            // sessions are surfaced separately via the "Currently sharing
+            // with" section under the toggle.
             viewModelScope.launch {
-                combine(
-                    settingsRepository.locationSharingEnabledFlow,
-                    telemetryCollectorManager.isEnabled,
-                ) { individualEnabled, groupSendEnabled ->
-                    individualEnabled || groupSendEnabled
-                }.collect { combined ->
-                    _state.update { it.copy(locationSharingEnabled = combined) }
+                settingsRepository.locationSharingEnabledFlow.collect { enabled ->
+                    _state.update { it.copy(locationSharingEnabled = enabled) }
                 }
             }
             viewModelScope.launch {
@@ -1688,14 +1688,14 @@ class SettingsViewModel
         fun setLocationSharingEnabled(enabled: Boolean) {
             viewModelScope.launch {
                 if (!enabled) {
-                    // Save group telemetry state before disabling so we can restore on re-enable
-                    groupTelemetryWasEnabled = telemetryCollectorManager.isEnabled.value
+                    // Hard kill-switch: stop everything currently sharing.
+                    // Per-conversation sessions get cease messages + removed,
+                    // group telemetry sends pause. Re-enabling later does NOT
+                    // auto-resume — under master-gate semantics the toggle is
+                    // a gate, not a status mirror. The user has to explicitly
+                    // re-start any sharing they want.
                     stopAllSharing()
                     telemetryCollectorManager.setEnabled(false)
-                } else if (groupTelemetryWasEnabled) {
-                    // Restore group telemetry if it was enabled before the toggle was turned off
-                    telemetryCollectorManager.setEnabled(true)
-                    groupTelemetryWasEnabled = false
                 }
                 settingsRepository.saveLocationSharingEnabled(enabled)
                 Log.d(TAG, "Location sharing ${if (enabled) "enabled" else "disabled"}")

--- a/app/src/main/java/network/columba/app/viewmodel/SettingsViewModel.kt
+++ b/app/src/main/java/network/columba/app/viewmodel/SettingsViewModel.kt
@@ -8,8 +8,11 @@ import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.FlowPreview
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.delay
+import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.SharedFlow
 import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asSharedFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.debounce
@@ -2003,7 +2006,24 @@ class SettingsViewModel
                     _state.update { it.copy(isRequestingTelemetry = requesting) }
                 }
             }
+            // Mirror master-gate refusals from TelemetryCollectorManager
+            // into a user-facing message flow. SettingsScreen renders Toast.
+            viewModelScope.launch {
+                telemetryCollectorManager.setEnabledRefused.collect {
+                    _telemetryCollectorMessage.emit(
+                        "Location sharing is off. Enable it above (master toggle) to share with a group.",
+                    )
+                }
+            }
         }
+
+        // User-facing feedback for telemetry-collector actions blocked by
+        // the master `Settings → Location Sharing` toggle. SettingsScreen
+        // subscribes and renders a Toast. Belt-and-suspenders alongside
+        // the preemptive UI disable in LocationSharingCard's
+        // TelemetryCollectorSection.
+        private val _telemetryCollectorMessage = MutableSharedFlow<String>(extraBufferCapacity = 4)
+        val telemetryCollectorMessage: SharedFlow<String> = _telemetryCollectorMessage.asSharedFlow()
 
         /**
          * Set the telemetry collector enabled state.

--- a/app/src/test/java/network/columba/app/repository/SettingsRepositoryTest.kt
+++ b/app/src/test/java/network/columba/app/repository/SettingsRepositoryTest.kt
@@ -1100,6 +1100,73 @@ class SettingsRepositoryTest {
             assertTrue("Both should be true", methodValue)
         }
 
+    // ========== Allow Calls From Contacts Only Flow Tests ==========
+
+    @Test
+    fun allowCallsFromContactsOnlyFlow_emitsOnlyOnChange() =
+        runTest {
+            repository.allowCallsFromContactsOnlyFlow.test(timeout = 5.seconds) {
+                val initial = awaitItem()
+
+                // Save same value - should NOT emit
+                repository.saveAllowCallsFromContactsOnly(initial)
+                expectNoEvents()
+
+                // Save opposite value - should emit
+                repository.saveAllowCallsFromContactsOnly(!initial)
+                assertEquals(!initial, awaitItem())
+
+                cancelAndIgnoreRemainingEvents()
+            }
+        }
+
+    @Test
+    fun getAllowCallsFromContactsOnly_matchesFlow() =
+        runTest {
+            repository.saveAllowCallsFromContactsOnly(true)
+            testDispatcher.scheduler.advanceUntilIdle()
+
+            val flowValue = repository.allowCallsFromContactsOnlyFlow.first()
+            val methodValue = repository.getAllowCallsFromContactsOnly()
+
+            assertEquals("Flow and method should return same value", flowValue, methodValue)
+            assertTrue("Both should be true after save(true)", methodValue)
+        }
+
+    // ========== Allow Voice Calls (master) Flow Tests ==========
+
+    @Test
+    fun allowVoiceCallsFlow_emitsOnlyOnChange() =
+        runTest {
+            repository.allowVoiceCallsFlow.test(timeout = 5.seconds) {
+                val initial = awaitItem()
+
+                // Save same value - should NOT emit
+                repository.saveAllowVoiceCalls(initial)
+                expectNoEvents()
+
+                // Save opposite value - should emit
+                repository.saveAllowVoiceCalls(!initial)
+                assertEquals(!initial, awaitItem())
+
+                cancelAndIgnoreRemainingEvents()
+            }
+        }
+
+    @Test
+    fun getAllowVoiceCalls_matchesFlow() =
+        runTest {
+            // Default is true; flip to false then assert both sources agree.
+            repository.saveAllowVoiceCalls(false)
+            testDispatcher.scheduler.advanceUntilIdle()
+
+            val flowValue = repository.allowVoiceCallsFlow.first()
+            val methodValue = repository.getAllowVoiceCalls()
+
+            assertEquals("Flow and method should return same value", flowValue, methodValue)
+            assertFalse("Both should be false after save(false)", methodValue)
+        }
+
     // ========== Telemetry Collector Flow Tests ==========
 
     @Test

--- a/app/src/test/java/network/columba/app/service/TelemetryCollectorManagerTest.kt
+++ b/app/src/test/java/network/columba/app/service/TelemetryCollectorManagerTest.kt
@@ -66,6 +66,7 @@ class TelemetryCollectorManagerTest {
     private val requestIntervalFlow = MutableStateFlow(SettingsRepository.DEFAULT_TELEMETRY_REQUEST_INTERVAL_SECONDS)
     private val lastRequestTimeFlow = MutableStateFlow<Long?>(null)
     private val allowedRequestersFlow = MutableStateFlow<Set<String>>(emptySet())
+    private val locationSharingEnabledFlow = MutableStateFlow(true)
 
     @Suppress("NoRelaxedMocks") // Android Context requires relaxed mock
     @Before
@@ -90,6 +91,7 @@ class TelemetryCollectorManagerTest {
         every { mockSettingsRepository.telemetryRequestIntervalSecondsFlow } returns requestIntervalFlow
         every { mockSettingsRepository.lastTelemetryRequestTimeFlow } returns lastRequestTimeFlow
         every { mockSettingsRepository.telemetryAllowedRequestersFlow } returns allowedRequestersFlow
+        every { mockSettingsRepository.locationSharingEnabledFlow } returns locationSharingEnabledFlow
         every { mockRnsCore.networkStatus } returns networkStatusFlow
 
         // Setup save methods

--- a/app/src/test/java/network/columba/app/ui/screens/AnnounceStreamScreenTest.kt
+++ b/app/src/test/java/network/columba/app/ui/screens/AnnounceStreamScreenTest.kt
@@ -4,9 +4,12 @@ import android.app.Application
 import androidx.compose.ui.test.assertIsDisplayed
 import androidx.compose.ui.test.assertIsEnabled
 import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.hasScrollAction
+import androidx.compose.ui.test.hasText
 import androidx.compose.ui.test.onNodeWithContentDescription
 import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.performClick
+import androidx.compose.ui.test.performScrollToNode
 import androidx.paging.PagingData
 import io.mockk.Runs
 import io.mockk.every
@@ -212,11 +215,15 @@ class AnnounceStreamScreenTest {
             AnnounceStreamScreen(viewModel = mockViewModel)
         }
 
-        composeTestRule.onNodeWithText("Local").assertIsDisplayed()
-        composeTestRule.onNodeWithText("TCP").assertIsDisplayed()
-        composeTestRule.onNodeWithText("Bluetooth").assertIsDisplayed()
-        composeTestRule.onNodeWithText("RNode").assertIsDisplayed()
-        composeTestRule.onNodeWithText("Other").assertIsDisplayed()
+        // Interface chip row is a LazyRow; later chips ("Other") sit past the
+        // default test viewport. Scroll the row to surface each chip before
+        // asserting. `hasScrollAction()` matches both chip rows (aspect + interface)
+        // — index [1] selects the interface row, which is second in the column.
+        val interfaceRow = composeTestRule.onAllNodes(hasScrollAction())[1]
+        listOf("Local", "TCP", "TCP Server", "Bluetooth", "RNode", "Other").forEach { label ->
+            interfaceRow.performScrollToNode(hasText(label))
+            composeTestRule.onNodeWithText(label).assertIsDisplayed()
+        }
     }
 
     @Test

--- a/app/src/test/java/network/columba/app/ui/screens/MessagingScreenTest.kt
+++ b/app/src/test/java/network/columba/app/ui/screens/MessagingScreenTest.kt
@@ -106,6 +106,8 @@ class MessagingScreenTest {
         every { mockViewModel.draftText } returns MutableStateFlow(null)
         // Shared image error mock (share pictures feature)
         every { mockViewModel.sharedImageError } returns MutableSharedFlow()
+        // Location-sharing refusal message (master-gate OFF Toast)
+        every { mockViewModel.locationSharingMessage } returns MutableSharedFlow()
         // Recent photos mock (share pictures feature)
         every { mockViewModel.recentPhotos } returns MutableStateFlow(emptyList())
         // Message font scale mock (text size dialog)

--- a/app/src/test/java/network/columba/app/ui/screens/settings/cards/LocationSharingCardTest.kt
+++ b/app/src/test/java/network/columba/app/ui/screens/settings/cards/LocationSharingCardTest.kt
@@ -321,7 +321,7 @@ class LocationSharingCardTest {
             )
         }
 
-        composeTestRule.onNodeWithText("Share your real-time location with contacts.", substring = true).assertIsDisplayed()
+        composeTestRule.onNodeWithText("Allow this app to share your location.", substring = true).assertIsDisplayed()
     }
 
     @Test

--- a/app/src/test/java/network/columba/app/ui/screens/settings/cards/PrivacyCardTest.kt
+++ b/app/src/test/java/network/columba/app/ui/screens/settings/cards/PrivacyCardTest.kt
@@ -36,10 +36,12 @@ class PrivacyCardTest {
     // ========== Callback Tracking Variables ==========
 
     private var blockUnknownSendersChanged: Boolean? = null
+    private var allowCallsFromContactsOnlyChanged: Boolean? = null
 
     @Before
     fun resetCallbackTrackers() {
         blockUnknownSendersChanged = null
+        allowCallsFromContactsOnlyChanged = null
     }
 
     // ========== Setup Helper ==========
@@ -47,6 +49,7 @@ class PrivacyCardTest {
     private fun setUpCard(
         isExpanded: Boolean = true,
         blockUnknownSenders: Boolean = false,
+        allowCallsFromContactsOnly: Boolean = false,
     ) {
         composeTestRule.setContent {
             Column(modifier = Modifier.verticalScroll(rememberScrollState())) {
@@ -55,6 +58,8 @@ class PrivacyCardTest {
                     onExpandedChange = {},
                     blockUnknownSenders = blockUnknownSenders,
                     onBlockUnknownSendersChange = { blockUnknownSendersChanged = it },
+                    allowCallsFromContactsOnly = allowCallsFromContactsOnly,
+                    onAllowCallsFromContactsOnlyChange = { allowCallsFromContactsOnlyChanged = it },
                 )
             }
         }

--- a/app/src/test/java/network/columba/app/ui/screens/settings/cards/PrivacyCardTest.kt
+++ b/app/src/test/java/network/columba/app/ui/screens/settings/cards/PrivacyCardTest.kt
@@ -125,4 +125,33 @@ class PrivacyCardTest {
             "Anyone can send you messages, including unknown senders.",
         ).assertIsDisplayed()
     }
+
+    @Test
+    fun privacyCard_displaysMessagesFromContactsOnly_rowLabel() {
+        // The block-unknown-senders toggle was moved out of the card header into
+        // the body so it's equal-billed with the calls toggle. Verify the row
+        // label renders alongside the existing description text.
+        setUpCard(isExpanded = true)
+
+        composeTestRule.onNodeWithText("Messages from contacts only").assertIsDisplayed()
+    }
+
+    @Test
+    fun privacyCard_displaysCallsFromContactsOnly_rowLabelAndOffDescription() {
+        setUpCard(isExpanded = true, allowCallsFromContactsOnly = false)
+
+        composeTestRule.onNodeWithText("Calls from contacts only").assertIsDisplayed()
+        composeTestRule.onNodeWithText(
+            "Anyone can call you, including unknown callers.",
+        ).assertIsDisplayed()
+    }
+
+    @Test
+    fun privacyCard_displaysCallsFromContactsOnly_onDescription() {
+        setUpCard(isExpanded = true, allowCallsFromContactsOnly = true)
+
+        composeTestRule.onNodeWithText(
+            "Only contacts can call you. Other callers' link attempts are silently dropped.",
+        ).assertIsDisplayed()
+    }
 }

--- a/app/src/test/java/network/columba/app/ui/util/InterfaceInfoTest.kt
+++ b/app/src/test/java/network/columba/app/ui/util/InterfaceInfoTest.kt
@@ -335,15 +335,6 @@ class InterfaceInfoTest {
         assertEquals("TCPClientInterface — /192.168.1.100:4965", info.subtitle)
     }
 
-    @Test
-    fun `Auto prefix without full AutoInterface name recognized`() {
-        // Test the startsWith("auto") branch
-        val info = getInterfaceInfo("AutoDiscovery[LAN]")
-
-        assertEquals(Icons.Default.Wifi, info.icon)
-        assertEquals("LAN", info.text)
-        assertEquals("AutoDiscovery", info.subtitle)
-    }
 
     @Test
     fun `IPv6 link-local address starting with fe80 shows address in subtitle`() {

--- a/app/src/test/java/network/columba/app/viewmodel/AnnounceStreamViewModelTest.kt
+++ b/app/src/test/java/network/columba/app/viewmodel/AnnounceStreamViewModelTest.kt
@@ -279,7 +279,7 @@ class AnnounceStreamViewModelTest {
                     timestamp = 1000L,
                     nodeType = "NODE",
                     receivingInterface = "ble0",
-                    receivingInterfaceType = "ANDROID_BLE",
+                    receivingInterfaceType = "BLE",
                     aspect = any(),
                     stampCost = any(),
                     stampCostFlexibility = any(),

--- a/app/src/test/java/network/columba/app/viewmodel/MapViewModelTest.kt
+++ b/app/src/test/java/network/columba/app/viewmodel/MapViewModelTest.kt
@@ -16,6 +16,7 @@ import io.mockk.mockk
 import io.mockk.verify
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.test.UnconfinedTestDispatcher
@@ -105,6 +106,7 @@ class MapViewModelTest {
         every { conversationDao.getAllPeerNameLookups() } returns flowOf(emptyList())
         every { locationSharingManager.isSharing } returns MutableStateFlow(false)
         every { locationSharingManager.activeSessions } returns MutableStateFlow(emptyList())
+        every { locationSharingManager.sharingEvents } returns MutableSharedFlow()
         every { locationSharingManager.startSharing(any(), any(), any()) } just Runs
         every { locationSharingManager.stopSharing(any()) } just Runs
         every { settingsRepository.hasDismissedLocationPermissionSheetFlow } returns flowOf(false)

--- a/app/src/test/java/network/columba/app/viewmodel/MessagingViewModelImageLoadingTest.kt
+++ b/app/src/test/java/network/columba/app/viewmodel/MessagingViewModelImageLoadingTest.kt
@@ -153,6 +153,7 @@ class MessagingViewModelImageLoadingTest {
 
         // Mock locationSharingManager flows
         every { locationSharingManager.activeSessions } returns MutableStateFlow(emptyList())
+        every { locationSharingManager.sharingEvents } returns MutableSharedFlow()
 
         // Mock activeConversationManager
         every { activeConversationManager.setActive(any()) } just Runs

--- a/app/src/test/java/network/columba/app/viewmodel/MessagingViewModelTest.kt
+++ b/app/src/test/java/network/columba/app/viewmodel/MessagingViewModelTest.kt
@@ -152,6 +152,7 @@ class MessagingViewModelTest {
 
         // Mock locationSharingManager flows
         every { locationSharingManager.activeSessions } returns MutableStateFlow(emptyList())
+        every { locationSharingManager.sharingEvents } returns MutableSharedFlow()
 
         // Mock default contact repository behavior
         every { contactRepository.hasContactFlow(any()) } returns flowOf(false)
@@ -576,6 +577,7 @@ class MessagingViewModelTest {
 
             val failingLocationSharingManager: LocationSharingManager = mockk()
             every { failingLocationSharingManager.activeSessions } returns MutableStateFlow(emptyList())
+            every { failingLocationSharingManager.sharingEvents } returns MutableSharedFlow()
             every { failingLocationSharingManager.startSharing(any(), any(), any()) } just Runs
             every { failingLocationSharingManager.stopSharing(any()) } just Runs
 

--- a/app/src/test/java/network/columba/app/viewmodel/SettingsViewModelIncomingMessageLimitTest.kt
+++ b/app/src/test/java/network/columba/app/viewmodel/SettingsViewModelIncomingMessageLimitTest.kt
@@ -65,6 +65,7 @@ class SettingsViewModelIncomingMessageLimitTest {
     private lateinit var rnsCore: RnsCore
     private lateinit var rnsLxmf: RnsLxmf
     private lateinit var rnsTransportAdmin: RnsTransportAdmin
+    private lateinit var rnsTelephony: network.columba.app.rns.api.RnsTelephony
     private lateinit var interfaceConfigManager: InterfaceConfigManager
     private lateinit var propagationNodeManager: PropagationNodeManager
     private lateinit var locationSharingManager: LocationSharingManager
@@ -107,6 +108,7 @@ class SettingsViewModelIncomingMessageLimitTest {
         rnsCore = mockk()
         rnsLxmf = mockk()
         rnsTransportAdmin = mockk()
+        rnsTelephony = mockk(relaxed = true)
         interfaceConfigManager = mockk()
         propagationNodeManager = mockk()
         locationSharingManager = mockk()
@@ -186,6 +188,8 @@ class SettingsViewModelIncomingMessageLimitTest {
 
         // Privacy settings flows
         every { settingsRepository.blockUnknownSendersFlow } returns MutableStateFlow(false)
+        every { settingsRepository.allowCallsFromContactsOnlyFlow } returns MutableStateFlow(false)
+        every { settingsRepository.allowVoiceCallsFlow } returns MutableStateFlow(true)
 
         // Telemetry request settings flows
         every { settingsRepository.telemetryRequestEnabledFlow } returns MutableStateFlow(false)
@@ -236,6 +240,7 @@ class SettingsViewModelIncomingMessageLimitTest {
             rnsCore = rnsCore,
             rnsLxmf = rnsLxmf,
             rnsTransportAdmin = rnsTransportAdmin,
+            rnsTelephony = rnsTelephony,
             interfaceConfigManager = interfaceConfigManager,
             propagationNodeManager = propagationNodeManager,
             locationSharingManager = locationSharingManager,

--- a/app/src/test/java/network/columba/app/viewmodel/SettingsViewModelIncomingMessageLimitTest.kt
+++ b/app/src/test/java/network/columba/app/viewmodel/SettingsViewModelIncomingMessageLimitTest.kt
@@ -108,7 +108,10 @@ class SettingsViewModelIncomingMessageLimitTest {
         rnsCore = mockk()
         rnsLxmf = mockk()
         rnsTransportAdmin = mockk()
-        rnsTelephony = mockk(relaxed = true)
+        rnsTelephony = mockk()
+        // setAllowVoiceCalls fires setIncomingEnabled — stubbed as no-op since the test
+        // covers incoming-message-limit logic, not the telephony AIDL round-trip.
+        coEvery { rnsTelephony.setIncomingEnabled(any()) } just Runs
         interfaceConfigManager = mockk()
         propagationNodeManager = mockk()
         locationSharingManager = mockk()

--- a/app/src/test/java/network/columba/app/viewmodel/SettingsViewModelTest.kt
+++ b/app/src/test/java/network/columba/app/viewmodel/SettingsViewModelTest.kt
@@ -68,6 +68,7 @@ class SettingsViewModelTest {
     private lateinit var rnsCore: RnsCore
     private lateinit var rnsLxmf: RnsLxmf
     private lateinit var rnsTransportAdmin: RnsTransportAdmin
+    private lateinit var rnsTelephony: network.columba.app.rns.api.RnsTelephony
     private lateinit var interfaceConfigManager: InterfaceConfigManager
     private lateinit var propagationNodeManager: PropagationNodeManager
     private lateinit var locationSharingManager: LocationSharingManager
@@ -112,6 +113,7 @@ class SettingsViewModelTest {
         rnsCore = mockk()
         rnsLxmf = mockk()
         rnsTransportAdmin = mockk()
+        rnsTelephony = mockk(relaxed = true) // setAllowVoiceCalls fires setIncomingEnabled
         interfaceConfigManager = mockk()
         propagationNodeManager = mockk()
         locationSharingManager = mockk()
@@ -180,6 +182,8 @@ class SettingsViewModelTest {
         every { settingsRepository.incomingMessageSizeLimitKbFlow } returns flowOf(500)
         every { settingsRepository.notificationsEnabledFlow } returns flowOf(true)
         every { settingsRepository.blockUnknownSendersFlow } returns flowOf(false)
+        every { settingsRepository.allowCallsFromContactsOnlyFlow } returns flowOf(false)
+        every { settingsRepository.allowVoiceCallsFlow } returns flowOf(true)
         every { settingsRepository.telemetryCollectorEnabledFlow } returns flowOf(false)
         every { settingsRepository.telemetryCollectorAddressFlow } returns flowOf(null)
         every { settingsRepository.telemetrySendIntervalSecondsFlow } returns flowOf(60)
@@ -272,6 +276,7 @@ class SettingsViewModelTest {
             rnsCore = rnsCore,
             rnsLxmf = rnsLxmf,
             rnsTransportAdmin = rnsTransportAdmin,
+            rnsTelephony = rnsTelephony,
             interfaceConfigManager = interfaceConfigManager,
             propagationNodeManager = propagationNodeManager,
             locationSharingManager = locationSharingManager,
@@ -1600,6 +1605,7 @@ class SettingsViewModelTest {
                     rnsCore = serviceRnsCore,
                     rnsLxmf = rnsLxmf,
                     rnsTransportAdmin = rnsTransportAdmin,
+                    rnsTelephony = rnsTelephony,
                     interfaceConfigManager = interfaceConfigManager,
                     propagationNodeManager = propagationNodeManager,
                     locationSharingManager = locationSharingManager,
@@ -1651,6 +1657,7 @@ class SettingsViewModelTest {
                     rnsCore = serviceRnsCore,
                     rnsLxmf = rnsLxmf,
                     rnsTransportAdmin = rnsTransportAdmin,
+                    rnsTelephony = rnsTelephony,
                     interfaceConfigManager = interfaceConfigManager,
                     propagationNodeManager = propagationNodeManager,
                     locationSharingManager = locationSharingManager,
@@ -2280,6 +2287,7 @@ class SettingsViewModelTest {
                     rnsCore = serviceRnsCore,
                     rnsLxmf = rnsLxmf,
                     rnsTransportAdmin = serviceRnsTransportAdmin,
+                    rnsTelephony = rnsTelephony,
                     interfaceConfigManager = interfaceConfigManager,
                     propagationNodeManager = propagationNodeManager,
                     locationSharingManager = locationSharingManager,
@@ -2328,6 +2336,7 @@ class SettingsViewModelTest {
                     rnsCore = serviceRnsCore,
                     rnsLxmf = rnsLxmf,
                     rnsTransportAdmin = rnsTransportAdmin,
+                    rnsTelephony = rnsTelephony,
                     interfaceConfigManager = interfaceConfigManager,
                     propagationNodeManager = propagationNodeManager,
                     locationSharingManager = locationSharingManager,

--- a/app/src/test/java/network/columba/app/viewmodel/SettingsViewModelTest.kt
+++ b/app/src/test/java/network/columba/app/viewmodel/SettingsViewModelTest.kt
@@ -113,7 +113,10 @@ class SettingsViewModelTest {
         rnsCore = mockk()
         rnsLxmf = mockk()
         rnsTransportAdmin = mockk()
-        rnsTelephony = mockk(relaxed = true) // setAllowVoiceCalls fires setIncomingEnabled
+        rnsTelephony = mockk()
+        // setAllowVoiceCalls fires setIncomingEnabled — stubbed as no-op since the test
+        // covers VM-state behavior, not the AIDL round-trip.
+        coEvery { rnsTelephony.setIncomingEnabled(any()) } just Runs
         interfaceConfigManager = mockk()
         propagationNodeManager = mockk()
         locationSharingManager = mockk()

--- a/data/src/main/java/network/columba/app/data/db/dao/ContactDao.kt
+++ b/data/src/main/java/network/columba/app/data/db/dao/ContactDao.kt
@@ -117,6 +117,37 @@ interface ContactDao {
     ): Boolean
 
     /**
+     * Check if a contact exists for ANY destination owned by the peer
+     * whose RNS identity hash matches [callerIdentityHash], scoped to the
+     * given local-owner [ownerIdentityHash].
+     *
+     * Same peer can have multiple announce rows — typically one
+     * `lxmf.delivery` destination and one `lxst.telephony` destination
+     * — sharing a single `computedIdentityHash`. Contact-add flows
+     * (`addContactFromConversation`, etc.) only store the LXMF
+     * destination, but inbound LXST calls identify by the same RNS
+     * identity. A "do I know this peer?" check must therefore consider
+     * any destination cross-linked under that identity hash, not just
+     * the first row that happens to come back.
+     *
+     * Used by `CallsFromContactsGate.shouldSilentlyDrop` (`:rns-host`).
+     */
+    @Query(
+        """
+        SELECT EXISTS(
+            SELECT 1 FROM contacts c
+            INNER JOIN announces a ON a.destinationHash = c.destinationHash
+            WHERE a.computedIdentityHash = :callerIdentityHash
+              AND c.identityHash = :ownerIdentityHash
+        )
+        """,
+    )
+    suspend fun contactExistsByIdentityHash(
+        callerIdentityHash: String,
+        ownerIdentityHash: String,
+    ): Boolean
+
+    /**
      * Get contact existence as Flow (for observing star button state)
      */
     @Query(

--- a/data/src/main/java/network/columba/app/data/model/InterfaceType.kt
+++ b/data/src/main/java/network/columba/app/data/model/InterfaceType.kt
@@ -1,39 +1,117 @@
 package network.columba.app.data.model
 
 /**
- * Represents the type of network interface through which an announce was received.
+ * Canonical classifier for the transport an RNS interface runs over.
+ *
+ * Sole source of truth for "what kind of interface is this?" decisions
+ * anywhere in the codebase — UI categorization, announce filtering, the
+ * RNode-specific UI affordance check, etc. — replace ad-hoc
+ * `name.contains("RNode")`-style matching with [fromInterfaceName] so a
+ * single grep updates every consumer when a new interface variant lands
+ * upstream.
+ *
+ * Identifiers are the five operator-facing transports the user configures
+ * in Settings → Interface Management:
+ *
+ * - [AUTO]       — `AutoInterface` (LAN multicast discovery) and its
+ *                  per-peer `AutoInterfacePeer` children.
+ * - [TCP_CLIENT] — `TCPClientInterface`, `TCPInterface[host:port]`,
+ *                  Backbone, and any future TCP-client variant.
+ * - [TCP_SERVER] — `TCPServerInterface` (listen-side, distinct because
+ *                  routing semantics + UI affordances differ from client).
+ * - [BLE]        — `AndroidBLE` (in-app Reticulum-over-BLE), legacy
+ *                  `Bluetooth` strings.
+ * - [RNODE]      — `RNodeInterface`, `RNodeMultiInterface`,
+ *                  `ColumbaRNodeInterface` (BLE-attached RNode hardware).
+ *
+ * [displayLabel] is the short string shown in chips / pills; [storageName]
+ * is what gets persisted to the `announces.receivingInterfaceType` column.
+ * Backwards-compat: [fromName] also recognises the legacy stored values
+ * (`"AUTO_INTERFACE"`, `"ANDROID_BLE"`) so pre-rename rows still classify
+ * correctly without a DB migration.
  */
 enum class InterfaceType(
     val displayLabel: String,
+    val storageName: String,
 ) {
-    AUTO_INTERFACE("Local"),
-    TCP_CLIENT("TCP"),
-    ANDROID_BLE("BLE"),
-    RNODE("RNode"),
-    UNKNOWN("Unknown"),
+    AUTO("Local", "AUTO"),
+    TCP_CLIENT("TCP", "TCP_CLIENT"),
+    TCP_SERVER("TCP Server", "TCP_SERVER"),
+    BLE("BLE", "BLE"),
+    RNODE("RNode", "RNODE"),
+    UNKNOWN("Unknown", "UNKNOWN"),
     ;
 
     companion object {
         /**
-         * Parse interface type from the interface name string.
-         * Interface names follow patterns like:
-         * - "AutoInterface[Local]", "AutoInterface[fe80::...]", or "Auto Discovery"
-         * - "TCPInterface[192.168.1.100:4965]", "TCPClientInterface[...]",
-         *   "TCPServerInterface[...]", or Backbone
-         * - "BLE", "Bluetooth", or "AndroidBLE"
-         * - Names containing "RNode"
+         * Classify a raw interface display string (as seen on
+         * `announces.receivingInterface`, `messages.sentInterface`,
+         * `LXMessage.method`-side debug logs, etc.) into one of the five
+         * canonical transports.
+         *
+         * Observed inputs include:
+         *   - `"AutoInterface[Local]"`, `"AutoInterface[fe80::…]"`,
+         *     `"AutoInterfacePeer[wlan0/fe80::…]"`, `"Auto Discovery"`
+         *   - `"TCPClientInterface[192.168.1.100:4965]"`,
+         *     `"TCPInterface[host/ip:port]"`, `"Backbone…"`
+         *   - `"TCPServerInterface[0.0.0.0:4242]"`
+         *   - `"AndroidBLE"`, `"BLE"`, `"Bluetooth…"`
+         *   - `"RNodeInterface[My Radio]"`, `"RNodeMultiInterface[…]"`,
+         *     `"ColumbaRNodeInterface[…]"`
+         *
+         * Returns [UNKNOWN] for null, blank, `"None"`, or anything else.
          */
-        fun fromInterfaceName(interfaceName: String?): InterfaceType {
-            if (interfaceName.isNullOrBlank() || interfaceName == "None") return UNKNOWN
+        fun fromName(rawName: String?): InterfaceType {
+            if (rawName.isNullOrBlank() || rawName == "None") return UNKNOWN
 
-            val name = interfaceName.lowercase()
+            // Exact-match legacy storage values first (cheap, deterministic)
+            // so the parser stays correct against pre-rename DB rows.
+            when (rawName) {
+                "AUTO_INTERFACE", "AUTO" -> return AUTO
+                "TCP_CLIENT" -> return TCP_CLIENT
+                "TCP_SERVER" -> return TCP_SERVER
+                "ANDROID_BLE", "BLE" -> return BLE
+                "RNODE" -> return RNODE
+                "UNKNOWN" -> return UNKNOWN
+            }
+
+            val name = rawName.lowercase()
             return when {
-                name.contains("autointerface") || name.contains("auto discovery") -> AUTO_INTERFACE
-                name.contains("tcpclient") || name.contains("tcpinterface") || name.contains("tcpserver") || name.contains("backbone") -> TCP_CLIENT
-                name.contains("rnode") -> RNODE
-                name.contains("ble") || name.contains("bluetooth") || name.contains("androidble") -> ANDROID_BLE
+                // Order matters — "tcpserver" must be checked before
+                // the looser "tcp*" patterns. "rnode" must be checked
+                // before BLE-keyword fallback because the BLE-attached
+                // RNode driver string is `ColumbaRNodeInterface` which
+                // contains neither "BLE" nor "Bluetooth".
+                name.contains("autointerface") ||
+                    name.contains("autointerfacepeer") ||
+                    name.contains("auto discovery") -> AUTO
+                // KISSInterface is RNode's serial wire framing; "lora" /
+                // "weave" cover legacy and downstream LoRa interface
+                // variants that all bottom out at RNode hardware.
+                name.contains("rnode") ||
+                    name.contains("kiss") ||
+                    name.contains("lora") ||
+                    name.contains("weave") -> RNODE
+                name.contains("tcpserver") -> TCP_SERVER
+                name.contains("tcpclient") ||
+                    name.contains("tcpinterface") ||
+                    name.contains("backbone") -> TCP_CLIENT
+                name.contains("androidble") ||
+                    name.contains("ble") ||
+                    name.contains("bluetooth") -> BLE
                 else -> UNKNOWN
             }
         }
+
+        /**
+         * Legacy alias: pre-existing call sites used [fromInterfaceName].
+         * Kept as a thin delegate so renaming everywhere isn't required for
+         * the canonical-enum migration. Prefer [fromName] in new code.
+         */
+        @Deprecated(
+            "Use fromName for parity with the new naming.",
+            ReplaceWith("fromName(interfaceName)"),
+        )
+        fun fromInterfaceName(interfaceName: String?): InterfaceType = fromName(interfaceName)
     }
 }

--- a/data/src/main/java/network/columba/app/data/model/InterfaceType.kt
+++ b/data/src/main/java/network/columba/app/data/model/InterfaceType.kt
@@ -62,32 +62,37 @@ enum class InterfaceType(
          * Returns [UNKNOWN] for null, blank, `"None"`, or anything else.
          */
         fun fromName(rawName: String?): InterfaceType {
-            if (rawName.isNullOrBlank() || rawName == "None") return UNKNOWN
-
+            val raw = rawName?.takeUnless { it.isBlank() || it == "None" } ?: return UNKNOWN
             // Exact-match legacy storage values first (cheap, deterministic)
             // so the parser stays correct against pre-rename DB rows.
-            when (rawName) {
-                "AUTO_INTERFACE", "AUTO" -> return AUTO
-                "TCP_CLIENT" -> return TCP_CLIENT
-                "TCP_SERVER" -> return TCP_SERVER
-                "ANDROID_BLE", "BLE" -> return BLE
-                "RNODE" -> return RNODE
-                "UNKNOWN" -> return UNKNOWN
-            }
+            return EXACT_STORAGE_NAMES[raw] ?: classifyByPattern(raw.lowercase())
+        }
 
-            val name = rawName.lowercase()
-            return when {
-                // Order matters — "tcpserver" must be checked before
-                // the looser "tcp*" patterns. "rnode" must be checked
-                // before BLE-keyword fallback because the BLE-attached
-                // RNode driver string is `ColumbaRNodeInterface` which
-                // contains neither "BLE" nor "Bluetooth".
+        // Exact-match storage names. Kept as a Map so the classification path
+        // stays a single Map lookup before falling through to substring matching.
+        private val EXACT_STORAGE_NAMES =
+            mapOf(
+                "AUTO_INTERFACE" to AUTO,
+                "AUTO" to AUTO,
+                "TCP_CLIENT" to TCP_CLIENT,
+                "TCP_SERVER" to TCP_SERVER,
+                "ANDROID_BLE" to BLE,
+                "BLE" to BLE,
+                "RNODE" to RNODE,
+                "UNKNOWN" to UNKNOWN,
+            )
+
+        // Order matters — "tcpserver" must be checked before the looser "tcp*"
+        // patterns. "rnode" must be checked before BLE-keyword fallback because
+        // the BLE-attached RNode driver string is `ColumbaRNodeInterface` which
+        // contains neither "BLE" nor "Bluetooth". KISSInterface is RNode's
+        // serial wire framing; "lora" / "weave" cover legacy and downstream
+        // LoRa interface variants that all bottom out at RNode hardware.
+        private fun classifyByPattern(name: String): InterfaceType =
+            when {
                 name.contains("autointerface") ||
                     name.contains("autointerfacepeer") ||
                     name.contains("auto discovery") -> AUTO
-                // KISSInterface is RNode's serial wire framing; "lora" /
-                // "weave" cover legacy and downstream LoRa interface
-                // variants that all bottom out at RNode hardware.
                 name.contains("rnode") ||
                     name.contains("kiss") ||
                     name.contains("lora") ||
@@ -101,7 +106,6 @@ enum class InterfaceType(
                     name.contains("bluetooth") -> BLE
                 else -> UNKNOWN
             }
-        }
 
         /**
          * Legacy alias: pre-existing call sites used [fromInterfaceName].

--- a/data/src/test/java/network/columba/app/data/model/InterfaceTypeTest.kt
+++ b/data/src/test/java/network/columba/app/data/model/InterfaceTypeTest.kt
@@ -5,131 +5,181 @@ import org.junit.Test
 
 class InterfaceTypeTest {
     @Test
-    fun `fromInterfaceName returns AUTO_INTERFACE for AutoInterface names`() {
-        assertEquals(InterfaceType.AUTO_INTERFACE, InterfaceType.fromInterfaceName("AutoInterface[Local]"))
-        assertEquals(InterfaceType.AUTO_INTERFACE, InterfaceType.fromInterfaceName("AutoInterface[fe80::1%wlan0]"))
-        assertEquals(InterfaceType.AUTO_INTERFACE, InterfaceType.fromInterfaceName("AutoInterface"))
+    fun `fromName returns AUTO for AutoInterface names`() {
+        assertEquals(InterfaceType.AUTO, InterfaceType.fromName("AutoInterface[Local]"))
+        assertEquals(InterfaceType.AUTO, InterfaceType.fromName("AutoInterface[fe80::1%wlan0]"))
+        assertEquals(InterfaceType.AUTO, InterfaceType.fromName("AutoInterface"))
     }
 
     @Test
-    fun `fromInterfaceName returns TCP_CLIENT for TCPClientInterface names`() {
-        assertEquals(InterfaceType.TCP_CLIENT, InterfaceType.fromInterfaceName("TCPClientInterface[192.168.1.100:4965]"))
-        assertEquals(InterfaceType.TCP_CLIENT, InterfaceType.fromInterfaceName("TCPClientInterface[example.com:4965]"))
-        assertEquals(InterfaceType.TCP_CLIENT, InterfaceType.fromInterfaceName("TCPClient"))
+    fun `fromName returns AUTO for AutoInterfacePeer names`() {
+        // RNS's AutoInterfacePeer is the per-peer child class created when an
+        // AutoInterface discovers a remote peer. Its toString() format is
+        // `AutoInterfacePeer[wlan0/fe80::…]` and that's what shows up on
+        // messages.sentInterface for propagation-link traffic via LAN.
+        assertEquals(InterfaceType.AUTO, InterfaceType.fromName("AutoInterfacePeer[wlan0/fe80::10af:905f:7605:214e]"))
+        assertEquals(InterfaceType.AUTO, InterfaceType.fromName("AutoInterfacePeer"))
     }
 
     @Test
-    fun `fromInterfaceName returns TCP_CLIENT for TCPInterface names`() {
-        assertEquals(InterfaceType.TCP_CLIENT, InterfaceType.fromInterfaceName("TCPInterface[192.168.1.100:4965]"))
-        assertEquals(InterfaceType.TCP_CLIENT, InterfaceType.fromInterfaceName("TCPInterface[Testnet/127.0.0.1:4242]"))
-        assertEquals(InterfaceType.TCP_CLIENT, InterfaceType.fromInterfaceName("TCPInterface"))
+    fun `fromName returns AUTO for Auto Discovery string`() {
+        assertEquals(InterfaceType.AUTO, InterfaceType.fromName("Auto Discovery"))
     }
 
     @Test
-    fun `fromInterfaceName returns TCP_CLIENT for BackboneInterface names`() {
-        assertEquals(InterfaceType.TCP_CLIENT, InterfaceType.fromInterfaceName("BackboneInterface[noDNS2/193.26.158.230:4965]"))
-        assertEquals(InterfaceType.TCP_CLIENT, InterfaceType.fromInterfaceName("BackboneClientInterface[Beleth RNS Hub]"))
-        assertEquals(InterfaceType.TCP_CLIENT, InterfaceType.fromInterfaceName("BackboneInterface"))
+    fun `fromName returns TCP_CLIENT for TCPClientInterface names`() {
+        assertEquals(InterfaceType.TCP_CLIENT, InterfaceType.fromName("TCPClientInterface[192.168.1.100:4965]"))
+        assertEquals(InterfaceType.TCP_CLIENT, InterfaceType.fromName("TCPClientInterface[example.com:4965]"))
+        assertEquals(InterfaceType.TCP_CLIENT, InterfaceType.fromName("TCPClient"))
     }
 
     @Test
-    fun `fromInterfaceName returns ANDROID_BLE for BLE interface names`() {
-        assertEquals(InterfaceType.ANDROID_BLE, InterfaceType.fromInterfaceName("AndroidBLEInterface[AA:BB:CC:DD:EE:FF]"))
-        assertEquals(InterfaceType.ANDROID_BLE, InterfaceType.fromInterfaceName("BLE Device"))
-        assertEquals(InterfaceType.ANDROID_BLE, InterfaceType.fromInterfaceName("My BLE"))
+    fun `fromName returns TCP_CLIENT for TCPInterface names`() {
+        assertEquals(InterfaceType.TCP_CLIENT, InterfaceType.fromName("TCPInterface[192.168.1.100:4965]"))
+        assertEquals(InterfaceType.TCP_CLIENT, InterfaceType.fromName("TCPInterface[Testnet/127.0.0.1:4242]"))
+        assertEquals(InterfaceType.TCP_CLIENT, InterfaceType.fromName("TCPInterface"))
     }
 
     @Test
-    fun `fromInterfaceName returns ANDROID_BLE for AndroidBLE interface names`() {
-        assertEquals(InterfaceType.ANDROID_BLE, InterfaceType.fromInterfaceName("AndroidBLEInterface"))
-        assertEquals(InterfaceType.ANDROID_BLE, InterfaceType.fromInterfaceName("MyAndroidBLEDevice"))
+    fun `fromName returns TCP_CLIENT for BackboneInterface names`() {
+        assertEquals(InterfaceType.TCP_CLIENT, InterfaceType.fromName("BackboneInterface[noDNS2/193.26.158.230:4965]"))
+        assertEquals(InterfaceType.TCP_CLIENT, InterfaceType.fromName("BackboneClientInterface[Beleth RNS Hub]"))
+        assertEquals(InterfaceType.TCP_CLIENT, InterfaceType.fromName("BackboneInterface"))
     }
 
     @Test
-    fun `fromInterfaceName returns ANDROID_BLE for BLEPeerInterface names`() {
+    fun `fromName returns TCP_SERVER for TCPServerInterface names`() {
+        // TCPServer must be matched BEFORE the looser tcp* patterns,
+        // otherwise "TCPServerInterface" gets caught by the
+        // "tcpinterface" rule and misclassifies as TCP_CLIENT.
+        assertEquals(InterfaceType.TCP_SERVER, InterfaceType.fromName("TCPServerInterface[0.0.0.0:4242]"))
+        assertEquals(InterfaceType.TCP_SERVER, InterfaceType.fromName("TCPServerInterface[Listen/192.168.1.5:4965]"))
+        assertEquals(InterfaceType.TCP_SERVER, InterfaceType.fromName("TCPServer"))
+        assertEquals(InterfaceType.TCP_SERVER, InterfaceType.fromName("tcpserverinterface"))
+    }
+
+    @Test
+    fun `fromName returns BLE for BLE interface names`() {
+        assertEquals(InterfaceType.BLE, InterfaceType.fromName("AndroidBLEInterface[AA:BB:CC:DD:EE:FF]"))
+        assertEquals(InterfaceType.BLE, InterfaceType.fromName("BLE Device"))
+        assertEquals(InterfaceType.BLE, InterfaceType.fromName("My BLE"))
+    }
+
+    @Test
+    fun `fromName returns BLE for AndroidBLE interface names`() {
+        assertEquals(InterfaceType.BLE, InterfaceType.fromName("AndroidBLEInterface"))
+        assertEquals(InterfaceType.BLE, InterfaceType.fromName("MyAndroidBLEDevice"))
+    }
+
+    @Test
+    fun `fromName returns BLE for BLEPeerInterface names`() {
         // BLEPeerInterface is a spawned interface from BLEInterface - contains "ble"
-        assertEquals(InterfaceType.ANDROID_BLE, InterfaceType.fromInterfaceName("BLEPeerInterface[AA:BB:CC:DD:EE:FF]"))
-        assertEquals(InterfaceType.ANDROID_BLE, InterfaceType.fromInterfaceName("BLEPeerInterface[RNS-1b85e7]"))
+        assertEquals(InterfaceType.BLE, InterfaceType.fromName("BLEPeerInterface[AA:BB:CC:DD:EE:FF]"))
+        assertEquals(InterfaceType.BLE, InterfaceType.fromName("BLEPeerInterface[RNS-1b85e7]"))
     }
 
     @Test
-    fun `fromInterfaceName returns RNODE for RNode interface names`() {
-        assertEquals(InterfaceType.RNODE, InterfaceType.fromInterfaceName("RNodeInterface[/dev/ttyUSB0]"))
-        assertEquals(InterfaceType.RNODE, InterfaceType.fromInterfaceName("RNode LoRa"))
-        assertEquals(InterfaceType.RNODE, InterfaceType.fromInterfaceName("My RNode Device"))
+    fun `fromName returns RNODE for RNode interface names`() {
+        assertEquals(InterfaceType.RNODE, InterfaceType.fromName("RNodeInterface[/dev/ttyUSB0]"))
+        assertEquals(InterfaceType.RNODE, InterfaceType.fromName("RNode LoRa"))
+        assertEquals(InterfaceType.RNODE, InterfaceType.fromName("My RNode Device"))
     }
 
     @Test
-    fun `fromInterfaceName returns RNODE for BLE-connected RNode interfaces`() {
+    fun `fromName returns RNODE for BLE-connected RNode interfaces`() {
         // RNode connected via BLE gets a name containing both "RNode" and "BLE"
-        // Must resolve to RNODE, not ANDROID_BLE
-        assertEquals(InterfaceType.RNODE, InterfaceType.fromInterfaceName("ColumbaRNodeInterface[RNode 5A3F BLE]"))
-        assertEquals(InterfaceType.RNODE, InterfaceType.fromInterfaceName("RNodeInterface[RNode ABC1 BLE]"))
+        // Must resolve to RNODE, not BLE
+        assertEquals(InterfaceType.RNODE, InterfaceType.fromName("ColumbaRNodeInterface[RNode 5A3F BLE]"))
+        assertEquals(InterfaceType.RNODE, InterfaceType.fromName("RNodeInterface[RNode ABC1 BLE]"))
+        assertEquals(InterfaceType.RNODE, InterfaceType.fromName("RNodeMultiInterface[/dev/ttyUSB0]"))
     }
 
     @Test
-    fun `fromInterfaceName returns UNKNOWN for null`() {
-        assertEquals(InterfaceType.UNKNOWN, InterfaceType.fromInterfaceName(null))
+    fun `fromName recognises legacy stored values for backwards compat`() {
+        // Pre-rename DB rows on the `announces.receivingInterfaceType`
+        // column will have these literal strings. The parser must still
+        // classify them correctly so the announce-stream filter UI works
+        // against pre-rename data without requiring a DB migration.
+        assertEquals(InterfaceType.AUTO, InterfaceType.fromName("AUTO_INTERFACE"))
+        assertEquals(InterfaceType.BLE, InterfaceType.fromName("ANDROID_BLE"))
+        // And the new canonical storage names round-trip:
+        assertEquals(InterfaceType.AUTO, InterfaceType.fromName("AUTO"))
+        assertEquals(InterfaceType.TCP_CLIENT, InterfaceType.fromName("TCP_CLIENT"))
+        assertEquals(InterfaceType.TCP_SERVER, InterfaceType.fromName("TCP_SERVER"))
+        assertEquals(InterfaceType.BLE, InterfaceType.fromName("BLE"))
+        assertEquals(InterfaceType.RNODE, InterfaceType.fromName("RNODE"))
     }
 
     @Test
-    fun `fromInterfaceName returns UNKNOWN for None string`() {
-        assertEquals(InterfaceType.UNKNOWN, InterfaceType.fromInterfaceName("None"))
+    fun `fromName returns UNKNOWN for null`() {
+        assertEquals(InterfaceType.UNKNOWN, InterfaceType.fromName(null))
     }
 
     @Test
-    fun `fromInterfaceName returns UNKNOWN for blank string`() {
-        assertEquals(InterfaceType.UNKNOWN, InterfaceType.fromInterfaceName(""))
-        assertEquals(InterfaceType.UNKNOWN, InterfaceType.fromInterfaceName("   "))
+    fun `fromName returns UNKNOWN for None string`() {
+        assertEquals(InterfaceType.UNKNOWN, InterfaceType.fromName("None"))
     }
 
     @Test
-    fun `fromInterfaceName returns UNKNOWN for unrecognized names`() {
-        assertEquals(InterfaceType.UNKNOWN, InterfaceType.fromInterfaceName("UnknownInterface"))
-        assertEquals(InterfaceType.UNKNOWN, InterfaceType.fromInterfaceName("SomeOtherDevice"))
-        assertEquals(InterfaceType.UNKNOWN, InterfaceType.fromInterfaceName("UDP"))
+    fun `fromName returns UNKNOWN for blank string`() {
+        assertEquals(InterfaceType.UNKNOWN, InterfaceType.fromName(""))
+        assertEquals(InterfaceType.UNKNOWN, InterfaceType.fromName("   "))
     }
 
     @Test
-    fun `fromInterfaceName is case insensitive`() {
-        assertEquals(InterfaceType.AUTO_INTERFACE, InterfaceType.fromInterfaceName("autointerface[local]"))
-        assertEquals(InterfaceType.AUTO_INTERFACE, InterfaceType.fromInterfaceName("AUTOINTERFACE[LOCAL]"))
-        assertEquals(InterfaceType.TCP_CLIENT, InterfaceType.fromInterfaceName("tcpclientinterface"))
-        assertEquals(InterfaceType.TCP_CLIENT, InterfaceType.fromInterfaceName("TCPCLIENT"))
-        assertEquals(InterfaceType.TCP_CLIENT, InterfaceType.fromInterfaceName("tcpinterface"))
-        assertEquals(InterfaceType.TCP_CLIENT, InterfaceType.fromInterfaceName("TCPINTERFACE"))
-        assertEquals(InterfaceType.TCP_CLIENT, InterfaceType.fromInterfaceName("backboneinterface"))
-        assertEquals(InterfaceType.TCP_CLIENT, InterfaceType.fromInterfaceName("BACKBONE"))
-        assertEquals(InterfaceType.ANDROID_BLE, InterfaceType.fromInterfaceName("BLE"))
-        assertEquals(InterfaceType.ANDROID_BLE, InterfaceType.fromInterfaceName("ble"))
-        assertEquals(InterfaceType.ANDROID_BLE, InterfaceType.fromInterfaceName("ANDROIDBLE"))
-        assertEquals(InterfaceType.ANDROID_BLE, InterfaceType.fromInterfaceName("androidble"))
-        assertEquals(InterfaceType.RNODE, InterfaceType.fromInterfaceName("rnode"))
-        assertEquals(InterfaceType.RNODE, InterfaceType.fromInterfaceName("RNODE"))
+    fun `fromName returns UNKNOWN for unrecognized names`() {
+        assertEquals(InterfaceType.UNKNOWN, InterfaceType.fromName("UnknownInterface"))
+        assertEquals(InterfaceType.UNKNOWN, InterfaceType.fromName("SomeOtherDevice"))
+        assertEquals(InterfaceType.UNKNOWN, InterfaceType.fromName("UDP"))
     }
 
     @Test
-    fun `fromInterfaceName detects embedded interface type names`() {
+    fun `fromName is case insensitive`() {
+        assertEquals(InterfaceType.AUTO, InterfaceType.fromName("autointerface[local]"))
+        assertEquals(InterfaceType.AUTO, InterfaceType.fromName("AUTOINTERFACE[LOCAL]"))
+        assertEquals(InterfaceType.TCP_CLIENT, InterfaceType.fromName("tcpclientinterface"))
+        assertEquals(InterfaceType.TCP_CLIENT, InterfaceType.fromName("TCPCLIENT"))
+        assertEquals(InterfaceType.TCP_CLIENT, InterfaceType.fromName("tcpinterface"))
+        assertEquals(InterfaceType.TCP_CLIENT, InterfaceType.fromName("TCPINTERFACE"))
+        assertEquals(InterfaceType.TCP_CLIENT, InterfaceType.fromName("backboneinterface"))
+        assertEquals(InterfaceType.TCP_CLIENT, InterfaceType.fromName("BACKBONE"))
+        assertEquals(InterfaceType.TCP_SERVER, InterfaceType.fromName("tcpserver"))
+        assertEquals(InterfaceType.BLE, InterfaceType.fromName("ble"))
+        assertEquals(InterfaceType.BLE, InterfaceType.fromName("ANDROIDBLE"))
+        assertEquals(InterfaceType.BLE, InterfaceType.fromName("androidble"))
+        assertEquals(InterfaceType.RNODE, InterfaceType.fromName("rnode"))
+    }
+
+    @Test
+    fun `fromName detects embedded interface type names`() {
         // Interface names may be embedded in longer strings (e.g., peer interfaces)
-        assertEquals(InterfaceType.AUTO_INTERFACE, InterfaceType.fromInterfaceName("PeerAutoInterface[local]"))
-        assertEquals(InterfaceType.TCP_CLIENT, InterfaceType.fromInterfaceName("PeerTCPClientInterface[host]"))
-        assertEquals(InterfaceType.TCP_CLIENT, InterfaceType.fromInterfaceName("PeerTCPInterface[host]"))
-        assertEquals(InterfaceType.ANDROID_BLE, InterfaceType.fromInterfaceName("PeerBLEInterface[addr]"))
-        assertEquals(InterfaceType.RNODE, InterfaceType.fromInterfaceName("PeerRNodeInterface[dev]"))
+        assertEquals(InterfaceType.AUTO, InterfaceType.fromName("PeerAutoInterface[local]"))
+        assertEquals(InterfaceType.TCP_CLIENT, InterfaceType.fromName("PeerTCPClientInterface[host]"))
+        assertEquals(InterfaceType.TCP_CLIENT, InterfaceType.fromName("PeerTCPInterface[host]"))
+        assertEquals(InterfaceType.BLE, InterfaceType.fromName("PeerBLEInterface[addr]"))
+        assertEquals(InterfaceType.RNODE, InterfaceType.fromName("PeerRNodeInterface[dev]"))
     }
 
     @Test
     fun `enum values are correct`() {
-        assertEquals(5, InterfaceType.entries.size)
+        assertEquals(6, InterfaceType.entries.size)
         assertEquals(
             setOf(
-                InterfaceType.AUTO_INTERFACE,
+                InterfaceType.AUTO,
                 InterfaceType.TCP_CLIENT,
-                InterfaceType.ANDROID_BLE,
+                InterfaceType.TCP_SERVER,
+                InterfaceType.BLE,
                 InterfaceType.RNODE,
                 InterfaceType.UNKNOWN,
             ),
             InterfaceType.entries.toSet(),
         )
+    }
+
+    @Test
+    fun `deprecated fromInterfaceName delegates to fromName`() {
+        // Just verify backwards-compat alias still works.
+        @Suppress("DEPRECATION")
+        assertEquals(InterfaceType.AUTO, InterfaceType.fromInterfaceName("AutoInterface"))
     }
 }

--- a/rns-api/src/main/aidl/network/columba/app/rns/ipc/IRnsTelephony.aidl
+++ b/rns-api/src/main/aidl/network/columba/app/rns/ipc/IRnsTelephony.aidl
@@ -1,8 +1,9 @@
 // AIDL surface mirroring the Kotlin RnsTelephony interface (LXST voice).
 //
 // Bundle key conventions for IRnsResultCallback payloads:
-//   - getCallState   → "state": VoiceCallState
-//   - Result<Unit>   → Bundle.EMPTY
+//   - getCallState      → "state": VoiceCallState
+//   - setIncomingEnabled→ Bundle.EMPTY
+//   - Result<Unit>      → Bundle.EMPTY
 //
 // profileCode is a nullable int — represented as (value, hasValue) for AIDL
 // since boxed Int isn't supported. Pass hasValue=false to mean null.
@@ -79,4 +80,15 @@ oneway interface IRnsTelephony {
     void setSpeakerLocally(boolean enabled, in IRnsResultCallback cb);
     void setPttModeLocally(boolean enabled, in IRnsResultCallback cb);
     void setPttActiveLocally(boolean active, in IRnsResultCallback cb);
+
+    // ==================== Master incoming-calls toggle ====================
+    //
+    // setIncomingEnabled(false) deregisters the lxst.telephony destination
+    // in :reticulum so peers cannot reach this device for inbound calls
+    // (outbound is unaffected — outbound creates an ephemeral OUT
+    // destination per call). setIncomingEnabled(true) re-registers and
+    // re-announces. Idempotent on both sides.
+    //
+    // Mirrors RnsTelephony.setIncomingEnabled on the Kotlin side.
+    void setIncomingEnabled(boolean enabled, in IRnsResultCallback cb);
 }

--- a/rns-api/src/main/java/network/columba/app/rns/api/RnsTelephony.kt
+++ b/rns-api/src/main/java/network/columba/app/rns/api/RnsTelephony.kt
@@ -153,6 +153,28 @@ interface RnsTelephony {
     suspend fun setPttActiveLocally(active: Boolean)
 
     /**
+     * Master toggle for inbound voice-call reachability.
+     *
+     * `false` → the backend deregisters the `lxst.telephony` destination
+     * (python: `Transport.deregister_destination(dest)` via Chaquopy;
+     * kotlin: [Transport.deregisterDestination] on reticulum-kt) and hangs
+     * up any active call. Subsequent peer call attempts time out without
+     * reaching this device. Outbound calls continue to work — they
+     * construct an ephemeral OUT destination per call.
+     *
+     * `true` → the backend re-registers the destination, re-announces it,
+     * and resumes accepting inbound link requests.
+     *
+     * Both states are persisted via `ServiceSettingsAccessor.getAllowVoiceCalls`
+     * so the desired state survives `:reticulum` restarts. This AIDL call
+     * is the runtime delivery path; the SharedPreferences write done by
+     * the UI handles the cold-start path.
+     *
+     * Idempotent — applying the same state twice is a no-op.
+     */
+    suspend fun setIncomingEnabled(enabled: Boolean)
+
+    /**
      * True when [callState] is currently in any non-terminal phase
      * (Connecting / Ringing / Incoming / Active). Derived from
      * [callState] — does not cross the AIDL boundary on every call.

--- a/rns-api/src/main/java/network/columba/app/rns/api/model/ReceivedMessage.kt
+++ b/rns-api/src/main/java/network/columba/app/rns/api/model/ReceivedMessage.kt
@@ -25,4 +25,12 @@ data class ReceivedMessage(
     // Signal quality metrics (from RNode/BLE — null for TCP/AutoInterface).
     val receivedRssi: Int? = null,
     val receivedSnr: Float? = null,
+    // LXMF delivery method this message arrived via:
+    //   "opportunistic" — single-packet, no link
+    //   "direct"        — link-based with retries
+    //   "propagated"    — fetched from a propagation node
+    //   null            — pre-feature messages or backend couldn't determine
+    // Mirrors the string vocabulary already used for outbound on
+    // `MessageEntity.deliveryMethod` and `MessageDetailScreen.getDeliveryMethodInfo`.
+    val deliveryMethod: String? = null,
 ) : Parcelable

--- a/rns-backend-kt/src/main/kotlin/network/columba/app/rns/backend/kt/HostBridges.kt
+++ b/rns-backend-kt/src/main/kotlin/network/columba/app/rns/backend/kt/HostBridges.kt
@@ -62,3 +62,33 @@ interface RNodeHostBridge {
      */
     fun rnodeFramebufferData(): ByteArray?
 }
+
+/**
+ * Tiny bridge into `:rns-host`-side privacy state for the LXST inbound-call
+ * path. Mirrors [RNodeHostBridge] in shape — `:rns-backend-kt` cannot
+ * import `:rns-host` (would cycle the Gradle dep graph), so this interface
+ * lives here and the adapter implementing it lives in
+ * `:rns-host/src/kotlinBackend/.../HostBackendModule.kt`, wrapping
+ * `CallsFromContactsGate` + `ServiceSettingsAccessor`.
+ *
+ * Both methods are called from the reticulum-kt callback thread on every
+ * inbound link / caller-identified event. They must be fast + safe to call
+ * synchronously — the gate uses `runBlocking(Dispatchers.IO)` internally,
+ * marked `// THREADING: allowed` per the audit-script convention.
+ */
+interface CallPrivacyBridge {
+    /**
+     * @return `true` → silently tear down the inbound link (no signal back
+     * to the originator, no UI surface on this device). `false` → let the
+     * call ring through. Reads the `allow_calls_from_contacts_only` toggle
+     * on every call so live UI toggles take effect immediately.
+     */
+    fun shouldSilentlyDrop(identityHashHex: String): Boolean
+
+    /**
+     * @return current persisted value of `allow_voice_calls` (default true).
+     * Read at `NativeCallManager.setup()` to apply the master toggle's
+     * last value before the first announce goes out.
+     */
+    fun getAllowVoiceCalls(): Boolean
+}

--- a/rns-backend-kt/src/main/kotlin/network/columba/app/rns/backend/kt/NativeCallManager.kt
+++ b/rns-backend-kt/src/main/kotlin/network/columba/app/rns/backend/kt/NativeCallManager.kt
@@ -17,6 +17,7 @@ import network.reticulum.common.DestinationType
 import network.reticulum.destination.Destination
 import network.reticulum.identity.Identity
 import network.reticulum.link.Link
+import network.reticulum.transport.Transport
 import tech.torlando.lxst.audio.Signalling
 import tech.torlando.lxst.core.AudioDevice
 import tech.torlando.lxst.core.AudioPacketHandler
@@ -63,6 +64,7 @@ class NativeCallManager(
     private val context: Context,
     private val deliveryIdentity: Identity,
     val transport: NativeNetworkTransport,
+    private val callPrivacyBridge: CallPrivacyBridge? = null,
 ) : CallController {
     companion object {
         private const val TAG = "NativeCallManager"
@@ -88,6 +90,18 @@ class NativeCallManager(
      * Held to prevent GC and to allow cleanup on [shutdown].
      */
     private var telephonyDestination: Destination? = null
+
+    /**
+     * Master incoming-calls toggle state. Mirrors `:rns-host/pythonBackend`'s
+     * sibling. Read by [onInboundLinkEstablished] as a TOCTOU guard against
+     * an inbound link that crossed the wire just before [disableIncoming]
+     * ran; written only inside [incomingLock].
+     */
+    @Volatile
+    private var incomingDisabled: Boolean = false
+
+    /** Serialises [disableIncoming] / [enableIncoming] transitions. */
+    private val incomingLock = Any()
 
     // ===== Initialization =====
 
@@ -135,6 +149,15 @@ class NativeCallManager(
         // Announce immediately so peers can resolve a path to our telephony destination
         // even before the next coupled LXMF auto-announce fires.
         announce()
+
+        // Cold-start application of the persisted master toggle. If the user
+        // turned voice calls OFF before the last process tear-down (or before
+        // this fresh-start), apply that now — register+immediately-deregister
+        // is marginally wasteful but lets re-enable share one helper.
+        if (callPrivacyBridge?.getAllowVoiceCalls() == false) {
+            Log.i(TAG, "Cold-start: Allow voice calls = false, deregistering destination")
+            disableIncoming()
+        }
 
         Log.i(TAG, "Native telephony stack ready")
     }
@@ -198,6 +221,17 @@ class NativeCallManager(
     private fun onInboundLinkEstablished(link: Link) {
         Log.i(TAG, "Inbound call link arrived")
 
+        // Defense-in-depth TOCTOU guard: an inbound link may have been
+        // admitted by reticulum-kt's Transport in the brief window before
+        // deregisterDestination returned. Drop it silently — STATUS_AVAILABLE
+        // has not yet been sent, so the caller sees the same "remote went
+        // away" timeout as the toggle-off path below.
+        if (incomingDisabled) {
+            Log.d(TAG, "Inbound link but incoming disabled, silently tearing down")
+            link.teardown()
+            return
+        }
+
         if (telephone.isCallActive()) {
             Log.w(TAG, "Line busy — signalling busy and rejecting inbound link")
             link.send(packSignal(Signalling.STATUS_BUSY))
@@ -247,6 +281,18 @@ class NativeCallManager(
     ) {
         val identityHash = identity.hexHash
         Log.i(TAG, "Caller identified: ${identityHash.take(16)}")
+
+        // Calls-from-contacts-only gate. Fires BEFORE STATUS_RINGING and
+        // BEFORE Telephone.onIncomingCall, so the originator only sees a
+        // wait-time timeout (no STATUS_BUSY / STATUS_REJECTED) and this
+        // device shows no UI / no ringtone. Sibling of the same gate in
+        // PythonCallManager; both share the same CallsFromContactsGate
+        // singleton via the CallPrivacyBridge adapter.
+        if (callPrivacyBridge?.shouldSilentlyDrop(identityHash) == true) {
+            Log.i(TAG, "Calls-only-from-contacts: dropping ${identityHash.take(16)}")
+            link.teardown()
+            return
+        }
 
         if (telephone.isCallActive()) {
             Log.w(TAG, "Line became busy after identify — signalling busy")
@@ -308,6 +354,53 @@ class NativeCallManager(
 
     override fun setSpeaker(enabled: Boolean) {
         audioBridge.setSpeakerphoneOn(enabled)
+    }
+
+    // ===== Master incoming-calls toggle =====
+
+    /**
+     * Apply [setIncomingEnabled] for this manager.
+     *
+     * Invoked by [NativeRnsBackendImpl.setIncomingEnabledHook] (wired in
+     * [NativeRnsBackendImpl.setupNativeTelephone] once this manager is
+     * constructed) when the UI calls `RnsTelephony.setIncomingEnabled(...)`
+     * across the AIDL boundary.
+     *
+     * Idempotent — applying the same state twice is a no-op.
+     */
+    fun setIncomingEnabled(enabled: Boolean) {
+        if (enabled) enableIncoming() else disableIncoming()
+    }
+
+    private fun disableIncoming() = synchronized(incomingLock) {
+        if (incomingDisabled) return@synchronized
+        incomingDisabled = true
+        telephonyDestination?.let { dest ->
+            try {
+                Transport.deregisterDestination(dest)
+                Log.i(TAG, "lxst.telephony destination deregistered")
+            } catch (e: Exception) {
+                Log.w(TAG, "deregisterDestination failed", e)
+            }
+        }
+        telephonyDestination = null
+        if (::telephone.isInitialized && telephone.isCallActive()) {
+            // Hang up before the link's transport state goes away so the
+            // remote sees a clean drop (hangup signal sent over the active
+            // call link, not the destination).
+            try {
+                telephone.hangup()
+            } catch (e: Exception) {
+                Log.w(TAG, "Ignored hangup error during disableIncoming: ${e.message}")
+            }
+        }
+    }
+
+    private fun enableIncoming() = synchronized(incomingLock) {
+        if (!incomingDisabled && telephonyDestination != null) return@synchronized
+        incomingDisabled = false
+        registerTelephonyDestination()
+        announce()
     }
 
     // ===== Lifecycle =====

--- a/rns-backend-kt/src/main/kotlin/network/columba/app/rns/backend/kt/NativeRnsBackend.kt
+++ b/rns-backend-kt/src/main/kotlin/network/columba/app/rns/backend/kt/NativeRnsBackend.kt
@@ -34,6 +34,7 @@ import network.columba.app.rns.api.RnsTransportAdmin
 class NativeRnsBackend(
     appContext: Context? = null,
     rnodeHostBridge: RNodeHostBridge? = null,
+    callPrivacyBridge: CallPrivacyBridge? = null,
 ) : RnsBackend {
     init {
         // Defense-in-depth A.10 assertion: this constructor MUST only run in
@@ -68,6 +69,7 @@ class NativeRnsBackend(
     val impl: NativeRnsBackendImpl = NativeRnsBackendImpl(
         appContext = appContext,
         rnodeHostBridge = rnodeHostBridge,
+        callPrivacyBridge = callPrivacyBridge,
     )
 
     override val core: RnsCore = impl

--- a/rns-backend-kt/src/main/kotlin/network/columba/app/rns/backend/kt/NativeRnsBackendImpl.kt
+++ b/rns-backend-kt/src/main/kotlin/network/columba/app/rns/backend/kt/NativeRnsBackendImpl.kt
@@ -92,6 +92,13 @@ class NativeRnsBackendImpl(
      * May be null in unit-test mode.
      */
     private val rnodeHostBridge: RNodeHostBridge? = null,
+    /**
+     * Bridge into `:rns-host`-side privacy state for inbound voice calls.
+     * Supplied by the kotlinBackend Hilt module wrapping `CallsFromContactsGate`
+     * + `ServiceSettingsAccessor`. Null in unit-test mode → all calls are
+     * allowed through (preserves the pre-feature behaviour).
+     */
+    private val callPrivacyBridge: CallPrivacyBridge? = null,
 ) : network.columba.app.rns.api.RnsCore,
     network.columba.app.rns.api.RnsLxmf,
     network.columba.app.rns.api.RnsTelephony,
@@ -2017,9 +2024,20 @@ class NativeRnsBackendImpl(
 
     private fun setupNativeTelephone(identity: NativeIdentity) {
         val ctx = appContext ?: return
-        val manager = NativeCallManager(ctx, identity, callTransport)
+        val manager = NativeCallManager(
+            context = ctx,
+            deliveryIdentity = identity,
+            transport = callTransport,
+            callPrivacyBridge = callPrivacyBridge,
+        )
         manager.setup()
         callManager = manager
+        // Wire the AIDL master-toggle hook now that the manager exists.
+        // Until this point setIncomingEnabledHook is null and the stub on
+        // this class logs + returns. The Hilt eager-init path constructs
+        // NativeRnsBackend at app start, but setupNativeTelephone runs
+        // later inside initialize() after Reticulum + identity are ready.
+        setIncomingEnabledHook = manager::setIncomingEnabled
         Log.i(TAG, "📞 Native Telephone ready")
     }
 

--- a/rns-backend-kt/src/main/kotlin/network/columba/app/rns/backend/kt/NativeRnsBackendImpl.kt
+++ b/rns-backend-kt/src/main/kotlin/network/columba/app/rns/backend/kt/NativeRnsBackendImpl.kt
@@ -2108,6 +2108,24 @@ class NativeRnsBackendImpl(
         callCoordinator.setPttActiveLocally(active)
     }
 
+    /**
+     * Master incoming-calls toggle. Wired to [NativeCallManager] in
+     * `setupNativeTelephone` once the call manager is constructed
+     * (commit 5). Until then this is a no-op log so the AIDL boundary
+     * compiles end-to-end.
+     */
+    @Volatile
+    var setIncomingEnabledHook: ((Boolean) -> Unit)? = null
+
+    override suspend fun setIncomingEnabled(enabled: Boolean) {
+        val hook = setIncomingEnabledHook
+        if (hook == null) {
+            Log.w(TAG, "setIncomingEnabled($enabled) before NativeCallManager wired hook")
+        } else {
+            hook(enabled)
+        }
+    }
+
     override suspend fun getCallState(): Result<VoiceCallState> =
         runCatching {
             val coordinator =

--- a/rns-backend-kt/src/main/kotlin/network/columba/app/rns/backend/kt/NativeRnsBackendImpl.kt
+++ b/rns-backend-kt/src/main/kotlin/network/columba/app/rns/backend/kt/NativeRnsBackendImpl.kt
@@ -1041,8 +1041,26 @@ class NativeRnsBackendImpl(
             receivedInterface = receivingInterfaceName,
             receivedRssi = message.receivedRssi,
             receivedSnr = message.receivedSnr,
+            deliveryMethod = nativeDeliveryMethodName(message.method),
         )
     }
+
+    /**
+     * Map an inbound `LXMessage.method` (reticulum-kt's `DeliveryMethod`
+     * enum) to the lowercase-string vocabulary the UI + persistence layer
+     * use for outbound (`MessageEntity.deliveryMethod`,
+     * `MessageDetailScreen.getDeliveryMethodInfo`). Returning null for an
+     * unset method keeps the UI's null-guarded card hidden rather than
+     * rendering "Unknown".
+     */
+    private fun nativeDeliveryMethodName(method: NativeDeliveryMethod?): String? =
+        when (method) {
+            NativeDeliveryMethod.OPPORTUNISTIC -> "opportunistic"
+            NativeDeliveryMethod.DIRECT -> "direct"
+            NativeDeliveryMethod.PROPAGATED -> "propagated"
+            NativeDeliveryMethod.PAPER -> "paper"
+            else -> null
+        }
 
     override val locationTelemetryFlow = _locationTelemetryFlow.asSharedFlow()
 
@@ -1286,17 +1304,17 @@ class NativeRnsBackendImpl(
     ): Result<PropagationState> =
         try {
             val r = router ?: return Result.success(PropagationState.IDLE)
-            // Sideband's `request_lxmf_sync` idle guard: only start a fresh
-            // sync when the router is IDLE or a previous sync has reached
-            // COMPLETE. Re-firing mid-`PR_LINK_ESTABLISHING` / `PR_RECEIVING`
-            // would thrash the outbound link.
-            val currentState = r.propagationTransferState
-            val isInTransit = currentState.ordinal in
-                PropagationState.STATE_PATH_REQUESTED until PropagationState.STATE_COMPLETE
-            if (isInTransit) {
-                Log.i(TAG, "Propagation sync already in flight (state=$currentState); not re-triggering")
-                return Result.success(readPropagationState(r))
-            }
+            // No external idle-guard. Upstream LXMRouter's
+            // `requestMessagesFromPropagationNode` handles being called
+            // while a previous request is in flight — it re-uses the
+            // existing outbound link if alive, or tears down + rebuilds
+            // if not. Matches `release/v0.10.x` + the python sibling.
+            // An earlier port of Sideband's `request_lxmf_sync` idle
+            // check was load-bearing in the wrong direction: when
+            // upstream got stuck at `PR_REQUEST_SENT` (propagation node
+            // unresponsive, link silently lost), the guard permanently
+            // locked out every retry — manual or periodic — until the
+            // process restarted.
             val activeNode = r.getActivePropagationNode()
             val propNodeCount = r.getPropagationNodes().size
             Log.d(TAG, "Propagation sync: activeNode=${activeNode?.hexHash?.take(12)}, totalPropNodes=$propNodeCount")

--- a/rns-backend-py/src/main/kotlin/network/columba/app/rns/backend/py/PythonEventBridge.kt
+++ b/rns-backend-py/src/main/kotlin/network/columba/app/rns/backend/py/PythonEventBridge.kt
@@ -194,6 +194,7 @@ class PythonEventBridge {
                 stampCost = stampCost,
                 stampCostFlexibility = stampFlex,
                 peeringCost = peeringCost,
+                receivingInterface = payload.dictStr("receiving_interface"),
             )
             _announces.tryEmit(event)
         }.onFailure { Log.e(TAG, "announce translation failed", it) }

--- a/rns-backend-py/src/main/kotlin/network/columba/app/rns/backend/py/PythonEventBridge.kt
+++ b/rns-backend-py/src/main/kotlin/network/columba/app/rns/backend/py/PythonEventBridge.kt
@@ -19,6 +19,7 @@ import network.columba.app.rns.api.util.isUserVisibleChatMessage
 import network.columba.app.rns.api.util.LxmfFields
 import network.columba.app.rns.api.util.TelemeterCodec
 import network.columba.app.rns.api.util.hexToBytes
+import org.json.JSONArray
 import org.json.JSONObject
 
 /**
@@ -358,37 +359,38 @@ class PythonEventBridge {
         val streamArr = fields.optJSONArray(FIELD_TELEMETRY_STREAM_KEY) ?: return
         for (i in 0 until streamArr.length()) {
             val entry = streamArr.optJSONArray(i) ?: continue
-            if (entry.length() < 3) continue
-            // [0] source_hash (hex-encoded bytes from _jsonable)
-            val entrySourceHex = entry.optString(0, "").takeIf { it.isNotBlank() } ?: continue
-            // [1] timestamp seconds (Telemeter convention is seconds; we
-            //     multiply to ms for the LocationTelemetry.ts contract)
-            val entryTsSeconds = entry.optLong(1, 0L)
-            // [2] packed Telemeter bytes (hex)
-            val packedHex = entry.optString(2, "").takeIf { it.isNotBlank() } ?: continue
-            val packedBytes = packedHex.hexToBytes() ?: continue
-            val decoded = TelemeterCodec.unpackLocationTelemetry(packedBytes) ?: continue
-            // [3] appearance (optional; null or [name, fg_hex, bg_hex])
-            val appearance =
-                entry.opt(3)?.let { raw ->
-                    when (raw) {
-                        JSONObject.NULL -> null
-                        is org.json.JSONArray -> {
-                            val parts = (0 until raw.length()).map { raw.opt(it) }
-                            AppDataParser.parseIconAppearance(parts)
-                        }
-                        else -> null
-                    }
-                }
-            _locationTelemetry.tryEmit(
-                decoded.copy(
-                    ts = if (entryTsSeconds > 0) entryTsSeconds * 1000L else decoded.ts,
-                    sourceHash = entrySourceHex.lowercase(),
-                    appearance = appearance,
-                ),
-            )
+            parseTelemetryStreamEntry(entry)?.let { _locationTelemetry.tryEmit(it) }
         }
     }
+
+    // Entry layout from event_bridge.py's collector relay:
+    //   [0] source_hash (hex-encoded bytes from _jsonable)
+    //   [1] timestamp in seconds (Telemeter convention is seconds; we multiply
+    //       to ms for the LocationTelemetry.ts contract)
+    //   [2] packed Telemeter bytes (hex)
+    //   [3] appearance (optional; null or [name, fg_hex, bg_hex])
+    private fun parseTelemetryStreamEntry(entry: JSONArray): LocationTelemetry? {
+        if (entry.length() < 3) return null
+        val entrySourceHex = entry.optString(0, "").takeIf { it.isNotBlank() } ?: return null
+        val packedBytes =
+            entry.optString(2, "").takeIf { it.isNotBlank() }?.hexToBytes()
+        val decoded = packedBytes?.let { TelemeterCodec.unpackLocationTelemetry(it) }
+        return decoded?.copy(
+            ts = entry.optLong(1, 0L).takeIf { it > 0 }?.let { it * 1000L } ?: decoded.ts,
+            sourceHash = entrySourceHex.lowercase(),
+            appearance = parseTelemetryStreamAppearance(entry.opt(3)),
+        )
+    }
+
+    private fun parseTelemetryStreamAppearance(raw: Any?): IconAppearance? =
+        when (raw) {
+            null, JSONObject.NULL -> null
+            is JSONArray -> {
+                val parts = (0 until raw.length()).map { raw.opt(it) }
+                AppDataParser.parseIconAppearance(parts)
+            }
+            else -> null
+        }
 
     /**
      * Reaction-channel routing — `FIELD_REACTION` (0x10) is a

--- a/rns-backend-py/src/main/kotlin/network/columba/app/rns/backend/py/PythonEventBridge.kt
+++ b/rns-backend-py/src/main/kotlin/network/columba/app/rns/backend/py/PythonEventBridge.kt
@@ -45,6 +45,36 @@ class PythonEventBridge {
     private companion object {
         const val TAG = "PythonEventBridge"
 
+        /**
+         * Upstream `LXMF.LXMessage.PROPAGATED` = 0x03. Inlined (rather than
+         * importing LXMF Kotlin bindings) because this bridge only needs the
+         * integer for the delivery-status branch — distinguishing "stored on
+         * the relay" from "ack'd by recipient". Matches the matching
+         * `_LXMF_METHOD_PROPAGATED` constant in `event_bridge.py`.
+         */
+        const val LXMF_METHOD_OPPORTUNISTIC = 0x01
+        const val LXMF_METHOD_DIRECT = 0x02
+        const val LXMF_METHOD_PROPAGATED = 0x03
+        const val LXMF_METHOD_PAPER = 0x04
+
+        /**
+         * Map an upstream `LXMessage.method` int to the lowercase-string
+         * vocabulary the UI + persistence layer already use for outbound
+         * messages (see `MessageEntity.deliveryMethod`,
+         * `MessageDetailScreen.getDeliveryMethodInfo`). Keeps inbound and
+         * outbound rendering paths sharing one set of labels — null when the
+         * method is unknown so the UI's null-guarded card disappears
+         * gracefully rather than rendering "Unknown".
+         */
+        fun lxmfMethodName(method: Int?): String? =
+            when (method) {
+                LXMF_METHOD_OPPORTUNISTIC -> "opportunistic"
+                LXMF_METHOD_DIRECT -> "direct"
+                LXMF_METHOD_PROPAGATED -> "propagated"
+                LXMF_METHOD_PAPER -> "paper"
+                else -> null
+            }
+
         // event_bridge.py emits the field map as `json.dumps({str(k): ...})`,
         // so JSON-keyed lookups need the stringified form of every LXMF field
         // ID. Derived from `LxmfFields` so the source-of-truth values live in
@@ -201,6 +231,7 @@ class PythonEventBridge {
                 receivedInterface = payload.dictStr("receiving_interface"),
                 receivedRssi = payload.dictInt("rssi"),
                 receivedSnr = payload.dictDouble("snr")?.toFloat(),
+                deliveryMethod = lxmfMethodName(payload.dictInt("method")),
             )
 
             // Side-channels always route — independent of the chat-emit
@@ -341,12 +372,25 @@ class PythonEventBridge {
 
     private fun handleLxmfDelivered(payload: PyObject) {
         runCatching {
-            // Mirrors NativeMessageSender — "delivered" is the same status
-            // string the kotlin backend emits on a delivery proof.
+            // Mirrors `NativeMessageSender.installDeliveryCallbacks`: same
+            // upstream-LXMF callback fires for both PROPAGATED (success ==
+            // "stored on the relay node") and DIRECT/OPPORTUNISTIC (success
+            // == "ack from recipient"). The split is by `method`, not state.
+            // Without this distinction the UI would render ✓✓ ("delivered")
+            // for every PROPAGATED send the moment it lands on the relay,
+            // misrepresenting the actual delivery promise.
+            val method = payload.dictInt("method") ?: -1
+            val desired = payload.dictInt("desired_method") ?: -1
+            val status =
+                if (method == LXMF_METHOD_PROPAGATED || desired == LXMF_METHOD_PROPAGATED) {
+                    "propagated"
+                } else {
+                    "delivered"
+                }
             _deliveryStatus.tryEmit(
                 DeliveryStatusUpdate(
                     messageHash = payload.dictStr("hash").orEmpty(),
-                    status = "delivered",
+                    status = status,
                     timestamp = System.currentTimeMillis(),
                 ),
             )

--- a/rns-backend-py/src/main/kotlin/network/columba/app/rns/backend/py/PythonEventBridge.kt
+++ b/rns-backend-py/src/main/kotlin/network/columba/app/rns/backend/py/PythonEventBridge.kt
@@ -276,6 +276,18 @@ class PythonEventBridge {
     ) {
         runCatching {
             val fields = JSONObject(fieldsJson)
+
+            // FIELD_TELEMETRY_STREAM (0x03) — collector-host response with
+            // a list of `[source_hash_bytes, timestamp, packed_telemetry,
+            // appearance]` entries. Sent by a group-tracker host in
+            // response to a FIELD_COMMANDS telemetry request. Each entry
+            // gets its OWN source hash (the original telemetry author),
+            // NOT the LXMessage sender (which is the collector relaying
+            // for everyone). Re-emit each entry as a separate
+            // LocationTelemetry so the UI's per-peer marker logic stays
+            // simple — one entry, one peer pin.
+            handleTelemetryStream(fields)
+
             val telemetryHex = fields.optString(FIELD_TELEMETRY_KEY, "")
             if (telemetryHex.isBlank()) return@runCatching
             val telemetryBytes = telemetryHex.hexToBytes() ?: return@runCatching
@@ -319,6 +331,63 @@ class PythonEventBridge {
                 ),
             )
         }.onFailure { Log.w(TAG, "location telemetry assembly failed", it) }
+    }
+
+    /**
+     * Unpack a FIELD_TELEMETRY_STREAM payload into individual
+     * [LocationTelemetry] emissions, one per entry. The stream wire
+     * format (defined by Sideband, re-used by Columba) is:
+     *
+     *   [
+     *     [source_hash: bytes, timestamp: int, packed_telemetry: bytes,
+     *      appearance: [icon_name: str, fg: bytes, bg: bytes] | null],
+     *     ...
+     *   ]
+     *
+     * `event_bridge.py:_jsonable` hex-encodes the bytes fields before
+     * passing through JSON, so this reads everything as JSON strings /
+     * arrays and decodes the hex back out per-entry.
+     *
+     * Per-entry source_hash is what the map / DB key on, NOT the
+     * LXMessage sender (which is the collector relaying everyone's
+     * positions). Without this de-aliasing, every received stream entry
+     * would overwrite the collector's pin instead of populating each
+     * group member's.
+     */
+    private fun handleTelemetryStream(fields: JSONObject) {
+        val streamArr = fields.optJSONArray(FIELD_TELEMETRY_STREAM_KEY) ?: return
+        for (i in 0 until streamArr.length()) {
+            val entry = streamArr.optJSONArray(i) ?: continue
+            if (entry.length() < 3) continue
+            // [0] source_hash (hex-encoded bytes from _jsonable)
+            val entrySourceHex = entry.optString(0, "").takeIf { it.isNotBlank() } ?: continue
+            // [1] timestamp seconds (Telemeter convention is seconds; we
+            //     multiply to ms for the LocationTelemetry.ts contract)
+            val entryTsSeconds = entry.optLong(1, 0L)
+            // [2] packed Telemeter bytes (hex)
+            val packedHex = entry.optString(2, "").takeIf { it.isNotBlank() } ?: continue
+            val packedBytes = packedHex.hexToBytes() ?: continue
+            val decoded = TelemeterCodec.unpackLocationTelemetry(packedBytes) ?: continue
+            // [3] appearance (optional; null or [name, fg_hex, bg_hex])
+            val appearance =
+                entry.opt(3)?.let { raw ->
+                    when (raw) {
+                        JSONObject.NULL -> null
+                        is org.json.JSONArray -> {
+                            val parts = (0 until raw.length()).map { raw.opt(it) }
+                            AppDataParser.parseIconAppearance(parts)
+                        }
+                        else -> null
+                    }
+                }
+            _locationTelemetry.tryEmit(
+                decoded.copy(
+                    ts = if (entryTsSeconds > 0) entryTsSeconds * 1000L else decoded.ts,
+                    sourceHash = entrySourceHex.lowercase(),
+                    appearance = appearance,
+                ),
+            )
+        }
     }
 
     /**

--- a/rns-backend-py/src/main/kotlin/network/columba/app/rns/backend/py/PythonRnsCore.kt
+++ b/rns-backend-py/src/main/kotlin/network/columba/app/rns/backend/py/PythonRnsCore.kt
@@ -320,11 +320,64 @@ class PythonRnsCore(
 
     override suspend fun getNextHopInterfaceName(destinationHash: ByteArray): String? =
         pyCall {
-            // RNS.Transport.next_hop_interface returns the Interface object; .name
-            // is its formatted name (e.g. "TCPInterface[Server/1.2.3.4:4242]").
-            transport().callAttr("next_hop_interface", destinationHash.toPyBytes())
-                ?.get("name")?.toString()
+            val transport = transport()
+            val pyHash = destinationHash.toPyBytes()
+
+            // Strategy 1 — Standard `RNS.Transport.next_hop_interface` lookup.
+            // Returns the interface the destination's path is cached on.
+            // For AutoInterface, the path-table stores the per-peer
+            // `AutoInterfacePeer` (a subclass whose `.name` attribute is
+            // empty — its `__str__` carries the useful `wlan0/fe80::…`
+            // info instead). For everything else `.name` is populated.
+            val rawIface = transport.callAttr("next_hop_interface", pyHash)
+            val name1 = rawIface?.let { pyInterfaceName(it) }
+            if (name1 != null) return@pyCall name1
+
+            // Strategy 2 — Fall back to `LXMRouter.outbound_propagation_link`
+            // when querying the configured propagation node. The link is
+            // long-lived and reused across syncs; its `attached_interface`
+            // is the interface the propagation packets physically travel
+            // over even when `path_table[prop_node_hash]` happens to be
+            // empty.
+            val router = runtime.lxmRouter ?: return@pyCall null
+            val propNode = runCatching {
+                router.callAttr("get_outbound_propagation_node")
+                    ?.toJava(ByteArray::class.java)
+            }.getOrNull()
+            if (propNode == null || !propNode.contentEquals(destinationHash)) {
+                return@pyCall null
+            }
+            val propLink = router["outbound_propagation_link"]?.takeIf { it.toString() != "None" }
+                ?: return@pyCall null
+            val attached = propLink["attached_interface"]?.takeIf { it.toString() != "None" }
+                ?: return@pyCall null
+            pyInterfaceName(attached)
         }
+
+    /**
+     * Best-effort interface-name extraction from a Python `Interface`-like
+     * object. Tries `.name` first (set by classes that override it —
+     * `AutoInterface`, `TCPInterface`, `RNodeInterface`, …); falls back to
+     * `__str__()` (always set, includes useful disambiguators like
+     * `wlan0/fe80::…` for `AutoInterfacePeer`); finally to the class name.
+     * Returns null only when the input is null or every accessor yielded
+     * blank / `"None"`.
+     *
+     * Necessary because Reticulum's `AutoInterfacePeer` doesn't set
+     * `self.name` — its `__init__` only sets `self.ifname` + `self.addr`.
+     * Reading `.name` returns the Interface base class's empty default,
+     * so the original one-liner `.get("name")?.toString()` always
+     * produced null for propagation-link traffic on AutoInterface.
+     */
+    private fun pyInterfaceName(iface: com.chaquo.python.PyObject): String? {
+        val nameAttr = iface.get("name")?.toString()?.takeIf { it.isNotBlank() && it != "None" }
+        if (nameAttr != null) return nameAttr
+        val strRepr = iface.toString().takeIf { it.isNotBlank() && it != "None" }
+        if (strRepr != null) return strRepr
+        return iface.callAttr("__class__")?.get("__name__")
+            ?.toString()
+            ?.takeIf { it.isNotBlank() && it != "None" }
+    }
 
     override suspend fun getPathTableHashes(): List<String> =
         pyCall {

--- a/rns-backend-py/src/main/kotlin/network/columba/app/rns/backend/py/PythonRnsLxmf.kt
+++ b/rns-backend-py/src/main/kotlin/network/columba/app/rns/backend/py/PythonRnsLxmf.kt
@@ -446,17 +446,19 @@ class PythonRnsLxmf(
         pyResult {
             val router = runtime.lxmRouter
                 ?: throw RnsException(RnsError.BackendNotReady)
-            // Sideband's `request_lxmf_sync` idle guard: only start a fresh
-            // sync when the router is IDLE or a previous sync has reached
-            // COMPLETE. Re-firing mid-`PR_LINK_ESTABLISHING` / `PR_RECEIVING`
-            // would thrash the outbound link.
-            val pre = readPropagationState(router)
-            val isInTransit = pre.state in
-                PropagationState.STATE_PATH_REQUESTED until PropagationState.STATE_COMPLETE
-            if (isInTransit) {
-                Log.i(TAG, "Propagation sync already in flight (state=${pre.stateName}); not re-triggering")
-                return@pyResult pre.also { _propagationStateFlow.tryEmit(it) }
-            }
+            // No external idle-guard. Upstream `LXMRouter.request_messages_from_propagation_node`
+            // already handles being called while a previous request is in
+            // flight — it re-uses the existing outbound link if alive, or
+            // tears down + rebuilds if not. Matches `release/v0.10.x`'s
+            // `reticulum_wrapper.request_messages_from_propagation_node`
+            // shape, which has shipped without this guard since the
+            // propagation feature went GA. An earlier port of Sideband's
+            // `request_lxmf_sync` idle check was added here and turned out
+            // to be load-bearing in the wrong direction: when upstream's
+            // state machine got stuck at `PR_REQUEST_SENT` (propagation
+            // node unresponsive, link silently lost), the guard permanently
+            // locked out every retry — manual or periodic — until the
+            // process restarted.
 
             // The sync runs as the identity that owns the delivery destination.
             // identityPrivateKey lets a caller sync as a different identity; if

--- a/rns-backend-py/src/main/kotlin/network/columba/app/rns/backend/py/PythonRnsTelemetry.kt
+++ b/rns-backend-py/src/main/kotlin/network/columba/app/rns/backend/py/PythonRnsTelemetry.kt
@@ -3,6 +3,12 @@ package network.columba.app.rns.backend.py
 import android.util.Log
 import com.chaquo.python.PyObject
 import kotlinx.coroutines.flow.SharedFlow
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.double
+import kotlinx.serialization.json.float
+import kotlinx.serialization.json.jsonObject
+import kotlinx.serialization.json.jsonPrimitive
+import kotlinx.serialization.json.long
 import network.columba.app.rns.api.RnsError
 import network.columba.app.rns.api.RnsException
 import network.columba.app.rns.api.RnsTelemetry
@@ -124,14 +130,15 @@ class PythonRnsTelemetry(
 
     override suspend fun setTelemetryCollectorMode(enabled: Boolean): Result<Unit> =
         pyResult {
-            // Honest minimal impl: track the mode flag backend-side so a restart
-            // re-applies it. Wiring the upstream LXMF FIELD_TELEMETRY_STREAM
-            // responder (the LXMRouter delivery callback that inspects inbound
-            // FIELD_COMMANDS and replies with the stored stream) is on-device
-            // follow-up — it needs the upstream responder path verified live.
-            // TODO(on-device): full collector-host wiring against upstream LXMF.
+            // Push state into event_bridge — the actual LXMF FIELD_COMMANDS
+            // responder + collected-telemetry store live there (Python-side
+            // because the response path needs `RNS.Identity.recall` +
+            // `RNS.Destination` + `router.handle_outbound`, all native
+            // Python objects). Kotlin retains a mirror flag for the
+            // `storeOwnTelemetry` re-sync check on send paths.
             collectorHostModeEnabled = enabled
-            Log.i(TAG, "telemetry collector host mode -> $enabled (responder wiring is on-device follow-up)")
+            runtime.eventBridge.callAttr("set_collector_enabled", enabled)
+            Log.i(TAG, "telemetry collector host mode -> $enabled")
         }
 
     override suspend fun storeOwnTelemetry(
@@ -139,27 +146,56 @@ class PythonRnsTelemetry(
         iconAppearance: IconAppearance?,
     ): Result<Unit> =
         pyResult {
-            // Honest minimal impl: keep the host's own latest telemetry so it can
-            // be folded into FIELD_TELEMETRY_STREAM responses once the responder
-            // is wired. Keyed by the local delivery identity hash.
-            // TODO(on-device): full collector-host wiring against upstream LXMF.
+            // Pack the JSON into a Sideband-compatible FIELD_TELEMETRY
+            // blob via the shared `TelemeterCodec`, then hand it to
+            // `event_bridge.store_own_telemetry` so it lands in the same
+            // `_collected_telemetry` dict the FIELD_COMMANDS responder
+            // serves. Keyed in event_bridge by the local delivery
+            // destination hash — no need to pass the key from here.
+            val parsed = Json.parseToJsonElement(locationJson).jsonObject
+            val telemetry =
+                LocationTelemetry(
+                    lat = parsed["lat"]?.jsonPrimitive?.double ?: 0.0,
+                    lng = parsed["lng"]?.jsonPrimitive?.double ?: 0.0,
+                    acc = parsed["acc"]?.jsonPrimitive?.float ?: 0f,
+                    ts = parsed["ts"]?.jsonPrimitive?.long ?: System.currentTimeMillis(),
+                    altitude = parsed["altitude"]?.jsonPrimitive?.double ?: 0.0,
+                    speed = parsed["speed"]?.jsonPrimitive?.double ?: 0.0,
+                    bearing = parsed["bearing"]?.jsonPrimitive?.double ?: 0.0,
+                )
+            val packedBytes = TelemeterCodec.packLocationTelemetry(telemetry)
+            val tsSeconds = telemetry.ts / 1000L
+            val appearancePy =
+                iconAppearance?.let { it.toPyField() }
+                    ?: runtime.python.getBuiltins().get("None")
+            runtime.eventBridge.callAttr(
+                "store_own_telemetry",
+                packedBytes.toPyBytes(),
+                tsSeconds,
+                appearancePy,
+            )
+            // Keep the local mirror so a debug `ownTelemetry` inspection
+            // still shows what was last stored — the canonical store now
+            // lives Python-side.
             val key = runtime.localIdentity
                 ?.get("hash")
                 ?.toJava(ByteArray::class.java)
                 ?.toHex()
                 ?: "local"
             ownTelemetry[key] = locationJson
-            Log.d(TAG, "stored own telemetry for $key (${locationJson.length} chars)")
+            Log.d(TAG, "stored own telemetry for $key (${packedBytes.size} packed bytes)")
         }
 
     override suspend fun setTelemetryAllowedRequesters(allowedHashes: Set<String>): Result<Unit> =
         pyResult {
-            // Honest minimal impl: maintain the allow-set backend-side so a
-            // restart re-applies it. The responder that actually filters inbound
-            // FIELD_COMMANDS requests against this set is on-device follow-up.
-            // TODO(on-device): full collector-host wiring against upstream LXMF.
+            // Push allow-set into event_bridge so the responder's
+            // permission check (run on the LXMRouter delivery thread) sees
+            // it without a JNI hop per request. Kotlin retains a mirror
+            // for state inspection.
             allowedRequesters.clear()
             allowedRequesters.addAll(allowedHashes)
+            val pySet = runtime.python.getBuiltins().callAttr("set", allowedHashes.toTypedArray())
+            runtime.eventBridge.callAttr("set_collector_allowed_requesters", pySet)
             Log.i(TAG, "telemetry allowed-requesters set updated: ${allowedRequesters.size} entries")
         }
 

--- a/rns-backend-py/src/main/kotlin/network/columba/app/rns/backend/py/PythonRnsTelephony.kt
+++ b/rns-backend-py/src/main/kotlin/network/columba/app/rns/backend/py/PythonRnsTelephony.kt
@@ -186,6 +186,29 @@ class PythonRnsTelephony(
         callCoordinator.setPttActiveLocally(active)
     }
 
+    /**
+     * Wired by `PythonCallManager`'s init block so the manager can react to
+     * the toggle without `PythonRnsTelephony` itself needing to know about
+     * Chaquopy / `Transport.deregister_destination`. Same single-listener
+     * shape used by every other `*Hook` on this class — the manager owns the
+     * destination lifecycle, this class owns the AIDL contract.
+     *
+     * Null between class construction and PythonCallManager init — the
+     * implementation logs and treats the call as a no-op rather than
+     * crashing the binder thread.
+     */
+    @Volatile
+    var setIncomingEnabledHook: ((Boolean) -> Unit)? = null
+
+    override suspend fun setIncomingEnabled(enabled: Boolean) {
+        val hook = setIncomingEnabledHook
+        if (hook == null) {
+            Log.w(TAG, "setIncomingEnabled($enabled) before PythonCallManager wired hook")
+        } else {
+            hook(enabled)
+        }
+    }
+
     // ==================== One-shot snapshot ====================
 
     override suspend fun getCallState(): Result<VoiceCallState> =

--- a/rns-backend-py/src/main/python/event_bridge.py
+++ b/rns-backend-py/src/main/python/event_bridge.py
@@ -836,11 +836,27 @@ def attach_lxmessage_callbacks(
     """
     def _delivered(msg):
         msg_hash_hex = _hex(getattr(msg, "hash", None))
+        # Carry method + desired_method through so the Kotlin side can
+        # distinguish PROPAGATED (success means "stored on the relay")
+        # from DIRECT/OPPORTUNISTIC (success means "ack from recipient").
+        # NativeMessageSender on the kotlin backend does the same split via
+        # NativeDeliveryMethod; the python flavor must surface enough state
+        # for PythonEventBridge.handleLxmfDelivered to make the same call.
+        # Without these fields a PROPAGATED success gets stamped "delivered"
+        # in the UI (✓✓) instead of "propagated" (✓).
+        method = getattr(msg, "method", None)
+        desired = getattr(msg, "desired_method", None)
+        payload = {
+            "hash": msg_hash_hex,
+            "method": method if method is not None else -1,
+            "desired_method": desired if desired is not None else -1,
+        }
         RNS.log(
-            f"event_bridge: _delivered fired for {msg_hash_hex}",
+            f"event_bridge: _delivered fired for {msg_hash_hex} "
+            f"(method={method}, desired={desired})",
             RNS.LOG_DEBUG,
         )
-        _emit(on_delivered, {"hash": msg_hash_hex})
+        _emit(on_delivered, payload)
 
     def _failed(msg):
         # Sideband pattern: if try_propagation_on_fail was set on the message

--- a/rns-backend-py/src/main/python/event_bridge.py
+++ b/rns-backend-py/src/main/python/event_bridge.py
@@ -473,12 +473,41 @@ class _AnnounceHandler:
         # "unknown" aspect, and collide into the "Site" filter.
         if enrichment.get("aspect") is None:
             return
+        # Receiving interface annotation. RNS doesn't surface a per-announce
+        # `received_on` interface on `received_announce(...)` — we have to
+        # look it up from `Transport.path_table[destination_hash][5]` (the
+        # IDX_PT_RVCD_IF slot). Same fallback the LXMF delivery handler
+        # uses below. Without this every announce shipped to Kotlin had
+        # `receiving_interface = ""`, so 99% of `announces` rows landed
+        # with `receivingInterfaceType = "UNKNOWN"` and the announce-stream
+        # interface-type icon never rendered.
+        recv_iface_name = None
+        try:
+            path_entry = RNS.Transport.path_table.get(destination_hash)
+            if path_entry is not None and len(path_entry) > 5:
+                iface = path_entry[5]
+                if iface is not None:
+                    # `.name` is set on most Interface subclasses but blank
+                    # on AutoInterfacePeer (its `__init__` only writes
+                    # `ifname` + `addr`). Fall back to `__str__()` for those.
+                    recv_iface_name = (
+                        getattr(iface, "name", None)
+                        or str(iface)
+                        or type(iface).__name__
+                    )
+        except Exception as e:  # noqa: BLE001 — annotation is best-effort, never fatal
+            RNS.log(
+                f"event_bridge: receiving_interface lookup failed: {e}",
+                RNS.LOG_DEBUG,
+            )
+
         payload = {
             "destination_hash": _hex(destination_hash),
             "identity_hash": _hex(announced_identity.hash) if announced_identity is not None else None,
             "public_key": _hex(announced_identity.get_public_key()) if announced_identity is not None else None,
             "app_data": _hex(app_data),
             "announce_packet_hash": _hex(announce_packet_hash),
+            "receiving_interface": recv_iface_name,
         }
         payload.update(enrichment)
         _emit(_on_announce, payload)

--- a/rns-backend-py/src/main/python/event_bridge.py
+++ b/rns-backend-py/src/main/python/event_bridge.py
@@ -34,13 +34,19 @@ The Kotlin sub-impls attach them at the point they create those objects.
 import json
 import signal
 
+import LXMF
 import RNS
 
-# `_LXMF_METHOD_PROPAGATED` upstream — the int the failure-callback retry
-# path assigns to `desired_method` when escalating a failed DIRECT/OPPORTUNISTIC
-# send to propagation. Mirrors `LXMF/LXMessage.py` PROPAGATED = 0x03. Inlined
-# (rather than `import LXMF`) so this module's slim-Python budget stays tight.
-_LXMF_METHOD_PROPAGATED = 0x03
+# Sideband FIELD_COMMANDS sub-command IDs. NOT in upstream LXMF — these
+# are Sideband-specific command identifiers carried inside an LXMF
+# FIELD_COMMANDS frame; the wire format is `[{cmd_id: [args...]}, ...]`.
+_COMMAND_TELEMETRY_REQUEST = 0x01
+
+# How long collected telemetry entries are kept on the host before
+# eviction. Mirrors `release/v0.10.x`'s `telemetry_retention_seconds`
+# (24h) — long enough to survive infrequent group-tracker sync cycles,
+# short enough that stale fixes don't accumulate forever.
+_COLLECTOR_RETENTION_SECONDS = 24 * 60 * 60
 
 # Telemeter encode/decode used to live here (~190 lines of Columba-
 # authored Python). It moved to `rns-api/.../util/TelemeterCodec.kt`
@@ -582,9 +588,309 @@ def _signal_metrics(interface_obj):
     return rssi, snr
 
 
+# ----------------------------------------------------------------------------
+# Telemetry collector / host-mode state. When `_collector_enabled` is True the
+# inbound delivery callback below mirrors any FIELD_TELEMETRY message into
+# `_collected_telemetry`, and responds to FIELD_COMMANDS requests from
+# allow-listed identities with FIELD_TELEMETRY_STREAM. State held module-level
+# so an "Apply & Restart" lifecycle re-applies via Kotlin's
+# `PythonRnsTelemetry` re-calling the setters at init.
+#
+# Mirrors `release/v0.10.x`'s
+# `reticulum_wrapper.set_telemetry_collector_enabled / store_own_telemetry /
+# set_telemetry_allowed_requesters` exactly. The dual-build hosts the same
+# responder logic in this Python module rather than in a Kotlin Chaquopy
+# bridge because the LXMF response (`router.handle_outbound`) needs the
+# live `RNS.Destination` / `RNS.Identity.recall` Python objects — staying
+# on the Python side avoids a JNI round-trip per request.
+# ----------------------------------------------------------------------------
+_collector_enabled = False
+# {hex_source_hash: {"timestamp": int, "packed_telemetry": bytes,
+#                    "appearance": list_or_None, "received_at": float}}
+_collected_telemetry = {}
+# Set of lowercase 32-char hex identity hashes allowed to request the
+# stream. Empty set means "block all requests" (matches Sideband + the UI
+# warning in LocationSharingCard's AllowedRequestersSection).
+_collector_allowed_requesters = set()
+
+
+def _local_lxmf_destination():
+    """Return the host's local LXMF delivery `RNS.Destination`, or None.
+
+    `LXMRouter` exposes registered delivery destinations as a
+    `delivery_destinations` dict (keyed by destination hash, value is the
+    `RNS.Destination` instance). Columba registers exactly one identity
+    per process via `LXMRouter.register_delivery_identity` — we want that
+    sole destination as both the `source` for outbound LXMessages and the
+    key (its `hexhash`) for storing the host's own telemetry. Returns the
+    first registered destination, or None when the router hasn't built
+    one yet (early-init race).
+    """
+    if _lxmf_router is None:
+        return None
+    try:
+        dests = getattr(_lxmf_router, "delivery_destinations", None)
+        if not dests:
+            return None
+        # `delivery_destinations` is a dict — values() handles both
+        # legacy list shape (defensive) and the documented dict shape.
+        for d in dests.values() if isinstance(dests, dict) else dests:
+            return d
+        return None
+    except Exception as e:  # noqa: BLE001 — defensive; never wedge on a missing attr
+        RNS.log(f"event_bridge: _local_lxmf_destination failed: {e}", RNS.LOG_DEBUG)
+        return None
+
+
+def set_collector_enabled(enabled):
+    """Toggle telemetry-host mode. Called by `PythonRnsTelemetry.setTelemetryCollectorMode`.
+
+    On disable, drop any collected telemetry so a stale set doesn't get
+    served the next time the host re-enables. Idempotent.
+    """
+    global _collector_enabled
+    _collector_enabled = bool(enabled)
+    if not _collector_enabled:
+        _collected_telemetry.clear()
+    RNS.log(
+        f"event_bridge: telemetry collector mode -> {_collector_enabled}",
+        RNS.LOG_DEBUG,
+    )
+
+
+def set_collector_allowed_requesters(hashes_iter):
+    """Replace the allow-list of requester identity hashes. Lowercased here
+    so the inbound-command check can match without re-normalising.
+
+    Empty set is allowed and means "block all" — matches Sideband.
+    """
+    global _collector_allowed_requesters
+    _collector_allowed_requesters = {str(h).lower() for h in hashes_iter if h}
+    RNS.log(
+        f"event_bridge: telemetry allowed-requesters -> "
+        f"{len(_collector_allowed_requesters)} entries",
+        RNS.LOG_DEBUG,
+    )
+
+
+def store_own_telemetry(packed_bytes, timestamp_seconds, appearance):
+    """Fold the host's own latest telemetry into the collected set so it
+    rides out in FIELD_TELEMETRY_STREAM responses to group members.
+
+    Called by `PythonRnsTelemetry.storeOwnTelemetry` whenever the host
+    runs its periodic / Send-Now path with `collectorAddress == self`.
+    Keyed by the host's local LXMF destination hash.
+
+    `appearance` is the FIELD_ICON_APPEARANCE list `[icon_name, fg_bytes,
+    bg_bytes]` or None.
+    """
+    if not _collector_enabled:
+        # Host mode flipped off between the Kotlin send and this call —
+        # silently ignore. The Kotlin side already gates this earlier
+        # but the race exists at process startup.
+        return
+    delivery_dest = _local_lxmf_destination()
+    if delivery_dest is None:
+        RNS.log(
+            "event_bridge: store_own_telemetry skipped — no local LXMF delivery destination",
+            RNS.LOG_DEBUG,
+        )
+        return
+    own_hash_hex = delivery_dest.hexhash
+    packed = bytes(packed_bytes) if not isinstance(packed_bytes, (bytes, bytearray)) else bytes(packed_bytes)
+    appearance_list = None
+    if appearance is not None:
+        try:
+            # Chaquopy may hand over a List<Object>; normalise to a real Python list
+            # so the eventual msgpack encode doesn't choke on jvm types.
+            appearance_list = list(appearance)
+            # bytes fields inside the appearance list (fg + bg color bytes) likewise.
+            appearance_list = [
+                bytes(v) if isinstance(v, (bytes, bytearray)) or hasattr(v, "__iter__") and not isinstance(v, str) else v
+                for v in appearance_list
+            ]
+        except Exception as e:  # noqa: BLE001 — appearance is optional
+            RNS.log(f"event_bridge: appearance normalisation failed: {e}", RNS.LOG_DEBUG)
+            appearance_list = None
+    _store_telemetry_for_collector(own_hash_hex, packed, int(timestamp_seconds), appearance_list)
+
+
+def _store_telemetry_for_collector(source_hash_hex, packed_telemetry, timestamp, appearance):
+    """Internal: insert/update one entry in the collected set.
+
+    Called from `store_own_telemetry` for the host's own location AND
+    from `_lxmf_delivery_callback` for inbound member telemetry while
+    host mode is on.
+    """
+    import time as _time
+    _collected_telemetry[source_hash_hex] = {
+        "timestamp": int(timestamp),
+        "packed_telemetry": packed_telemetry,
+        "appearance": appearance,
+        "received_at": _time.time(),
+    }
+
+
+def _cleanup_expired_collected_telemetry():
+    """Evict collector entries older than `_COLLECTOR_RETENTION_SECONDS`.
+    Called immediately before building a stream response so the bytes on
+    the wire stay bounded.
+    """
+    import time as _time
+    now = _time.time()
+    expired = [k for k, v in _collected_telemetry.items()
+               if now - v.get("received_at", 0) > _COLLECTOR_RETENTION_SECONDS]
+    for k in expired:
+        _collected_telemetry.pop(k, None)
+
+
+def _send_telemetry_stream_response(requester_hash_bytes, requester_identity, timebase):
+    """Build + handoff a FIELD_TELEMETRY_STREAM LXMessage to the requester.
+
+    `requester_hash_bytes` is the source_hash of the inbound request
+    (the requester's LXMF delivery hash). `requester_identity` is the
+    `RNS.Identity` instance, looked up via `RNS.Identity.recall`.
+    `timebase` is the request's timebase int — entries with
+    `received_at >= timebase` are included (0 / None means "all").
+
+    Mirrors `release/v0.10.x`'s shape so a Columba <-> Columba host /
+    member pair on either branch interops over the same wire format.
+    """
+    delivery_dest = _local_lxmf_destination()
+    if delivery_dest is None:
+        RNS.log(
+            "event_bridge: stream response skipped — no local LXMF delivery destination",
+            RNS.LOG_WARNING,
+        )
+        return
+    try:
+        _cleanup_expired_collected_telemetry()
+        entries = []
+        for source_hash_hex, entry in _collected_telemetry.items():
+            received_at = entry.get("received_at", 0)
+            if timebase and received_at < timebase:
+                continue
+            entries.append([
+                bytes.fromhex(source_hash_hex),
+                int(entry.get("timestamp", 0)),
+                entry.get("packed_telemetry", b""),
+                entry.get("appearance"),
+            ])
+
+        RNS.log(
+            f"event_bridge: telemetry stream response to "
+            f"{requester_hash_bytes.hex()[:16]} — {len(entries)} entries (timebase={timebase})",
+            RNS.LOG_DEBUG,
+        )
+
+        destination = RNS.Destination(
+            requester_identity,
+            RNS.Destination.OUT,
+            RNS.Destination.SINGLE,
+            "lxmf",
+            "delivery",
+        )
+        fields = {LXMF.FIELD_TELEMETRY_STREAM: entries}
+        lxmessage = LXMF.LXMessage(
+            destination,
+            delivery_dest,
+            "",
+            fields=fields,
+            desired_method=LXMF.LXMessage.DIRECT,
+        )
+        _lxmf_router.handle_outbound(lxmessage)
+    except Exception as e:  # noqa: BLE001 — never wedge the delivery thread
+        RNS.log(f"event_bridge: telemetry stream response failed: {e}", RNS.LOG_ERROR)
+
+
+def _maybe_handle_telemetry_request(message):
+    """Inspect an inbound LXMessage for a Sideband telemetry request command.
+
+    Returns True if the message was consumed by the collector responder
+    (no further processing needed — the delivery callback should skip
+    chat emission). Returns False otherwise.
+    """
+    if not _collector_enabled:
+        return False
+    fields = getattr(message, "fields", None)
+    if not fields or LXMF.FIELD_COMMANDS not in fields:
+        return False
+    commands = fields[LXMF.FIELD_COMMANDS]
+    if not isinstance(commands, list):
+        return False
+    handled = False
+    for command_dict in commands:
+        if not isinstance(command_dict, dict):
+            continue
+        if _COMMAND_TELEMETRY_REQUEST not in command_dict:
+            continue
+        args = command_dict[_COMMAND_TELEMETRY_REQUEST]
+        timebase = args[0] if isinstance(args, (list, tuple)) and len(args) > 0 else 0
+        # Sideband sometimes packs args[1] = is_collector_request; we
+        # respond to any telemetry request from an allow-listed requester.
+        requester_hash = _hex(getattr(message, "source_hash", None))
+        if not requester_hash:
+            continue
+        if requester_hash not in _collector_allowed_requesters:
+            RNS.log(
+                f"event_bridge: telemetry request BLOCKED from "
+                f"{requester_hash[:16]} (not in allow-list; have "
+                f"{len(_collector_allowed_requesters)} entries)",
+                RNS.LOG_DEBUG,
+            )
+            handled = True
+            continue
+        requester_identity = RNS.Identity.recall(message.source_hash) or \
+            RNS.Identity.recall(message.source_hash, from_identity_hash=True)
+        if requester_identity is None:
+            RNS.log(
+                f"event_bridge: telemetry request from {requester_hash[:16]} "
+                "had no recallable identity — dropping",
+                RNS.LOG_WARNING,
+            )
+            handled = True
+            continue
+        _send_telemetry_stream_response(message.source_hash, requester_identity, timebase)
+        handled = True
+    return handled
+
+
+def _maybe_collect_inbound_telemetry(message):
+    """Mirror an inbound member's FIELD_TELEMETRY into `_collected_telemetry`
+    while host mode is on, so subsequent FIELD_COMMANDS requests see it.
+    """
+    if not _collector_enabled:
+        return
+    fields = getattr(message, "fields", None)
+    if not fields or LXMF.FIELD_TELEMETRY not in fields:
+        return
+    source_hash = getattr(message, "source_hash", None)
+    if source_hash is None:
+        return
+    source_hash_hex = _hex(source_hash)
+    packed = fields[LXMF.FIELD_TELEMETRY]
+    if not isinstance(packed, (bytes, bytearray)):
+        return
+    timestamp = getattr(message, "timestamp", None) or 0
+    appearance = fields.get(LXMF.FIELD_ICON_APPEARANCE)
+    _store_telemetry_for_collector(source_hash_hex, bytes(packed), int(timestamp), appearance)
+
+
 def _lxmf_delivery_callback(message):
     """LXMRouter delivery callback. `message` is an upstream LXMessage."""
     try:
+        # Telemetry collector / host-mode hooks. Run BEFORE the usual
+        # message-emit path so a telemetry-stream request is consumed
+        # silently (no chat row) and so an inbound FIELD_TELEMETRY from a
+        # group member is folded into our collected set in time to be
+        # served by the next FIELD_COMMANDS response.
+        _maybe_collect_inbound_telemetry(message)
+        if _maybe_handle_telemetry_request(message):
+            # Pure command-frame request — Sideband never carries chat
+            # content alongside one. Skip the rest of the delivery handler
+            # so this never appears as a user-visible message.
+            return
+
         # Post-reassembly inbound size cap — see set_incoming_message_size_limit().
         if _incoming_message_size_limit_kb > 0:
             packed = getattr(message, "packed", None)
@@ -897,7 +1203,7 @@ def attach_lxmessage_callbacks(
             and not getattr(msg, "_columba_propagation_retry_attempted", False)
             and _lxmf_router is not None
             and getattr(_lxmf_router, "outbound_propagation_node", None) is not None
-            and getattr(msg, "desired_method", None) != _LXMF_METHOD_PROPAGATED
+            and getattr(msg, "desired_method", None) != LXMF.LXMessage.PROPAGATED
         ):
             msg._columba_propagation_retry_attempted = True
             # Clear retry flag so a second failure doesn't loop.
@@ -911,7 +1217,7 @@ def attach_lxmessage_callbacks(
             msg.propagation_packed = None
             msg.propagation_stamp = None
             msg.defer_propagation_stamp = True
-            msg.desired_method = _LXMF_METHOD_PROPAGATED
+            msg.desired_method = LXMF.LXMessage.PROPAGATED
             try:
                 _lxmf_router.handle_outbound(msg)
                 _emit(on_retrying_propagated, {"hash": _hex(getattr(msg, "hash", None))})

--- a/rns-host/src/kotlinBackend/kotlin/network/columba/app/rns/host/HostBackendModule.kt
+++ b/rns-host/src/kotlinBackend/kotlin/network/columba/app/rns/host/HostBackendModule.kt
@@ -8,11 +8,14 @@ import dagger.hilt.InstallIn
 import dagger.hilt.android.qualifiers.ApplicationContext
 import dagger.hilt.components.SingletonComponent
 import network.columba.app.rns.api.RnsBackend
+import network.columba.app.rns.backend.kt.CallPrivacyBridge
 import network.columba.app.rns.backend.kt.NativeRnsBackend
 import network.columba.app.rns.backend.kt.RNodeHostBridge
 import network.columba.app.rns.host.call.rnode.BluetoothLeConnection
 import network.columba.app.rns.host.call.rnode.ColumbaLogo
 import network.columba.app.rns.host.di.LocalBackend
+import network.columba.app.rns.host.persistence.CallsFromContactsGate
+import network.columba.app.rns.host.persistence.ServiceSettingsAccessor
 import network.columba.app.rns.host.usb.KotlinUSBBridge
 import java.io.InputStream
 import java.io.OutputStream
@@ -47,12 +50,38 @@ object HostBackendModule {
     fun provideRNodeHostBridge(@ApplicationContext context: Context): RNodeHostBridge =
         AndroidRNodeHostBridge(context)
 
+    /**
+     * Bridge adapter wrapping the shared [CallsFromContactsGate] +
+     * [ServiceSettingsAccessor] (provided by [network.columba.app.rns.host.di.PersistenceModule])
+     * behind the [CallPrivacyBridge] interface that `:rns-backend-kt`
+     * declares. `:rns-backend-kt` cannot import these classes directly
+     * (Gradle dep graph would cycle), so we adapt here.
+     */
+    @Provides
+    @Singleton
+    fun provideCallPrivacyBridge(
+        contactsGate: CallsFromContactsGate,
+        settingsAccessor: ServiceSettingsAccessor,
+    ): CallPrivacyBridge =
+        object : CallPrivacyBridge {
+            override fun shouldSilentlyDrop(identityHashHex: String): Boolean =
+                contactsGate.shouldSilentlyDrop(identityHashHex)
+
+            override fun getAllowVoiceCalls(): Boolean = settingsAccessor.getAllowVoiceCalls()
+        }
+
     @Provides
     @Singleton
     fun provideNativeRnsBackend(
         @ApplicationContext context: Context,
         bridge: RNodeHostBridge,
-    ): NativeRnsBackend = NativeRnsBackend(appContext = context, rnodeHostBridge = bridge)
+        callPrivacyBridge: CallPrivacyBridge,
+    ): NativeRnsBackend =
+        NativeRnsBackend(
+            appContext = context,
+            rnodeHostBridge = bridge,
+            callPrivacyBridge = callPrivacyBridge,
+        )
 
     /**
      * Flavor-local [RnsBackend] view of [NativeRnsBackend]. [LocalBackend]

--- a/rns-host/src/main/kotlin/network/columba/app/rns/host/di/PersistenceModule.kt
+++ b/rns-host/src/main/kotlin/network/columba/app/rns/host/di/PersistenceModule.kt
@@ -1,0 +1,46 @@
+package network.columba.app.rns.host.di
+
+import android.content.Context
+import dagger.Module
+import dagger.Provides
+import dagger.hilt.InstallIn
+import dagger.hilt.android.qualifiers.ApplicationContext
+import dagger.hilt.components.SingletonComponent
+import network.columba.app.rns.host.persistence.CallsFromContactsGate
+import network.columba.app.rns.host.persistence.ServiceSettingsAccessor
+import javax.inject.Singleton
+
+/**
+ * Hilt wiring for `:reticulum`-side persistence helpers that need to be
+ * injected into flavor-specific call managers.
+ *
+ * Both [ServiceSettingsAccessor] and [CallsFromContactsGate] are
+ * flavor-independent (no `pythonBackend` / `kotlinBackend` references) so
+ * they live in `:rns-host/src/main/` rather than being duplicated in both
+ * flavor `HostBackendModule.kt`s.
+ *
+ * Note that [ServiceSettingsAccessor] is also constructed manually inside
+ * [network.columba.app.rns.host.di.ServiceModule.createManagers] for the
+ * UI-process binder path. That path predates Hilt being available to
+ * `:reticulum` (it explicitly notes "Hilt doesn't work across process
+ * boundaries"). Both constructions are cheap — the class is stateless above
+ * `SharedPreferences` — so the duplicate is acceptable. Consumers that go
+ * through Hilt (the call managers + the contacts gate) all share the
+ * `@Singleton`-scoped instance provided here.
+ */
+@Module
+@InstallIn(SingletonComponent::class)
+object PersistenceModule {
+    @Provides
+    @Singleton
+    fun provideServiceSettingsAccessor(
+        @ApplicationContext context: Context,
+    ): ServiceSettingsAccessor = ServiceSettingsAccessor(context)
+
+    @Provides
+    @Singleton
+    fun provideCallsFromContactsGate(
+        @ApplicationContext context: Context,
+        settingsAccessor: ServiceSettingsAccessor,
+    ): CallsFromContactsGate = CallsFromContactsGate(context, settingsAccessor)
+}

--- a/rns-host/src/main/kotlin/network/columba/app/rns/host/ipc/BoundRnsTelephony.kt
+++ b/rns-host/src/main/kotlin/network/columba/app/rns/host/ipc/BoundRnsTelephony.kt
@@ -116,4 +116,8 @@ internal class BoundRnsTelephony(
     override suspend fun setPttActiveLocally(active: Boolean) {
         awaitBound().telephony.setPttActiveLocally(active)
     }
+
+    override suspend fun setIncomingEnabled(enabled: Boolean) {
+        awaitBound().telephony.setIncomingEnabled(enabled)
+    }
 }

--- a/rns-host/src/main/kotlin/network/columba/app/rns/host/persistence/CallsFromContactsGate.kt
+++ b/rns-host/src/main/kotlin/network/columba/app/rns/host/persistence/CallsFromContactsGate.kt
@@ -1,0 +1,98 @@
+package network.columba.app.rns.host.persistence
+
+import android.content.Context
+import android.util.Log
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.runBlocking
+import network.columba.app.data.db.ColumbaDatabase
+import network.columba.app.rns.host.di.ServiceDatabaseProvider
+
+/**
+ * Decides whether an inbound LXST link request should be silently dropped
+ * because the caller is not in the user's contacts list.
+ *
+ * Both `PythonCallManager` and `NativeCallManager` invoke
+ * [shouldSilentlyDrop] from their `onCallerIdentified` callback BEFORE
+ * sending `STATUS_RINGING` and BEFORE notifying `Telephone.onIncomingCall`.
+ * If this returns `true`, the call manager tears down the link without any
+ * signal, leaving the originator with a wait-time timeout that's
+ * indistinguishable from "remote went away" — no `STATUS_BUSY`, no
+ * `STATUS_REJECTED`, no notification on this device.
+ *
+ * The lookup walks the same two indices used elsewhere in the persistence
+ * layer (see [ServicePersistenceManager.shouldBlockUnknownSender]):
+ *
+ *   1. `announceDao.getAnnounceByIdentityHash(identityHashHex)` to translate
+ *      the inbound RNS identity hash into the destination hash the contacts
+ *      table is keyed on. No announce → treat as unknown (drop).
+ *   2. `localIdentityDao.getActiveIdentitySync()` to find the current
+ *      active local identity. Missing → fail open (allow).
+ *   3. `contactDao.contactExists(announce.destinationHash, active.identityHash)`
+ *      to confirm the (destination, owner) pair is in the contacts table.
+ *
+ * Any other exception inside the gate logs and returns `false` (allow). This
+ * mirrors the fail-open semantics of `block_unknown_senders` for messages so
+ * the toggle can never accidentally brick all inbound calls if a DAO query
+ * fails.
+ *
+ * Hilt-provided as a `@Singleton` in both flavor `HostBackendModule.kt`s.
+ */
+class CallsFromContactsGate(
+    private val context: Context,
+    private val settingsAccessor: ServiceSettingsAccessor,
+) {
+    private companion object {
+        const val TAG = "CallsFromContactsGate"
+    }
+
+    private val database: ColumbaDatabase by lazy { ServiceDatabaseProvider.getDatabase(context) }
+    private val announceDao by lazy { database.announceDao() }
+    private val contactDao by lazy { database.contactDao() }
+    private val localIdentityDao by lazy { database.localIdentityDao() }
+
+    /**
+     * @return `true` → silently tear down the inbound link (don't surface the
+     * call to UI, don't send any signal back to the originator).
+     * `false` → let the call ring normally.
+     *
+     * Reads `getAllowCallsFromContactsOnly()` on every call so live UI
+     * toggles take effect immediately without requiring any IPC.
+     */
+    fun shouldSilentlyDrop(identityHashHex: String): Boolean =
+        try {
+            if (!settingsAccessor.getAllowCallsFromContactsOnly()) {
+                false
+            } else {
+                // RNS reactor / Chaquopy callback thread expects a synchronous
+                // decision before STATUS_RINGING or STATUS_AVAILABLE can be
+                // sent. Matches the message-side block_unknown_senders gate's
+                // sync-on-receive shape.
+                runBlocking(Dispatchers.IO) { // THREADING: allowed — inbound-link callback requires synchronous gate decision
+                    val normalised = identityHashHex.lowercase()
+                    val announce = announceDao.getAnnounceByIdentityHash(normalised)
+                    if (announce == null) {
+                        Log.d(TAG, "Drop: no announce for $normalised")
+                        true
+                    } else {
+                        val active = localIdentityDao.getActiveIdentitySync()
+                        if (active == null) {
+                            // No active local identity — fail open. We can't
+                            // meaningfully check contacts without an owner.
+                            Log.w(TAG, "Allow: no active local identity, contacts check skipped")
+                            false
+                        } else {
+                            val known = contactDao.contactExists(announce.destinationHash, active.identityHash)
+                            if (!known) {
+                                Log.d(TAG, "Drop: ${announce.destinationHash.take(16)} not a contact of ${active.identityHash.take(16)}")
+                            }
+                            !known
+                        }
+                    }
+                }
+            }
+        } catch (e: Exception) {
+            // Fail open — a DAO blowup should not stop all inbound calls.
+            Log.w(TAG, "Contact gate failed, allowing call: ${e.message}", e)
+            false
+        }
+}

--- a/rns-host/src/main/kotlin/network/columba/app/rns/host/persistence/CallsFromContactsGate.kt
+++ b/rns-host/src/main/kotlin/network/columba/app/rns/host/persistence/CallsFromContactsGate.kt
@@ -19,16 +19,21 @@ import network.columba.app.rns.host.di.ServiceDatabaseProvider
  * indistinguishable from "remote went away" — no `STATUS_BUSY`, no
  * `STATUS_REJECTED`, no notification on this device.
  *
- * The lookup walks the same two indices used elsewhere in the persistence
- * layer (see [ServicePersistenceManager.shouldBlockUnknownSender]):
+ * The lookup runs as a single indexed JOIN — `contactExistsByIdentityHash`
+ * walks contacts → announces by `destinationHash` and filters on
+ * `computedIdentityHash`. The earlier two-step shape (`getAnnounceByIdentityHash`
+ * then `contactExists(announce.destinationHash, owner)`) silently dropped
+ * contacts whose peer announces both an LXMF and an LXST destination —
+ * `LIMIT 1` could return the LXST row while the contact-add flow only stores
+ * the LXMF row, so the (dest, owner) check failed even though the peer was a
+ * known contact. The JOIN considers every cross-linked destination at once.
  *
- *   1. `announceDao.getAnnounceByIdentityHash(identityHashHex)` to translate
- *      the inbound RNS identity hash into the destination hash the contacts
- *      table is keyed on. No announce → treat as unknown (drop).
- *   2. `localIdentityDao.getActiveIdentitySync()` to find the current
+ *   1. `localIdentityDao.getActiveIdentitySync()` to find the current
  *      active local identity. Missing → fail open (allow).
- *   3. `contactDao.contactExists(announce.destinationHash, active.identityHash)`
- *      to confirm the (destination, owner) pair is in the contacts table.
+ *   2. `contactDao.contactExistsByIdentityHash(callerIdentity, owner)`
+ *      returns true if ANY announce row with `computedIdentityHash =
+ *      callerIdentity` has a `destinationHash` in the contacts table for
+ *      this owner.
  *
  * Any other exception inside the gate logs and returns `false` (allow). This
  * mirrors the fail-open semantics of `block_unknown_senders` for messages so
@@ -46,7 +51,6 @@ class CallsFromContactsGate(
     }
 
     private val database: ColumbaDatabase by lazy { ServiceDatabaseProvider.getDatabase(context) }
-    private val announceDao by lazy { database.announceDao() }
     private val contactDao by lazy { database.contactDao() }
     private val localIdentityDao by lazy { database.localIdentityDao() }
 
@@ -69,24 +73,18 @@ class CallsFromContactsGate(
                 // sync-on-receive shape.
                 runBlocking(Dispatchers.IO) { // THREADING: allowed — inbound-link callback requires synchronous gate decision
                     val normalised = identityHashHex.lowercase()
-                    val announce = announceDao.getAnnounceByIdentityHash(normalised)
-                    if (announce == null) {
-                        Log.d(TAG, "Drop: no announce for $normalised")
-                        true
+                    val active = localIdentityDao.getActiveIdentitySync()
+                    if (active == null) {
+                        // No active local identity — fail open. We can't
+                        // meaningfully check contacts without an owner.
+                        Log.w(TAG, "Allow: no active local identity, contacts check skipped")
+                        false
                     } else {
-                        val active = localIdentityDao.getActiveIdentitySync()
-                        if (active == null) {
-                            // No active local identity — fail open. We can't
-                            // meaningfully check contacts without an owner.
-                            Log.w(TAG, "Allow: no active local identity, contacts check skipped")
-                            false
-                        } else {
-                            val known = contactDao.contactExists(announce.destinationHash, active.identityHash)
-                            if (!known) {
-                                Log.d(TAG, "Drop: ${announce.destinationHash.take(16)} not a contact of ${active.identityHash.take(16)}")
-                            }
-                            !known
+                        val known = contactDao.contactExistsByIdentityHash(normalised, active.identityHash)
+                        if (!known) {
+                            Log.d(TAG, "Drop: no contact for identity ${normalised.take(16)} (owner ${active.identityHash.take(16)})")
                         }
+                        !known
                     }
                 }
             }

--- a/rns-host/src/main/kotlin/network/columba/app/rns/host/persistence/ServiceSettingsAccessor.kt
+++ b/rns-host/src/main/kotlin/network/columba/app/rns/host/persistence/ServiceSettingsAccessor.kt
@@ -21,6 +21,8 @@ class ServiceSettingsAccessor(
 
         // Keys for cross-process settings
         const val KEY_BLOCK_UNKNOWN_SENDERS = "block_unknown_senders"
+        const val KEY_ALLOW_CALLS_FROM_CONTACTS_ONLY = "allow_calls_from_contacts_only"
+        const val KEY_ALLOW_VOICE_CALLS = "allow_voice_calls"
         const val KEY_NETWORK_CHANGE_ANNOUNCE_TIME = "network_change_announce_time"
         const val KEY_LAST_AUTO_ANNOUNCE_TIME = "last_auto_announce_time"
         const val KEY_LAST_NETWORK_STATUS = "last_network_status"
@@ -66,6 +68,28 @@ class ServiceSettingsAccessor(
      * @return true if unknown senders should be blocked, false otherwise (default)
      */
     fun getBlockUnknownSenders(): Boolean = getCrossProcessPrefs().getBoolean(KEY_BLOCK_UNKNOWN_SENDERS, false)
+
+    /**
+     * Get the calls-from-contacts-only setting.
+     * When enabled, inbound LXST link requests from non-contacts are silently dropped
+     * after caller identification (no STATUS_RINGING to the originator, no UI surface).
+     *
+     * @return true if non-contact callers should be silently dropped, false (default) otherwise
+     */
+    fun getAllowCallsFromContactsOnly(): Boolean =
+        getCrossProcessPrefs().getBoolean(KEY_ALLOW_CALLS_FROM_CONTACTS_ONLY, false)
+
+    /**
+     * Get the master allow-voice-calls setting.
+     * When false, the `lxst.telephony` Destination should be deregistered so peers
+     * cannot reach it. Outbound calls remain functional regardless (they construct
+     * a fresh OUT destination per call). Defaults to true so a fresh install can
+     * receive calls without onboarding past this toggle.
+     *
+     * @return true (default) if incoming voice calls should be accepted, false otherwise
+     */
+    fun getAllowVoiceCalls(): Boolean =
+        getCrossProcessPrefs().getBoolean(KEY_ALLOW_VOICE_CALLS, true)
 
     /**
      * Persist the app process's current network-status string so the service process can

--- a/rns-host/src/pythonBackend/kotlin/network/columba/app/rns/host/HostBackendModule.kt
+++ b/rns-host/src/pythonBackend/kotlin/network/columba/app/rns/host/HostBackendModule.kt
@@ -10,6 +10,8 @@ import network.columba.app.rns.api.RnsBackend
 import network.columba.app.rns.backend.py.ChaquopyRnsBackend
 import network.columba.app.rns.host.ble.bridge.KotlinBLEBridge
 import network.columba.app.rns.host.di.LocalBackend
+import network.columba.app.rns.host.persistence.CallsFromContactsGate
+import network.columba.app.rns.host.persistence.ServiceSettingsAccessor
 import tech.torlando.lxst.core.CallCoordinator
 import javax.inject.Singleton
 
@@ -78,12 +80,16 @@ object HostBackendModule {
         backend: ChaquopyRnsBackend,
         transport: PythonNetworkTransport,
         callCoordinator: CallCoordinator,
+        settingsAccessor: ServiceSettingsAccessor,
+        contactsGate: CallsFromContactsGate,
     ): PythonCallManager =
         PythonCallManager(
             context = context,
             backend = backend,
             transport = transport,
             callCoordinator = callCoordinator,
+            settingsAccessor = settingsAccessor,
+            contactsGate = contactsGate,
         )
 
     /**

--- a/rns-host/src/pythonBackend/kotlin/network/columba/app/rns/host/PythonCallManager.kt
+++ b/rns-host/src/pythonBackend/kotlin/network/columba/app/rns/host/PythonCallManager.kt
@@ -16,6 +16,8 @@ import network.columba.app.rns.backend.py.ChaquopyRnsBackend
 import network.columba.app.rns.backend.py.PyEventCallback
 import network.columba.app.rns.backend.py.PyTwoArgCallback
 import network.columba.app.rns.backend.py.PythonRnsRuntime
+import network.columba.app.rns.host.persistence.CallsFromContactsGate
+import network.columba.app.rns.host.persistence.ServiceSettingsAccessor
 import tech.torlando.lxst.audio.Signalling
 import tech.torlando.lxst.core.AudioDevice
 import tech.torlando.lxst.core.AudioPacketHandler
@@ -41,6 +43,8 @@ class PythonCallManager(
     private val backend: ChaquopyRnsBackend,
     private val transport: PythonNetworkTransport,
     private val callCoordinator: CallCoordinator,
+    private val settingsAccessor: ServiceSettingsAccessor,
+    private val contactsGate: CallsFromContactsGate,
 ) : CallController {
     private val runtime: PythonRnsRuntime = backend.runtime
     private val backendStatusFlow: StateFlow<NetworkStatus> = backend.core.networkStatus
@@ -60,13 +64,26 @@ class PythonCallManager(
     @Volatile
     private var setupRan: Boolean = false
 
+    /**
+     * Master incoming-calls toggle state. Mirrors `:rns-backend-kt`'s
+     * sibling. Read by [onInboundLinkEstablished] as a TOCTOU guard
+     * against a link that crossed the wire just before
+     * [disableIncoming] ran; written only inside [incomingLock].
+     */
+    @Volatile
+    private var incomingDisabled: Boolean = false
+
+    /** Serialises [disableIncoming] / [enableIncoming] transitions. */
+    private val incomingLock = Any()
+
     init {
         // Auto-run setup() at backend READY (:rns-backend-py can't reach
         // here, so observe its status flow instead of being called inline
         // like NativeRnsBackendImpl.setupNativeTelephone). Also install
         // the profile-aware call hook so PythonRnsTelephony.initiateCall
         // can pass the codec profile through (default CallCoordinator
-        // path drops it).
+        // path drops it), and the setIncomingEnabled hook so the master
+        // AIDL toggle reaches this manager from the UI process.
         scope.launch {
             backendStatusFlow.filter { it == NetworkStatus.READY }.first()
             if (!setupRan) {
@@ -77,6 +94,7 @@ class PythonCallManager(
             backend.telephonyImpl.profileAwareCallHook = { destHex, profileCode ->
                 call(destHex, profileCode)
             }
+            backend.telephonyImpl.setIncomingEnabledHook = ::setIncomingEnabled
         }
     }
 
@@ -131,6 +149,17 @@ class PythonCallManager(
         callCoordinator.setCallManager(this)
         registerTelephonyDestination(localIdentity)
         announce()
+
+        // Cold-start application of the persisted master toggle. If the
+        // user turned voice calls OFF before the last :reticulum tear-down
+        // (or before this fresh-start), apply that now — we register +
+        // immediately deregister rather than skipping registration, so the
+        // re-enable path uses the same single helper. Marginally wasteful
+        // (~ms of work) but correct + minimal-conditional.
+        if (!settingsAccessor.getAllowVoiceCalls()) {
+            Log.i(TAG, "Cold-start: Allow voice calls = false, deregistering destination")
+            disableIncoming()
+        }
 
         Log.i(TAG, "Python telephony stack ready")
     }
@@ -202,6 +231,17 @@ class PythonCallManager(
     private fun onInboundLinkEstablished(link: PyObject) {
         Log.i(TAG, "Inbound call link arrived")
 
+        // Defense-in-depth TOCTOU guard: an inbound link may have been
+        // admitted by RNS in the brief window before
+        // Transport.deregister_destination returned. Drop it silently —
+        // STATUS_AVAILABLE has not yet been sent, so the caller sees the
+        // same "remote went away" timeout as the toggle-off path below.
+        if (incomingDisabled) {
+            Log.d(TAG, "Inbound link but incoming disabled, silently tearing down")
+            runCatching { link.callAttr("teardown") }
+            return
+        }
+
         if (telephone.isCallActive()) {
             Log.w(TAG, "Line busy — signalling busy and rejecting inbound link")
             sendSignalOnLink(link, Signalling.STATUS_BUSY)
@@ -239,6 +279,18 @@ class PythonCallManager(
             ?.joinToString("") { "%02x".format(it) }
             .orEmpty()
         Log.i(TAG, "Caller identified: ${identityHash.take(16)}")
+
+        // Calls-from-contacts-only gate. Fires BEFORE STATUS_RINGING and
+        // BEFORE Telephone.onIncomingCall, so the originator only sees a
+        // wait-time timeout (no STATUS_BUSY / STATUS_REJECTED) and this
+        // device shows no UI / no ringtone. Same fail-open semantics as
+        // ServicePersistenceManager.shouldBlockUnknownSender on the
+        // message side.
+        if (contactsGate.shouldSilentlyDrop(identityHash)) {
+            Log.i(TAG, "Calls-only-from-contacts: dropping ${identityHash.take(16)}")
+            runCatching { link.callAttr("teardown") }
+            return
+        }
 
         if (telephone.isCallActive()) {
             Log.w(TAG, "Line became busy after identify — signalling busy")
@@ -304,6 +356,56 @@ class PythonCallManager(
 
     override fun setSpeaker(enabled: Boolean) {
         audioBridge.setSpeakerphoneOn(enabled)
+    }
+
+    // ===== Master incoming-calls toggle =====
+
+    /**
+     * Apply [setIncomingEnabled] for this manager.
+     *
+     * Invoked by [network.columba.app.rns.backend.py.PythonRnsTelephony]'s
+     * `setIncomingEnabledHook` (wired in [init]) when the UI calls
+     * `RnsTelephony.setIncomingEnabled(...)` across the AIDL boundary.
+     *
+     * Idempotent — applying the same state twice is a no-op.
+     */
+    fun setIncomingEnabled(enabled: Boolean) {
+        if (enabled) enableIncoming() else disableIncoming()
+    }
+
+    private fun disableIncoming() = synchronized(incomingLock) {
+        if (incomingDisabled) return@synchronized
+        incomingDisabled = true
+        telephonyDestination?.let { dest ->
+            runCatching {
+                runtime.rnsModule["Transport"]!!.callAttr("deregister_destination", dest)
+                Log.i(TAG, "lxst.telephony destination deregistered")
+            }.onFailure { Log.w(TAG, "deregister_destination failed", it) }
+        }
+        telephonyDestination = null
+        if (::telephone.isInitialized && telephone.isCallActive()) {
+            // Hang up active call so the remote sees a clean drop rather
+            // than dead air. Hangup signal must travel BEFORE the
+            // destination is gone, but we've already nulled it above —
+            // that's fine because outgoing audio uses transport.activeLink
+            // (set on accept) not the destination.
+            runCatching { telephone.hangup() }
+                .onFailure { Log.w(TAG, "Ignored hangup error during disableIncoming", it) }
+        }
+    }
+
+    private fun enableIncoming() = synchronized(incomingLock) {
+        if (!incomingDisabled && telephonyDestination != null) return@synchronized
+        incomingDisabled = false
+        val ident = runtime.localIdentity
+        if (ident == null) {
+            // setup() hasn't run yet (cold-start before backend READY).
+            // The flag is now `false`; setup() will register normally.
+            Log.d(TAG, "enableIncoming: localIdentity not ready, will register at setup")
+            return@synchronized
+        }
+        registerTelephonyDestination(ident)
+        announce()
     }
 
     /** Tear down the telephony stack. Mirrors `NativeCallManager.shutdown()`. */

--- a/rns-host/src/test/kotlin/network/columba/app/rns/host/ipc/BoundRnsBackendTest.kt
+++ b/rns-host/src/test/kotlin/network/columba/app/rns/host/ipc/BoundRnsBackendTest.kt
@@ -290,6 +290,7 @@ class BoundRnsBackendTest {
         override suspend fun setSpeakerLocally(enabled: Boolean) {}
         override suspend fun setPttModeLocally(enabled: Boolean) {}
         override suspend fun setPttActiveLocally(active: Boolean) {}
+        override suspend fun setIncomingEnabled(enabled: Boolean) {}
     }
 
     private class FakeRnsTransportAdmin : RnsTransportAdmin {

--- a/rns-host/src/test/kotlin/network/columba/app/rns/host/persistence/CallsFromContactsGateTest.kt
+++ b/rns-host/src/test/kotlin/network/columba/app/rns/host/persistence/CallsFromContactsGateTest.kt
@@ -1,0 +1,168 @@
+package network.columba.app.rns.host.persistence
+
+import android.content.Context
+import io.mockk.clearAllMocks
+import io.mockk.coEvery
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.mockkObject
+import io.mockk.unmockkObject
+import network.columba.app.data.db.ColumbaDatabase
+import network.columba.app.data.db.dao.AnnounceDao
+import network.columba.app.data.db.dao.ContactDao
+import network.columba.app.data.db.dao.LocalIdentityDao
+import network.columba.app.data.db.entity.AnnounceEntity
+import network.columba.app.data.db.entity.LocalIdentityEntity
+import network.columba.app.rns.host.di.ServiceDatabaseProvider
+import org.junit.After
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+
+/**
+ * Unit tests for CallsFromContactsGate.
+ *
+ * Covers the same shape ServicePersistenceManagerTest uses for
+ * shouldBlockUnknownSender — settings toggle, DAO mocks, fail-open on
+ * exception — so the inbound-call gate stays consistent with the
+ * inbound-message gate.
+ */
+class CallsFromContactsGateTest {
+    private lateinit var context: Context
+    private lateinit var database: ColumbaDatabase
+    private lateinit var announceDao: AnnounceDao
+    private lateinit var contactDao: ContactDao
+    private lateinit var localIdentityDao: LocalIdentityDao
+    private lateinit var settingsAccessor: ServiceSettingsAccessor
+    private lateinit var gate: CallsFromContactsGate
+
+    private val callerIdentityHash = "abcdef0123456789abcdef0123456789"
+    private val callerDestinationHash = "deadbeefcafef00ddeadbeefcafef00d"
+    private val ownerIdentityHash = "0011223344556677001122334455667700"
+
+    private val sampleAnnounce =
+        AnnounceEntity(
+            destinationHash = callerDestinationHash,
+            peerName = "Caller",
+            publicKey = ByteArray(32),
+            appData = null,
+            hops = 1,
+            lastSeenTimestamp = 0L,
+            nodeType = "LXMF_PEER",
+            receivingInterface = null,
+        )
+
+    private val sampleIdentity =
+        LocalIdentityEntity(
+            identityHash = ownerIdentityHash,
+            displayName = "Owner",
+            destinationHash = "deadbeefdeadbeefdeadbeefdeadbeef",
+            filePath = "/dev/null",
+            createdTimestamp = 0L,
+            lastUsedTimestamp = 0L,
+            isActive = true,
+        )
+
+    @Suppress("NoRelaxedMocks") // Android Context fixture — gate touches no Context methods directly
+    @Before
+    fun setup() {
+        context = mockk(relaxed = true)
+        database = mockk()
+        announceDao = mockk()
+        contactDao = mockk()
+        localIdentityDao = mockk()
+        settingsAccessor = mockk()
+
+        every { database.announceDao() } returns announceDao
+        every { database.contactDao() } returns contactDao
+        every { database.localIdentityDao() } returns localIdentityDao
+
+        mockkObject(ServiceDatabaseProvider)
+        every { ServiceDatabaseProvider.getDatabase(any()) } returns database
+
+        gate = CallsFromContactsGate(context, settingsAccessor)
+    }
+
+    @After
+    fun tearDown() {
+        unmockkObject(ServiceDatabaseProvider)
+        clearAllMocks()
+    }
+
+    @Test
+    fun `shouldSilentlyDrop returns false when toggle is off`() {
+        every { settingsAccessor.getAllowCallsFromContactsOnly() } returns false
+
+        assertFalse(gate.shouldSilentlyDrop(callerIdentityHash))
+    }
+
+    @Test
+    fun `shouldSilentlyDrop returns true when toggle on and no announce known`() {
+        every { settingsAccessor.getAllowCallsFromContactsOnly() } returns true
+        coEvery { announceDao.getAnnounceByIdentityHash(any()) } returns null
+
+        assertTrue(gate.shouldSilentlyDrop(callerIdentityHash))
+    }
+
+    @Test
+    fun `shouldSilentlyDrop returns false when caller is a known contact`() {
+        every { settingsAccessor.getAllowCallsFromContactsOnly() } returns true
+        coEvery { announceDao.getAnnounceByIdentityHash(callerIdentityHash) } returns sampleAnnounce
+        coEvery { localIdentityDao.getActiveIdentitySync() } returns sampleIdentity
+        coEvery { contactDao.contactExists(callerDestinationHash, ownerIdentityHash) } returns true
+
+        assertFalse(gate.shouldSilentlyDrop(callerIdentityHash))
+    }
+
+    @Test
+    fun `shouldSilentlyDrop returns true when announce exists but contact lookup misses`() {
+        every { settingsAccessor.getAllowCallsFromContactsOnly() } returns true
+        coEvery { announceDao.getAnnounceByIdentityHash(callerIdentityHash) } returns sampleAnnounce
+        coEvery { localIdentityDao.getActiveIdentitySync() } returns sampleIdentity
+        coEvery { contactDao.contactExists(callerDestinationHash, ownerIdentityHash) } returns false
+
+        assertTrue(gate.shouldSilentlyDrop(callerIdentityHash))
+    }
+
+    @Test
+    fun `shouldSilentlyDrop fails open when no active local identity exists`() {
+        // Without an owner identity we cannot meaningfully check contacts.
+        // Allowing the call through is safer than silently dropping every
+        // inbound during the first-launch / identity-rotation window.
+        every { settingsAccessor.getAllowCallsFromContactsOnly() } returns true
+        coEvery { announceDao.getAnnounceByIdentityHash(callerIdentityHash) } returns sampleAnnounce
+        coEvery { localIdentityDao.getActiveIdentitySync() } returns null
+
+        assertFalse(gate.shouldSilentlyDrop(callerIdentityHash))
+    }
+
+    @Test
+    fun `shouldSilentlyDrop normalises identity hash to lowercase before lookup`() {
+        every { settingsAccessor.getAllowCallsFromContactsOnly() } returns true
+        coEvery { announceDao.getAnnounceByIdentityHash(callerIdentityHash) } returns sampleAnnounce
+        coEvery { localIdentityDao.getActiveIdentitySync() } returns sampleIdentity
+        coEvery { contactDao.contactExists(callerDestinationHash, ownerIdentityHash) } returns true
+
+        // Uppercase + mixed-case inputs both reduce to the same lowercase lookup.
+        assertFalse(gate.shouldSilentlyDrop(callerIdentityHash.uppercase()))
+    }
+
+    @Test
+    fun `shouldSilentlyDrop fails open when announce DAO throws`() {
+        every { settingsAccessor.getAllowCallsFromContactsOnly() } returns true
+        coEvery { announceDao.getAnnounceByIdentityHash(any()) } throws RuntimeException("Room boom")
+
+        assertFalse(gate.shouldSilentlyDrop(callerIdentityHash))
+    }
+
+    @Test
+    fun `shouldSilentlyDrop fails open when contact DAO throws`() {
+        every { settingsAccessor.getAllowCallsFromContactsOnly() } returns true
+        coEvery { announceDao.getAnnounceByIdentityHash(callerIdentityHash) } returns sampleAnnounce
+        coEvery { localIdentityDao.getActiveIdentitySync() } returns sampleIdentity
+        coEvery { contactDao.contactExists(any(), any()) } throws RuntimeException("Room boom")
+
+        assertFalse(gate.shouldSilentlyDrop(callerIdentityHash))
+    }
+}

--- a/rns-host/src/test/kotlin/network/columba/app/rns/host/persistence/CallsFromContactsGateTest.kt
+++ b/rns-host/src/test/kotlin/network/columba/app/rns/host/persistence/CallsFromContactsGateTest.kt
@@ -8,10 +8,8 @@ import io.mockk.mockk
 import io.mockk.mockkObject
 import io.mockk.unmockkObject
 import network.columba.app.data.db.ColumbaDatabase
-import network.columba.app.data.db.dao.AnnounceDao
 import network.columba.app.data.db.dao.ContactDao
 import network.columba.app.data.db.dao.LocalIdentityDao
-import network.columba.app.data.db.entity.AnnounceEntity
 import network.columba.app.data.db.entity.LocalIdentityEntity
 import network.columba.app.rns.host.di.ServiceDatabaseProvider
 import org.junit.After
@@ -31,27 +29,13 @@ import org.junit.Test
 class CallsFromContactsGateTest {
     private lateinit var context: Context
     private lateinit var database: ColumbaDatabase
-    private lateinit var announceDao: AnnounceDao
     private lateinit var contactDao: ContactDao
     private lateinit var localIdentityDao: LocalIdentityDao
     private lateinit var settingsAccessor: ServiceSettingsAccessor
     private lateinit var gate: CallsFromContactsGate
 
     private val callerIdentityHash = "abcdef0123456789abcdef0123456789"
-    private val callerDestinationHash = "deadbeefcafef00ddeadbeefcafef00d"
     private val ownerIdentityHash = "0011223344556677001122334455667700"
-
-    private val sampleAnnounce =
-        AnnounceEntity(
-            destinationHash = callerDestinationHash,
-            peerName = "Caller",
-            publicKey = ByteArray(32),
-            appData = null,
-            hops = 1,
-            lastSeenTimestamp = 0L,
-            nodeType = "LXMF_PEER",
-            receivingInterface = null,
-        )
 
     private val sampleIdentity =
         LocalIdentityEntity(
@@ -69,12 +53,10 @@ class CallsFromContactsGateTest {
     fun setup() {
         context = mockk(relaxed = true)
         database = mockk()
-        announceDao = mockk()
         contactDao = mockk()
         localIdentityDao = mockk()
         settingsAccessor = mockk()
 
-        every { database.announceDao() } returns announceDao
         every { database.contactDao() } returns contactDao
         every { database.localIdentityDao() } returns localIdentityDao
 
@@ -98,9 +80,13 @@ class CallsFromContactsGateTest {
     }
 
     @Test
-    fun `shouldSilentlyDrop returns true when toggle on and no announce known`() {
+    fun `shouldSilentlyDrop returns true when toggle on and no destination for identity matches a contact`() {
+        // contactExistsByIdentityHash returns false when there is no
+        // (announce, contact) join for this identity — including the "no
+        // announces at all" case.
         every { settingsAccessor.getAllowCallsFromContactsOnly() } returns true
-        coEvery { announceDao.getAnnounceByIdentityHash(any()) } returns null
+        coEvery { localIdentityDao.getActiveIdentitySync() } returns sampleIdentity
+        coEvery { contactDao.contactExistsByIdentityHash(callerIdentityHash, ownerIdentityHash) } returns false
 
         assertTrue(gate.shouldSilentlyDrop(callerIdentityHash))
     }
@@ -108,21 +94,25 @@ class CallsFromContactsGateTest {
     @Test
     fun `shouldSilentlyDrop returns false when caller is a known contact`() {
         every { settingsAccessor.getAllowCallsFromContactsOnly() } returns true
-        coEvery { announceDao.getAnnounceByIdentityHash(callerIdentityHash) } returns sampleAnnounce
         coEvery { localIdentityDao.getActiveIdentitySync() } returns sampleIdentity
-        coEvery { contactDao.contactExists(callerDestinationHash, ownerIdentityHash) } returns true
+        coEvery { contactDao.contactExistsByIdentityHash(callerIdentityHash, ownerIdentityHash) } returns true
 
         assertFalse(gate.shouldSilentlyDrop(callerIdentityHash))
     }
 
     @Test
-    fun `shouldSilentlyDrop returns true when announce exists but contact lookup misses`() {
+    fun `shouldSilentlyDrop allows caller when only their LXMF destination is in contacts but call arrives over LXST`() {
+        // Regression for the multi-destination bug: same peer publishes BOTH
+        // an `lxmf.delivery` and an `lxst.telephony` announce sharing one
+        // computedIdentityHash. The contact row stores only the LXMF
+        // destination. contactExistsByIdentityHash's JOIN must find the
+        // cross-link and return true regardless of which destination the
+        // inbound call's link is keyed to.
         every { settingsAccessor.getAllowCallsFromContactsOnly() } returns true
-        coEvery { announceDao.getAnnounceByIdentityHash(callerIdentityHash) } returns sampleAnnounce
         coEvery { localIdentityDao.getActiveIdentitySync() } returns sampleIdentity
-        coEvery { contactDao.contactExists(callerDestinationHash, ownerIdentityHash) } returns false
+        coEvery { contactDao.contactExistsByIdentityHash(callerIdentityHash, ownerIdentityHash) } returns true
 
-        assertTrue(gate.shouldSilentlyDrop(callerIdentityHash))
+        assertFalse(gate.shouldSilentlyDrop(callerIdentityHash))
     }
 
     @Test
@@ -131,7 +121,6 @@ class CallsFromContactsGateTest {
         // Allowing the call through is safer than silently dropping every
         // inbound during the first-launch / identity-rotation window.
         every { settingsAccessor.getAllowCallsFromContactsOnly() } returns true
-        coEvery { announceDao.getAnnounceByIdentityHash(callerIdentityHash) } returns sampleAnnounce
         coEvery { localIdentityDao.getActiveIdentitySync() } returns null
 
         assertFalse(gate.shouldSilentlyDrop(callerIdentityHash))
@@ -140,28 +129,18 @@ class CallsFromContactsGateTest {
     @Test
     fun `shouldSilentlyDrop normalises identity hash to lowercase before lookup`() {
         every { settingsAccessor.getAllowCallsFromContactsOnly() } returns true
-        coEvery { announceDao.getAnnounceByIdentityHash(callerIdentityHash) } returns sampleAnnounce
         coEvery { localIdentityDao.getActiveIdentitySync() } returns sampleIdentity
-        coEvery { contactDao.contactExists(callerDestinationHash, ownerIdentityHash) } returns true
+        coEvery { contactDao.contactExistsByIdentityHash(callerIdentityHash, ownerIdentityHash) } returns true
 
         // Uppercase + mixed-case inputs both reduce to the same lowercase lookup.
         assertFalse(gate.shouldSilentlyDrop(callerIdentityHash.uppercase()))
     }
 
     @Test
-    fun `shouldSilentlyDrop fails open when announce DAO throws`() {
-        every { settingsAccessor.getAllowCallsFromContactsOnly() } returns true
-        coEvery { announceDao.getAnnounceByIdentityHash(any()) } throws RuntimeException("Room boom")
-
-        assertFalse(gate.shouldSilentlyDrop(callerIdentityHash))
-    }
-
-    @Test
     fun `shouldSilentlyDrop fails open when contact DAO throws`() {
         every { settingsAccessor.getAllowCallsFromContactsOnly() } returns true
-        coEvery { announceDao.getAnnounceByIdentityHash(callerIdentityHash) } returns sampleAnnounce
         coEvery { localIdentityDao.getActiveIdentitySync() } returns sampleIdentity
-        coEvery { contactDao.contactExists(any(), any()) } throws RuntimeException("Room boom")
+        coEvery { contactDao.contactExistsByIdentityHash(any(), any()) } throws RuntimeException("Room boom")
 
         assertFalse(gate.shouldSilentlyDrop(callerIdentityHash))
     }

--- a/rns-host/src/test/kotlin/network/columba/app/rns/host/persistence/ServiceSettingsAccessorTest.kt
+++ b/rns-host/src/test/kotlin/network/columba/app/rns/host/persistence/ServiceSettingsAccessorTest.kt
@@ -136,6 +136,55 @@ class ServiceSettingsAccessorTest {
         assertTrue(accessor.getBlockUnknownSenders())
     }
 
+    // ========== getAllowCallsFromContactsOnly() Tests ==========
+
+    @Test
+    fun `getAllowCallsFromContactsOnly returns false by default`() {
+        assertFalse(accessor.getAllowCallsFromContactsOnly())
+    }
+
+    @Test
+    fun `getAllowCallsFromContactsOnly returns true when set`() {
+        prefs.edit().putBoolean(ServiceSettingsAccessor.KEY_ALLOW_CALLS_FROM_CONTACTS_ONLY, true).apply()
+
+        assertTrue(accessor.getAllowCallsFromContactsOnly())
+    }
+
+    @Test
+    fun `getAllowCallsFromContactsOnly reflects changes between calls`() {
+        assertFalse(accessor.getAllowCallsFromContactsOnly())
+
+        prefs.edit().putBoolean(ServiceSettingsAccessor.KEY_ALLOW_CALLS_FROM_CONTACTS_ONLY, true).apply()
+
+        assertTrue(accessor.getAllowCallsFromContactsOnly())
+    }
+
+    // ========== getAllowVoiceCalls() Tests ==========
+
+    @Test
+    fun `getAllowVoiceCalls returns true by default`() {
+        // Default is true so an upgrading user still receives calls without
+        // touching the toggle.
+        assertTrue(accessor.getAllowVoiceCalls())
+    }
+
+    @Test
+    fun `getAllowVoiceCalls returns false when explicitly set to false`() {
+        prefs.edit().putBoolean(ServiceSettingsAccessor.KEY_ALLOW_VOICE_CALLS, false).apply()
+
+        assertFalse(accessor.getAllowVoiceCalls())
+    }
+
+    @Test
+    fun `getAllowVoiceCalls reflects changes between calls`() {
+        // First call returns the true default
+        assertTrue(accessor.getAllowVoiceCalls())
+
+        prefs.edit().putBoolean(ServiceSettingsAccessor.KEY_ALLOW_VOICE_CALLS, false).apply()
+
+        assertFalse(accessor.getAllowVoiceCalls())
+    }
+
     // ========== Cross-process key constants Tests ==========
 
     @Test
@@ -146,6 +195,8 @@ class ServiceSettingsAccessorTest {
     @Test
     fun `companion object exposes correct key constants`() {
         assertEquals("block_unknown_senders", ServiceSettingsAccessor.KEY_BLOCK_UNKNOWN_SENDERS)
+        assertEquals("allow_calls_from_contacts_only", ServiceSettingsAccessor.KEY_ALLOW_CALLS_FROM_CONTACTS_ONLY)
+        assertEquals("allow_voice_calls", ServiceSettingsAccessor.KEY_ALLOW_VOICE_CALLS)
         assertEquals("network_change_announce_time", ServiceSettingsAccessor.KEY_NETWORK_CHANGE_ANNOUNCE_TIME)
         assertEquals("last_auto_announce_time", ServiceSettingsAccessor.KEY_LAST_AUTO_ANNOUNCE_TIME)
     }

--- a/rns-ipc/src/main/kotlin/network/columba/app/rns/ipc/client/ClientRnsTelephony.kt
+++ b/rns-ipc/src/main/kotlin/network/columba/app/rns/ipc/client/ClientRnsTelephony.kt
@@ -184,6 +184,10 @@ internal class ClientRnsTelephony(
     override suspend fun setPttActiveLocally(active: Boolean) {
         awaitResult { cb -> remote.setPttActiveLocally(active, cb) }
     }
+
+    override suspend fun setIncomingEnabled(enabled: Boolean) {
+        awaitResult { cb -> remote.setIncomingEnabled(enabled, cb) }
+    }
 }
 
 /** Snapshot read for the [CallState] StateFlow. */

--- a/rns-ipc/src/main/kotlin/network/columba/app/rns/ipc/server/ServerRnsTelephony.kt
+++ b/rns-ipc/src/main/kotlin/network/columba/app/rns/ipc/server/ServerRnsTelephony.kt
@@ -191,4 +191,9 @@ internal class ServerRnsTelephony(
         impl.setPttActiveLocally(active)
         Bundle.EMPTY
     }
+
+    override fun setIncomingEnabled(enabled: Boolean, cb: IRnsResultCallback) = dispatch(cb, scope) {
+        impl.setIncomingEnabled(enabled)
+        Bundle.EMPTY
+    }
 }

--- a/rns-ipc/src/test/java/network/columba/app/rns/ipc/RnsBackendIpcRoundTripTest.kt
+++ b/rns-ipc/src/test/java/network/columba/app/rns/ipc/RnsBackendIpcRoundTripTest.kt
@@ -201,6 +201,22 @@ class RnsBackendIpcRoundTripTest {
     }
 
     @Test
+    fun `setIncomingEnabled round-trips both true and false through the stub`() = runTest {
+        val (client, _) = buildClientAndServer()
+        advanceUntilIdle()
+
+        client.telephony.setIncomingEnabled(false)
+        advanceUntilIdle()
+        assertEquals(false, fake.telephony.incomingEnabled)
+
+        client.telephony.setIncomingEnabled(true)
+        advanceUntilIdle()
+        assertEquals(true, fake.telephony.incomingEnabled)
+
+        assertEquals(2, fake.telephony.setIncomingEnabledCalls)
+    }
+
+    @Test
     fun `capabilities observer pushes mutations into the client StateFlow`() = runTest {
         val (client, _) = buildClientAndServer()
         advanceUntilIdle()
@@ -263,6 +279,8 @@ private class FakeRnsTelephony : RnsTelephony {
     var nextAnswerResult: Result<Unit> = Result.success(Unit)
     var hangupCount = 0
     var declineCount = 0
+    var setIncomingEnabledCalls = 0
+    var incomingEnabled: Boolean? = null
     var nextCallState: Result<VoiceCallState> = Result.success(
         VoiceCallState("IDLE", isActive = false, isMuted = false, remoteIdentity = null, profile = null),
     )
@@ -308,6 +326,10 @@ private class FakeRnsTelephony : RnsTelephony {
     override suspend fun setSpeakerLocally(enabled: Boolean) { _isSpeakerOn.value = enabled }
     override suspend fun setPttModeLocally(enabled: Boolean) { _isPttMode.value = enabled }
     override suspend fun setPttActiveLocally(active: Boolean) { _isPttActive.value = active }
+    override suspend fun setIncomingEnabled(enabled: Boolean) {
+        setIncomingEnabledCalls++
+        incomingEnabled = enabled
+    }
 }
 
 private class FakeRnsLxmf : RnsLxmf {


### PR DESCRIPTION
## Summary

Stacks the LXST call privacy gates + telemetry collector-host responder on top of the merged dual-build foundation (#932). Originally lived on `feat/lxst-call-privacy-gates-dual-build` (built before the rns-dual-build SHA rewrite); cherry-picked the 12 genuinely new commits onto a fresh branch off main since the patch-id of the older commits no longer matched after the PII-scrub-driven history rewrite.

## What's here

**Privacy gates** (8 commits)
- DataStore prefs: `allow_calls_from_contacts_only`, `allow_voice_calls`
- `:rns-host` `CallsFromContactsGate` helper shared by both backends; considers all destinations under one identity
- `RnsTelephony.setIncomingEnabled` on the AIDL surface
- Wired in `NativeCallManager` (kotlinBackend) + `PythonCallManager` (pythonBackend)
- New Settings toggles: "Calls from contacts only" + "Allow voice calls"
- `block-unknown-senders` toggle moved into the PrivacyCard body

**Location-sharing master gate** (`fix(location)`)
- Settings → Location Sharing toggle is a true hard kill-switch (was a confused half-master / half-status hybrid). Active per-conversation shares now refuse when the master is OFF; UI emits a Toast explaining where to re-enable. Uses `HIGH_ACCURACY` while active.

**Announce / propagation fixes** (3 commits)
- Populate `receiving_interface` on announce events; UI uses canonical `InterfaceType.fromName` parser in `InterfaceTypeIcon`
- Propagated-status fixes (missing inbound metadata, `sentInterface` for propagated sends)
- Canonical InterfaceType refactor lands here as a side-effect

**Telemetry responder + UX polish** (`feat(telemetry,ui)`)
- Wires the collector-host responder + `FIELD_TELEMETRY_STREAM` receive on the python flavor (Telemeter-packed entries, per-entry source-hash de-aliasing, optional icon-appearance)

## Cleanup commits in this PR (not on the original branch)

- `test(app)`: align 11 test fixtures with new SUT call sites + drop one over-defensive `InterfaceInfoTest` case that targeted the now-removed `startsWith("auto")` fallback. Replaces 2 relaxed `rnsTelephony` mocks with explicit `setIncomingEnabled` stubs (clears `NoRelaxedMocks` detekt rule).
- `refactor`: split two over-complex methods that tripped detekt — `InterfaceType.fromName` lifted into an exact-match Map + a `classifyByPattern` helper; `PythonEventBridge.handleTelemetryStream` extracted per-entry parse + appearance parse into helpers. Pure refactors, no semantics change.

## Test plan

- [x] Full CI batch passes locally: lint + dual-flavor build + all 9 unit-test tasks + threading audit + cpdCheck
- [x] `:app:testNoSentryKotlinBackendDebugUnitTest` — 5641 tests pass
- [x] Detekt — 0 findings across `:app`, `:data`, `:rns-api`, `:rns-ipc`, `:rns-host`, `:rns-backend-kt`, `:rns-backend-py`
- [x] Both `noSentryKotlinBackend` + `noSentryPythonBackend` debug APKs build
- [ ] CI green on this PR
- [ ] Manual: install python-flavor APK, exercise Settings → Privacy toggles (calls + voice), confirm RnsTelephony.setIncomingEnabled fires
- [ ] Manual: Settings → Location Sharing master toggle OFF, attempt per-conversation share, confirm Toast + refusal
- [ ] Manual: collector-host receive a `FIELD_TELEMETRY_STREAM` from a peer, confirm pin appears with the source's icon/color (not the collector's)

🤖 Generated with [Claude Code](https://claude.com/claude-code)