### PR TITLE
ci(release): bump release build timeout 20m → 40m

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -37,7 +37,10 @@ jobs:
           echo "Building version: $VERSION from tag: $TAG_NAME"
 
       - name: Build Release APK
-        timeout-minutes: 20
+        # 40m to match build-prerelease-apk.yml: assembleRelease builds the two
+        # pythonBackend flavors, which bundle a Python runtime per ABI via
+        # Chaquopy and overrun the old 20m budget.
+        timeout-minutes: 40
         env:
           KEYSTORE_FILE: ${{ secrets.KEYSTORE_FILE }}
           KEYSTORE_PASSWORD: ${{ secrets.KEYSTORE_PASSWORD }}


### PR DESCRIPTION
## Problem
The tagged-release workflow's **Build Release APK** step (`release.yml`) has `timeout-minutes: 20` and timed out. `assembleRelease` builds all four flavor combos — including the two **pythonBackend** flavors, which bundle a CPython runtime per ABI via Chaquopy and are much slower than the old single-backend build the 20m budget was set for.

## Fix
Bump `release.yml`'s build step to **40m**, matching `build-prerelease-apk.yml`, which was already bumped to 40m for exactly this reason. (Only the build step's timeout changes; nothing else.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)