### PR TITLE
feat(telemetry): consent-based crash reporting + build-time Sentry removal

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -139,11 +139,17 @@ android {
             isDefault = true
             // SENTRY_DSN from environment - Sentry enabled in release builds
             buildConfigField("String", "SENTRY_DSN", "\"${System.getenv("SENTRY_DSN") ?: ""}\"")
+            // Crash reporting UI (onboarding page, settings toggle, update prompt) is
+            // only present in this flavor; consent gates whether anything is uploaded.
+            buildConfigField("boolean", "CRASH_REPORTING_AVAILABLE", "true")
         }
         create("noSentry") {
             dimension = "telemetry"
             // Empty DSN - Sentry fully disabled (no init, no network calls)
             buildConfigField("String", "SENTRY_DSN", "\"\"")
+            // Sentry SDK is stripped from this flavor entirely (see sentryImplementation
+            // + autoInstallation/ignoredFlavors below); hide all crash-reporting UI.
+            buildConfigField("boolean", "CRASH_REPORTING_AVAILABLE", "false")
         }
 
         // RNS backend selection. `kotlinBackend` ships reticulum-kt / lxmf-kt /
@@ -384,6 +390,29 @@ sentry {
     autoUploadSourceContext.set(hasAuth)
     autoUploadNativeSymbols.set(false) // No native code
 
+    // CRITICAL: the io.sentry:sentry-android dependency is declared manually and scoped to
+    // the `sentry` flavor only (see `sentryImplementation` in dependencies). With
+    // autoInstallation enabled the plugin would re-add the SDK to the noSentry flavor
+    // (which has no direct Sentry dependency), defeating the build-time removal.
+    autoInstallation {
+        enabled.set(false)
+    }
+
+    // Exclude all noSentry* variants from bytecode instrumentation, logcat breadcrumbs,
+    // and mapping upload — the Sentry SDK is not present there, so any injected reference
+    // (e.g. SentryLogcatAdapter) would NoClassDefFoundError at runtime. ignoredFlavors
+    // alone did not gate the logcat instrumentation in this plugin version, so the full
+    // noSentry variant names are listed explicitly via ignoredVariants as well.
+    ignoredFlavors.set(setOf("noSentry"))
+    ignoredVariants.set(
+        setOf(
+            "noSentryKotlinBackendDebug",
+            "noSentryKotlinBackendRelease",
+            "noSentryPythonBackendDebug",
+            "noSentryPythonBackendRelease",
+        ),
+    )
+
     // Logcat integration - captures android.util.Log calls as breadcrumbs
     tracingInstrumentation {
         enabled.set(true)
@@ -455,7 +484,10 @@ dependencies {
 
     // Crash Reporting - GlitchTip (Sentry-compatible)
     // Phase 4 Task 4.2: Production Observability
-    implementation("io.sentry:sentry-android:8.31.0")
+    // Scoped to the `sentry` flavor ONLY so the SDK is entirely absent from the noSentry
+    // APK. The noSentry flavor uses src/noSentry/.../NoOpCrashReporter instead. Requires
+    // autoInstallation.enabled = false in the sentry { } block above.
+    "sentryImplementation"("io.sentry:sentry-android:8.31.0")
 
     // Performance Monitoring - JankStats for frame monitoring
     // Phase 1 Plan 01-03: Frame tracking integration with Sentry

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -333,13 +333,16 @@ android {
                 val total = project.findProperty("testShardTotal")?.toString()?.toIntOrNull()
                 if (shard != null && total != null && total > 1) {
                     val testSourceDir = project.file("src/test/java")
-                    val allTestClasses = project.fileTree(testSourceDir) {
-                        include("**/*Test.kt")
-                    }.files.map { f ->
-                        f.relativeTo(testSourceDir)
-                            .path.replace(File.separatorChar, '.')
-                            .removeSuffix(".kt")
-                    }.sorted()
+                    val allTestClasses =
+                        project.fileTree(testSourceDir) {
+                            include("**/*Test.kt")
+                        }.files
+                            .map { f ->
+                                f.relativeTo(testSourceDir)
+                                    .path
+                                    .replace(File.separatorChar, '.')
+                                    .removeSuffix(".kt")
+                            }.sorted()
                     val shardClasses = allTestClasses.filterIndexed { i, _ -> i % total == shard }
                     shardClasses.forEach { cls -> it.filter.includeTestsMatching(cls) }
                 }

--- a/app/src/main/java/network/columba/app/ColumbaApplication.kt
+++ b/app/src/main/java/network/columba/app/ColumbaApplication.kt
@@ -26,6 +26,8 @@ import network.columba.app.service.TelemetryCollectorManager
 import network.columba.app.startup.ConfigApplyFlagManager
 import network.columba.app.startup.ServiceIdentityVerifier
 import network.columba.app.startup.StartupConfigLoader
+import network.columba.app.telemetry.CrashReporter
+import network.columba.app.telemetry.CrashReporterProvider
 import network.columba.app.util.CrashReportManager
 import network.columba.app.util.HexUtils.hexStringToByteArray
 import javax.inject.Inject
@@ -112,15 +114,27 @@ class ColumbaApplication : Application() {
     // SupervisorJob ensures failures don't crash the entire app
     private val applicationScope = CoroutineScope(SupervisorJob() + Dispatchers.Default)
 
+    // Build-time-swappable crash reporter. The `sentry` flavor binds a Sentry-backed
+    // implementation; `noSentry` binds a no-op (the SDK is stripped from that APK).
+    // Constructed via a plain factory rather than Hilt because it is used at the very top
+    // of onCreate(), before the DI graph is guaranteed ready.
+    private val crashReporter: CrashReporter = CrashReporterProvider.create()
+
     override fun onCreate() {
         super.onCreate()
 
         // Install crash handler FIRST (before anything else that might crash)
         // This ensures we capture crashes from any subsequent initialization
         crashReportManager.installCrashHandler()
-        // Initialize Sentry for crash reporting and performance monitoring
-        // Phase 1 Plan 01-03: Sentry Performance Monitoring
-        initializeSentry()
+        // Initialize crash reporting (Sentry flavor only). Consent is read synchronously
+        // from the SharedPreferences mirror so we never block the main thread on DataStore.
+        // When consent is not granted, the reporter does not initialize or upload anything.
+        crashReporter.initialize(
+            context = this,
+            environment = if (BuildConfig.DEBUG) "debug" else "production",
+            isDebug = BuildConfig.DEBUG,
+            consentGranted = crashReportManager.isCrashReportingConsentGranted(),
+        )
 
         // Phase 4 Task 4.1: StrictMode for debug builds
         // Detect threading violations during development
@@ -1006,68 +1020,4 @@ class ColumbaApplication : Application() {
         android.util.Log.d("ColumbaApplication", "✓ Batch restore complete: $totalRestored peer identities restored")
     }
 
-    /**
-     * Initialize Sentry SDK for crash reporting and performance monitoring.
-     * Phase 1 Plan 01-03: Production observability for performance issues.
-     */
-    private fun initializeSentry() {
-        try {
-            io.sentry.android.core.SentryAndroid.init(this) { options ->
-                // DSN from BuildConfig - set via SENTRY_DSN environment variable at build time
-                // Empty DSN = Sentry disabled (used by noSentry build variant in Phase 2)
-                options.dsn = BuildConfig.SENTRY_DSN
-
-                // Sentry is enabled when DSN is provided (not empty).
-                // Both debug and release builds report, distinguished by environment.
-                options.isEnabled = BuildConfig.SENTRY_DSN.isNotEmpty()
-
-                // Tag the environment so events are filterable in the Sentry dashboard.
-                // "debug" for local/dev builds, "production" for release builds.
-                options.environment = if (BuildConfig.DEBUG) "debug" else "production"
-
-                // Performance Monitoring - Tracing
-                // Debug builds use lower sampling to reduce noise during development.
-                if (BuildConfig.DEBUG) {
-                    options.tracesSampleRate = 0.1 // 10% sampling for debug
-                    options.profilesSampleRate = 0.0 // No profiling in debug
-                } else {
-                    options.tracesSampleRate = 0.5 // 50% sampling appropriate for <500 users
-                    options.profilesSampleRate = 0.1 // Profile 10% of sampled transactions
-                }
-
-                // Activity & Fragment tracing (enabled by default)
-                options.isEnableActivityLifecycleTracingAutoFinish = true
-
-                // User Interaction tracing (clicks, scrolls, swipes)
-                options.isEnableUserInteractionTracing = true
-                options.isEnableUserInteractionBreadcrumbs = true
-
-                // App Start performance tracking (cold/warm starts)
-                options.isEnableAppStartProfiling = !BuildConfig.DEBUG
-
-                // ANR Detection (Application Not Responding)
-                options.isAnrEnabled = true
-                options.anrTimeoutIntervalMillis = 5000 // 5 second ANR threshold
-                options.isAttachAnrThreadDump = true
-
-                // Frame Tracking (slow/frozen frames)
-                options.isEnableFramesTracking = true
-
-                // Breadcrumbs for debugging
-                options.isEnableActivityLifecycleBreadcrumbs = true
-                options.isEnableAppComponentBreadcrumbs = true
-                options.isEnableSystemEventBreadcrumbs = true
-
-                android.util.Log.d(
-                    "ColumbaApplication",
-                    "Sentry initialized: enabled=${options.isEnabled}, " +
-                        "environment=${options.environment}, " +
-                        "tracing=${options.tracesSampleRate}, " +
-                        "hasDsn=${BuildConfig.SENTRY_DSN.isNotEmpty()}",
-                )
-            }
-        } catch (e: Exception) {
-            android.util.Log.e("ColumbaApplication", "Failed to initialize Sentry", e)
-        }
-    }
 }

--- a/app/src/main/java/network/columba/app/MainActivity.kt
+++ b/app/src/main/java/network/columba/app/MainActivity.kt
@@ -156,23 +156,35 @@ class MainActivity : ComponentActivity() {
     // State to hold pending navigation from intent
     private val pendingNavigation = mutableStateOf<PendingNavigation?>(null)
 
+    // Build-time-swappable crash reporter (no-op in the noSentry flavor). Breadcrumbs are
+    // recorded against the global reporting hub initialized by ColumbaApplication.
+    private val crashReporter: network.columba.app.telemetry.CrashReporter =
+        network.columba.app.telemetry.CrashReporterProvider.create()
+
     // JankStats for performance monitoring (Phase 1 Plan 01-03)
     private lateinit var jankStats: androidx.metrics.performance.JankStats
 
     private val jankFrameListener =
         androidx.metrics.performance.JankStats.OnFrameListener { frameData ->
-            // Report janky frames to Sentry as breadcrumbs
+            // Report janky frames as breadcrumbs (flavor-gated via crashReporter)
             if (frameData.isJank) {
                 val durationMs = frameData.frameDurationUiNanos / 1_000_000
-                io.sentry.Sentry.addBreadcrumb(
-                    io.sentry.Breadcrumb().apply {
-                        category = "performance"
-                        message = "Janky frame: ${durationMs}ms"
-                        level = if (durationMs > 100) io.sentry.SentryLevel.WARNING else io.sentry.SentryLevel.INFO
-                        setData("frame_duration_ms", durationMs)
-                        val stateString = frameData.states.joinToString { "${it.key}=${it.value}" }
-                        setData("states", stateString)
-                    },
+                crashReporter.addBreadcrumb(
+                    network.columba.app.telemetry.CrashBreadcrumb(
+                        category = "performance",
+                        message = "Janky frame: ${durationMs}ms",
+                        level =
+                            if (durationMs > 100) {
+                                network.columba.app.telemetry.CrashReportLevel.WARNING
+                            } else {
+                                network.columba.app.telemetry.CrashReportLevel.INFO
+                            },
+                        data =
+                            mapOf(
+                                "frame_duration_ms" to durationMs,
+                                "states" to frameData.states.joinToString { "${it.key}=${it.value}" },
+                            ),
+                    ),
                 )
 
                 // Log for local debugging
@@ -614,6 +626,9 @@ fun ColumbaNavigation(
 
     // Collect settings state (includes theme preference)
     val settingsState by settingsViewModel.state.collectAsState()
+
+    // One-time anonymous crash-reporting opt-in prompt for existing users (sentry flavor).
+    val showCrashReportingOptIn by settingsViewModel.shouldShowCrashReportingPrompt.collectAsState()
 
     // Access MapViewModel at navigation level so "Locate on Map" can set pending focus
     val mapViewModel: MapViewModel = hiltViewModel()
@@ -2226,6 +2241,16 @@ fun ColumbaNavigation(
                         },
                         sheetState = sheetState,
                         primaryActionLabel = if (useAppSettings) "Open Settings" else "Grant Permissions",
+                    )
+                }
+
+                // One-time anonymous crash-reporting opt-in for existing users. The
+                // ViewModel gates visibility (sentry flavor, onboarding complete, prompt
+                // not yet seen, not already opted in) and marks it seen on either choice.
+                if (showCrashReportingOptIn) {
+                    network.columba.app.ui.screens.settings.dialogs.CrashReportingOptInDialog(
+                        onEnable = { settingsViewModel.enableCrashReportingFromPrompt() },
+                        onDismiss = { settingsViewModel.dismissCrashReportingPrompt() },
                     )
                 }
             }

--- a/app/src/main/java/network/columba/app/repository/SettingsRepository.kt
+++ b/app/src/main/java/network/columba/app/repository/SettingsRepository.kt
@@ -166,6 +166,13 @@ class SettingsRepository
 
             // Message sort order: false = received time (default), true = sent time
             val SORT_MESSAGES_BY_SENT_TIME = booleanPreferencesKey("sort_messages_by_sent_time")
+
+            // Anonymous crash reporting (sentry flavor only). Opt-in: defaults to false.
+            val CRASH_REPORTING_CONSENT = booleanPreferencesKey("crash_reporting_consent")
+
+            // Whether the one-time crash-reporting opt-in prompt has been shown to an
+            // existing user (who completed onboarding before the feature existed).
+            val HAS_SEEN_CRASH_REPORTING_PROMPT = booleanPreferencesKey("has_seen_crash_reporting_prompt")
         }
 
         // Cross-process SharedPreferences for service communication
@@ -447,6 +454,48 @@ class SettingsRepository
         suspend fun markOnboardingCompleted() {
             context.dataStore.edit { preferences ->
                 preferences[PreferencesKeys.HAS_COMPLETED_ONBOARDING] = true
+            }
+        }
+
+        // Crash reporting (sentry flavor only)
+
+        /**
+         * Flow of the anonymous crash reporting consent. Opt-in: defaults to false.
+         * This is the source of truth; [CrashReportManager.setCrashReportingConsentMirror]
+         * mirrors it into SharedPreferences for synchronous reads at app startup.
+         */
+        val crashReportingConsentFlow: Flow<Boolean> =
+            context.dataStore.data
+                .map { preferences ->
+                    preferences[PreferencesKeys.CRASH_REPORTING_CONSENT] ?: false
+                }.distinctUntilChanged()
+
+        /**
+         * Persist the anonymous crash reporting consent. Callers should also update the
+         * synchronous mirror via CrashReportManager and call CrashReporter.setEnabled().
+         */
+        suspend fun setCrashReportingConsent(enabled: Boolean) {
+            context.dataStore.edit { preferences ->
+                preferences[PreferencesKeys.CRASH_REPORTING_CONSENT] = enabled
+            }
+        }
+
+        /**
+         * Flow tracking whether the one-time crash-reporting opt-in prompt has been shown.
+         * Defaults to false.
+         */
+        val hasSeenCrashReportingPromptFlow: Flow<Boolean> =
+            context.dataStore.data
+                .map { preferences ->
+                    preferences[PreferencesKeys.HAS_SEEN_CRASH_REPORTING_PROMPT] ?: false
+                }.distinctUntilChanged()
+
+        /**
+         * Mark the one-time crash-reporting opt-in prompt as seen so it never reappears.
+         */
+        suspend fun markCrashReportingPromptSeen() {
+            context.dataStore.edit { preferences ->
+                preferences[PreferencesKeys.HAS_SEEN_CRASH_REPORTING_PROMPT] = true
             }
         }
 

--- a/app/src/main/java/network/columba/app/telemetry/CrashReporter.kt
+++ b/app/src/main/java/network/columba/app/telemetry/CrashReporter.kt
@@ -1,0 +1,55 @@
+package network.columba.app.telemetry
+
+import android.content.Context
+
+/**
+ * Severity for breadcrumbs / captured events, decoupled from any reporting SDK so that
+ * shared `src/main` code never imports `io.sentry.*` directly.
+ */
+enum class CrashReportLevel { DEBUG, INFO, WARNING, ERROR }
+
+/**
+ * Lightweight breadcrumb model so callers never touch `io.sentry.Breadcrumb`.
+ */
+data class CrashBreadcrumb(
+    val category: String,
+    val message: String,
+    val level: CrashReportLevel = CrashReportLevel.INFO,
+    val data: Map<String, Any> = emptyMap(),
+)
+
+/**
+ * Build-time-swappable crash/performance reporting seam.
+ *
+ * The `sentry` product flavor provides a Sentry-backed implementation (src/sentry); the
+ * `noSentry` flavor provides a no-op (src/noSentry) so that the Sentry SDK is entirely
+ * absent from that APK. Shared `src/main` code must depend ONLY on this interface — no
+ * `io.sentry.*` imports are allowed in `src/main`.
+ *
+ * Reporting is consent-gated: nothing is initialized or uploaded until the user opts in.
+ */
+interface CrashReporter {
+    /**
+     * Initialize the reporter. Must be safe to call from `Application.onCreate()`.
+     *
+     * @param consentGranted user opt-in, read synchronously at startup. When `false` the
+     *   reporter must NOT initialize the SDK or perform any network upload.
+     */
+    fun initialize(
+        context: Context,
+        environment: String,
+        isDebug: Boolean,
+        consentGranted: Boolean,
+    )
+
+    /**
+     * Enable or disable reporting at runtime after the consent preference changes.
+     * Implementations should lazily initialize the SDK on the first `setEnabled(true)` if
+     * [initialize] was called with `consentGranted == false`.
+     */
+    fun setEnabled(enabled: Boolean)
+
+    fun addBreadcrumb(breadcrumb: CrashBreadcrumb)
+
+    fun captureException(throwable: Throwable)
+}

--- a/app/src/main/java/network/columba/app/ui/screens/SettingsScreen.kt
+++ b/app/src/main/java/network/columba/app/ui/screens/SettingsScreen.kt
@@ -535,6 +535,8 @@ fun SettingsScreen(
                         state.shareInstanceHostingEnabled != state.appliedShareInstanceHosting,
                     onRestartReticulum = { viewModel.restartService() },
                     isRestarting = state.isRestarting,
+                    crashReportingEnabled = state.crashReportingEnabled,
+                    onCrashReportingToggle = { viewModel.setCrashReportingEnabled(it) },
                 )
 
                 // About section

--- a/app/src/main/java/network/columba/app/ui/screens/onboarding/OnboardingPagerScreen.kt
+++ b/app/src/main/java/network/columba/app/ui/screens/onboarding/OnboardingPagerScreen.kt
@@ -31,6 +31,7 @@ import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -41,8 +42,10 @@ import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.LifecycleEventObserver
 import androidx.lifecycle.compose.LocalLifecycleOwner
+import network.columba.app.BuildConfig
 import network.columba.app.ui.screens.onboarding.pages.CompletePage
 import network.columba.app.ui.screens.onboarding.pages.ConnectivityPage
+import network.columba.app.ui.screens.onboarding.pages.CrashReportingPage
 import network.columba.app.ui.screens.onboarding.pages.IdentityPage
 import network.columba.app.ui.screens.onboarding.pages.PermissionsPage
 import network.columba.app.ui.screens.onboarding.pages.WelcomePage
@@ -70,7 +73,12 @@ fun OnboardingPagerScreen(
     val context = LocalContext.current
     val lifecycleOwner = LocalLifecycleOwner.current
     val scope = rememberCoroutineScope()
-    val pagerState = rememberPagerState(pageCount = { ONBOARDING_PAGE_COUNT })
+
+    // Ordered pages for this flavor. The crash-reporting opt-in page is only present when
+    // crash reporting is available (sentry flavor). Navigation below is relative
+    // (page + 1 / page - 1) so a missing page never breaks indices.
+    val pages = remember { onboardingPages(BuildConfig.CRASH_REPORTING_AVAILABLE) }
+    val pagerState = rememberPagerState(pageCount = { pages.size })
 
     // Identity data for QR code dialog
     val identityHash by debugViewModel.identityHash.collectAsState()
@@ -132,8 +140,8 @@ fun OnboardingPagerScreen(
     // Update viewmodel when user swipes
     LaunchedEffect(pagerState.currentPage) {
         viewModel.setCurrentPage(pagerState.currentPage)
-        // Refresh identity data when entering the CompletePage (page 4)
-        if (pagerState.currentPage == 4) {
+        // Refresh identity data when entering the CompletePage
+        if (pages.getOrNull(pagerState.currentPage) == OnboardingPage.COMPLETE) {
             debugViewModel.refreshIdentityData()
         }
     }
@@ -159,6 +167,7 @@ fun OnboardingPagerScreen(
                 // Top bar with Skip button
                 TopBar(
                     currentPage = pagerState.currentPage,
+                    pageCount = pages.size,
                     onSkip = {
                         viewModel.skipOnboarding { onOnboardingComplete(false) }
                     },
@@ -175,32 +184,24 @@ fun OnboardingPagerScreen(
                             .weight(1f),
                     userScrollEnabled = false,
                 ) { page ->
-                    when (page) {
-                        0 ->
+                    // Relative navigation: pages are in fixed order, so the next/previous
+                    // page is always page +/- 1 regardless of which pages this flavor includes.
+                    val goNext = { scope.launch { pagerState.animateScrollToPage(page + 1) } }
+                    val goBack = { scope.launch { pagerState.animateScrollToPage(page - 1) } }
+                    when (pages[page]) {
+                        OnboardingPage.WELCOME ->
                             WelcomePage(
-                                onGetStarted = {
-                                    scope.launch {
-                                        pagerState.animateScrollToPage(1)
-                                    }
-                                },
+                                onGetStarted = { goNext() },
                                 onRestoreFromBackup = onImportData,
                             )
-                        1 ->
+                        OnboardingPage.IDENTITY ->
                             IdentityPage(
                                 displayName = state.displayName,
                                 onDisplayNameChange = viewModel::updateDisplayName,
-                                onBack = {
-                                    scope.launch {
-                                        pagerState.animateScrollToPage(0)
-                                    }
-                                },
-                                onContinue = {
-                                    scope.launch {
-                                        pagerState.animateScrollToPage(2)
-                                    }
-                                },
+                                onBack = { goBack() },
+                                onContinue = { goNext() },
                             )
-                        2 ->
+                        OnboardingPage.CONNECTIVITY ->
                             ConnectivityPage(
                                 selectedInterfaces = state.selectedInterfaces,
                                 onInterfaceToggle = { interfaceType ->
@@ -217,18 +218,10 @@ fun OnboardingPagerScreen(
                                 },
                                 blePermissionsGranted = state.blePermissionsGranted,
                                 blePermissionsDenied = state.blePermissionsDenied,
-                                onBack = {
-                                    scope.launch {
-                                        pagerState.animateScrollToPage(1)
-                                    }
-                                },
-                                onContinue = {
-                                    scope.launch {
-                                        pagerState.animateScrollToPage(3)
-                                    }
-                                },
+                                onBack = { goBack() },
+                                onContinue = { goNext() },
                             )
-                        3 ->
+                        OnboardingPage.PERMISSIONS ->
                             PermissionsPage(
                                 notificationsGranted = state.notificationsGranted,
                                 batteryOptimizationExempt = state.batteryOptimizationExempt,
@@ -250,18 +243,17 @@ fun OnboardingPagerScreen(
                                         BatteryOptimizationManager.requestBatteryOptimizationExemption(context)
                                     }
                                 },
-                                onBack = {
-                                    scope.launch {
-                                        pagerState.animateScrollToPage(2)
-                                    }
-                                },
-                                onContinue = {
-                                    scope.launch {
-                                        pagerState.animateScrollToPage(4)
-                                    }
-                                },
+                                onBack = { goBack() },
+                                onContinue = { goNext() },
                             )
-                        4 ->
+                        OnboardingPage.CRASH_REPORTING ->
+                            CrashReportingPage(
+                                crashReportingEnabled = state.crashReportingEnabled,
+                                onCrashReportingToggle = viewModel::setCrashReportingEnabled,
+                                onBack = { goBack() },
+                                onContinue = { goNext() },
+                            )
+                        OnboardingPage.COMPLETE ->
                             CompletePage(
                                 displayName = state.displayName,
                                 selectedInterfaces = state.selectedInterfaces,
@@ -283,7 +275,7 @@ fun OnboardingPagerScreen(
 
                 // Page indicators
                 PageIndicator(
-                    pageCount = ONBOARDING_PAGE_COUNT,
+                    pageCount = pages.size,
                     currentPage = pagerState.currentPage,
                     modifier =
                         Modifier
@@ -299,6 +291,7 @@ fun OnboardingPagerScreen(
 @Composable
 private fun TopBar(
     currentPage: Int,
+    pageCount: Int,
     onSkip: () -> Unit,
     enabled: Boolean,
     modifier: Modifier = Modifier,
@@ -310,7 +303,7 @@ private fun TopBar(
                 .padding(horizontal = 8.dp, vertical = 8.dp),
     ) {
         // Skip button (not shown on last page)
-        if (currentPage < ONBOARDING_PAGE_COUNT - 1) {
+        if (currentPage < pageCount - 1) {
             TextButton(
                 onClick = onSkip,
                 enabled = enabled,

--- a/app/src/main/java/network/columba/app/ui/screens/onboarding/OnboardingState.kt
+++ b/app/src/main/java/network/columba/app/ui/screens/onboarding/OnboardingState.kt
@@ -13,6 +13,7 @@ data class OnboardingState(
     val notificationsEnabled: Boolean = false,
     val notificationsGranted: Boolean = false,
     val batteryOptimizationExempt: Boolean = false,
+    val crashReportingEnabled: Boolean = false,
     val isSaving: Boolean = false,
     val isLoading: Boolean = true,
     val hasCompletedOnboarding: Boolean = false,
@@ -53,6 +54,23 @@ enum class OnboardingInterfaceType(
 }
 
 /**
- * Total number of onboarding pages.
+ * Ordered onboarding pages. [CRASH_REPORTING] is only present in the `sentry` flavor
+ * (gated by BuildConfig.CRASH_REPORTING_AVAILABLE when the page list is built).
  */
-const val ONBOARDING_PAGE_COUNT = 5
+enum class OnboardingPage {
+    WELCOME,
+    IDENTITY,
+    CONNECTIVITY,
+    PERMISSIONS,
+    CRASH_REPORTING,
+    COMPLETE,
+}
+
+/**
+ * Build the ordered list of onboarding pages for the current build flavor. The crash
+ * reporting opt-in page is omitted entirely when crash reporting is not available.
+ */
+fun onboardingPages(crashReportingAvailable: Boolean): List<OnboardingPage> =
+    OnboardingPage.entries.filter {
+        it != OnboardingPage.CRASH_REPORTING || crashReportingAvailable
+    }

--- a/app/src/main/java/network/columba/app/ui/screens/onboarding/pages/CrashReportingPage.kt
+++ b/app/src/main/java/network/columba/app/ui/screens/onboarding/pages/CrashReportingPage.kt
@@ -1,0 +1,170 @@
+package network.columba.app.ui.screens.onboarding.pages
+
+import androidx.compose.animation.animateColorAsState
+import androidx.compose.foundation.BorderStroke
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.BugReport
+import androidx.compose.material3.Button
+import androidx.compose.material3.Card
+import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.FilledTonalButton
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Switch
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.unit.dp
+
+/**
+ * Crash reporting opt-in page (sentry flavor only).
+ *
+ * Asks the user whether to send anonymous crash reports. Defaults to off; the user must
+ * explicitly opt in. The choice is persisted when onboarding completes.
+ */
+@Composable
+fun CrashReportingPage(
+    crashReportingEnabled: Boolean,
+    onCrashReportingToggle: (Boolean) -> Unit,
+    onBack: () -> Unit,
+    onContinue: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    Column(
+        modifier =
+            modifier
+                .fillMaxSize()
+                .verticalScroll(rememberScrollState())
+                .padding(horizontal = 24.dp),
+        horizontalAlignment = Alignment.CenterHorizontally,
+    ) {
+        Spacer(modifier = Modifier.height(16.dp))
+
+        Icon(
+            imageVector = Icons.Default.BugReport,
+            contentDescription = null,
+            modifier = Modifier.size(64.dp),
+            tint = MaterialTheme.colorScheme.primary,
+        )
+
+        Spacer(modifier = Modifier.height(24.dp))
+
+        Text(
+            text = "Help Us Improve",
+            style = MaterialTheme.typography.headlineMedium,
+            fontWeight = FontWeight.Bold,
+            color = MaterialTheme.colorScheme.onBackground,
+            textAlign = TextAlign.Center,
+        )
+
+        Spacer(modifier = Modifier.height(8.dp))
+
+        Text(
+            text =
+                "Columba can send anonymous crash and error reports to help the " +
+                    "developer find and fix bugs. No message content, contacts, or " +
+                    "identity information is ever included.",
+            style = MaterialTheme.typography.bodyLarge,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+            textAlign = TextAlign.Center,
+        )
+
+        Spacer(modifier = Modifier.height(24.dp))
+
+        // Opt-in toggle card
+        val borderColor by animateColorAsState(
+            targetValue =
+                if (crashReportingEnabled) {
+                    MaterialTheme.colorScheme.primary
+                } else {
+                    MaterialTheme.colorScheme.outline
+                },
+            label = "crashReportingBorder",
+        )
+
+        Card(
+            modifier = Modifier.fillMaxWidth(),
+            shape = RoundedCornerShape(12.dp),
+            colors =
+                CardDefaults.cardColors(
+                    containerColor = MaterialTheme.colorScheme.surface,
+                ),
+            border = BorderStroke(1.dp, borderColor),
+        ) {
+            Row(
+                modifier =
+                    Modifier
+                        .fillMaxWidth()
+                        .padding(16.dp),
+                verticalAlignment = Alignment.CenterVertically,
+                horizontalArrangement = Arrangement.SpaceBetween,
+            ) {
+                Column(modifier = Modifier.weight(1f)) {
+                    Text(
+                        text = "Anonymous Crash Reports",
+                        style = MaterialTheme.typography.titleMedium,
+                        fontWeight = FontWeight.Medium,
+                        color = MaterialTheme.colorScheme.onSurface,
+                    )
+                    Text(
+                        text = "You can change this anytime in Settings → Advanced",
+                        style = MaterialTheme.typography.bodyMedium,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    )
+                }
+                Switch(
+                    checked = crashReportingEnabled,
+                    onCheckedChange = onCrashReportingToggle,
+                )
+            }
+        }
+
+        Spacer(modifier = Modifier.weight(1f))
+
+        // Navigation buttons
+        Row(
+            modifier = Modifier.fillMaxWidth(),
+            horizontalArrangement = Arrangement.spacedBy(12.dp),
+        ) {
+            FilledTonalButton(
+                onClick = onBack,
+                modifier =
+                    Modifier
+                        .weight(1f)
+                        .height(56.dp),
+                shape = RoundedCornerShape(12.dp),
+            ) {
+                Text("Back")
+            }
+
+            Button(
+                onClick = onContinue,
+                modifier =
+                    Modifier
+                        .weight(1f)
+                        .height(56.dp),
+                shape = RoundedCornerShape(12.dp),
+            ) {
+                Text("Continue")
+            }
+        }
+
+        Spacer(modifier = Modifier.height(24.dp))
+    }
+}

--- a/app/src/main/java/network/columba/app/ui/screens/settings/cards/AdvancedCard.kt
+++ b/app/src/main/java/network/columba/app/ui/screens/settings/cards/AdvancedCard.kt
@@ -7,6 +7,7 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.size
 import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.BugReport
 import androidx.compose.material.icons.filled.Cast
 import androidx.compose.material.icons.filled.Hub
 import androidx.compose.material.icons.filled.RestartAlt
@@ -23,6 +24,7 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
+import network.columba.app.BuildConfig
 import network.columba.app.ui.components.CollapsibleSettingsCard
 import network.columba.app.ui.components.LocalCapabilities
 
@@ -60,6 +62,8 @@ fun AdvancedCard(
     shareInstanceHostingPending: Boolean = false,
     onRestartReticulum: () -> Unit = {},
     isRestarting: Boolean = false,
+    crashReportingEnabled: Boolean = false,
+    onCrashReportingToggle: (Boolean) -> Unit = {},
 ) {
     val canHostShareInstance = LocalCapabilities.current.performance.shareInstanceHosting
     CollapsibleSettingsCard(
@@ -187,6 +191,45 @@ fun AdvancedCard(
                     }
                 }
             }
+        }
+
+        // Anonymous crash reporting toggle (sentry flavor only — the SDK is stripped from
+        // the noSentry flavor, so the toggle would do nothing there).
+        if (BuildConfig.CRASH_REPORTING_AVAILABLE) {
+            Spacer(Modifier.height(16.dp))
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                verticalAlignment = Alignment.CenterVertically,
+                horizontalArrangement = Arrangement.SpaceBetween,
+            ) {
+                Row(
+                    verticalAlignment = Alignment.CenterVertically,
+                    horizontalArrangement = Arrangement.spacedBy(8.dp),
+                ) {
+                    Icon(
+                        imageVector = Icons.Default.BugReport,
+                        contentDescription = null,
+                        tint = MaterialTheme.colorScheme.primary,
+                    )
+                    Text(
+                        text = "Anonymous Crash Reports",
+                        style = MaterialTheme.typography.bodyLarge,
+                        fontWeight = FontWeight.Medium,
+                    )
+                }
+                Switch(
+                    checked = crashReportingEnabled,
+                    onCheckedChange = onCrashReportingToggle,
+                )
+            }
+            Text(
+                text =
+                    "Send anonymous crash and error reports to help the developer fix bugs. " +
+                        "No message content, contacts, or identity information is ever included. " +
+                        "Off by default; you can change this at any time.",
+                style = MaterialTheme.typography.bodySmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
         }
     }
 }

--- a/app/src/main/java/network/columba/app/ui/screens/settings/dialogs/CrashReportingOptInDialog.kt
+++ b/app/src/main/java/network/columba/app/ui/screens/settings/dialogs/CrashReportingOptInDialog.kt
@@ -1,0 +1,49 @@
+package network.columba.app.ui.screens.settings.dialogs
+
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.BugReport
+import androidx.compose.material3.AlertDialog
+import androidx.compose.material3.Icon
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.runtime.Composable
+
+/**
+ * One-time opt-in dialog shown on launch to existing users (those who completed onboarding
+ * before anonymous crash reporting existed). Only used in the sentry flavor. Either choice
+ * marks the prompt seen so it never reappears.
+ */
+@Composable
+fun CrashReportingOptInDialog(
+    onEnable: () -> Unit,
+    onDismiss: () -> Unit,
+) {
+    AlertDialog(
+        onDismissRequest = onDismiss,
+        icon = {
+            Icon(
+                imageVector = Icons.Default.BugReport,
+                contentDescription = null,
+            )
+        },
+        title = { Text("Help improve Columba?") },
+        text = {
+            Text(
+                "Columba can send anonymous crash and error reports so the developer can " +
+                    "find and fix bugs. No message content, contacts, or identity " +
+                    "information is ever included. You can change this anytime in " +
+                    "Settings → Advanced.",
+            )
+        },
+        confirmButton = {
+            TextButton(onClick = onEnable) {
+                Text("Enable")
+            }
+        },
+        dismissButton = {
+            TextButton(onClick = onDismiss) {
+                Text("Not now")
+            }
+        },
+    )
+}

--- a/app/src/main/java/network/columba/app/util/CrashReportManager.kt
+++ b/app/src/main/java/network/columba/app/util/CrashReportManager.kt
@@ -122,7 +122,12 @@ class CrashReportManager
          * the value is available for the next cold start.
          */
         fun setCrashReportingConsentMirror(granted: Boolean) {
-            prefs.edit().putBoolean(KEY_CRASH_CONSENT, granted).apply()
+            // commit() (synchronous) rather than apply(): the mirror gates Sentry init at
+            // the next cold start, so a crash between the DataStore write and an async SP
+            // flush must not leave a stale `true` that re-enables reporting after the user
+            // revoked consent. Callers run on a coroutine thread, so the blocking write is
+            // negligible for a single boolean.
+            prefs.edit().putBoolean(KEY_CRASH_CONSENT, granted).commit()
         }
 
         /**

--- a/app/src/main/java/network/columba/app/util/CrashReportManager.kt
+++ b/app/src/main/java/network/columba/app/util/CrashReportManager.kt
@@ -55,6 +55,11 @@ class CrashReportManager
             private const val KEY_STACK_TRACE = "stack_trace"
             private const val KEY_LOGS = "logs"
 
+            // Synchronous mirror of the crash-reporting consent preference (the DataStore
+            // value in SettingsRepository is the source of truth). Mirrored here so it can
+            // be read without coroutines at the top of Application.onCreate().
+            private const val KEY_CRASH_CONSENT = "crash_reporting_consent"
+
             // Privacy filter patterns
             private val HASH_PATTERN = Regex("([a-fA-F0-9]{16,})")
             private val IP_PATTERN = Regex("\\b(?:\\d{1,3}\\.){3}\\d{1,3}\\b")
@@ -101,6 +106,23 @@ class CrashReportManager
          */
         fun hasPendingCrashReport(): Boolean {
             return prefs.getBoolean(KEY_HAS_CRASH, false)
+        }
+
+        /**
+         * Synchronously read whether the user has opted in to anonymous crash reporting.
+         * Defaults to false (opt-in). Safe to call from Application.onCreate().
+         */
+        fun isCrashReportingConsentGranted(): Boolean {
+            return prefs.getBoolean(KEY_CRASH_CONSENT, false)
+        }
+
+        /**
+         * Update the synchronous consent mirror. Call this alongside
+         * SettingsRepository.setCrashReportingConsent() (the DataStore source of truth) so
+         * the value is available for the next cold start.
+         */
+        fun setCrashReportingConsentMirror(granted: Boolean) {
+            prefs.edit().putBoolean(KEY_CRASH_CONSENT, granted).apply()
         }
 
         /**

--- a/app/src/main/java/network/columba/app/viewmodel/OnboardingViewModel.kt
+++ b/app/src/main/java/network/columba/app/viewmodel/OnboardingViewModel.kt
@@ -22,9 +22,11 @@ import network.columba.app.repository.InterfaceRepository
 import network.columba.app.repository.SettingsRepository
 import network.columba.app.rns.api.model.InterfaceConfig
 import network.columba.app.service.InterfaceConfigManager
+import network.columba.app.telemetry.CrashReporterProvider
 import network.columba.app.ui.screens.onboarding.OnboardingInterfaceType
 import network.columba.app.ui.screens.onboarding.OnboardingState
 import network.columba.app.util.BatteryOptimizationManager
+import network.columba.app.util.CrashReportManager
 import network.columba.app.util.getBlePermissions
 import javax.inject.Inject
 
@@ -40,6 +42,7 @@ class OnboardingViewModel
         private val identityRepository: IdentityRepository,
         private val interfaceRepository: InterfaceRepository,
         private val interfaceConfigManager: InterfaceConfigManager,
+        private val crashReportManager: CrashReportManager,
     ) : ViewModel() {
         companion object {
             private const val TAG = "OnboardingViewModel"
@@ -106,6 +109,14 @@ class OnboardingViewModel
          */
         fun updateDisplayName(name: String) {
             _state.value = _state.value.copy(displayName = name, error = null)
+        }
+
+        /**
+         * Update the anonymous crash reporting opt-in choice. Persisted when onboarding
+         * completes (see [completeOnboarding]).
+         */
+        fun setCrashReportingEnabled(enabled: Boolean) {
+            _state.value = _state.value.copy(crashReportingEnabled = enabled)
         }
 
         /**
@@ -267,6 +278,16 @@ class OnboardingViewModel
 
                     // Mark onboarding as completed - this is critical and will throw if it fails
                     settingsRepository.markOnboardingCompleted()
+
+                    // Persist the crash-reporting opt-in choice. Writes the DataStore source
+                    // of truth + the synchronous startup mirror, and activates reporting
+                    // immediately (no restart). Mark the one-time update prompt seen since
+                    // the user has now made an explicit choice during onboarding.
+                    val crashReportingEnabled = _state.value.crashReportingEnabled
+                    settingsRepository.setCrashReportingConsent(crashReportingEnabled)
+                    crashReportManager.setCrashReportingConsentMirror(crashReportingEnabled)
+                    settingsRepository.markCrashReportingPromptSeen()
+                    CrashReporterProvider.create().setEnabled(crashReportingEnabled)
 
                     // Restart service to apply changes. Flip UI to "done" at Step 9
                     // (RNS ready) rather than after the full apply — on a fresh

--- a/app/src/main/java/network/columba/app/viewmodel/SettingsViewModel.kt
+++ b/app/src/main/java/network/columba/app/viewmodel/SettingsViewModel.kt
@@ -11,6 +11,7 @@ import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharedFlow
+import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asSharedFlow
 import kotlinx.coroutines.flow.asStateFlow
@@ -20,8 +21,10 @@ import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.flow.drop
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
+import network.columba.app.BuildConfig
 import network.columba.app.data.model.EnrichedContact
 import network.columba.app.data.model.ImageCompressionPreset
 import network.columba.app.data.repository.ContactRepository
@@ -123,6 +126,8 @@ data class SettingsState(
     // Transport node + battery profile state
     val transportNodeEnabled: Boolean = true,
     val batteryProfile: BatteryProfile = BatteryProfile.BALANCED,
+    // Anonymous crash reporting opt-in (sentry flavor only). Defaults to off.
+    val crashReportingEnabled: Boolean = false,
     // RNS shared-instance HOSTING (python backend only; capability-gated in UI).
     //
     // - `shareInstanceHostingEnabled` mirrors the persisted preference — what
@@ -215,6 +220,7 @@ class SettingsViewModel
         private val telemetryCollectorManager: TelemetryCollectorManager,
         private val contactRepository: ContactRepository,
         private val updateChecker: network.columba.app.service.UpdateChecker,
+        private val crashReportManager: network.columba.app.util.CrashReportManager,
     ) : ViewModel() {
         companion object {
             private const val TAG = "SettingsViewModel"
@@ -363,6 +369,7 @@ class SettingsViewModel
                         settingsRepository.autoRetrieveEnabledFlow,
                         settingsRepository.retrievalIntervalSecondsFlow,
                         settingsRepository.shareInstanceHostingEnabledFlow,
+                        settingsRepository.crashReportingConsentFlow,
                     ) { flows ->
                         @Suppress("UNCHECKED_CAST")
                         val activeIdentity = flows[0] as network.columba.app.data.db.entity.LocalIdentityEntity?
@@ -417,6 +424,9 @@ class SettingsViewModel
                         @Suppress("UNCHECKED_CAST")
                         val shareInstanceHostingEnabled = flows[16] as Boolean
 
+                        @Suppress("UNCHECKED_CAST")
+                        val crashReportingEnabled = flows[17] as Boolean
+
                         val displayName = activeIdentity?.displayName ?: defaultName
                         val resolvedIdentityHash = identityInfo.first ?: activeIdentity?.identityHash ?: _state.value.identityHash
                         val resolvedDestinationHash = identityInfo.second ?: activeIdentity?.destinationHash ?: _state.value.destinationHash
@@ -463,6 +473,7 @@ class SettingsViewModel
                             // Transport node + battery profile state
                             transportNodeEnabled = transportNodeEnabled,
                             batteryProfile = batteryProfile,
+                            crashReportingEnabled = crashReportingEnabled,
                             // Share-instance hosting: persisted preference reflected
                             // immediately. `applied` anchors to the persisted value
                             // on the first emission (isLoading flips false in the
@@ -1707,6 +1718,57 @@ class SettingsViewModel
                 if (!_state.value.isRestarting) {
                     restartService()
                 }
+            }
+        }
+
+        /**
+         * Set the anonymous crash reporting opt-in (sentry flavor only).
+         * Persists the DataStore source of truth + the synchronous startup mirror, and
+         * activates/deactivates reporting immediately (no restart required).
+         */
+        fun setCrashReportingEnabled(enabled: Boolean) {
+            viewModelScope.launch {
+                settingsRepository.setCrashReportingConsent(enabled)
+                crashReportManager.setCrashReportingConsentMirror(enabled)
+                network.columba.app.telemetry.CrashReporterProvider
+                    .create()
+                    .setEnabled(enabled)
+                Log.d(TAG, "Crash reporting ${if (enabled) "enabled" else "disabled"}")
+            }
+        }
+
+        /**
+         * Whether to show the one-time crash-reporting opt-in dialog. True only for an
+         * existing user (onboarding complete) on the sentry flavor who has neither seen the
+         * prompt nor already opted in. New users make this choice during onboarding.
+         */
+        val shouldShowCrashReportingPrompt: StateFlow<Boolean> =
+            combine(
+                settingsRepository.hasCompletedOnboardingFlow,
+                settingsRepository.hasSeenCrashReportingPromptFlow,
+                settingsRepository.crashReportingConsentFlow,
+            ) { completed, seen, consent ->
+                BuildConfig.CRASH_REPORTING_AVAILABLE && completed && !seen && !consent
+            }.stateIn(
+                scope = viewModelScope,
+                started = SharingStarted.WhileSubscribed(5000L),
+                initialValue = false,
+            )
+
+        /** Opt in from the one-time prompt and mark it seen so it never reappears. */
+        fun enableCrashReportingFromPrompt() {
+            setCrashReportingEnabled(true)
+            markCrashReportingPromptSeen()
+        }
+
+        /** Decline the one-time prompt; mark it seen so it never reappears. */
+        fun dismissCrashReportingPrompt() {
+            markCrashReportingPromptSeen()
+        }
+
+        private fun markCrashReportingPromptSeen() {
+            viewModelScope.launch {
+                settingsRepository.markCrashReportingPromptSeen()
             }
         }
 

--- a/app/src/noSentry/java/network/columba/app/telemetry/CrashReporterProvider.kt
+++ b/app/src/noSentry/java/network/columba/app/telemetry/CrashReporterProvider.kt
@@ -1,0 +1,15 @@
+package network.columba.app.telemetry
+
+/**
+ * Flavor-bound factory. The `noSentry` flavor returns a no-op reporter, ensuring no
+ * crash/telemetry data ever leaves the device and the Sentry SDK is not linked in.
+ *
+ * The matching object in `src/sentry` returns the Sentry-backed reporter. Both source
+ * sets declare the same fully-qualified name so `src/main` resolves the correct
+ * implementation at compile time per flavor.
+ */
+object CrashReporterProvider {
+    private val instance: CrashReporter by lazy { NoOpCrashReporter() }
+
+    fun create(): CrashReporter = instance
+}

--- a/app/src/noSentry/java/network/columba/app/telemetry/NoOpCrashReporter.kt
+++ b/app/src/noSentry/java/network/columba/app/telemetry/NoOpCrashReporter.kt
@@ -1,0 +1,25 @@
+package network.columba.app.telemetry
+
+import android.content.Context
+
+/**
+ * No-op [CrashReporter] used by the `noSentry` product flavor.
+ *
+ * This class — and the entire `noSentry` source set — contains zero references to
+ * `io.sentry.*`, which is what guarantees the Sentry SDK is fully absent from the
+ * `noSentry` APK. Every method is intentionally empty.
+ */
+internal class NoOpCrashReporter : CrashReporter {
+    override fun initialize(
+        context: Context,
+        environment: String,
+        isDebug: Boolean,
+        consentGranted: Boolean,
+    ) = Unit
+
+    override fun setEnabled(enabled: Boolean) = Unit
+
+    override fun addBreadcrumb(breadcrumb: CrashBreadcrumb) = Unit
+
+    override fun captureException(throwable: Throwable) = Unit
+}

--- a/app/src/sentry/java/network/columba/app/telemetry/CrashReporterProvider.kt
+++ b/app/src/sentry/java/network/columba/app/telemetry/CrashReporterProvider.kt
@@ -1,0 +1,17 @@
+package network.columba.app.telemetry
+
+/**
+ * Flavor-bound factory. The `sentry` flavor returns the Sentry-backed reporter.
+ *
+ * The matching object in `src/noSentry` returns a no-op so the Sentry SDK is absent from
+ * that APK. Both source sets declare the same fully-qualified name so `src/main` resolves
+ * the correct implementation at compile time per flavor.
+ */
+object CrashReporterProvider {
+    // Process-wide singleton so that ColumbaApplication.initialize(...) and a later
+    // setEnabled(...) from settings/onboarding act on the same instance (the latter can
+    // then lazily initialize Sentry using the args captured at startup).
+    private val instance: CrashReporter by lazy { SentryCrashReporter() }
+
+    fun create(): CrashReporter = instance
+}

--- a/app/src/sentry/java/network/columba/app/telemetry/SentryCrashReporter.kt
+++ b/app/src/sentry/java/network/columba/app/telemetry/SentryCrashReporter.kt
@@ -1,0 +1,146 @@
+package network.columba.app.telemetry
+
+import android.content.Context
+import android.util.Log
+import io.sentry.Breadcrumb
+import io.sentry.Sentry
+import io.sentry.SentryLevel
+import io.sentry.android.core.SentryAndroid
+import network.columba.app.BuildConfig
+
+/**
+ * Sentry-backed [CrashReporter] used by the `sentry` product flavor.
+ *
+ * Initialization is consent-gated: [SentryAndroid.init] is only ever called once the user
+ * has opted in. Until then nothing is sent to the Sentry servers.
+ */
+internal class SentryCrashReporter : CrashReporter {
+    private companion object {
+        private const val TAG = "SentryCrashReporter"
+    }
+
+    @Volatile
+    private var initialized = false
+
+    // Captured init args so consent granted later (via [setEnabled]) can lazily init.
+    private var appContext: Context? = null
+    private var environment: String = "production"
+    private var isDebug: Boolean = false
+
+    override fun initialize(
+        context: Context,
+        environment: String,
+        isDebug: Boolean,
+        consentGranted: Boolean,
+    ) {
+        appContext = context.applicationContext
+        this.environment = environment
+        this.isDebug = isDebug
+
+        if (consentGranted) {
+            initSentry()
+        } else {
+            Log.d(TAG, "Crash reporting consent not granted; Sentry not initialized")
+        }
+    }
+
+    override fun setEnabled(enabled: Boolean) {
+        if (enabled) {
+            if (!initialized) initSentry()
+        } else {
+            // Once initialized, Sentry cannot be torn down mid-process; closing it is the
+            // closest equivalent and stops further uploads until the next launch.
+            if (initialized) {
+                Sentry.close()
+                initialized = false
+                Log.d(TAG, "Sentry closed; crash reporting disabled")
+            }
+        }
+    }
+
+    // The Sentry static API delegates to a global no-op hub when the SDK is not
+    // initialized, so these are safe to call without an instance-level guard. This also
+    // lets a separate CrashReporter instance (e.g. in MainActivity) record breadcrumbs
+    // against the global hub that ColumbaApplication initialized after consent.
+    override fun addBreadcrumb(breadcrumb: CrashBreadcrumb) {
+        Sentry.addBreadcrumb(
+            Breadcrumb().apply {
+                category = breadcrumb.category
+                message = breadcrumb.message
+                level = breadcrumb.level.toSentryLevel()
+                breadcrumb.data.forEach { (key, value) -> setData(key, value) }
+            },
+        )
+    }
+
+    override fun captureException(throwable: Throwable) {
+        Sentry.captureException(throwable)
+    }
+
+    private fun initSentry() {
+        val context = appContext ?: return
+        try {
+            SentryAndroid.init(context) { options ->
+                // DSN from BuildConfig - set via SENTRY_DSN environment variable at build time.
+                options.dsn = BuildConfig.SENTRY_DSN
+
+                // Defense-in-depth: never enable without a DSN even if consent is granted.
+                options.isEnabled = BuildConfig.SENTRY_DSN.isNotEmpty()
+
+                // Tag the environment so events are filterable in the Sentry dashboard.
+                options.environment = environment
+
+                // Performance Monitoring - Tracing
+                if (isDebug) {
+                    options.tracesSampleRate = 0.1 // 10% sampling for debug
+                    options.profilesSampleRate = 0.0 // No profiling in debug
+                } else {
+                    options.tracesSampleRate = 0.5 // 50% sampling appropriate for <500 users
+                    options.profilesSampleRate = 0.1 // Profile 10% of sampled transactions
+                }
+
+                // Activity & Fragment tracing (enabled by default)
+                options.isEnableActivityLifecycleTracingAutoFinish = true
+
+                // User Interaction tracing (clicks, scrolls, swipes)
+                options.isEnableUserInteractionTracing = true
+                options.isEnableUserInteractionBreadcrumbs = true
+
+                // App Start performance tracking (cold/warm starts)
+                options.isEnableAppStartProfiling = !isDebug
+
+                // ANR Detection (Application Not Responding)
+                options.isAnrEnabled = true
+                options.anrTimeoutIntervalMillis = 5000 // 5 second ANR threshold
+                options.isAttachAnrThreadDump = true
+
+                // Frame Tracking (slow/frozen frames)
+                options.isEnableFramesTracking = true
+
+                // Breadcrumbs for debugging
+                options.isEnableActivityLifecycleBreadcrumbs = true
+                options.isEnableAppComponentBreadcrumbs = true
+                options.isEnableSystemEventBreadcrumbs = true
+
+                Log.d(
+                    TAG,
+                    "Sentry initialized: enabled=${options.isEnabled}, " +
+                        "environment=${options.environment}, " +
+                        "tracing=${options.tracesSampleRate}, " +
+                        "hasDsn=${BuildConfig.SENTRY_DSN.isNotEmpty()}",
+                )
+            }
+            initialized = true
+        } catch (e: Exception) {
+            Log.e(TAG, "Failed to initialize Sentry", e)
+        }
+    }
+
+    private fun CrashReportLevel.toSentryLevel(): SentryLevel =
+        when (this) {
+            CrashReportLevel.DEBUG -> SentryLevel.DEBUG
+            CrashReportLevel.INFO -> SentryLevel.INFO
+            CrashReportLevel.WARNING -> SentryLevel.WARNING
+            CrashReportLevel.ERROR -> SentryLevel.ERROR
+        }
+}

--- a/app/src/test/java/network/columba/app/ui/screens/onboarding/OnboardingPagerScreenTest.kt
+++ b/app/src/test/java/network/columba/app/ui/screens/onboarding/OnboardingPagerScreenTest.kt
@@ -39,6 +39,12 @@ class OnboardingPagerScreenTest {
 
     val composeTestRule get() = composeRule
 
+    // Index of the CompletePage for the current build flavor. The crash-reporting opt-in
+    // page is inserted before CompletePage in the sentry flavor, so this is not a constant.
+    private val completePageIndex =
+        onboardingPages(network.columba.app.BuildConfig.CRASH_REPORTING_AVAILABLE)
+            .indexOf(OnboardingPage.COMPLETE)
+
     // ========== Test 1: Initial render shows welcome page (page 0) ==========
 
     @Test
@@ -308,7 +314,7 @@ class OnboardingPagerScreenTest {
     fun pagerContainsAllPages_page4_completePage() {
         // Given
         var refreshIdentityDataCalled = false
-        val mockViewModel = createMockOnboardingViewModel(currentPage = 4)
+        val mockViewModel = createMockOnboardingViewModel(currentPage = completePageIndex)
         val mockDebugViewModel = createMockDebugViewModel()
         every { mockDebugViewModel.refreshIdentityData() } answers {
             refreshIdentityDataCalled = true
@@ -448,7 +454,7 @@ class OnboardingPagerScreenTest {
         var refreshIdentityDataCalled = false
         val mockViewModel =
             createMockOnboardingViewModel(
-                currentPage = 4,
+                currentPage = completePageIndex,
                 selectedInterfaces = setOf(OnboardingInterfaceType.AUTO),
             )
         val mockDebugViewModel = createMockDebugViewModel()
@@ -492,7 +498,7 @@ class OnboardingPagerScreenTest {
         var refreshIdentityDataCalled = false
         val mockViewModel =
             createMockOnboardingViewModel(
-                currentPage = 4,
+                currentPage = completePageIndex,
                 selectedInterfaces = setOf(OnboardingInterfaceType.AUTO, OnboardingInterfaceType.RNODE),
             )
         val mockDebugViewModel = createMockDebugViewModel()
@@ -553,7 +559,7 @@ class OnboardingPagerScreenTest {
     @Test
     fun skipButton_hiddenOnLastPage() {
         // Given - On the complete page (page 4 = ONBOARDING_PAGE_COUNT - 1)
-        val mockViewModel = createMockOnboardingViewModel(currentPage = 4)
+        val mockViewModel = createMockOnboardingViewModel(currentPage = completePageIndex)
         val mockDebugViewModel = createMockDebugViewModel()
 
         // When
@@ -600,7 +606,7 @@ class OnboardingPagerScreenTest {
     fun completePage_triggersRefreshIdentityData() {
         // Given
         var refreshIdentityDataCalled = false
-        val mockViewModel = createMockOnboardingViewModel(currentPage = 4)
+        val mockViewModel = createMockOnboardingViewModel(currentPage = completePageIndex)
         val mockDebugViewModel = createMockDebugViewModel()
         every { mockDebugViewModel.refreshIdentityData() } answers {
             refreshIdentityDataCalled = true

--- a/app/src/test/java/network/columba/app/viewmodel/OnboardingViewModelPermissionsTest.kt
+++ b/app/src/test/java/network/columba/app/viewmodel/OnboardingViewModelPermissionsTest.kt
@@ -73,7 +73,8 @@ class OnboardingViewModelPermissionsTest {
         mockIdentityRepository = mockk()
         mockInterfaceRepository = mockk()
         mockInterfaceConfigManager = mockk()
-        mockCrashReportManager = mockk(relaxed = true)
+        mockCrashReportManager = mockk()
+        every { mockCrashReportManager.setCrashReportingConsentMirror(any()) } returns Unit
 
         coEvery { mockSettingsRepository.hasCompletedOnboardingFlow } returns MutableStateFlow(false)
         coEvery { mockSettingsRepository.needsIdentityUnlockFlow } returns MutableStateFlow(false)

--- a/app/src/test/java/network/columba/app/viewmodel/OnboardingViewModelPermissionsTest.kt
+++ b/app/src/test/java/network/columba/app/viewmodel/OnboardingViewModelPermissionsTest.kt
@@ -60,6 +60,7 @@ class OnboardingViewModelPermissionsTest {
     private lateinit var mockIdentityRepository: IdentityRepository
     private lateinit var mockInterfaceRepository: InterfaceRepository
     private lateinit var mockInterfaceConfigManager: InterfaceConfigManager
+    private lateinit var mockCrashReportManager: network.columba.app.util.CrashReportManager
     private val testDispatcher = StandardTestDispatcher()
     private lateinit var context: Context
 
@@ -72,6 +73,7 @@ class OnboardingViewModelPermissionsTest {
         mockIdentityRepository = mockk()
         mockInterfaceRepository = mockk()
         mockInterfaceConfigManager = mockk()
+        mockCrashReportManager = mockk(relaxed = true)
 
         coEvery { mockSettingsRepository.hasCompletedOnboardingFlow } returns MutableStateFlow(false)
         coEvery { mockSettingsRepository.needsIdentityUnlockFlow } returns MutableStateFlow(false)
@@ -98,6 +100,7 @@ class OnboardingViewModelPermissionsTest {
             mockIdentityRepository,
             mockInterfaceRepository,
             mockInterfaceConfigManager,
+            mockCrashReportManager,
         )
 
     private fun stubBlePermissionsAllGranted() {

--- a/app/src/test/java/network/columba/app/viewmodel/OnboardingViewModelTest.kt
+++ b/app/src/test/java/network/columba/app/viewmodel/OnboardingViewModelTest.kt
@@ -58,7 +58,8 @@ class OnboardingViewModelTest {
         mockIdentityRepository = mockk()
         mockInterfaceRepository = mockk()
         mockInterfaceConfigManager = mockk()
-        mockCrashReportManager = mockk(relaxed = true)
+        mockCrashReportManager = mockk()
+        every { mockCrashReportManager.setCrashReportingConsentMirror(any()) } returns Unit
 
         // Default stubs for SettingsRepository
         coEvery { mockSettingsRepository.hasCompletedOnboardingFlow } returns MutableStateFlow(false)

--- a/app/src/test/java/network/columba/app/viewmodel/OnboardingViewModelTest.kt
+++ b/app/src/test/java/network/columba/app/viewmodel/OnboardingViewModelTest.kt
@@ -47,6 +47,7 @@ class OnboardingViewModelTest {
     private lateinit var mockIdentityRepository: IdentityRepository
     private lateinit var mockInterfaceRepository: InterfaceRepository
     private lateinit var mockInterfaceConfigManager: InterfaceConfigManager
+    private lateinit var mockCrashReportManager: network.columba.app.util.CrashReportManager
     private val testDispatcher = StandardTestDispatcher()
 
     @Before
@@ -57,11 +58,14 @@ class OnboardingViewModelTest {
         mockIdentityRepository = mockk()
         mockInterfaceRepository = mockk()
         mockInterfaceConfigManager = mockk()
+        mockCrashReportManager = mockk(relaxed = true)
 
         // Default stubs for SettingsRepository
         coEvery { mockSettingsRepository.hasCompletedOnboardingFlow } returns MutableStateFlow(false)
         coEvery { mockSettingsRepository.needsIdentityUnlockFlow } returns MutableStateFlow(false)
         coEvery { mockSettingsRepository.markOnboardingCompleted() } just Runs
+        coEvery { mockSettingsRepository.setCrashReportingConsent(any()) } just Runs
+        coEvery { mockSettingsRepository.markCrashReportingPromptSeen() } just Runs
 
         // Default stubs for IdentityRepository
         coEvery { mockIdentityRepository.getActiveIdentitySync() } returns null
@@ -94,6 +98,7 @@ class OnboardingViewModelTest {
             mockIdentityRepository,
             mockInterfaceRepository,
             mockInterfaceConfigManager,
+            mockCrashReportManager,
         )
 
     private fun createTestIdentity(

--- a/app/src/test/java/network/columba/app/viewmodel/SettingsViewModelIncomingMessageLimitTest.kt
+++ b/app/src/test/java/network/columba/app/viewmodel/SettingsViewModelIncomingMessageLimitTest.kt
@@ -121,7 +121,8 @@ class SettingsViewModelIncomingMessageLimitTest {
         telemetryCollectorManager = mockk()
         contactRepository = mockk()
         updateChecker = mockk()
-        crashReportManager = mockk(relaxed = true)
+        crashReportManager = mockk()
+        every { crashReportManager.setCrashReportingConsentMirror(any()) } returns Unit
         context =
             mockk {
                 val mockEditor =

--- a/app/src/test/java/network/columba/app/viewmodel/SettingsViewModelIncomingMessageLimitTest.kt
+++ b/app/src/test/java/network/columba/app/viewmodel/SettingsViewModelIncomingMessageLimitTest.kt
@@ -74,6 +74,7 @@ class SettingsViewModelIncomingMessageLimitTest {
     private lateinit var telemetryCollectorManager: TelemetryCollectorManager
     private lateinit var contactRepository: network.columba.app.data.repository.ContactRepository
     private lateinit var updateChecker: network.columba.app.service.UpdateChecker
+    private lateinit var crashReportManager: network.columba.app.util.CrashReportManager
     private lateinit var context: android.content.Context
     private lateinit var viewModel: SettingsViewModel
 
@@ -120,6 +121,7 @@ class SettingsViewModelIncomingMessageLimitTest {
         telemetryCollectorManager = mockk()
         contactRepository = mockk()
         updateChecker = mockk()
+        crashReportManager = mockk(relaxed = true)
         context =
             mockk {
                 val mockEditor =
@@ -173,6 +175,9 @@ class SettingsViewModelIncomingMessageLimitTest {
         every { settingsRepository.autoRetrieveEnabledFlow } returns autoRetrieveEnabledFlow
         every { settingsRepository.retrievalIntervalSecondsFlow } returns retrievalIntervalSecondsFlow
         every { settingsRepository.transportNodeEnabledFlow } returns transportNodeEnabledFlow
+        every { settingsRepository.crashReportingConsentFlow } returns kotlinx.coroutines.flow.MutableStateFlow(false)
+        every { settingsRepository.hasCompletedOnboardingFlow } returns kotlinx.coroutines.flow.MutableStateFlow(true)
+        every { settingsRepository.hasSeenCrashReportingPromptFlow } returns kotlinx.coroutines.flow.MutableStateFlow(true)
         every { settingsRepository.defaultDeliveryMethodFlow } returns defaultDeliveryMethodFlow
         every { settingsRepository.locationSharingEnabledFlow } returns MutableStateFlow(false)
         every { settingsRepository.defaultSharingDurationFlow } returns MutableStateFlow("ONE_HOUR")
@@ -260,6 +265,7 @@ class SettingsViewModelIncomingMessageLimitTest {
             telemetryCollectorManager = telemetryCollectorManager,
             contactRepository = contactRepository,
             updateChecker = updateChecker,
+            crashReportManager = crashReportManager,
         )
 
     // ========== Initial State Tests ==========

--- a/app/src/test/java/network/columba/app/viewmodel/SettingsViewModelTest.kt
+++ b/app/src/test/java/network/columba/app/viewmodel/SettingsViewModelTest.kt
@@ -77,6 +77,7 @@ class SettingsViewModelTest {
     private lateinit var telemetryCollectorManager: TelemetryCollectorManager
     private lateinit var contactRepository: ContactRepository
     private lateinit var updateChecker: network.columba.app.service.UpdateChecker
+    private lateinit var crashReportManager: network.columba.app.util.CrashReportManager
     private lateinit var context: android.content.Context
     private lateinit var viewModel: SettingsViewModel
 
@@ -126,6 +127,7 @@ class SettingsViewModelTest {
         telemetryCollectorManager = mockk()
         contactRepository = mockk()
         updateChecker = mockk()
+        crashReportManager = mockk(relaxed = true)
         context =
             mockk {
                 val mockEditor =
@@ -175,6 +177,9 @@ class SettingsViewModelTest {
         every { settingsRepository.autoRetrieveEnabledFlow } returns autoRetrieveEnabledFlow
         every { settingsRepository.retrievalIntervalSecondsFlow } returns retrievalIntervalSecondsFlow
         every { settingsRepository.transportNodeEnabledFlow } returns transportNodeEnabledFlow
+        every { settingsRepository.crashReportingConsentFlow } returns kotlinx.coroutines.flow.MutableStateFlow(false)
+        every { settingsRepository.hasCompletedOnboardingFlow } returns kotlinx.coroutines.flow.MutableStateFlow(true)
+        every { settingsRepository.hasSeenCrashReportingPromptFlow } returns kotlinx.coroutines.flow.MutableStateFlow(true)
         every { settingsRepository.batteryProfileFlow } returns batteryProfileFlow
         every { settingsRepository.defaultDeliveryMethodFlow } returns defaultDeliveryMethodFlow
         every { settingsRepository.imageCompressionPresetFlow } returns imageCompressionPresetFlow
@@ -293,6 +298,7 @@ class SettingsViewModelTest {
             telemetryCollectorManager = telemetryCollectorManager,
             contactRepository = contactRepository,
             updateChecker = updateChecker,
+            crashReportManager = crashReportManager,
         )
 
     // region parseRpcKey Tests
@@ -1622,6 +1628,7 @@ class SettingsViewModelTest {
                     telemetryCollectorManager = telemetryCollectorManager,
                     contactRepository = contactRepository,
                     updateChecker = updateChecker,
+                    crashReportManager = crashReportManager,
                 )
 
             viewModel.state.test {
@@ -1674,6 +1681,7 @@ class SettingsViewModelTest {
                     telemetryCollectorManager = telemetryCollectorManager,
                     contactRepository = contactRepository,
                     updateChecker = updateChecker,
+                    crashReportManager = crashReportManager,
                 )
 
             viewModel.state.test {
@@ -2304,6 +2312,7 @@ class SettingsViewModelTest {
                     telemetryCollectorManager = telemetryCollectorManager,
                     contactRepository = contactRepository,
                     updateChecker = updateChecker,
+                    crashReportManager = crashReportManager,
                 )
 
             // Wait for any potential async operations to settle
@@ -2353,6 +2362,7 @@ class SettingsViewModelTest {
                     telemetryCollectorManager = telemetryCollectorManager,
                     contactRepository = contactRepository,
                     updateChecker = updateChecker,
+                    crashReportManager = crashReportManager,
                 )
 
             // The ViewModel should be created successfully with NativeReticulumProtocol

--- a/app/src/test/java/network/columba/app/viewmodel/SettingsViewModelTest.kt
+++ b/app/src/test/java/network/columba/app/viewmodel/SettingsViewModelTest.kt
@@ -127,7 +127,8 @@ class SettingsViewModelTest {
         telemetryCollectorManager = mockk()
         contactRepository = mockk()
         updateChecker = mockk()
-        crashReportManager = mockk(relaxed = true)
+        crashReportManager = mockk()
+        every { crashReportManager.setCrashReportingConsentMirror(any()) } returns Unit
         context =
             mockk {
                 val mockEditor =

--- a/rns-backend-kt/build.gradle.kts
+++ b/rns-backend-kt/build.gradle.kts
@@ -93,9 +93,6 @@ dependencies {
     // Room runtime (native process access to Reticulum stores).
     implementation(libs.room)
 
-    // Crash Reporting - Sentry (for instrumented metrics).
-    implementation("io.sentry:sentry-android:8.31.0")
-
     // Testing
     testImplementation(libs.junit)
     testImplementation(libs.junit.jupiter)

--- a/rns-host/build.gradle.kts
+++ b/rns-host/build.gradle.kts
@@ -142,9 +142,6 @@ dependencies {
     // directly from the :reticulum process.
     implementation(project(":data"))
 
-    // Crash reporting — KotlinBLEBridge metrics already wire through Sentry.
-    implementation("io.sentry:sentry-android:8.31.0")
-
     // Testing
     testImplementation(libs.junit)
     testImplementation(libs.junit.jupiter)


### PR DESCRIPTION
## Summary

Reworks Sentry crash reporting so that (1) the `noSentry` flavor truly ships with **no Sentry SDK in the binary**, and (2) the `sentry` flavor reports **nothing until the user opts in**.

Previously the Sentry SDK was compiled into *both* flavors — `noSentry` only had an empty DSN — and the `sentry` flavor uploaded automatically whenever a DSN was present, with no user consent.

## Part 1 — Build-time removal from `noSentry`

- New `CrashReporter` abstraction in `src/main` (`telemetry/CrashReporter.kt`) — no `io.sentry.*` imports.
- `SentryCrashReporter` in `src/sentry/`, `NoOpCrashReporter` in `src/noSentry/`, bound via a per-flavor `CrashReporterProvider` (process-wide singleton).
- `ColumbaApplication` / `MainActivity` call only the abstraction.
- `app/build.gradle.kts`: dependency scoped to `sentryImplementation`, `autoInstallation.enabled = false`, and `noSentry` variants excluded from instrumentation via `ignoredVariants` (`ignoredFlavors` alone did **not** gate the logcat instrumentation, which would have left dangling `SentryLogcatAdapter` refs → `NoClassDefFoundError`).
- Removed two **unused** `io.sentry:sentry-android` dependencies from `:rns-host` and `:rns-backend-kt` that were leaking the SDK transitively into both flavors.

**Verified:** `noSentry` APK = **0** `io/sentry` references; `sentry` APK retains the SDK + instrumentation + `SentryCrashReporter`.

## Part 2 — Consent-first reporting (`sentry` flavor only)

Off by default; opt in via any of:
- a new **onboarding page** (`CrashReportingPage`),
- an **Advanced settings** toggle, or
- a **one-time launch prompt** for existing users (`HAS_SEEN_CRASH_REPORTING_PROMPT`, shows once).

Consent gates the entire Sentry init and is mirrored into `SharedPreferences` for a synchronous read at startup (the existing `CrashReportManager` owns that file). All crash-reporting UI is gated behind `BuildConfig.CRASH_REPORTING_AVAILABLE` so it never appears in `noSentry`.

## Testing

- Affected unit tests updated and passing (`OnboardingViewModelTest`, `OnboardingPagerScreenTest`, `SettingsViewModelTest`, `SettingsViewModelIncomingMessageLimitTest`, permissions test).
- Both flavors assemble; dex inspected to confirm stripping.
- Manually validated on-device (`sentry` flavor): onboarding page + Advanced toggle, and the one-time prompt via the skip path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)