### PR TITLE
feat(settings): add BLE Connections button to the Network card

### DIFF
--- a/app/src/main/java/network/columba/app/MainActivity.kt
+++ b/app/src/main/java/network/columba/app/MainActivity.kt
@@ -1407,6 +1407,9 @@ fun ColumbaNavigation(
                                     onNavigateToInterfaces = {
                                         navController.navigate("interface_management")
                                     },
+                                    onNavigateToBleConnections = {
+                                        navController.navigate("ble_connection_status")
+                                    },
                                     onNavigateToIdentity = {
                                         navController.navigate("my_identity")
                                     },

--- a/app/src/main/java/network/columba/app/ui/screens/SettingsScreen.kt
+++ b/app/src/main/java/network/columba/app/ui/screens/SettingsScreen.kt
@@ -91,6 +91,7 @@ fun SettingsScreen(
     crashReportManager: CrashReportManager,
     debugViewModel: DebugViewModel = hiltViewModel(),
     onNavigateToInterfaces: () -> Unit = {},
+    onNavigateToBleConnections: () -> Unit = {},
     onNavigateToIdentity: () -> Unit = {},
     onNavigateToNetworkStatus: () -> Unit = {},
     onNavigateToIdentityManager: () -> Unit = {},
@@ -279,6 +280,7 @@ fun SettingsScreen(
                     onExpandedChange = { viewModel.toggleCardExpanded(SettingsCardId.NETWORK, it) },
                     onViewStatus = onNavigateToNetworkStatus,
                     onManageInterfaces = onNavigateToInterfaces,
+                    onBleConnections = onNavigateToBleConnections,
                     isSharedInstance = state.isSharedInstance,
                     sharedInstanceOnline = state.sharedInstanceOnline,
                 )

--- a/app/src/main/java/network/columba/app/ui/screens/settings/cards/NetworkCard.kt
+++ b/app/src/main/java/network/columba/app/ui/screens/settings/cards/NetworkCard.kt
@@ -5,6 +5,7 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
 import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Bluetooth
 import androidx.compose.material.icons.filled.Info
 import androidx.compose.material.icons.filled.Sensors
 import androidx.compose.material.icons.filled.Settings
@@ -26,6 +27,7 @@ import network.columba.app.ui.components.CollapsibleSettingsCard
  * @param onExpandedChange Callback when expansion state changes
  * @param onViewStatus Callback when "View Network Status" is clicked
  * @param onManageInterfaces Callback when "Manage Interfaces" is clicked
+ * @param onBleConnections Callback when "BLE Connections" is clicked
  * @param isSharedInstance When true, interface management is disabled because
  *                         Columba is connected to a shared RNS instance
  * @param sharedInstanceOnline Whether the shared instance is currently reachable.
@@ -38,6 +40,7 @@ fun NetworkCard(
     onExpandedChange: (Boolean) -> Unit,
     onViewStatus: () -> Unit,
     onManageInterfaces: () -> Unit,
+    onBleConnections: () -> Unit = {},
     isSharedInstance: Boolean = false,
     sharedInstanceOnline: Boolean = true,
 ) {
@@ -106,6 +109,20 @@ fun NetworkCard(
             )
             Spacer(modifier = Modifier.width(8.dp))
             Text("Manage Interfaces")
+        }
+
+        // Secondary action - BLE Connections (status view; always enabled)
+        OutlinedButton(
+            onClick = onBleConnections,
+            modifier = Modifier.fillMaxWidth(),
+        ) {
+            Icon(
+                imageVector = Icons.Default.Bluetooth,
+                contentDescription = null,
+                modifier = Modifier.size(18.dp),
+            )
+            Spacer(modifier = Modifier.width(8.dp))
+            Text("BLE Connections")
         }
     }
 }


### PR DESCRIPTION
## What
Adds a third button — **"BLE Connections"** — to the Network card in Settings, below "View Network Status" and "Manage Interfaces". It navigates to the existing BLE Connections screen (the same `ble_connection_status` destination the Identity-screen card already used), making the live peer view reachable from Settings.

## How
- `NetworkCard` gains an `onBleConnections` callback (defaulted, so the existing ~36 test call sites are unaffected) and an always-enabled outlined button with a Bluetooth icon (it's a status view, not interface management).
- `SettingsScreen` threads `onNavigateToBleConnections` into `NetworkCard`.
- `MainActivity` wires it to `navController.navigate("ble_connection_status")`.

## Verification
On-device: the button appears on the Network card and tapping it opens the BLE Connections screen (showing the connected peer). Reuses the pre-existing route, so it works independently — the live connection data on that screen comes from #941.

🤖 Generated with [Claude Code](https://claude.com/claude-code)