### PR TITLE
fix(release): keep minified pythonBackend Python startup working (duplicate org.json)

### DIFF
--- a/app/proguard-rules.pro
+++ b/app/proguard-rules.pro
@@ -64,7 +64,6 @@
 # bridging needs generic-signature and inner-class metadata that R8 strips by
 # default, and that no -keep class rule restores.
 -keep class com.chaquo.python.** { *; }
--keepclassmembers class com.chaquo.python.** { *; }
 -dontwarn com.chaquo.python.**
 -keepattributes Signature
 -keepattributes Exceptions

--- a/app/proguard-rules.pro
+++ b/app/proguard-rules.pro
@@ -55,6 +55,26 @@
 # removed: that package no longer holds any shipped bridge (only test classes),
 # so the glob protected nothing.
 
+# ===== Chaquopy (Python runtime) =====
+# Restored from release/v0.10.x: the com.lxmf.messenger -> network.columba.app
+# rename dropped these rules, which regressed minified release builds — the
+# Python backend fails at interpreter startup with an asset AssertionError
+# (dumping assets/chaquopy/build.json). The -keepattributes below are the
+# critical part: Chaquopy's reflection / PyObject.toJava() Java<->Python type
+# bridging needs generic-signature and inner-class metadata that R8 strips by
+# default, and that no -keep class rule restores.
+-keep class com.chaquo.python.** { *; }
+-keepclassmembers class com.chaquo.python.** { *; }
+-dontwarn com.chaquo.python.**
+-keepattributes Signature
+-keepattributes Exceptions
+-keepattributes InnerClasses
+-keepattributes EnclosingMethod
+# Keep classes used with PyObject.toJava()
+-keepclassmembers class * {
+    *** toJava(...);
+}
+
 # ===== MessagePack Serialization =====
 # MessagePack uses reflection to load buffer implementations
 # Without these rules, LXMF message deserialization crashes

--- a/rns-api/build.gradle.kts
+++ b/rns-api/build.gradle.kts
@@ -80,6 +80,10 @@ dependencies {
     testImplementation(libs.junit.jupiter)
     testImplementation(libs.mockk)
     testImplementation(libs.coroutines.test)
+    // org.json is compileOnly above (Android provides it at runtime), so the
+    // real impl must be on the JVM unit-test classpath — otherwise toJsonString()
+    // hits the android.jar "Stub!" org.json. Matches the other modules' test deps.
+    testImplementation("org.json:json:20240303")
     testImplementation(libs.robolectric)
     testImplementation(libs.test.core)
 }

--- a/rns-api/build.gradle.kts
+++ b/rns-api/build.gradle.kts
@@ -58,7 +58,17 @@ dependencies {
     // serialization concern lives with the type rather than with the storage
     // layer (:data) so consumers don't need a separate dep just to round-trip
     // an interface config.
-    implementation("org.json:json:20240303")
+    //
+    // compileOnly, NOT implementation: org.json ships in the Android framework
+    // (bootclasspath), so it's present at runtime for free. Bundling the
+    // reference `org.json:json` artifact into the APK creates a DUPLICATE
+    // org.json on the classpath whose method signatures differ from the
+    // framework's. R8 (optimize/obfuscate) then binds call sites against the
+    // bundled copy, but the framework copy wins at runtime — producing
+    // NoSuchMethodError (e.g. JSONObject.optInt) and breaking Chaquopy's
+    // build.json walk (isinstance mismatch), which crashed the minified
+    // pythonBackend release. Keep it off the runtime classpath.
+    compileOnly("org.json:json:20240303")
 
     // msgpack-core powers `util.AppDataParser` — the announce app_data
     // parser is consumed by every backend (kotlin native + python flavor)

--- a/rns-api/src/main/java/network/columba/app/rns/api/RnsError.kt
+++ b/rns-api/src/main/java/network/columba/app/rns/api/RnsError.kt
@@ -174,7 +174,16 @@ class RnsException(val error: RnsError) : RuntimeException(describe(error)) {
     private companion object {
         fun describe(error: RnsError): String =
             when (error) {
-                is RnsError.Generic -> error.message
+                is RnsError.Generic ->
+                    // Generic is the "unexpected failure" bucket — append the backend
+                    // stack text (preserved across the AIDL boundary because the live
+                    // Throwable can't cross) so it lands in logs/Sentry. For the python
+                    // backend this carries Chaquopy's python traceback frames.
+                    if (error.stackTraceText.isNullOrBlank()) {
+                        error.message
+                    } else {
+                        "${error.message}\n${error.stackTraceText}"
+                    }
                 is RnsError.BackendNotReady -> "Backend not ready"
                 is RnsError.IdentityNotFound -> "Identity not found: ${error.hashHex}"
                 is RnsError.TimeoutExceeded -> "Timeout (${error.timeoutMs}ms) on ${error.operation}"


### PR DESCRIPTION
## Problem
The minified `pythonBackend` release crashed at Python startup with an asset `AssertionError` dumping `assets/chaquopy/build.json`. Debug builds and non-minified release worked, so it surfaced only in shipped release builds.

## Root cause
`:rns-api` declared `implementation("org.json:json:20240303")`, **bundling the reference org.json into the APK**. `org.json` is on Android's bootclasspath, so this is a duplicate whose method signatures differ. R8 (optimize/obfuscate) binds call sites against the bundled copy, but the framework copy wins at runtime:
- **app:** `InterfaceRepository.entityToConfig` → `NoSuchMethodError optInt(I,Ljava/lang/String;)I` (swapped args)
- **Chaquopy:** `java/android/__init__.py convert_json_object` asserts because `isinstance(buildJson, org.json.JSONObject)` is `false` (class-identity mismatch) — `AndroidPlatform.onStart` passes the JSON via `callAttr()`.

A shrink-only build only "worked" because tree-shaking dropped the unused bundled copy. New on `main` because the JSON-based `InterfaceRepository` exercises the org.json overloads R8 mishandles.

## Fix
- `org.json:json` → **`compileOnly`** in `:rns-api` (framework provides it at runtime; not packaged → no duplicate).
- Restore the Chaquopy ProGuard keeps dropped in the `com.lxmf.messenger` → `network.columba.app` rename.
- **Observability (kept):** `RnsException.describe()` now appends `RnsError.Generic.stackTraceText`, so backend failures — including Chaquopy's `<python>` traceback frames, already serialized across the AIDL boundary — reach logs/Sentry instead of just the bare message. This is what made the crash diagnosable.

## Verification
Built `assembleNoSentryPythonBackendRelease` (full R8: optimize + obfuscate + shrink) and confirmed on a device: Python interpreter starts, Reticulum runs, messages flow. Verified on two separate phones
🤖 Generated with [Claude Code](https://claude.com/claude-code)