### PR TITLE
fix(rns): inbound LXST voice R8 regression + enforce @ReflectivelyKept keep contract

### DIFF
--- a/app/proguard-rules.pro
+++ b/app/proguard-rules.pro
@@ -46,14 +46,19 @@
     volatile <fields>;
 }
 
-# ===== Python <-> Kotlin bridge classes =====
-# The Chaquopy-called bridges (KotlinRNodeBridge, KotlinBLEBridge,
-# KotlinUSBBridge in :rns-host, PythonEventBridge in :rns-backend-py) are now
-# kept via @Keep (androidx.annotation.Keep) on the classes themselves — see
-# PythonKotlinBridgeR8Test for the CI gate. The old
-# `-keep class network.columba.app.reticulum.protocol.** { *; }` rule was
-# removed: that package no longer holds any shipped bridge (only test classes),
-# so the glob protected nothing.
+# ===== Reflectively-invoked bridge classes (Chaquopy / JNI-by-name) =====
+# Classes invoked by name across a boundary R8 can't see (Python via Chaquopy,
+# JNI) carry @network.columba.app.rns.api.annotation.ReflectivelyKept. Keeping
+# them at class level preserves all current AND future members, so adding a
+# method to a bridge needs no rule change. The ReflectivelyKeptRequired detekt
+# rule enforces the annotation on Chaquopy bridge shapes (fun interfaces in
+# :rns-backend-py + Kotlin*Bridge classes) so a new bridge can't merge
+# unprotected.
+#
+# (Replaces the previous per-class androidx.annotation.Keep convention; the old
+# `-keep class network.columba.app.reticulum.protocol.** { *; }` glob was
+# already removed — it protected only test classes after a package rename.)
+-keep @network.columba.app.rns.api.annotation.ReflectivelyKept class * { *; }
 
 # ===== Chaquopy (Python runtime) =====
 # Restored from release/v0.10.x: the com.lxmf.messenger -> network.columba.app

--- a/detekt-config.yml
+++ b/detekt-config.yml
@@ -132,6 +132,8 @@ columba:
     active: true
   NoVerifyOnlyTests:
     active: true
+  ReflectivelyKeptRequired:
+    active: true
   StateFlowPollingLoop:
     active: true
 

