### PR TITLE
fix(rns): TCP/interface type shows as obfuscated "wy2" in release builds

### DIFF
--- a/app/src/main/java/network/columba/app/data/database/InterfaceDatabase.kt
+++ b/app/src/main/java/network/columba/app/data/database/InterfaceDatabase.kt
@@ -10,7 +10,6 @@ import network.columba.app.data.database.dao.InterfaceDao
 import network.columba.app.data.database.entity.InterfaceEntity
 import network.columba.app.rns.api.model.InterfaceConfig
 import network.columba.app.rns.api.model.toJsonString
-import network.columba.app.rns.api.model.typeName
 import java.io.File
 import javax.inject.Provider
 

--- a/app/src/main/java/network/columba/app/repository/InterfaceRepository.kt
+++ b/app/src/main/java/network/columba/app/repository/InterfaceRepository.kt
@@ -8,7 +8,6 @@ import network.columba.app.data.database.entity.InterfaceEntity
 import network.columba.app.rns.api.model.InterfaceConfig
 import network.columba.app.rns.api.model.NetworkRestriction
 import network.columba.app.rns.api.model.toJsonString
-import network.columba.app.rns.api.model.typeName
 import network.columba.app.util.validation.InputValidator
 import network.columba.app.util.validation.ValidationResult
 import org.json.JSONException

--- a/app/src/test/java/network/columba/app/repository/InterfaceRepositoryTest.kt
+++ b/app/src/test/java/network/columba/app/repository/InterfaceRepositoryTest.kt
@@ -16,7 +16,6 @@ import network.columba.app.data.database.entity.InterfaceEntity
 import network.columba.app.rns.api.model.InterfaceConfig
 import network.columba.app.rns.api.model.NetworkRestriction
 import network.columba.app.rns.api.model.toJsonString
