### PR TITLE
fix(ci): raise Gradle heap to 6GB to stop release APK packaging OOM

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,8 +1,13 @@
 # Project-wide Gradle settings.
-# Heap capped at 3GB for CI runners with 8Gi total memory.
+# Heap set to 6GB. GitHub's ubuntu-latest runners have 16GB RAM (the old 3GB
+# cap assumed an 8Gi runner that no longer exists). 3GB OOM'd while packaging
+# the release APKs: PackageAndroidArtifact/ApkFlinger reads each entry fully
+# into a heap byte array via zipflinger, and the per-ABI Chaquopy Python
+# runtimes bundled across four release flavors blew past 3GB. 6GB heap + 1GB
+# metaspace + overhead still leaves ample headroom on the 16GB runner.
 # Metaspace bumped to 1GB: Hilt + KSP + Sentry instrumentation exhaust 512m
 # and trigger worker-drain deadlocks on CI (off-heap, doesn't touch -Xmx budget).
-org.gradle.jvmargs=-Xmx3072m -XX:MaxMetaspaceSize=1g -Dfile.encoding=UTF-8
+org.gradle.jvmargs=-Xmx6144m -XX:MaxMetaspaceSize=1g -Dfile.encoding=UTF-8
 org.gradle.parallel=true
 org.gradle.caching=true
 org.gradle.workers.max=2


### PR DESCRIPTION
## Problem

The `Build Release APK` step in the tagged-release workflow [failed with an OOM](https://github.com/torlando-tech/columba/actions/runs/26265137509/job/77306691598):

```
Caused by: java.lang.OutOfMemoryError: Java heap space
  at ...NioFileInterceptors.intercept_readAllBytes
  at com.android.zipflinger.BytesSource.<init>
  at com.android.builder.internal.packaging.ApkFlinger$writeFile$1.call
```

This is a genuine Java heap OOM during **APK packaging**. `assembleRelease` builds four flavors (`sentry`/`noSentry` × `python`/`kotlin` backend) in one `--no-daemon` invocation. Zipflinger reads each archive entry fully into a heap byte array, and the per-ABI Chaquopy Python runtimes bundled across the python flavors blew past the `-Xmx3072m` cap.

## Fix

The 3GB cap in `gradle.properties` was justified by a comment assuming "CI runners with 8Gi total memory" — a stale assumption. GitHub's `ubuntu-latest` runners now have **16 GB RAM**, so 3GB is needlessly tight for packaging four Python-bundling release APKs.

Bumped the heap to `-Xmx6144m`. With the 1GB metaspace and process overhead, this still leaves ~8GB headroom on the runner. Raising `-Xmx` only lifts the ceiling — the JVM commits lazily, so local dev builds that don't need it won't grab more.

This also protects `build-prerelease-apk.yml`, which runs the same `assembleRelease` and has identical packaging exposure.

🤖 Generated with [Claude Code](https://claude.com/claude-code)