--- a/detekt-rules/src/main/kotlin/network/columba/app/detekt/rules/ColumbaRuleSetProvider.kt
+++ b/detekt-rules/src/main/kotlin/network/columba/app/detekt/rules/ColumbaRuleSetProvider.kt
@@ -18,6 +18,7 @@ class ColumbaRuleSetProvider : RuleSetProvider {
                 DiscardedConcurrencyReturnRule(config),
                 NoCallCoordinatorGetInstanceOutsideHostRule(config),
                 NoRnsFacadeInPythonBackend(config),
+                ReflectivelyKeptRequiredRule(config),
                 NoRelaxedMocksRule(config),
                 NoVerifyOnlyTestsRule(config),
                 StateFlowPollingLoopRule(config),

--- a/detekt-rules/src/main/kotlin/network/columba/app/detekt/rules/ReflectivelyKeptRequiredRule.kt
+++ b/detekt-rules/src/main/kotlin/network/columba/app/detekt/rules/ReflectivelyKeptRequiredRule.kt
@@ -1,0 +1,93 @@
+package network.columba.app.detekt.rules
+
+import io.gitlab.arturbosch.detekt.api.CodeSmell
+import io.gitlab.arturbosch.detekt.api.Config
+import io.gitlab.arturbosch.detekt.api.Debt
+import io.gitlab.arturbosch.detekt.api.Entity
+import io.gitlab.arturbosch.detekt.api.Issue
+import io.gitlab.arturbosch.detekt.api.Rule
+import io.gitlab.arturbosch.detekt.api.Severity
+import org.jetbrains.kotlin.lexer.KtTokens
+import org.jetbrains.kotlin.psi.KtClass
+import org.jetbrains.kotlin.psi.KtClassOrObject
+
+/**
+ * Requires `@network.columba.app.rns.api.annotation.ReflectivelyKept` on the
+ * Chaquopy bridge shapes, so R8 cannot rename/strip a class that Python invokes
+ * by name in a minified release build.
+ *
+ * This is the enforcement half of the `@ReflectivelyKept` contract: the
+ * annotation is class-level (keeps all current + future members), but nothing
+ * in Kotlin can see that Python calls the class — so a new bridge added without
+ * the annotation would compile, pass tests, and only fail in release. That is
+ * exactly the inbound-voice `PyTwoArgCallback` regression that motivated this.
+ *
+ * **What it flags** (in `:rns-backend-py` / `:rns-host` only):
+ *  1. a `fun interface` in the `network.columba.app.rns.backend.py` package —
+ *     the Chaquopy callback SAM shape (`PyEventCallback`, `PyTwoArgCallback`);
+ *  2. a class/object named `Kotlin*Bridge` — the host-bridge naming convention
+ *     (`KotlinBLEBridge`, `KotlinRNodeBridge`, `KotlinUSBBridge`).
+ *
+ * These two shapes cover every Chaquopy bridge in the tree with no false
+ * positives (Android callbacks like `GattCallback`/`ProgressCallback` and the
+ * kotlin-backend `AndroidRNodeHostBridge` don't match). Bridges that fit
+ * neither shape (e.g. `PythonEventBridge`, `StampGeneratorCallback`) still carry
+ * the annotation but aren't auto-detectable here — keep new Chaquopy bridges to
+ * one of the two shapes so this rule can guard them.
+ */
+class ReflectivelyKeptRequiredRule(
+    config: Config = Config.empty,
+) : Rule(config) {
+    override val issue =
+        Issue(
+            id = "ReflectivelyKeptRequired",
+            severity = Severity.Defect,
+            description =
+                "Chaquopy bridge classes invoked by name from Python must be annotated " +
+                    "@ReflectivelyKept, or R8 renames/strips them in minified release builds " +
+                    "and the by-name call fails silently at runtime.",
+            debt = Debt.FIVE_MINS,
+        )
+
+    override fun visitClassOrObject(classOrObject: KtClassOrObject) {
+        super.visitClassOrObject(classOrObject)
+
+        if (!isBridgeModule(classOrObject.containingKtFile.virtualFilePath)) return
+        if (!isChaquopyBridgeShape(classOrObject)) return
+        if (hasReflectivelyKept(classOrObject)) return
+
+        report(
+            CodeSmell(
+                issue = issue,
+                entity = Entity.from(classOrObject),
+                message =
+                    "`${classOrObject.name}` is a Chaquopy bridge shape (a fun interface in " +
+                        ":rns-backend-py, or a Kotlin*Bridge class) but is not annotated " +
+                        "@ReflectivelyKept. Without it, R8 renames/strips it in release builds " +
+                        "and the by-name Python call fails silently — add " +
+                        "@network.columba.app.rns.api.annotation.ReflectivelyKept (class-level, " +
+                        "so it keeps all current and future members).",
+            ),
+        )
+    }
+
+    private fun isBridgeModule(filePath: String): Boolean =
+        filePath.contains("/rns-backend-py/") || filePath.contains("/rns-host/")
+
+    private fun isChaquopyBridgeShape(classOrObject: KtClassOrObject): Boolean {
+        if (isFunInterfaceInPyBackend(classOrObject)) return true
+        val name = classOrObject.name ?: return false
+        return name.startsWith("Kotlin") && name.endsWith("Bridge")
+    }
+
+    private fun isFunInterfaceInPyBackend(classOrObject: KtClassOrObject): Boolean {
+        val ktClass = classOrObject as? KtClass ?: return false
+        if (!ktClass.isInterface()) return false
+        if (!ktClass.hasModifier(KtTokens.FUN_KEYWORD)) return false
+        return classOrObject.containingKtFile.packageFqName.asString()
+            .startsWith("network.columba.app.rns.backend.py")
+    }
+
+    private fun hasReflectivelyKept(classOrObject: KtClassOrObject): Boolean =
+        classOrObject.annotationEntries.any { it.shortName?.asString() == "ReflectivelyKept" }
+}

--- a/detekt-rules/src/test/kotlin/network/columba/app/detekt/rules/ReflectivelyKeptRequiredRuleTest.kt
+++ b/detekt-rules/src/test/kotlin/network/columba/app/detekt/rules/ReflectivelyKeptRequiredRuleTest.kt
@@ -1,0 +1,162 @@
+package network.columba.app.detekt.rules
+
+import io.github.detekt.test.utils.compileContentForTest
+import io.gitlab.arturbosch.detekt.api.Config
+import io.gitlab.arturbosch.detekt.api.Finding
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+
+/**
+ * Tests for [ReflectivelyKeptRequiredRule].
+ *
+ * The rule is path-scoped (`/rns-backend-py/`, `/rns-host/`) and package-scoped
+ * (the `fun interface` shape), so — like [NoCallCoordinatorGetInstanceOutsideHostRuleTest]
+ * — tests compile the snippet under a synthetic virtual path via
+ * `compileContentForTest` and invoke the visitor directly.
+ */
+class ReflectivelyKeptRequiredRuleTest {
+    @Test
+    fun `flags a fun interface in rns-backend-py without the annotation`() {
+        val source =
+            """
+            package network.columba.app.rns.backend.py
+            import com.chaquo.python.PyObject
+            fun interface PyThreeArgCallback {
+                fun onEvent(a: PyObject, b: PyObject, c: PyObject)
+            }
+            """.trimIndent()
+        val findings =
+            findingsFor(
+                source,
+                "/repo/rns-backend-py/src/main/kotlin/network/columba/app/rns/backend/py/PyThreeArgCallback.kt",
+            )
+        assertEquals(1, findings.size, "Unannotated Chaquopy SAM should be flagged")
+        assertEquals("ReflectivelyKeptRequired", findings[0].issue.id)
+    }
+
+    @Test
+    fun `allows a fun interface in rns-backend-py with the annotation`() {
+        val source =
+            """
+            package network.columba.app.rns.backend.py
+            import com.chaquo.python.PyObject
+            import network.columba.app.rns.api.annotation.ReflectivelyKept
+            @ReflectivelyKept
+            fun interface PyThreeArgCallback {
+                fun onEvent(a: PyObject, b: PyObject, c: PyObject)
+            }
+            """.trimIndent()
+        val findings =
+            findingsFor(
+                source,
+                "/repo/rns-backend-py/src/main/kotlin/network/columba/app/rns/backend/py/PyThreeArgCallback.kt",
+            )
+        assertEquals(0, findings.size, "Annotated SAM must not be flagged")
+    }
+
+    @Test
+    fun `flags a Kotlin Bridge class without the annotation`() {
+        val source =
+            """
+            package network.columba.app.rns.host.thing
+            class KotlinThingBridge {
+                fun doThing() = Unit
+            }
+            """.trimIndent()
+        val findings =
+            findingsFor(
+                source,
+                "/repo/rns-host/src/main/kotlin/network/columba/app/rns/host/thing/KotlinThingBridge.kt",
+            )
+        assertEquals(1, findings.size, "Unannotated Kotlin*Bridge should be flagged")
+    }
+
+    @Test
+    fun `allows a Kotlin Bridge class with the annotation`() {
+        val source =
+            """
+            package network.columba.app.rns.host.thing
+            import network.columba.app.rns.api.annotation.ReflectivelyKept
+            @ReflectivelyKept
+            class KotlinThingBridge {
+                fun doThing() = Unit
+            }
+            """.trimIndent()
+        val findings =
+            findingsFor(
+                source,
+                "/repo/rns-host/src/main/kotlin/network/columba/app/rns/host/thing/KotlinThingBridge.kt",
+            )
+        assertEquals(0, findings.size, "Annotated Kotlin*Bridge must not be flagged")
+    }
+
+    @Test
+    fun `does not flag an Android callback class that is not a Chaquopy bridge`() {
+        // AndroidRNodeHostBridge / GattCallback / ProgressCallback shapes — not
+        // Python-invoked, must not trip the rule.
+        val source =
+            """
+            package network.columba.app.rns.host.rnode
+            internal class AndroidRNodeHostBridge {
+                interface ProgressCallback { fun onProgress(p: Int) }
+                inner class GattCallback
+            }
+            """.trimIndent()
+        val findings =
+            findingsFor(
+                source,
+                "/repo/rns-host/src/kotlinBackend/kotlin/network/columba/app/rns/host/rnode/AndroidRNodeHostBridge.kt",
+            )
+        assertEquals(0, findings.size, "Non-Chaquopy callbacks/bridges must not be flagged")
+    }
+
+    @Test
+    fun `does not flag a fun interface outside the python backend package`() {
+        val source =
+            """
+            package network.columba.app.viewmodel
+            fun interface ClickHandler {
+                fun onClick()
+            }
+            """.trimIndent()
+        val findings =
+            findingsFor(
+                source,
+                "/repo/app/src/main/java/network/columba/app/viewmodel/ClickHandler.kt",
+            )
+        assertEquals(0, findings.size, "fun interfaces outside :rns-backend-py are unrelated")
+    }
+
+    @Test
+    fun `flagged message names the annotation`() {
+        val source =
+            """
+            package network.columba.app.rns.backend.py
+            import com.chaquo.python.PyObject
+            fun interface PyThreeArgCallback {
+                fun onEvent(a: PyObject, b: PyObject, c: PyObject)
+            }
+            """.trimIndent()
+        val findings =
+            findingsFor(
+                source,
+                "/repo/rns-backend-py/src/main/kotlin/network/columba/app/rns/backend/py/PyThreeArgCallback.kt",
+            )
+        assertEquals(1, findings.size)
+        assertTrue(
+            findings[0].message.contains("ReflectivelyKept"),
+            "Message should name the annotation: ${findings[0].message}",
+        )
+    }
+
+    private fun findingsFor(
+        source: String,
+        path: String,
+    ): List<Finding> {
+        val rule = ReflectivelyKeptRequiredRule(Config.empty)
+        val ktFile = compileContentForTest(source, path)
+        rule.visitFile(ktFile)
+        return rule.findings
+    }
+}

--- a/rns-api/src/main/java/network/columba/app/rns/api/annotation/ReflectivelyKept.kt
+++ b/rns-api/src/main/java/network/columba/app/rns/api/annotation/ReflectivelyKept.kt
@@ -1,0 +1,29 @@
+package network.columba.app.rns.api.annotation
+
+/**
+ * Marks a class that is invoked **by name across a boundary R8 cannot see** —
+ * Chaquopy (Python → Kotlin via `callAttr` / a callback's `onEvent`/`generate`)
+ * or JNI-by-name. R8's static analysis never sees those call sites, so without
+ * this marker it is free to rename or strip the class and its members, which
+ * silently breaks the bridge in minified release builds (see the inbound-voice
+ * `PyTwoArgCallback` regression that motivated this).
+ *
+ * **Protection is class-level.** A single rule in `app/proguard-rules.pro`:
+ * ```
+ * -keep @network.columba.app.rns.api.annotation.ReflectivelyKept class * { *; }
+ * ```
+ * keeps the annotated class and **all** its members — current and future — so
+ * adding a method to an annotated bridge needs no further action.
+ *
+ * **Enforced.** The `ReflectivelyKeptRequired` detekt rule (`:detekt-rules`)
+ * requires this annotation on the two Chaquopy bridge shapes — `fun interface`s
+ * in `:rns-backend-py` and `Kotlin*Bridge` classes — so a new bridge cannot be
+ * merged unprotected. The R8 mapping check (when wired) enumerates every
+ * `@ReflectivelyKept` class and asserts R8 left its name unchanged.
+ *
+ * Retention is BINARY (in the class file, not visible to runtime reflection):
+ * R8 reads it at build time; nothing needs it at runtime.
+ */
+@Retention(AnnotationRetention.BINARY)
+@Target(AnnotationTarget.CLASS)
+annotation class ReflectivelyKept

--- a/rns-backend-py/src/main/kotlin/network/columba/app/rns/backend/py/PyEventCallback.kt
+++ b/rns-backend-py/src/main/kotlin/network/columba/app/rns/backend/py/PyEventCallback.kt
@@ -1,7 +1,7 @@
 package network.columba.app.rns.backend.py
 
-import androidx.annotation.Keep
 import com.chaquo.python.PyObject
+import network.columba.app.rns.api.annotation.ReflectivelyKept
 
 /**
  * Single-method event sink that `event_bridge.py` invokes for each flattened
@@ -16,7 +16,7 @@ import com.chaquo.python.PyObject
  * into the `:rns-api` model types and publishes onto the same
  * `MutableSharedFlow`s the kotlin backend exposes.
  */
-@Keep // event_bridge.py calls `callback.onEvent(payload)` by name via Chaquopy — R8 must not rename the SAM
+@ReflectivelyKept // event_bridge.py calls onEvent(payload) by name via Chaquopy
 fun interface PyEventCallback {
     /**
      * @param payload a Python `dict` (str -> primitive) built by

--- a/rns-backend-py/src/main/kotlin/network/columba/app/rns/backend/py/PyTwoArgCallback.kt
+++ b/rns-backend-py/src/main/kotlin/network/columba/app/rns/backend/py/PyTwoArgCallback.kt
@@ -1,8 +1,10 @@
 package network.columba.app.rns.backend.py
 
+import androidx.annotation.Keep
 import com.chaquo.python.PyObject
 
 /** Two-arg sibling of [PyEventCallback] — currently for `Link.set_remote_identified_callback`. */
+@Keep // event_bridge.py calls `callback.onEvent(link, identity)` by name via Chaquopy — R8 must not rename the SAM
 fun interface PyTwoArgCallback {
     fun onEvent(first: PyObject, second: PyObject)
 }

--- a/rns-backend-py/src/main/kotlin/network/columba/app/rns/backend/py/PyTwoArgCallback.kt
+++ b/rns-backend-py/src/main/kotlin/network/columba/app/rns/backend/py/PyTwoArgCallback.kt
@@ -1,10 +1,10 @@
 package network.columba.app.rns.backend.py
 
-import androidx.annotation.Keep
 import com.chaquo.python.PyObject
+import network.columba.app.rns.api.annotation.ReflectivelyKept
 
 /** Two-arg sibling of [PyEventCallback] — currently for `Link.set_remote_identified_callback`. */
-@Keep // event_bridge.py calls `callback.onEvent(link, identity)` by name via Chaquopy — R8 must not rename the SAM
+@ReflectivelyKept // event_bridge.py calls onEvent(link, identity) by name via Chaquopy
 fun interface PyTwoArgCallback {
     fun onEvent(first: PyObject, second: PyObject)
 }

--- a/rns-backend-py/src/main/kotlin/network/columba/app/rns/backend/py/PythonEventBridge.kt
+++ b/rns-backend-py/src/main/kotlin/network/columba/app/rns/backend/py/PythonEventBridge.kt
@@ -1,11 +1,11 @@
 package network.columba.app.rns.backend.py
 
-import androidx.annotation.Keep
 import android.util.Log
 import com.chaquo.python.PyObject
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.SharedFlow
 import kotlinx.coroutines.flow.asSharedFlow
+import network.columba.app.rns.api.annotation.ReflectivelyKept
 import network.columba.app.rns.api.model.AnnounceEvent
 import network.columba.app.rns.api.model.DeliveryStatusUpdate
 import network.columba.app.rns.api.model.IconAppearance
@@ -43,7 +43,7 @@ import org.json.JSONObject
  * threads and must return fast. The buffer capacities mirror
  * `NativeRnsBackendImpl`.
  */
-@Keep // Python (event_bridge.py) calls this via Chaquopy reflection — R8 must not strip/rename it
+@ReflectivelyKept // Python (event_bridge.py) calls this via Chaquopy reflection — R8 must not strip/rename it
 class PythonEventBridge {
     private companion object {
         const val TAG = "PythonEventBridge"

--- a/rns-backend-py/src/main/kotlin/network/columba/app/rns/backend/py/PythonRnsCore.kt
+++ b/rns-backend-py/src/main/kotlin/network/columba/app/rns/backend/py/PythonRnsCore.kt
@@ -274,6 +274,10 @@ class PythonRnsCore(
             val router = runtime.lxmRouter
                 ?: throw RnsException(RnsError.BackendNotReady)
             router.callAttr("announce", runtime.localDestination?.get("hash"))
+            // Keep lxst.telephony announced on the same cadence as
+            // lxmf.delivery so inbound callers can resolve a fresh path
+            // (PythonCallManager installs this hook in setup()).
+            runtime.onLxmfReannounce?.invoke()
             Unit
         }
 

--- a/rns-backend-py/src/main/kotlin/network/columba/app/rns/backend/py/PythonRnsRuntime.kt
+++ b/rns-backend-py/src/main/kotlin/network/columba/app/rns/backend/py/PythonRnsRuntime.kt
@@ -2,6 +2,7 @@ package network.columba.app.rns.backend.py
 
 import android.content.Context
 import android.util.Log
+import androidx.annotation.Keep
 import network.columba.app.rns.api.util.StampGenerator
 import network.columba.app.rns.api.util.toHex
 import com.chaquo.python.PyObject
@@ -134,6 +135,22 @@ class PythonRnsRuntime(
      */
     @Volatile
     var usbBridge: Any? = null
+
+    /**
+     * Optional hook fired right after the LXMF delivery destination is
+     * (re-)announced via [PythonRnsCore.triggerAutoAnnounce].
+     *
+     * Set by `:rns-host`'s `PythonCallManager` so the `lxst.telephony`
+     * destination is re-announced on the same cadence as `lxmf.delivery`
+     * (periodic auto-announce + network-change announce). Without this the
+     * telephony destination is only announced once at backend READY, so its
+     * path goes stale and inbound callers can't reach it. Typed as a plain
+     * lambda + held here (a shared object both `PythonRnsCore` and
+     * `PythonCallManager` already reference) to avoid a Hilt construction
+     * cycle between `ChaquopyRnsBackend` → `PythonRnsCore` → `PythonCallManager`.
+     */
+    @Volatile
+    var onLxmfReannounce: (() -> Unit)? = null
 
     private val running = AtomicBoolean(false)
 
@@ -472,6 +489,7 @@ class PythonRnsRuntime(
  * builtin so they expose the buffer protocol that LXStamper then
  * concatenates with the workblock.
  */
+@Keep // event_bridge.py calls `callback.generate(workblock, cost)` by name via Chaquopy — R8 must not rename/strip it
 internal class StampGeneratorCallback(
     private val generator: StampGenerator,
 ) {

--- a/rns-backend-py/src/main/kotlin/network/columba/app/rns/backend/py/PythonRnsRuntime.kt
+++ b/rns-backend-py/src/main/kotlin/network/columba/app/rns/backend/py/PythonRnsRuntime.kt
@@ -2,7 +2,7 @@ package network.columba.app.rns.backend.py
 
 import android.content.Context
 import android.util.Log
-import androidx.annotation.Keep
+import network.columba.app.rns.api.annotation.ReflectivelyKept
 import network.columba.app.rns.api.util.StampGenerator
 import network.columba.app.rns.api.util.toHex
 import com.chaquo.python.PyObject
@@ -489,7 +489,7 @@ class PythonRnsRuntime(
  * builtin so they expose the buffer protocol that LXStamper then
  * concatenates with the workblock.
  */
-@Keep // event_bridge.py calls `callback.generate(workblock, cost)` by name via Chaquopy — R8 must not rename/strip it
+@ReflectivelyKept // event_bridge.py calls generate(workblock, cost) by name via Chaquopy — R8 must not rename/strip it
 internal class StampGeneratorCallback(
     private val generator: StampGenerator,
 ) {

--- a/rns-host/src/main/kotlin/network/columba/app/rns/host/ble/bridge/KotlinBLEBridge.kt
+++ b/rns-host/src/main/kotlin/network/columba/app/rns/host/ble/bridge/KotlinBLEBridge.kt
@@ -1,7 +1,7 @@
 package network.columba.app.rns.host.ble.bridge
 
-import androidx.annotation.Keep
 import com.chaquo.python.PyObject
+import network.columba.app.rns.api.annotation.ReflectivelyKept
 import network.columba.app.rns.api.util.toHex
 import android.annotation.SuppressLint
 import android.bluetooth.BluetoothAdapter
@@ -64,7 +64,7 @@ import java.util.concurrent.ConcurrentHashMap
 // baselined; adding the BleConnectionSource supertype changed detekt's class
 // signature so the baseline ID stopped matching — suppress inline instead.
 @Suppress("InjectDispatcher", "TooManyFunctions") // DI-free bridge; dispatchers used for BLE ops
-@Keep // Python (BLE driver / event_bridge.py) calls this via Chaquopy reflection — R8 must not strip/rename it
+@ReflectivelyKept // Python (BLE driver / event_bridge.py) calls this via Chaquopy reflection — R8 must not strip/rename it
 class KotlinBLEBridge(
     private val context: Context,
     private val bluetoothManager: BluetoothManager,

--- a/rns-host/src/main/kotlin/network/columba/app/rns/host/rnode/KotlinRNodeBridge.kt
+++ b/rns-host/src/main/kotlin/network/columba/app/rns/host/rnode/KotlinRNodeBridge.kt
@@ -1,7 +1,7 @@
 package network.columba.app.rns.host.rnode
 
-import androidx.annotation.Keep
 import android.annotation.SuppressLint
+import network.columba.app.rns.api.annotation.ReflectivelyKept
 import android.bluetooth.BluetoothAdapter
 import android.bluetooth.BluetoothDevice
 import android.bluetooth.BluetoothGatt
@@ -101,7 +101,7 @@ interface RNodeOnlineStatusListener {
  */
 @SuppressLint("MissingPermission")
 @Suppress("LargeClass", "InjectDispatcher") // Bridge class doesn't use DI - dispatcher used for BLE/serial I/O
-@Keep // Python (rnode_interface.py) calls this via Chaquopy reflection — R8 must not strip/rename it
+@ReflectivelyKept // Python (rnode_interface.py) calls this via Chaquopy reflection — R8 must not strip/rename it
 class KotlinRNodeBridge(
     private val context: Context,
 ) {

--- a/rns-host/src/main/kotlin/network/columba/app/rns/host/usb/KotlinUSBBridge.kt
+++ b/rns-host/src/main/kotlin/network/columba/app/rns/host/usb/KotlinUSBBridge.kt
@@ -1,7 +1,7 @@
 package network.columba.app.rns.host.usb
 
-import androidx.annotation.Keep
 import android.app.PendingIntent
+import network.columba.app.rns.api.annotation.ReflectivelyKept
 import android.content.BroadcastReceiver
 import android.content.Context
 import android.content.Intent
@@ -76,7 +76,7 @@ interface UsbConnectionListener {
  * @property context Application context for USB access
  */
 @Suppress("TooManyFunctions", "LargeClass")
-@Keep // Python (rnode_interface.py / usb_bridge.py) calls this via Chaquopy reflection — R8 must not strip/rename it
+@ReflectivelyKept // Python (rnode_interface.py / usb_bridge.py) calls this via Chaquopy reflection — R8 must not strip/rename it
 class KotlinUSBBridge(
     private val context: Context,
 ) : SerialInputOutputManager.Listener {

--- a/rns-host/src/pythonBackend/kotlin/network/columba/app/rns/host/PythonCallManager.kt
+++ b/rns-host/src/pythonBackend/kotlin/network/columba/app/rns/host/PythonCallManager.kt
@@ -150,6 +150,14 @@ class PythonCallManager(
         registerTelephonyDestination(localIdentity)
         announce()
 
+        // Re-announce lxst.telephony whenever lxmf.delivery is (re-)announced
+        // (periodic auto-announce + network-change announce, both routed
+        // through PythonRnsCore.triggerAutoAnnounce). A one-time setup()
+        // announce alone lets the telephony path go stale, so inbound callers
+        // silently fail to reach us. announce() no-ops when the destination is
+        // deregistered (incoming disabled), so the hook is safe to leave set.
+        runtime.onLxmfReannounce = { announce() }
+
         // Cold-start application of the persisted master toggle. If the
         // user turned voice calls OFF before the last :reticulum tear-down
         // (or before this fresh-start), apply that now — we register +
@@ -205,7 +213,15 @@ class PythonCallManager(
     /** Public so callers can couple lxst.telephony announces to LXMF reannounces. */
     fun announce(appData: ByteArray? = null) {
         val dest = telephonyDestination ?: run {
-            Log.w(TAG, "Cannot announce lxst.telephony: destination not registered")
+            // No destination is the expected, intended state when incoming
+            // calls are disabled (the master toggle deregistered it) — stay
+            // silent so the periodic LXMF-coupled re-announce doesn't spam a
+            // warning each interval. Warn only if it's missing unexpectedly.
+            if (incomingDisabled) {
+                Log.d(TAG, "Skipping lxst.telephony announce: incoming calls disabled")
+            } else {
+                Log.w(TAG, "Cannot announce lxst.telephony: destination not registered")
+            }
             return
         }
         try {
@@ -411,6 +427,7 @@ class PythonCallManager(
     /** Tear down the telephony stack. Mirrors `NativeCallManager.shutdown()`. */
     fun shutdown() {
         Log.i(TAG, "Shutting down PythonCallManager")
+        runtime.onLxmfReannounce = null
         if (::telephone.isInitialized && telephone.isCallActive()) {
             runCatching { telephone.hangup() }
                 .onFailure { Log.w(TAG, "Ignored error hanging up on shutdown", it) }

--- a/scripts/assert_bridges_kept.py
+++ b/scripts/assert_bridges_kept.py
@@ -5,9 +5,10 @@ Chaquopy resolves the bridge classes/methods by name from Python, so R8
 obfuscation silently breaks the pythonBackend release at runtime. This reads
 R8's own mapping.txt (the authoritative rename table) and fails the build if any
 bridge class was renamed/stripped, any host-bridge method Python calls was
-renamed, or the PyEventCallback SAM (`onEvent`) was renamed.
+renamed, or a callback SAM (`onEvent`) was renamed.
 
-The defense is `@Keep` on each class; this is the regression gate that proves it.
+The defense is `@ReflectivelyKept` on each class (kept via a single proguard
+rule); this is the regression gate that proves R8 honored it.
 
 Usage: assert_bridges_kept.py <path-to-mapping.txt>
 Exit: 0 = all kept, 1 = something obfuscated, 2 = usage/IO error.
@@ -16,13 +17,15 @@ import re
 import sys
 from pathlib import Path
 
-# Every bridge class Chaquopy touches must keep its name (proves @Keep fired).
+# Every bridge class Chaquopy touches must keep its name (proves @ReflectivelyKept fired).
 BRIDGE_CLASSES = [
     "network.columba.app.rns.host.rnode.KotlinRNodeBridge",
     "network.columba.app.rns.host.ble.bridge.KotlinBLEBridge",
     "network.columba.app.rns.host.usb.KotlinUSBBridge",
     "network.columba.app.rns.backend.py.PythonEventBridge",
     "network.columba.app.rns.backend.py.PyEventCallback",
+    "network.columba.app.rns.backend.py.PyTwoArgCallback",
+    "network.columba.app.rns.backend.py.StampGeneratorCallback",
 ]
 
 # Method names Python calls on each host bridge (from the call sites in
@@ -45,11 +48,25 @@ BRIDGE_METHODS = {
     "network.columba.app.rns.host.usb.KotlinUSBBridge": {
         "connect", "disconnect", "findDeviceByVidPid", "isConnected", "notifyBluetoothPin", "read",
     },
+    "network.columba.app.rns.backend.py.StampGeneratorCallback": {
+        # event_bridge.install_external_stamp_generator calls generate(workblock, cost) by name.
+        "generate",
+    },
 }
 
-# PythonEventBridge's handle* methods are called Kotlin-side (by the SAMs), not by
-# Python — Python calls `callback.onEvent(payload)`. So the SAM is what must survive.
-SAM_RE = re.compile(r"onEvent\(com\.chaquo\.python\.PyObject\).* -> onEvent$")
+# Chaquopy callback SAMs Python invokes by name:
+#   PyEventCallback.onEvent(PyObject)             — 1 arg (register_callbacks sinks)
+#   PyTwoArgCallback.onEvent(PyObject, PyObject)  — 2 args (set_remote_identified_callback)
+# Abstract interface methods get no mapping line, so we match a surviving
+# *implementation* mapped to `onEvent` that carries that many PyObject params.
+# Supplementary to the class-level checks above (which, with the
+# `-keep @ReflectivelyKept class * { *; }` rule, already keep these members).
+SAM_PATTERNS = {
+    "PyEventCallback.onEvent(PyObject)":
+        re.compile(r"com\.chaquo\.python\.PyObject\).* -> onEvent$"),
+    "PyTwoArgCallback.onEvent(PyObject, PyObject)":
+        re.compile(r"com\.chaquo\.python\.PyObject,com\.chaquo\.python\.PyObject\).* -> onEvent$"),
+}
 
 
 def parse_blocks(lines):
@@ -97,7 +114,7 @@ def main():
         if b is None:
             failures.append(f"class stripped entirely (not in mapping): {cls}")
         elif b["mapped"] != cls:
-            failures.append(f"class RENAMED by R8: {cls} -> {b['mapped']}  (add @Keep)")
+            failures.append(f"class RENAMED by R8: {cls} -> {b['mapped']}  (add @ReflectivelyKept)")
 
     for cls, expected in BRIDGE_METHODS.items():
         b = blocks.get(cls)
@@ -105,13 +122,14 @@ def main():
             continue  # already reported as stripped
         missing = expected - kept_method_names(b["members"])
         if missing:
-            failures.append(f"methods renamed/stripped on {cls}: {sorted(missing)}  (ensure @Keep)")
+            failures.append(f"methods renamed/stripped on {cls}: {sorted(missing)}  (ensure @ReflectivelyKept)")
 
-    if not any(SAM_RE.search(ln) for ln in lines):
-        failures.append(
-            "PyEventCallback SAM onEvent(PyObject) was renamed/stripped  "
-            "(add @Keep to PyEventCallback — event_bridge.py calls it by name)",
-        )
+    for label, sam_re in SAM_PATTERNS.items():
+        if not any(sam_re.search(ln) for ln in lines):
+            failures.append(
+                f"{label} SAM was renamed/stripped  "
+                "(ensure @ReflectivelyKept on the SAM — Python calls it by name)",
+            )
 
     if failures:
         print("✗ R8 bridge keep-check FAILED:")

--- a/scripts/assert_bridges_kept.py
+++ b/scripts/assert_bridges_kept.py
@@ -63,7 +63,10 @@ BRIDGE_METHODS = {
 # `-keep @ReflectivelyKept class * { *; }` rule, already keep these members).
 SAM_PATTERNS = {
     "PyEventCallback.onEvent(PyObject)":
-        re.compile(r"com\.chaquo\.python\.PyObject\).* -> onEvent$"),
+        # Anchor the open paren so a single-PyObject signature can't be matched by
+        # a two-PyObject line (which also ends `…PyObject) -> onEvent`) — otherwise
+        # a stripped PyEventCallback could pass on a surviving PyTwoArgCallback line.
+        re.compile(r"\(com\.chaquo\.python\.PyObject\).* -> onEvent$"),
     "PyTwoArgCallback.onEvent(PyObject, PyObject)":
         re.compile(r"com\.chaquo\.python\.PyObject,com\.chaquo\.python\.PyObject\).* -> onEvent$"),
 }


### PR DESCRIPTION
## Problem

On **release (R8-minified)** python-backend builds, inbound LXST voice calls (Sideband → Columba) silently failed — the call never rang. Outbound worked.

## Root cause

`event_bridge.py` invokes Kotlin callbacks **by name** via Chaquopy reflection (`callback.onEvent(link, identity)`). The SAM `PyTwoArgCallback` — used only for `Link.set_remote_identified_callback` → `onCallerIdentified` — lacked `@Keep`, so R8 renamed its method. On-device log (release build):

```
PythonCallManager: Inbound call link arrived
event_bridge: remote-identified dispatch failed: vg3.onEvent takes 1 argument (2 given)
PythonCallManager: Inbound call link closed before identification
```

A second, independent bug: `lxst.telephony` was announced only once at backend READY, never coupled to the periodic / network-change LXMF re-announce, so its path went stale and inbound callers couldn't resolve the destination at all.

## Fix (commit 1)

- `@ReflectivelyKept` on `PyTwoArgCallback` (and `StampGeneratorCallback`, which had the same latent gap for LXMF stamp generation).
- Couple the `lxst.telephony` announce to `triggerAutoAnnounce` via a `PythonRnsRuntime` hook (avoids a Hilt construction cycle); no-ops while incoming calls are disabled, so a disabled toggle never announces telephony.

**Verified on-device** (Fold7 python release ↔ S21 Sideband): inbound rings with no manual toggle; outbound unaffected.

## Hardening (commit 2)

Generalises the fix into an enforced contract so this bug class can't regress:

- **`@ReflectivelyKept`** annotation (`:rns-api`) + one rule `-keep @ReflectivelyKept class * { *; }`. Class-level → keeps all current **and future** members, so adding a method to a bridge needs no rule change. Migrated all 7 Chaquopy bridges off `androidx.annotation.Keep`.
- **`ReflectivelyKeptRequired` detekt rule** (`:detekt-rules`) fails the build when a Chaquopy bridge shape (a `fun interface` in `:rns-backend-py` or a `Kotlin*Bridge` class) lacks the annotation. Kotlin can't see the Python call site, so this enforcement — not the annotation alone — is the regression guard.

## Verification

- All 7 bridges map to themselves (kept, unrenamed) in the real `noSentryPythonBackendRelease` R8 mapping; the Kotlin-only `onLxmfReannounce` field is correctly obfuscated (boundary protected, not over-kept).
- `ktlint` + `detekt` pass on the changed modules; the detekt rule's unit tests (7) pass, including one proving it flags an unannotated SAM.

## Follow-ups (not in this PR)

- An automated `verifyR8Keep` mapping-gate that asserts in CI what was checked by hand here (enumerate `@ReflectivelyKept` classes, assert each maps to itself in `mapping.txt`).
- Audit also surfaced stale proguard globs that protect nothing (`network.columba.app.I**`, `data.local.entities.**`, possibly `service.**`) and an unguarded persisted enum (`ContactStatus`) — separate cleanup.

🤖 Generated with [Claude Code](https://claude.com/claude-code)