-import network.columba.app.rns.api.model.typeName
 import org.junit.After
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNull
@@ -1122,23 +1121,24 @@ class InterfaceRepositoryTest {
      * `this::class.simpleName`. In the minified release build that returned the
      * obfuscated class name (e.g. "wy2"), which was persisted to the `type`
      * column and then failed `entityToConfig`'s `when (entity.type)` with
-     * "Unknown interface type: wy2".
+     * "Unknown interface type: wy2". `typeName` is now an abstract member each
+     * subclass overrides with an explicit literal, so the class identity can't be
+     * obfuscated and the compiler forces every subclass to declare one.
      *
      * This test exercises the REAL save path — `typeName` + `toJsonString`, the
      * exact pair `InterfaceRepository.configToEntity` uses — and feeds it back
      * through `entityToConfig`. It cannot reproduce R8 obfuscation (unit tests
      * run unobfuscated), but it does fail if:
-     *   - a `typeName` literal is typo'd so it no longer matches a deserializer
-     *     branch (falls through to the "Unknown" else), or
-     *   - a new InterfaceConfig subclass gets a `typeName` literal but a
-     *     forgotten `entityToConfig` branch — the deserializer's `else` is NOT
-     *     compile-checked, unlike the now-exhaustive `typeName` `when`.
+     *   - a subclass's `typeName` literal is typo'd so it no longer matches a
+     *     deserializer branch (falls through to the "Unknown" else), or
+     *   - a new InterfaceConfig subclass declares a `typeName` but its
+     *     `entityToConfig` branch is forgotten — the deserializer's `else` is NOT
+     *     compile-checked, unlike the abstract `typeName` member.
      *
      * Forcing function for new types: `expectedTypeName` below is an exhaustive
      * `when` with no `else`, so adding a 7th InterfaceConfig subclass fails to
-     * compile here until it is handled — the same compile-time guard the
-     * production `typeName` `when` now has, extended to the deserializer side
-     * (whose `else` branch is otherwise the silent failure point).
+     * compile here until it is handled and given a sample above — pinning the
+     * expected wire value and exercising the deserializer's `else`-prone path.
      */
     @Test
     fun `every InterfaceConfig type round-trips through typeName and entityToConfig`() =
@@ -1165,11 +1165,10 @@ class InterfaceRepositoryTest {
                         is InterfaceConfig.AndroidBLE -> "AndroidBLE"
                         is InterfaceConfig.RNode -> "RNode"
                     }
-                // Catches the R8-style regression directly: if typeName ever goes
-                // back to ::class.simpleName, an obfuscated build yields "wy2" here.
-                // (Unit tests run unobfuscated, so this specifically guards a typo'd
-                // or drifted literal; the obfuscation case is covered in CI — see
-                // scripts/assert_bridges_kept.py philosophy.)
+                // Guards against a subclass's typeName override drifting from the
+                // persisted discriminator. (Unit tests run unobfuscated, so the R8
+                // rename itself isn't reproducible here; the obfuscation-survival
+                // class of bug is gated in CI — see scripts/assert_bridges_kept.py.)
                 assertEquals(
                     "typeName drifted from the persisted discriminator for ${source::class.simpleName}",
                     expectedTypeName,

--- a/app/src/test/java/network/columba/app/repository/InterfaceRepositoryTest.kt
+++ b/app/src/test/java/network/columba/app/repository/InterfaceRepositoryTest.kt
@@ -16,6 +16,7 @@ import network.columba.app.data.database.entity.InterfaceEntity
 import network.columba.app.rns.api.model.InterfaceConfig
 import network.columba.app.rns.api.model.NetworkRestriction
 import network.columba.app.rns.api.model.toJsonString
+import network.columba.app.rns.api.model.typeName
 import org.junit.After
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNull
@@ -1110,6 +1111,100 @@ class InterfaceRepositoryTest {
                         "round-trip lost CELLULAR_ONLY for $type",
                         NetworkRestriction.CELLULAR_ONLY,
                         parsed.networkRestriction,
+                    )
+                    cancelAndIgnoreRemainingEvents()
+                }
+            }
+        }
+
+    /**
+     * Regression guard for the R8 bug where `typeName` was derived from
+     * `this::class.simpleName`. In the minified release build that returned the
+     * obfuscated class name (e.g. "wy2"), which was persisted to the `type`
+     * column and then failed `entityToConfig`'s `when (entity.type)` with
+     * "Unknown interface type: wy2".
+     *
+     * This test exercises the REAL save path — `typeName` + `toJsonString`, the
+     * exact pair `InterfaceRepository.configToEntity` uses — and feeds it back
+     * through `entityToConfig`. It cannot reproduce R8 obfuscation (unit tests
+     * run unobfuscated), but it does fail if:
+     *   - a `typeName` literal is typo'd so it no longer matches a deserializer
+     *     branch (falls through to the "Unknown" else), or
+     *   - a new InterfaceConfig subclass gets a `typeName` literal but a
+     *     forgotten `entityToConfig` branch — the deserializer's `else` is NOT
+     *     compile-checked, unlike the now-exhaustive `typeName` `when`.
+     *
+     * Forcing function for new types: `expectedTypeName` below is an exhaustive
+     * `when` with no `else`, so adding a 7th InterfaceConfig subclass fails to
+     * compile here until it is handled — the same compile-time guard the
+     * production `typeName` `when` now has, extended to the deserializer side
+     * (whose `else` branch is otherwise the silent failure point).
+     */
+    @Test
+    fun `every InterfaceConfig type round-trips through typeName and entityToConfig`() =
+        runTest {
+            val samples: List<InterfaceConfig> =
+                listOf(
+                    InterfaceConfig.AutoInterface(name = "auto"),
+                    InterfaceConfig.TCPClient(name = "tcp", targetHost = "10.0.0.1", targetPort = 4242),
+                    InterfaceConfig.TCPServer(name = "tcps"),
+                    InterfaceConfig.UDP(name = "udp"),
+                    InterfaceConfig.AndroidBLE(name = "ble"),
+                    InterfaceConfig.RNode(name = "rnode", targetDeviceName = "RNode 1234", connectionMode = "classic"),
+                )
+
+            samples.forEachIndexed { idx, source ->
+                // Exhaustive (no `else`) — a new InterfaceConfig subclass breaks
+                // compilation here. The literals must match entityToConfig's branches.
+                val expectedTypeName =
+                    when (source) {
+                        is InterfaceConfig.AutoInterface -> "AutoInterface"
+                        is InterfaceConfig.TCPClient -> "TCPClient"
+                        is InterfaceConfig.TCPServer -> "TCPServer"
+                        is InterfaceConfig.UDP -> "UDP"
+                        is InterfaceConfig.AndroidBLE -> "AndroidBLE"
+                        is InterfaceConfig.RNode -> "RNode"
+                    }
+                // Catches the R8-style regression directly: if typeName ever goes
+                // back to ::class.simpleName, an obfuscated build yields "wy2" here.
+                // (Unit tests run unobfuscated, so this specifically guards a typo'd
+                // or drifted literal; the obfuscation case is covered in CI — see
+                // scripts/assert_bridges_kept.py philosophy.)
+                assertEquals(
+                    "typeName drifted from the persisted discriminator for ${source::class.simpleName}",
+                    expectedTypeName,
+                    source.typeName,
+                )
+
+                // Build the entity exactly as InterfaceRepository.configToEntity does:
+                // the discriminator comes from typeName (the field that broke under R8).
+                val entity =
+                    InterfaceEntity(
+                        id = idx + 1L,
+                        name = source.name,
+                        type = source.typeName,
+                        enabled = source.enabled,
+                        configJson = source.toJsonString(),
+                        displayOrder = idx,
+                    )
+                every { mockDao.getAllInterfaces() } returns flowOf(emptyList())
+                every { mockDao.getEnabledInterfaces() } returns flowOf(listOf(entity))
+                val repository = InterfaceRepository(mockDao)
+
+                repository.enabledInterfaces.test {
+                    val parsed = awaitItem()
+                    // A round-trip failure (typeName not matching a deserializer
+                    // branch) surfaces as the interface being dropped from the list.
+                    assertEquals(
+                        "type '${source.typeName}' (${source::class.simpleName}) did not round-trip " +
+                            "through entityToConfig — likely a typeName/deserializer mismatch",
+                        1,
+                        parsed.size,
+                    )
+                    assertEquals(
+                        "round-trip changed the interface subtype for '${source.typeName}'",
+                        source::class,
+                        parsed.single()::class,
                     )
                     cancelAndIgnoreRemainingEvents()
                 }

--- a/rns-api/src/main/java/network/columba/app/rns/api/model/InterfaceConfigExt.kt
+++ b/rns-api/src/main/java/network/columba/app/rns/api/model/InterfaceConfigExt.kt
@@ -108,23 +108,3 @@ private fun JSONObject.putRestrictionUnlessDefault(
 ) {
     if (value != default) put("network_restriction", value.value)
 }
-
-/**
- * Get the type name string for this InterfaceConfig.
- * Used for database storage.
- *
- * These are explicit, stable string literals — NOT derived from `::class.simpleName`.
- * Under R8/minification in release builds, `simpleName` returns the obfuscated class
- * name (e.g. "wy2"), which then fails to round-trip through `entityToConfig`'s
- * `when (entity.type)` and surfaces as "Unknown interface type: wy2". The literals
- * here must stay in sync with the branches in that deserializer.
- */
-val InterfaceConfig.typeName: String
-    get() = when (this) {
-        is InterfaceConfig.AutoInterface -> "AutoInterface"
-        is InterfaceConfig.TCPClient -> "TCPClient"
-        is InterfaceConfig.RNode -> "RNode"
-        is InterfaceConfig.UDP -> "UDP"
-        is InterfaceConfig.AndroidBLE -> "AndroidBLE"
-        is InterfaceConfig.TCPServer -> "TCPServer"
-    }

--- a/rns-api/src/main/java/network/columba/app/rns/api/model/InterfaceConfigExt.kt
+++ b/rns-api/src/main/java/network/columba/app/rns/api/model/InterfaceConfigExt.kt
@@ -112,6 +112,19 @@ private fun JSONObject.putRestrictionUnlessDefault(
 /**
  * Get the type name string for this InterfaceConfig.
  * Used for database storage.
+ *
+ * These are explicit, stable string literals — NOT derived from `::class.simpleName`.
+ * Under R8/minification in release builds, `simpleName` returns the obfuscated class
+ * name (e.g. "wy2"), which then fails to round-trip through `entityToConfig`'s
+ * `when (entity.type)` and surfaces as "Unknown interface type: wy2". The literals
+ * here must stay in sync with the branches in that deserializer.
  */
 val InterfaceConfig.typeName: String
-    get() = this::class.simpleName ?: "Unknown"
+    get() = when (this) {
+        is InterfaceConfig.AutoInterface -> "AutoInterface"
+        is InterfaceConfig.TCPClient -> "TCPClient"
+        is InterfaceConfig.RNode -> "RNode"
+        is InterfaceConfig.UDP -> "UDP"
+        is InterfaceConfig.AndroidBLE -> "AndroidBLE"
+        is InterfaceConfig.TCPServer -> "TCPServer"
+    }

--- a/rns-api/src/main/java/network/columba/app/rns/api/model/ReticulumConfig.kt
+++ b/rns-api/src/main/java/network/columba/app/rns/api/model/ReticulumConfig.kt
@@ -208,6 +208,17 @@ sealed class InterfaceConfig : Parcelable {
     abstract val networkRestriction: NetworkRestriction
 
     /**
+     * Stable type discriminator persisted to the `interfaces.type` DB column and matched
+     * in `InterfaceRepository.entityToConfig`. Declared per-subclass as an explicit literal,
+     * deliberately NOT `this::class.simpleName`: R8 obfuscates the class name to e.g. "wy2"
+     * in release builds, which then fails to round-trip and surfaces as "Unknown interface
+     * type: wy2". Lives alongside each subclass's Parcel `TAG_*` for the same reason — it's
+     * that subclass's identity — and decouples the wire/DB format from the Kotlin class name
+     * so the type can be renamed without a DB migration.
+     */
+    abstract val typeName: String
+
+    /**
      * AutoInterface - Automatically discovers peers on the local network.
      * Uses UDP multicast for peer discovery and establishes direct connections.
      *
@@ -229,6 +240,8 @@ sealed class InterfaceConfig : Parcelable {
         val mode: String = "full",
         override val networkRestriction: NetworkRestriction = NetworkRestriction.WIFI_ONLY,
     ) : InterfaceConfig() {
+        override val typeName: String get() = "AutoInterface"
+
         override fun writeToParcel(parcel: Parcel, flags: Int) {
             parcel.writeInt(TAG_AUTO_INTERFACE)
             parcel.writeString(name)
@@ -278,6 +291,8 @@ sealed class InterfaceConfig : Parcelable {
         val socksProxyPort: Int = 9050,
         override val networkRestriction: NetworkRestriction = NetworkRestriction.ANY,
     ) : InterfaceConfig() {
+        override val typeName: String get() = "TCPClient"
+
         override fun writeToParcel(parcel: Parcel, flags: Int) {
             parcel.writeInt(TAG_TCP_CLIENT)
             parcel.writeString(name)
@@ -343,6 +358,8 @@ sealed class InterfaceConfig : Parcelable {
         val enableFramebuffer: Boolean = true, // Display logo on RNode screen
         override val networkRestriction: NetworkRestriction = NetworkRestriction.ANY,
     ) : InterfaceConfig() {
+        override val typeName: String get() = "RNode"
+
         @Suppress("LongMethod") // Mechanical field serialization; one parcel.write per field.
         override fun writeToParcel(parcel: Parcel, flags: Int) {
             parcel.writeInt(TAG_RNODE)
@@ -392,6 +409,8 @@ sealed class InterfaceConfig : Parcelable {
         val mode: String = "full",
         override val networkRestriction: NetworkRestriction = NetworkRestriction.ANY,
     ) : InterfaceConfig() {
+        override val typeName: String get() = "UDP"
+
         override fun writeToParcel(parcel: Parcel, flags: Int) {
             parcel.writeInt(TAG_UDP)
             parcel.writeString(name)
@@ -429,6 +448,8 @@ sealed class InterfaceConfig : Parcelable {
         val bleAdvertisingRefreshIntervalMs: Long = 60_000L,
         override val networkRestriction: NetworkRestriction = NetworkRestriction.ANY,
     ) : InterfaceConfig() {
+        override val typeName: String get() = "AndroidBLE"
+
         override fun writeToParcel(parcel: Parcel, flags: Int) {
             parcel.writeInt(TAG_ANDROID_BLE)
             parcel.writeString(name)
@@ -467,6 +488,8 @@ sealed class InterfaceConfig : Parcelable {
         val passphrase: String? = null,
         override val networkRestriction: NetworkRestriction = NetworkRestriction.ANY,
     ) : InterfaceConfig() {
+        override val typeName: String get() = "TCPServer"
+
         override fun writeToParcel(parcel: Parcel, flags: Int) {
             parcel.writeInt(TAG_TCP_SERVER)
             parcel.writeString(name)


### PR DESCRIPTION
## Problem

On the Kotlin backend release build, adding any RNS interface (e.g. a TCP client) showed its type as **`wy2`**, the interface never enabled, and editing it failed with **"failed to load interface, unknown interface type, wy2."** Debug builds were fine.

## Root cause

`InterfaceConfig.typeName` derived the persisted type discriminator from `this::class.simpleName`:

```kotlin
val InterfaceConfig.typeName: String
    get() = this::class.simpleName ?: "Unknown"
```

Under R8 minification, `simpleName` returns the **obfuscated** class name (`wy2`), which gets written to the `interfaces.type` column on save. On load, `InterfaceRepository.entityToConfig`'s `when (entity.type)` matches against literals (`"TCPClient"`, `"AutoInterface"`, …), `"wy2"` matches nothing, and it throws `Unknown interface type: wy2`. Debug builds aren't obfuscated, so every unit test stayed green.

This is the same bug class the Python↔Kotlin bridge guard (`scripts/assert_bridges_kept.py`) protects against — a name used as a runtime key surviving R8 — but on the Kotlin side, which that guard doesn't cover.

## Fix

Make `typeName` an `abstract val` on the sealed `InterfaceConfig`, overridden per subclass with an explicit literal:

```kotlin
data class TCPClient(...) : InterfaceConfig() {
    override val typeName: String get() = "TCPClient"
    ...
}
```

This co-locates each subtype's DB/wire identity with the Parcel `TAG_*` int it already declares inline — same concern, same place — and the abstract member is itself the compiler-enforced "every subclass must declare one" guarantee (no external `when` to keep in sync). It's obfuscation-proof (literals, not reflection), emits the identical strings (no DB migration), and is decoupled from the class name so the Kotlin type can be renamed freely.

**AIDL-safe:** `typeName` is a derived body property, not a constructor param — so it stays out of `equals`/`hashCode`/`copy`, isn't written to the Parcel (we control `writeToParcel` manually), and doesn't touch the `CREATOR` contract. Binary IPC (int tag) and human-readable DB (string) remain separate concerns.

Chosen over a ProGuard `-keep` rule (which would re-couple the persisted string to the class name) and over kotlinx.serialization (a full rewrite of the hand-rolled JSON + Parcelable layer, out of scope).

## Test

Adds a round-trip regression test in `InterfaceRepositoryTest` that drives the **real save path** (`typeName` + `toJsonString` → `entityToConfig`) for every subtype. An exhaustive `when` for the expected discriminator means a new interface type can't silently skip the deserializer — whose `else` branch, unlike `typeName`, is not compile-checked.

**Honest limitation:** JVM unit tests run unobfuscated and cannot reproduce the R8 rename itself. The test guards against typo'd/drifted literals and forgotten deserializer branches; the obfuscation case proper is only catchable via the minified `mapping.txt` (the `assert_bridges_kept.py` approach).

## Migration note

Interfaces already saved on a broken release build have a bad `type` value persisted (and R8's obfuscated names aren't stable across builds, so they can't be reliably remapped). Those entries were non-functional anyway — **delete and re-add them** after installing a build with this fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)