### PR TITLE
fix(python-backend): map shows no discovered-interface markers

### DIFF
--- a/rns-backend-py/src/main/kotlin/network/columba/app/rns/backend/py/PythonRnsTransportAdmin.kt
+++ b/rns-backend-py/src/main/kotlin/network/columba/app/rns/backend/py/PythonRnsTransportAdmin.kt
@@ -379,6 +379,9 @@ class PythonRnsTransportAdmin(
         fun putLong(jsonKey: String, dictKey: String = jsonKey) {
             info.dictLong(dictKey)?.let { obj.put(jsonKey, it) }
         }
+        fun putDouble(jsonKey: String, dictKey: String = jsonKey) {
+            info.dictDouble(dictKey)?.let { obj.put(jsonKey, it) }
+        }
         putStr("name")
         putStr("type")
         putStr("transport_id")
@@ -398,6 +401,14 @@ class PythonRnsTransportAdmin(
         putInt("coding_rate")
         putStr("modulation")
         putInt("channel")
+        // Discovery location: upstream RNS stores `latitude` / `longitude` /
+        // `height` as floats (or None) in the announce dict. Without these,
+        // `DiscoveredInterface.hasLocation` is false and the Map screen's
+        // marker layer + the layers-sheet "Show on map" chip row stay empty
+        // for every Python-flavor interface.
+        putDouble("latitude")
+        putDouble("longitude")
+        putDouble("height")
         putStr("ifac_netname")
         putStr("ifac_netkey")
         info.dictGet("transport")?.let { obj.put("transport", it.toJava(Boolean::class.javaObjectType)) }


### PR DESCRIPTION
## Summary

Map screen's layers bottom sheet has no "Show on map" filter-chip row on the python flavor. Reported after PR #934 merged.

## Root cause

`PythonRnsTransportAdmin.discoveredInfoToJson` was dropping three keys from upstream RNS's discovery info dict during the PyObject→JSON conversion:

- `latitude`
- `longitude`
- `height`

Since they never made it into the JSON, `DiscoveredInterface.parseFromJson` read them back as null, `hasLocation` always returned false, and `MapViewModel.loadInterfaceMarkers().filter { it.hasLocation }` then filtered every Python-flavor interface out — leaving `state.interfaceMarkers` empty and the layers sheet's "Show on map" section omitted entirely (gated behind `if (categories.isNotEmpty())`).

Upstream `RNS/Discovery.py:270-272` stores all three as floats (or None) in the info dict. The kotlin backend (`NativeRnsBackendImpl.getDiscoveredInterfaces`) already populates them correctly from `info.latitude` / `.longitude` / `.height` — only the python serializer was missing them.

## Fix

Added a `putDouble(jsonKey, dictKey)` helper to mirror the existing `putStr` / `putInt` / `putLong` pattern, then called it for the three keys. Reused the existing `PyObject.dictDouble` extension.

## Test plan

- [x] `:rns-backend-py:ktlintCheck` + `:rns-backend-py:detekt` clean
- [x] `:rns-backend-py:testDebugUnitTest` + `:rns-host:testPythonBackendDebugUnitTest` pass
- [ ] CI green
- [ ] Manual on phone: open Map screen → Layers icon → confirm "Show on map" chip row appears with the right categories for the discovered interfaces that publish location

🤖 Generated with [Claude Code](https://claude.com/claude-code)