### PR TITLE
feat(ble): surface live BLE peer connections to the Network Status card

### DIFF
--- a/app/src/main/java/network/columba/app/data/repository/BleStatusRepository.kt
+++ b/app/src/main/java/network/columba/app/data/repository/BleStatusRepository.kt
@@ -47,7 +47,10 @@ class BleStatusRepository
             val connectionEventsFlow =
                 transportAdmin
                     .bleConnectionsFlow
-                    .onStart { emit("[]") } // Initial empty state
+                    // Seed with the current peers (live pull) rather than empty, so
+                    // opening Network Status after a peer connected shows it without
+                    // waiting for the next connect/disconnect push event.
+                    .onStart { emit(transportAdmin.getBleConnectionDetails()) }
                     .map { json -> parseConnectionsJson(json) }
 
             return combine(

--- a/rns-api/src/main/java/network/columba/app/rns/api/BleConnectionSource.kt
+++ b/rns-api/src/main/java/network/columba/app/rns/api/BleConnectionSource.kt
@@ -1,0 +1,34 @@
+package network.columba.app.rns.api
+
+/**
+ * Seam exposing live BLE peer-connection details from the host-side BLE bridge
+ * (`:rns-host`'s `KotlinBLEBridge`) to whichever backend `RnsTransportAdmin`
+ * is active.
+ *
+ * The bridge lives in `:rns-host`, which depends on the backend modules — not
+ * the reverse — so a backend can't reference `KotlinBLEBridge` directly. It
+ * holds the bridge only as `Any?` (to forward to Python via Chaquopy) and casts
+ * to this interface to surface connection state for the Network Status "BLE
+ * Connections" card. The bridge implements this; the active backend's
+ * transport-admin observes it (push) and queries it (pull), then republishes
+ * over the AIDL `bleConnectionsFlow` / `getBleConnectionDetails()` seam.
+ */
+interface BleConnectionSource {
+    /**
+     * Current connected peers as a JSON array string in the bridge's
+     * connection-details shape (`[{identityHash,address,hasCentralConnection,
+     * hasPeripheralConnection,mtu,rssi,...}]`). `"[]"` when no peers.
+     */
+    fun currentBleConnectionsJson(): String
+
+    /** Register [listener]; invoked with the JSON on every connection change. */
+    fun addBleConnectionsListener(listener: BleConnectionsListener)
+
+    /** Unregister a previously-added [listener]. */
+    fun removeBleConnectionsListener(listener: BleConnectionsListener)
+}
+
+/** Callback invoked with the connection-details JSON whenever BLE peers change. */
+fun interface BleConnectionsListener {
+    fun onBleConnectionsChanged(connectionsJson: String)
+}

--- a/rns-backend-py/src/main/kotlin/network/columba/app/rns/backend/py/PythonRnsTransportAdmin.kt
+++ b/rns-backend-py/src/main/kotlin/network/columba/app/rns/backend/py/PythonRnsTransportAdmin.kt
@@ -59,7 +59,7 @@ class PythonRnsTransportAdmin(
     // polled). They are owned here so consumers can subscribe unconditionally;
     // wiring them to real upstream events is on-device follow-up.
     private val _interfaceStatusChanged = MutableSharedFlow<Unit>(extraBufferCapacity = 16)
-    private val _bleConnectionsFlow = MutableSharedFlow<String>(extraBufferCapacity = 16)
+    private val _bleConnectionsFlow = MutableSharedFlow<String>(replay = 1, extraBufferCapacity = 16)
     private val _debugInfoFlow = MutableSharedFlow<String>(extraBufferCapacity = 64)
     private val _interfaceStatusFlow = MutableSharedFlow<String>(extraBufferCapacity = 16)
 
@@ -67,6 +67,30 @@ class PythonRnsTransportAdmin(
     override val bleConnectionsFlow: SharedFlow<String> = _bleConnectionsFlow.asSharedFlow()
     override val debugInfoFlow: SharedFlow<String> = _debugInfoFlow.asSharedFlow()
     override val interfaceStatusFlow: SharedFlow<String> = _interfaceStatusFlow.asSharedFlow()
+
+    // ===== BLE peer connection details (Network Status "BLE Connections" card) =====
+    // The host wires the live KotlinBLEBridge in via attachBleSource() right after
+    // creating it (HostBackendModule), as the rns-api BleConnectionSource seam — this
+    // module can't reference KotlinBLEBridge directly (reverse dep). We observe it
+    // (push -> _bleConnectionsFlow) and query it (pull -> getBleConnectionDetails).
+    // replay=1 means a UI subscriber that opens Network Status *after* a peer
+    // connected still sees the current peers.
+    @Volatile private var bleSource: network.columba.app.rns.api.BleConnectionSource? = null
+    private val bleListener =
+        network.columba.app.rns.api.BleConnectionsListener { json -> _bleConnectionsFlow.tryEmit(json) }
+
+    /**
+     * Attach the host-side BLE bridge as the live connection source. Idempotent:
+     * re-attaching swaps the source and re-seeds the flow with current peers.
+     */
+    fun attachBleSource(source: network.columba.app.rns.api.BleConnectionSource) {
+        bleSource?.removeBleConnectionsListener(bleListener)
+        bleSource = source
+        source.addBleConnectionsListener(bleListener)
+        // Seed current peers so the replay-1 flow + first pull reflect connections
+        // established before this wiring (or before the UI subscribed).
+        _bleConnectionsFlow.tryEmit(source.currentBleConnectionsJson())
+    }
 
     /** Reaction frames are sourced from the shared event bridge (LXMF Field 16). */
     override val reactionReceivedFlow: SharedFlow<String> = events.reactionReceived
@@ -303,11 +327,10 @@ class PythonRnsTransportAdmin(
 
     // ==================== BLE ====================
 
-    override fun getBleConnectionDetails(): String {
-        // No python-side BLE peer tracking in this cut — return the contract's
-        // documented empty-array value.
-        return EMPTY_JSON_ARRAY
-    }
+    override fun getBleConnectionDetails(): String =
+        // Pull live details from the host-side bridge (wired via attachBleSource).
+        // Falls back to the contract's empty-array value before wiring / on no peers.
+        bleSource?.currentBleConnectionsJson() ?: EMPTY_JSON_ARRAY
 
     // ==================== Internal helpers ====================
 

--- a/rns-backend-py/src/main/kotlin/network/columba/app/rns/backend/py/PythonRnsTransportAdmin.kt
+++ b/rns-backend-py/src/main/kotlin/network/columba/app/rns/backend/py/PythonRnsTransportAdmin.kt
@@ -82,7 +82,12 @@ class PythonRnsTransportAdmin(
     /**
      * Attach the host-side BLE bridge as the live connection source. Idempotent:
      * re-attaching swaps the source and re-seeds the flow with current peers.
+     *
+     * `@Synchronized` so the remove-old/swap/add-new sequence is atomic — a
+     * concurrent or re-entrant call must not leave [bleListener] registered on
+     * two sources (which would double-emit on [_bleConnectionsFlow]).
      */
+    @Synchronized
     fun attachBleSource(source: network.columba.app.rns.api.BleConnectionSource) {
         bleSource?.removeBleConnectionsListener(bleListener)
         bleSource = source

--- a/rns-host/src/main/kotlin/network/columba/app/rns/host/ble/bridge/KotlinBLEBridge.kt
+++ b/rns-host/src/main/kotlin/network/columba/app/rns/host/ble/bridge/KotlinBLEBridge.kt
@@ -65,7 +65,7 @@ import java.util.concurrent.ConcurrentHashMap
 class KotlinBLEBridge(
     private val context: Context,
     private val bluetoothManager: BluetoothManager,
-) {
+) : network.columba.app.rns.api.BleConnectionSource {
     companion object {
         private const val TAG = "Columba:BLE:K:Bridge"
         private const val MAX_BLE_PACKET_SIZE = 512 // Maximum BLE packet size in bytes for validation
@@ -224,36 +224,35 @@ class KotlinBLEBridge(
     private var dualConnectionRaceCount: Long = 0
 
     // Native connection change listeners (for IPC callbacks)
-    private val connectionChangeListeners = mutableListOf<ConnectionChangeListener>()
+    private val connectionChangeListeners = mutableListOf<network.columba.app.rns.api.BleConnectionsListener>()
     private val listenerLock = Any()
 
-    /**
-     * Listener interface for BLE connection state changes.
-     * Used by BleCoordinator to broadcast events via AIDL.
-     */
-    interface ConnectionChangeListener {
-        fun onConnectionsChanged(connectionDetailsJson: String)
-    }
+    // ===== BleConnectionSource (rns-api seam) =====
+    // Lets the active backend's RnsTransportAdmin observe (push) and query
+    // (pull) live peer connection details and republish them over the AIDL
+    // bleConnectionsFlow / getBleConnectionDetails() seam — without
+    // :rns-backend-* taking a reverse dependency on this :rns-host class.
+
+    /** Current connected-peer details as the connection-details JSON array. */
+    override fun currentBleConnectionsJson(): String = buildConnectionDetailsJson()
 
     /**
-     * Register a listener for connection state changes.
-     * Thread-safe: synchronized on listenerLock.
+     * Register a connections listener. Thread-safe: synchronized on listenerLock.
      */
-    fun addConnectionChangeListener(listener: ConnectionChangeListener) {
+    override fun addBleConnectionsListener(listener: network.columba.app.rns.api.BleConnectionsListener) {
         synchronized(listenerLock) {
             connectionChangeListeners.add(listener)
-            Log.d(TAG, "Connection change listener added (total: ${connectionChangeListeners.size})")
+            Log.d(TAG, "BLE connections listener added (total: ${connectionChangeListeners.size})")
         }
     }
 
     /**
-     * Unregister a connection state listener.
-     * Thread-safe: synchronized on listenerLock.
+     * Unregister a connections listener. Thread-safe: synchronized on listenerLock.
      */
-    fun removeConnectionChangeListener(listener: ConnectionChangeListener) {
+    override fun removeBleConnectionsListener(listener: network.columba.app.rns.api.BleConnectionsListener) {
         synchronized(listenerLock) {
             connectionChangeListeners.remove(listener)
-            Log.d(TAG, "Connection change listener removed (total: ${connectionChangeListeners.size})")
+            Log.d(TAG, "BLE connections listener removed (total: ${connectionChangeListeners.size})")
         }
     }
 
@@ -266,7 +265,7 @@ class KotlinBLEBridge(
         synchronized(listenerLock) {
             connectionChangeListeners.forEach { listener ->
                 try {
-                    listener.onConnectionsChanged(json)
+                    listener.onBleConnectionsChanged(json)
                 } catch (e: Exception) {
                     Log.e(TAG, "Error notifying connection change listener", e)
                 }

--- a/rns-host/src/main/kotlin/network/columba/app/rns/host/ble/bridge/KotlinBLEBridge.kt
+++ b/rns-host/src/main/kotlin/network/columba/app/rns/host/ble/bridge/KotlinBLEBridge.kt
@@ -60,7 +60,10 @@ import java.util.concurrent.ConcurrentHashMap
  * @property bluetoothManager Android Bluetooth manager
  */
 @SuppressLint("MissingPermission")
-@Suppress("InjectDispatcher") // Bridge class doesn't use DI - dispatchers are used for BLE operations
+// TooManyFunctions: large Android BLE bridge, already over the threshold and
+// baselined; adding the BleConnectionSource supertype changed detekt's class
+// signature so the baseline ID stopped matching — suppress inline instead.
+@Suppress("InjectDispatcher", "TooManyFunctions") // DI-free bridge; dispatchers used for BLE ops
 @Keep // Python (BLE driver / event_bridge.py) calls this via Chaquopy reflection — R8 must not strip/rename it
 class KotlinBLEBridge(
     private val context: Context,

--- a/rns-host/src/pythonBackend/kotlin/network/columba/app/rns/host/HostBackendModule.kt
+++ b/rns-host/src/pythonBackend/kotlin/network/columba/app/rns/host/HostBackendModule.kt
@@ -8,6 +8,7 @@ import dagger.hilt.android.qualifiers.ApplicationContext
 import dagger.hilt.components.SingletonComponent
 import network.columba.app.rns.api.RnsBackend
 import network.columba.app.rns.backend.py.ChaquopyRnsBackend
+import network.columba.app.rns.backend.py.PythonRnsTransportAdmin
 import network.columba.app.rns.host.ble.bridge.KotlinBLEBridge
 import network.columba.app.rns.host.di.LocalBackend
 import network.columba.app.rns.host.persistence.CallsFromContactsGate
@@ -66,7 +67,15 @@ object HostBackendModule {
             // Reticulum() is constructed. KotlinBLEBridge.getInstance is
             // process-singleton and idempotent — same instance the rest of
             // the host uses (BleCoordinator, BleStatusRepository).
-            it.runtime.bleBridge = KotlinBLEBridge.getInstance(context)
+            val bleBridge = KotlinBLEBridge.getInstance(context)
+            it.runtime.bleBridge = bleBridge
+
+            // Surface live BLE peer connections to the Network Status "BLE
+            // Connections" card. KotlinBLEBridge implements the rns-api
+            // BleConnectionSource seam; the python transport-admin observes +
+            // pulls it and republishes over the AIDL bleConnectionsFlow /
+            // getBleConnectionDetails() surface the UI repository consumes.
+            (it.transportAdmin as? PythonRnsTransportAdmin)?.attachBleSource(bleBridge)
 
             // Round 2 RNode: ColumbaRNodeInterface bridges to two singletons.
             //   • KotlinRNodeBridge — Bluetooth Classic (SPP) + BLE GATT

--- a/rns-host/src/test/kotlin/network/columba/app/rns/host/ble/bridge/KotlinBLEBridgeTest.kt
+++ b/rns-host/src/test/kotlin/network/columba/app/rns/host/ble/bridge/KotlinBLEBridgeTest.kt
@@ -898,20 +898,20 @@ class KotlinBLEBridgeTest {
             // Given
             val bridge = createBridgeWithMockScanner()
             val listener =
-                object : KotlinBLEBridge.ConnectionChangeListener {
-                    override fun onConnectionsChanged(connectionDetailsJson: String) {
+                object : network.columba.app.rns.api.BleConnectionsListener {
+                    override fun onBleConnectionsChanged(connectionDetailsJson: String) {
                         // No-op for this test
                     }
                 }
 
             // When
-            bridge.addConnectionChangeListener(listener)
+            bridge.addBleConnectionsListener(listener)
 
             // Then - verify via reflection that listener was added
             val listenersField = KotlinBLEBridge::class.java.getDeclaredField("connectionChangeListeners")
             listenersField.isAccessible = true
             @Suppress("UNCHECKED_CAST")
-            val listeners = listenersField.get(bridge) as MutableList<KotlinBLEBridge.ConnectionChangeListener>
+            val listeners = listenersField.get(bridge) as MutableList<network.columba.app.rns.api.BleConnectionsListener>
             assertEquals(1, listeners.size)
         }
 
@@ -921,21 +921,21 @@ class KotlinBLEBridgeTest {
             // Given
             val bridge = createBridgeWithMockScanner()
             val listener =
-                object : KotlinBLEBridge.ConnectionChangeListener {
-                    override fun onConnectionsChanged(connectionDetailsJson: String) {
+                object : network.columba.app.rns.api.BleConnectionsListener {
+                    override fun onBleConnectionsChanged(connectionDetailsJson: String) {
                         // No-op
                     }
                 }
 
             // When
-            bridge.addConnectionChangeListener(listener)
-            bridge.removeConnectionChangeListener(listener)
+            bridge.addBleConnectionsListener(listener)
+            bridge.removeBleConnectionsListener(listener)
 
             // Then - verify listener was removed
             val listenersField = KotlinBLEBridge::class.java.getDeclaredField("connectionChangeListeners")
             listenersField.isAccessible = true
             @Suppress("UNCHECKED_CAST")
-            val listeners = listenersField.get(bridge) as MutableList<KotlinBLEBridge.ConnectionChangeListener>
+            val listeners = listenersField.get(bridge) as MutableList<network.columba.app.rns.api.BleConnectionsListener>
             assertEquals(0, listeners.size)
         }
 
@@ -947,20 +947,20 @@ class KotlinBLEBridgeTest {
             val receivedJson = mutableListOf<String>()
 
             val listener1 =
-                object : KotlinBLEBridge.ConnectionChangeListener {
-                    override fun onConnectionsChanged(connectionDetailsJson: String) {
+                object : network.columba.app.rns.api.BleConnectionsListener {
+                    override fun onBleConnectionsChanged(connectionDetailsJson: String) {
                         receivedJson.add("L1:$connectionDetailsJson")
                     }
                 }
             val listener2 =
-                object : KotlinBLEBridge.ConnectionChangeListener {
-                    override fun onConnectionsChanged(connectionDetailsJson: String) {
+                object : network.columba.app.rns.api.BleConnectionsListener {
+                    override fun onBleConnectionsChanged(connectionDetailsJson: String) {
                         receivedJson.add("L2:$connectionDetailsJson")
                     }
                 }
 
-            bridge.addConnectionChangeListener(listener1)
-            bridge.addConnectionChangeListener(listener2)
+            bridge.addBleConnectionsListener(listener1)
+            bridge.addBleConnectionsListener(listener2)
 
             // When - trigger notifyConnectionChange via reflection
             val method = KotlinBLEBridge::class.java.getDeclaredMethod("notifyConnectionChange")


### PR DESCRIPTION
## Problem
The "BLE Connections" card showed **no connections** even with peers connected and messaging working over BLE. The data path from the host-side `KotlinBLEBridge` to the UI was never wired on the python backend:
- `PythonRnsTransportAdmin.getBleConnectionDetails()` returned a hardcoded `"[]"`,
- `_bleConnectionsFlow` was never emitted to,
- nothing ever registered the bridge's connection-change listener.

So both the push and pull paths were dead, and the card sat on its empty seed.

## Fix
Add a **`BleConnectionSource`** seam in `:rns-api`. The bridge lives in `:rns-host`, which depends on the backend modules (not the reverse), so the backend can't reference `KotlinBLEBridge` directly — it holds it only as `Any?`. Now:
- `KotlinBLEBridge` implements `BleConnectionSource` (replacing the never-registered `ConnectionChangeListener`).
- `PythonRnsTransportAdmin` observes it (push → `_bleConnectionsFlow`) and queries it (pull → `getBleConnectionDetails`).
- `HostBackendModule` attaches the bridge right after creating it.
- `_bleConnectionsFlow` is now `replay = 1` (matching the kotlin backend), and `BleStatusRepository` seeds from a live pull — so opening Network Status *after* a peer connected shows it without waiting for the next connect/disconnect event.

The Kotlin backend keeps its existing `"[]"` stub for now; it can adopt the same seam (it doesn't currently wire the bridge anywhere and is experimental).

## Verification
On a device, with a BLE peer connected, the card and the dedicated BLE Connections screen now show the peer (identity hash, MTU 514, RSSI, first/last seen). Confirmed `BLE connections listener added` fires and the count reflects the live peer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)