### PR TITLE
feat(reactions): migrate reaction wire format to canonical LXMF FIELD_REACTION (0x40)

### DIFF
--- a/app/src/main/java/network/columba/app/ui/model/MessageMapper.kt
+++ b/app/src/main/java/network/columba/app/ui/model/MessageMapper.kt
@@ -170,14 +170,14 @@ private fun parseReplyToFromField16(fieldsJson: String?): String? =
  *
  * Reaction layering — two distinct shapes exist:
  *
- *   1. **Wire format (per-event, interop-shared with MeshChatX):**
+ *   1. **Wire format (per-event):** canonical upstream-LXMF
+ *      `fields[0x40] = {0x00: <target hash bytes>, 0x01: <emoji UTF-8 bytes>}`
+ *      (`LXMF.py` commit 764758d), with a parse-only fallback to the legacy
  *      `fields[0x10] = {"reaction_to": <hex>, "emoji": "👍", "sender": <hex>}`
- *      One LXMF message per reaction event. Both Columba and
- *      MeshChatX put this shape on the wire — see GitHub issue #926
- *      and MeshChatX #14 (Ivan's confirmation). The backend reaction
- *      routers filter these events out before message persistence
- *      and dispatch them via `_reactionReceivedFlow` →
- *      `handleIncomingReaction`.
+ *      for un-upgraded Columba peers. One LXMF message per reaction event.
+ *      Both backends decode it via the shared `ReactionWireCodec` and the
+ *      reaction routers dispatch the normalized event via
+ *      `_reactionReceivedFlow` → `handleIncomingReaction`.
  *
  *   2. **DB-aggregated form (local-only, what this function reads):**
  *      Flat `{"👍": [sender1, sender2], "❤️": [sender3]}` stored in

--- a/data/src/main/java/network/columba/app/data/db/entity/MessageEntity.kt
+++ b/data/src/main/java/network/columba/app/data/db/entity/MessageEntity.kt
@@ -45,8 +45,9 @@ data class MessageEntity(
     val fieldsJson: String? = null,
     // Per-target-message reactions aggregation (DB-local, never on the wire).
     // Shape: {"👍": ["sender_hex_1", "sender_hex_2"], "❤️": ["sender_hex_3"]}
-    // The wire format is fields[0x10] = {reaction_to, emoji, sender} per-event;
-    // the receiver routes those events into this column on the *target* message.
+    // The canonical wire format is fields[0x40] = {0x00: hashBytes, 0x01:
+    // contentBytes} per-event (legacy fields[0x10] still parsed inbound); the
+    // receiver routes those events into this column on the *target* message.
     // Migrated v1→v2 from the prior fields[16].reactions overload — see
     // MIGRATION_1_2 in ColumbaDatabase.
     val reactionsJson: String? = null,

--- a/rns-api/src/main/java/network/columba/app/rns/api/RnsLxmf.kt
+++ b/rns-api/src/main/java/network/columba/app/rns/api/RnsLxmf.kt
@@ -13,8 +13,8 @@ import network.columba.app.rns.api.model.ReceivedMessage
 
 /**
  * LXMF messaging surface: send/receive messages, observe delivery state,
- * propagation node sync, reactions (LXMF Field 16), and message size
- * limits.
+ * propagation node sync, reactions (LXMF `FIELD_REACTION` 0x40), and
+ * message size limits.
  *
  * The LXMF identity/destination accessors live here (rather than in
  * [RnsCore]) because the binding LXMF identity is owned by the LXMF
@@ -66,14 +66,19 @@ interface RnsLxmf {
     ): Result<MessageReceipt>
 
     /**
-     * Send an emoji reaction to a message via LXMF Field 16.
+     * Send an emoji reaction to a message via the canonical LXMF
+     * `FIELD_REACTION` (0x40).
      *
-     * The reaction is sent as a lightweight LXMF message with Field 16 containing
-     * the reaction data: {"reaction_to": "...", "emoji": "...", "sender": "..."}.
+     * The reaction is sent as a lightweight, otherwise-empty LXMF message
+     * carrying `fields[0x40] = {0x00: <target hash bytes>, 0x01: <emoji UTF-8
+     * bytes>}` (upstream `LXMF.py` standard). The reacting user is derived
+     * from the message source on the receiving end, so it is not on the wire.
+     * Inbound parsing falls back to the legacy `0x10` dict for un-upgraded
+     * peers — see `ReactionWireCodec`.
      *
      * @param destinationHash Destination hash bytes (16 bytes) - the recipient
      * @param targetMessageId The message hash/ID being reacted to
-     * @param emoji The emoji reaction (e.g., "thumbs-up", "heart", etc.)
+     * @param emoji The reaction content (typically one Unicode emoji)
      * @param sourceIdentity Identity of the sender
      * @return Result containing MessageReceipt or failure
      */

--- a/rns-api/src/main/java/network/columba/app/rns/api/RnsTransportAdmin.kt
+++ b/rns-api/src/main/java/network/columba/app/rns/api/RnsTransportAdmin.kt
@@ -169,7 +169,8 @@ interface RnsTransportAdmin {
     val interfaceStatusFlow: SharedFlow<String>
 
     /**
-     * Stream of inbound LXMF reaction frames (Field 16). Surfaced as a
+     * Stream of inbound LXMF reaction frames (`FIELD_REACTION` 0x40, with a
+     * legacy 0x10 parse fallback). Surfaced as a
      * low-level diagnostic channel here rather than in [RnsLxmf] because
      * the transport reads them off the same packet pipeline as the BLE/
      * interface diagnostic events; the message-list ViewModel parses the

--- a/rns-api/src/main/java/network/columba/app/rns/api/util/LxmfFields.kt
+++ b/rns-api/src/main/java/network/columba/app/rns/api/util/LxmfFields.kt
@@ -49,18 +49,42 @@ object LxmfFields {
     const val FIELD_COMMANDS = 0x09
 
     /**
-     * Tap-back reaction field — `fields[0x10] = {reaction_to, emoji, sender}`
-     * per-event wire shape, shared with MeshChatX
-     * (`src/backend/lxmf_utils.py:11 LXMF_APP_EXTENSIONS_FIELD = 16`).
-     * `reaction_to` and `sender` are hex strings (no canonical case);
-     * `emoji` is Unicode. One reaction per LXMessage on the wire;
-     * receiver aggregates per-target-message locally for UI rendering.
+     * Canonical tap-back reaction field — `fields[0x40] = {0x00: bytes, 0x01: bytes}`
+     * per-event wire shape, standardised upstream in LXMF.py (commit
+     * `764758d`, "to be finalized in 1.0.0"):
+     *   - [REACTION_TO] (`0x00`) = raw bytes of the target `LXMessage.hash`.
+     *   - [REACTION_CONTENT] (`0x01`) = UTF-8 bytes of the reaction content
+     *     (the emoji). The sender is NOT carried on the wire — it is derived
+     *     from the inbound LXMF message's source hash on receive.
      *
-     * Upstream LXMF doesn't allocate this byte yet; both Columba and
-     * MeshChatX work in the unallocated range. Spec discussion:
-     * https://github.com/thatSFguy/reticulum-specifications/issues/8
+     * One reaction per LXMessage on the wire; the receiver aggregates
+     * per-target-message locally (the flat `reactionsJson` column) for UI
+     * rendering. Outbound writes this shape only; inbound parsing falls back
+     * to the legacy [FIELD_REACTION_LEGACY] for un-upgraded Columba peers —
+     * see `ReactionWireCodec`.
      */
-    const val FIELD_REACTION = 0x10
+    const val FIELD_REACTION = 0x40
+
+    /** [FIELD_REACTION] dict key — raw bytes of the target `LXMessage.hash`. */
+    const val REACTION_TO = 0x00
+
+    /** [FIELD_REACTION] dict key — UTF-8 bytes of the reaction content (emoji). */
+    const val REACTION_CONTENT = 0x01
+
+    /**
+     * Legacy tap-back reaction field — `fields[0x10] = {reaction_to, emoji, sender}`
+     * string-keyed dict (hex-string target + sender, Unicode emoji), shared
+     * historically with MeshChatX
+     * (`src/backend/lxmf_utils.py:11 LXMF_APP_EXTENSIONS_FIELD = 16`).
+     *
+     * **Parse-only fallback.** Outbound no longer writes this — it was
+     * superseded by the canonical [FIELD_REACTION] (`0x40`) once upstream
+     * LXMF standardised the field. `0x10` also now sits inside upstream's
+     * reserved `0x00`–`0x80` range, so squatting it risks a future
+     * collision. Kept on the inbound path so reactions from un-upgraded
+     * Columba peers still resolve — see `ReactionWireCodec`.
+     */
+    const val FIELD_REACTION_LEGACY = 0x10
 
     /**
      * Reply-target message hash — `fields[0x30] = ByteArray(32)` raw

--- a/rns-api/src/main/java/network/columba/app/rns/api/util/ReactionWireCodec.kt
+++ b/rns-api/src/main/java/network/columba/app/rns/api/util/ReactionWireCodec.kt
@@ -102,9 +102,10 @@ object ReactionWireCodec {
     /** Canonical `fields[0x40] = {0x00: bytes, 0x01: bytes}` (bytes arrive hex). */
     private fun parseCanonical(fields: JSONObject, sourceHashHex: String, timestamp: Long): String? {
         val dict = fields.optJSONObject(FIELD_REACTION_KEY) ?: return null
-        val reactionTo = dict.optString(REACTION_TO_KEY).takeIf { it.isNotBlank() } ?: return null
-        val contentHex = dict.optString(REACTION_CONTENT_KEY).takeIf { it.isNotBlank() } ?: return null
-        val emoji = decodeUtf8Hex(contentHex) ?: return null
+        val reactionTo = dict.optString(REACTION_TO_KEY).takeIf { it.isNotBlank() }
+        val emoji =
+            dict.optString(REACTION_CONTENT_KEY).takeIf { it.isNotBlank() }?.let { decodeUtf8Hex(it) }
+        if (reactionTo == null || emoji == null) return null
         // Standard: the reactor is the message source, not a wire field.
         return normalized(
             reactionTo = reactionTo.lowercase(),

--- a/rns-api/src/main/java/network/columba/app/rns/api/util/ReactionWireCodec.kt
+++ b/rns-api/src/main/java/network/columba/app/rns/api/util/ReactionWireCodec.kt
@@ -1,0 +1,153 @@
+package network.columba.app.rns.api.util
+
+import org.json.JSONObject
+
+/**
+ * Encodes and decodes LXMF tap-back reactions on the wire, shared by both
+ * backends (kotlin-native + python-flavor) so the two can never drift —
+ * same pattern as [TelemeterCodec].
+ *
+ * **Canonical wire shape** (upstream LXMF standard, `LXMF.py` commit
+ * `764758d`, "to be finalized in 1.0.0"):
+ * ```
+ * fields[0x40] = { 0x00: <target LXMessage.hash bytes>,
+ *                  0x01: <reaction content UTF-8 bytes> }
+ * ```
+ * The reacting user is NOT carried on the wire — upstream derives it from
+ * the LXMF message's source hash, so [parseInboundReaction] sets `sender`
+ * to the inbound source hash on the canonical path.
+ *
+ * **Legacy wire shape** (parse-only fallback, pre-standard Columba/MeshChatX):
+ * ```
+ * fields[0x10] = { "reaction_to": <hex>, "emoji": <unicode>, "sender": <hex> }
+ * ```
+ * Outbound never writes `0x10` anymore (clean cutover, mirrors the reply
+ * `0x30`/`0x31` migration); it is kept on the inbound path so reactions from
+ * un-upgraded Columba peers still resolve. See [LxmfFields.FIELD_REACTION] /
+ * [LxmfFields.FIELD_REACTION_LEGACY].
+ *
+ * **Normalized form** (what both backends emit downstream to
+ * `reactionReceived` / `MessagingViewModel.handleIncomingReaction`):
+ * ```
+ * {"reaction_to": <hex>, "emoji": <unicode>, "sender": <hex>,
+ *  "source_hash": <hex>, "timestamp": <ms>}
+ * ```
+ * The aggregation + DB storage (`reactionsJson` column) is unchanged by the
+ * wire migration — only the encode/decode here moved.
+ */
+object ReactionWireCodec {
+    // Field-map JSON keys are the decimal string of the integer field id
+    // (serializeFieldsToJson uses `key.toString()`; event_bridge.py uses
+    // `str(k)`). 0x40 -> "64"; nested dict keys 0x00 -> "0", 0x01 -> "1".
+    private val FIELD_REACTION_KEY = LxmfFields.FIELD_REACTION.toString()
+    private val REACTION_TO_KEY = LxmfFields.REACTION_TO.toString()
+    private val REACTION_CONTENT_KEY = LxmfFields.REACTION_CONTENT.toString()
+    private val FIELD_REACTION_LEGACY_KEY = LxmfFields.FIELD_REACTION_LEGACY.toString()
+
+    /**
+     * Build the canonical `fields[0x40]` map for an outbound reaction.
+     *
+     * Returns a field map ready to merge into an LXMessage's fields — native
+     * passes it straight through as `extraFields`; the python flavor wraps it
+     * with `pyDict(...)`. `ByteArray` values are packed as msgpack `bin` by
+     * both backends (and hex-encoded back across JNI by `event_bridge.py`'s
+     * `_jsonable` on the python receive side).
+     *
+     * @param targetMessageIdHex hex of the target `LXMessage.hash`
+     * @param emoji the reaction content (typically one Unicode emoji)
+     * @return `{0x40: {0x00: hashBytes, 0x01: emojiUtf8Bytes}}`, or null if
+     *   [targetMessageIdHex] is blank / not valid hex.
+     */
+    fun encodeReactionFields(targetMessageIdHex: String, emoji: String): Map<Int, Any>? {
+        val targetBytes =
+            runCatching { targetMessageIdHex.hexToBytes() }
+                .getOrNull()
+                ?.takeIf { it.isNotEmpty() }
+                ?: return null
+        return mapOf(
+            LxmfFields.FIELD_REACTION to
+                mapOf(
+                    LxmfFields.REACTION_TO to targetBytes,
+                    LxmfFields.REACTION_CONTENT to emoji.toByteArray(Charsets.UTF_8),
+                ),
+        )
+    }
+
+    /**
+     * Parse an inbound message's serialized `fieldsJson` into the normalized
+     * reaction JSON, trying the canonical `0x40` shape first and falling back
+     * to the legacy `0x10` shape.
+     *
+     * @param fieldsJson the message's fields serialized by
+     *   `AppDataParser.serializeFieldsToJson` (kotlin backend) or
+     *   `event_bridge.py` (python flavor) — byte values are already hex.
+     * @param sourceHashHex hex of the inbound LXMF message's source hash;
+     *   used as `sender` on the canonical path (per the upstream standard).
+     * @param timestamp inbound message timestamp (ms), echoed into the output.
+     * @return normalized reaction JSON, or null when no reaction field present
+     *   (or the field is malformed).
+     */
+    fun parseInboundReaction(fieldsJson: String?, sourceHashHex: String, timestamp: Long): String? {
+        if (fieldsJson.isNullOrEmpty()) return null
+        return try {
+            val fields = JSONObject(fieldsJson)
+            parseCanonical(fields, sourceHashHex, timestamp)
+                ?: parseLegacy(fields, sourceHashHex, timestamp)
+        } catch (_: Exception) {
+            // Malformed JSON — not a reaction we can route.
+            null
+        }
+    }
+
+    /** Canonical `fields[0x40] = {0x00: bytes, 0x01: bytes}` (bytes arrive hex). */
+    private fun parseCanonical(fields: JSONObject, sourceHashHex: String, timestamp: Long): String? {
+        val dict = fields.optJSONObject(FIELD_REACTION_KEY) ?: return null
+        val reactionTo = dict.optString(REACTION_TO_KEY).takeIf { it.isNotBlank() } ?: return null
+        val contentHex = dict.optString(REACTION_CONTENT_KEY).takeIf { it.isNotBlank() } ?: return null
+        val emoji = decodeUtf8Hex(contentHex) ?: return null
+        // Standard: the reactor is the message source, not a wire field.
+        return normalized(
+            reactionTo = reactionTo.lowercase(),
+            emoji = emoji,
+            sender = sourceHashHex,
+            sourceHashHex = sourceHashHex,
+            timestamp = timestamp,
+        )
+    }
+
+    /** Legacy `fields[0x10] = {reaction_to, emoji, sender}` (string-keyed). */
+    private fun parseLegacy(fields: JSONObject, sourceHashHex: String, timestamp: Long): String? {
+        val dict = fields.optJSONObject(FIELD_REACTION_LEGACY_KEY) ?: return null
+        val reactionTo = dict.optString("reaction_to").takeIf { it.isNotBlank() } ?: return null
+        val emoji = dict.optString("emoji")
+        // Legacy carried the reactor explicitly; fall back to the source hash
+        // if an old peer ever omitted it.
+        val sender = dict.optString("sender").takeIf { it.isNotBlank() } ?: sourceHashHex
+        return normalized(
+            reactionTo = reactionTo,
+            emoji = emoji,
+            sender = sender,
+            sourceHashHex = sourceHashHex,
+            timestamp = timestamp,
+        )
+    }
+
+    private fun normalized(
+        reactionTo: String,
+        emoji: String,
+        sender: String,
+        sourceHashHex: String,
+        timestamp: Long,
+    ): String =
+        JSONObject()
+            .put("reaction_to", reactionTo)
+            .put("emoji", emoji)
+            .put("sender", sender)
+            .put("source_hash", sourceHashHex)
+            .put("timestamp", timestamp)
+            .toString()
+
+    /** Hex string -> UTF-8 decoded text, or null if not valid hex. */
+    private fun decodeUtf8Hex(hex: String): String? =
+        runCatching { String(hex.hexToBytes(), Charsets.UTF_8) }.getOrNull()
+}

--- a/rns-api/src/test/java/network/columba/app/rns/api/util/ReactionWireCodecTest.kt
+++ b/rns-api/src/test/java/network/columba/app/rns/api/util/ReactionWireCodecTest.kt
@@ -1,0 +1,166 @@
+package network.columba.app.rns.api.util
+
+import org.json.JSONObject
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+
+/**
+ * Covers [ReactionWireCodec] — the shared reaction encode/decode both backends
+ * delegate to.
+ *
+ * The canonical-path round-trips go through [AppDataParser.serializeFieldsToJson],
+ * which is byte-for-byte what the kotlin-native backend puts on the JNI/UI
+ * boundary AND what the python flavor's `event_bridge.py` `_jsonable` produces
+ * (`{str(k): hex(bytes)}`), so one round-trip exercises both backends' wire
+ * shape. Robolectric is present because `AppDataParser` logs via
+ * `android.util.Log` on its malformed-input branches (mirrors `UtilTest`).
+ */
+@RunWith(RobolectricTestRunner::class)
+class ReactionWireCodecTest {
+    private val targetHash = "a1b2c3d4e5f6a7b8c9d0e1f2a3b4c5d6e7f8a9b0c1d2e3f4a5b6c7d8e9f0a1b2"
+    private val sourceHash = "00112233445566778899aabbccddeeff"
+
+    // ============================ encode ============================
+
+    @Test
+    fun `encode builds canonical 0x40 nested dict of raw bytes with no sender`() {
+        val fields = ReactionWireCodec.encodeReactionFields(targetHash, "👍")
+        requireNotNull(fields)
+
+        // Top-level key is FIELD_REACTION (0x40), not the legacy 0x10.
+        assertTrue(fields.containsKey(LxmfFields.FIELD_REACTION))
+        assertFalse(fields.containsKey(LxmfFields.FIELD_REACTION_LEGACY))
+
+        @Suppress("UNCHECKED_CAST")
+        val dict = fields[LxmfFields.FIELD_REACTION] as Map<Int, Any>
+        // Integer-keyed: 0x00 = target hash bytes, 0x01 = emoji UTF-8 bytes.
+        assertTrue(
+            (dict[LxmfFields.REACTION_TO] as ByteArray).contentEquals(targetHash.hexToBytes()),
+        )
+        assertTrue(
+            (dict[LxmfFields.REACTION_CONTENT] as ByteArray)
+                .contentEquals("👍".toByteArray(Charsets.UTF_8)),
+        )
+        // The reactor is NOT carried on the wire.
+        assertEquals(2, dict.size)
+    }
+
+    @Test
+    fun `encode returns null for blank or invalid target hash`() {
+        assertNull(ReactionWireCodec.encodeReactionFields("", "👍"))
+        assertNull(ReactionWireCodec.encodeReactionFields("xyz", "👍")) // non-hex
+        assertNull(ReactionWireCodec.encodeReactionFields("abc", "👍")) // odd length
+    }
+
+    // ===================== canonical round-trip =====================
+
+    @Test
+    fun `canonical encode-serialize-parse round-trips and derives sender from source`() {
+        val parsed = roundTrip(targetHash, "👍", sourceHash, timestamp = 1_700_000_000_000L)
+        requireNotNull(parsed)
+        assertEquals(targetHash, parsed.getString("reaction_to"))
+        assertEquals("👍", parsed.getString("emoji"))
+        // Standard: the reactor is the message source, not a wire field.
+        assertEquals(sourceHash, parsed.getString("sender"))
+        assertEquals(sourceHash, parsed.getString("source_hash"))
+        assertEquals(1_700_000_000_000L, parsed.getLong("timestamp"))
+    }
+
+    @Test
+    fun `canonical reaction_to is lowercased`() {
+        val parsed = roundTrip(targetHash.uppercase(), "🎉", sourceHash, timestamp = 1L)
+        requireNotNull(parsed)
+        assertEquals(targetHash, parsed.getString("reaction_to"))
+    }
+
+    @Test
+    fun `multi-codepoint emoji survive the bytes hex UTF-8 round-trip`() {
+        // Variation selector, skin-tone modifier, and a ZWJ family sequence —
+        // reaction content is arbitrary UTF-8 bytes, never assumed single-char.
+        for (emoji in listOf("❤️", "👍🏽", "👨‍👩‍👧‍👦", "🇺🇳")) {
+            val parsed = roundTrip(targetHash, emoji, sourceHash, timestamp = 1L)
+            requireNotNull(parsed) { "round-trip failed for $emoji" }
+            assertEquals(emoji, parsed.getString("emoji"))
+        }
+    }
+
+    // ===================== legacy 0x10 fallback =====================
+
+    @Test
+    fun `legacy 0x10 dict is parsed when no canonical field present`() {
+        val fieldsJson =
+            """{"16":{"reaction_to":"$targetHash","emoji":"😂","sender":"deadbeef"}}"""
+        val parsed =
+            ReactionWireCodec.parseInboundReaction(fieldsJson, sourceHash, 5L)?.let { JSONObject(it) }
+        requireNotNull(parsed)
+        assertEquals(targetHash, parsed.getString("reaction_to"))
+        assertEquals("😂", parsed.getString("emoji"))
+        // Legacy carried the reactor explicitly — preserve it.
+        assertEquals("deadbeef", parsed.getString("sender"))
+        assertEquals(sourceHash, parsed.getString("source_hash"))
+    }
+
+    @Test
+    fun `legacy 0x10 without sender falls back to source hash`() {
+        val fieldsJson = """{"16":{"reaction_to":"$targetHash","emoji":"😂"}}"""
+        val parsed =
+            ReactionWireCodec.parseInboundReaction(fieldsJson, sourceHash, 5L)?.let { JSONObject(it) }
+        requireNotNull(parsed)
+        assertEquals(sourceHash, parsed.getString("sender"))
+    }
+
+    @Test
+    fun `canonical 0x40 takes precedence over legacy 0x10 when both present`() {
+        // Carrier with BOTH a canonical and a (different) legacy reaction.
+        val canonical = ReactionWireCodec.encodeReactionFields(targetHash, "🔥")!!
+        val serialized = JSONObject(AppDataParser.serializeFieldsToJson(canonical)!!)
+        serialized.put(
+            "16",
+            JSONObject("""{"reaction_to":"ffff","emoji":"👎","sender":"cafef00d"}"""),
+        )
+
+        val parsed =
+            ReactionWireCodec.parseInboundReaction(serialized.toString(), sourceHash, 1L)
+                ?.let { JSONObject(it) }
+        requireNotNull(parsed)
+        assertEquals(targetHash, parsed.getString("reaction_to"))
+        assertEquals("🔥", parsed.getString("emoji"))
+        assertEquals(sourceHash, parsed.getString("sender")) // canonical → from source
+    }
+
+    // ============================ no-op / malformed ============================
+
+    @Test
+    fun `parse returns null for absent reaction field`() {
+        assertNull(ReactionWireCodec.parseInboundReaction(null, sourceHash, 1L))
+        assertNull(ReactionWireCodec.parseInboundReaction("", sourceHash, 1L))
+        assertNull(ReactionWireCodec.parseInboundReaction("not json", sourceHash, 1L))
+        // A non-reaction field map (e.g. an image) is not a reaction.
+        assertNull(ReactionWireCodec.parseInboundReaction("""{"6":"deadbeef"}""", sourceHash, 1L))
+    }
+
+    @Test
+    fun `canonical with missing target or content is rejected`() {
+        assertNull(
+            ReactionWireCodec.parseInboundReaction("""{"64":{"1":"f09f918d"}}""", sourceHash, 1L),
+        )
+        assertNull(
+            ReactionWireCodec.parseInboundReaction("""{"64":{"0":"$targetHash"}}""", sourceHash, 1L),
+        )
+        assertNull(
+            ReactionWireCodec.parseInboundReaction("""{"64":{"0":"","1":""}}""", sourceHash, 1L),
+        )
+    }
+
+    /** encode → serialize (native/python-equivalent JSON) → parse. */
+    private fun roundTrip(target: String, emoji: String, source: String, timestamp: Long): JSONObject? {
+        val fields = ReactionWireCodec.encodeReactionFields(target, emoji) ?: return null
+        val fieldsJson = AppDataParser.serializeFieldsToJson(fields) ?: return null
+        return ReactionWireCodec.parseInboundReaction(fieldsJson, source, timestamp)?.let { JSONObject(it) }
+    }
+}

--- a/rns-backend-kt/src/main/kotlin/network/columba/app/rns/backend/kt/NativeRnsBackendImpl.kt
+++ b/rns-backend-kt/src/main/kotlin/network/columba/app/rns/backend/kt/NativeRnsBackendImpl.kt
@@ -15,6 +15,7 @@ import network.columba.app.rns.api.model.VoiceCallState
 import network.columba.app.rns.api.util.AppDataParser
 import network.columba.app.rns.api.util.Aspects
 import network.columba.app.rns.api.util.LxmfFields
+import network.columba.app.rns.api.util.ReactionWireCodec
 import network.columba.app.rns.api.util.hexToBytes
 import network.columba.app.rns.api.util.isUserVisibleChatMessage
 import network.columba.app.rns.api.util.toHex
@@ -915,7 +916,7 @@ class NativeRnsBackendImpl(
             // appearance each have their own flow. We fire those routes
             // unconditionally — the chat-bubble emit below is gated
             // separately by `isUserVisibleChatMessage()`.
-            routeReactionSideChannel(fields, fieldsJson, sourceHash, message, timestamp)
+            routeReactionSideChannel(fieldsJson, sourceHash, message, timestamp)
             telemetryHandler.handleIncomingTelemetry(message = message, timestamp = timestamp)
             val iconAppearance = telemetryHandler.extractIconAppearance(fields)
             telemetryHandler.handleTelemetryCommands(message)
@@ -951,58 +952,29 @@ class NativeRnsBackendImpl(
     }
 
     /**
-     * Fire `_reactionReceivedFlow` if the inbound message carries a
-     * `fields[0x10] = {reaction_to, emoji, sender}` per-event reaction.
+     * Fire `_reactionReceivedFlow` if the inbound message carries a reaction —
+     * the canonical `fields[0x40] = {0x00: hashBytes, 0x01: contentBytes}` or
+     * the legacy `fields[0x10] = {reaction_to, emoji, sender}` fallback.
      * No-op for non-reaction messages.
      *
-     * Routing is separate from the chat-emit gate: a reaction-only
-     * message still flows through this routine, then naturally fails
-     * `isUserVisibleChatMessage` (no text, no attachments) and skips
-     * the chat bubble.
+     * Parses purely from the serialized `fieldsJson` (byte values already
+     * hex-encoded) via the shared `ReactionWireCodec`, so the kotlin-native
+     * and python-flavor backends decode reactions identically.
+     *
+     * Routing is separate from the chat-emit gate: a reaction-only message
+     * still flows through this routine, then naturally fails
+     * `isUserVisibleChatMessage` (no text, no attachments) and skips the
+     * chat bubble.
      */
     private fun routeReactionSideChannel(
-        fields: Map<Int, Any?>,
         fieldsJson: String?,
         sourceHash: ByteArray,
         message: LXMessage,
         timestamp: Long,
     ) {
-        val directReactionField = fields[16] as? Map<*, *>
-        val jsonReactionField =
-            fieldsJson
-                ?.let { runCatching { org.json.JSONObject(it).optJSONObject("16") }.getOrNull() }
-
-        if (fields.containsKey(16)) {
-            Log.d(
-                TAG,
-                "Incoming field16 type=${fields[16]?.javaClass?.name}, " +
-                    "directKeys=${directReactionField?.keys}, jsonField16=$jsonReactionField",
-            )
-        }
-
-        val reactionTo =
-            (directReactionField?.get("reaction_to") as? String)
-                ?: jsonReactionField?.optString("reaction_to")?.takeIf { it.isNotBlank() }
-                ?: return
-
-        val emoji =
-            (directReactionField?.get("emoji") as? String)
-                ?: jsonReactionField?.optString("emoji")
-                ?: ""
-        val sender =
-            (directReactionField?.get("sender") as? String)
-                ?: jsonReactionField?.optString("sender")
-                ?: ""
-
         val reactionJson =
-            org.json
-                .JSONObject()
-                .put("reaction_to", reactionTo)
-                .put("emoji", emoji)
-                .put("sender", sender)
-                .put("source_hash", sourceHash.toHex())
-                .put("timestamp", timestamp)
-                .toString()
+            ReactionWireCodec.parseInboundReaction(fieldsJson, sourceHash.toHex(), timestamp)
+                ?: return
 
         Log.d(
             TAG,
@@ -1398,22 +1370,24 @@ class NativeRnsBackendImpl(
         emoji: String,
         sourceIdentity: ColumbaIdentity,
     ): Result<MessageReceipt> {
-        val senderHash = sourceIdentity.hash.toHex()
+        // Canonical LXMF `fields[0x40] = {0x00: hashBytes, 0x01: emojiBytes}`
+        // (the reactor is derived from the message source on receive — no
+        // `sender` on the wire). Clean cutover: we no longer write the legacy
+        // `0x10` dict. See `ReactionWireCodec`.
+        val reactionFields =
+            ReactionWireCodec.encodeReactionFields(targetMessageId, emoji)
+                ?: return Result.failure(
+                    IllegalArgumentException(
+                        "Invalid reaction target hash: ${targetMessageId.take(16)}",
+                    ),
+                )
 
         return sendLxmfMessageWithMethod(
             destinationHash = destinationHash,
             content = "",
             sourceIdentity = sourceIdentity,
             deliveryMethod = DeliveryMethod.OPPORTUNISTIC,
-            extraFields =
-                mapOf(
-                    16 to
-                        mapOf(
-                            "reaction_to" to targetMessageId,
-                            "emoji" to emoji,
-                            "sender" to senderHash,
-                        ),
-                ),
+            extraFields = reactionFields,
         )
     }
 

--- a/rns-backend-py/src/main/kotlin/network/columba/app/rns/backend/py/PythonEventBridge.kt
+++ b/rns-backend-py/src/main/kotlin/network/columba/app/rns/backend/py/PythonEventBridge.kt
@@ -18,8 +18,10 @@ import network.columba.app.rns.api.model.ReceivedPacket
 import network.columba.app.rns.api.util.AppDataParser
 import network.columba.app.rns.api.util.isUserVisibleChatMessage
 import network.columba.app.rns.api.util.LxmfFields
+import network.columba.app.rns.api.util.ReactionWireCodec
 import network.columba.app.rns.api.util.TelemeterCodec
 import network.columba.app.rns.api.util.hexToBytes
+import network.columba.app.rns.api.util.toHex
 import org.json.JSONArray
 import org.json.JSONObject
 
@@ -86,7 +88,6 @@ class PythonEventBridge {
         val FIELD_TELEMETRY_STREAM_KEY = LxmfFields.FIELD_TELEMETRY_STREAM.toString()
         val FIELD_ICON_APPEARANCE_KEY = LxmfFields.FIELD_ICON_APPEARANCE.toString()
         val FIELD_CUSTOM_META_KEY = LxmfFields.FIELD_CUSTOM_META.toString()
-        val FIELD_REACTION_KEY = LxmfFields.FIELD_REACTION.toString()
     }
 
     private val _announces = MutableSharedFlow<AnnounceEvent>(extraBufferCapacity = 64)
@@ -244,7 +245,7 @@ class PythonEventBridge {
             // store and location map update.
             if (fieldsJson != null) {
                 assembleLocationTelemetry(fieldsJson, sourceHash, message.iconAppearance)
-                routeReactionSideChannel(fieldsJson)
+                routeReactionSideChannel(fieldsJson, sourceHash, message.timestamp)
             }
 
             // Chat emit is gated by the shared predicate
@@ -395,16 +396,19 @@ class PythonEventBridge {
         }
 
     /**
-     * Reaction-channel routing — `FIELD_REACTION` (0x10) is a
-     * Columba-specific field that doesn't go through Telemeter, so
-     * it stays a JSON-string side-channel as before.
+     * Reaction-channel routing — decodes the canonical `fields[0x40]` (or the
+     * legacy `fields[0x10]` fallback) into the normalized reaction JSON via the
+     * shared `ReactionWireCodec`, then emits it on `_reactionReceived`.
+     *
+     * The reactor (`sender`) is derived from the inbound message's
+     * [sourceHash] on the canonical path — the standard does not carry it on
+     * the wire. Using the shared codec keeps this byte-for-byte identical to
+     * the kotlin-native backend's `routeReactionSideChannel`.
      */
-    private fun routeReactionSideChannel(fieldsJson: String) {
+    private fun routeReactionSideChannel(fieldsJson: String, sourceHash: ByteArray, timestamp: Long) {
         runCatching {
-            val fields = JSONObject(fieldsJson)
-            if (fields.has(FIELD_REACTION_KEY)) {
-                _reactionReceived.tryEmit(fields.get(FIELD_REACTION_KEY).toString())
-            }
+            ReactionWireCodec.parseInboundReaction(fieldsJson, sourceHash.toHex(), timestamp)
+                ?.let { _reactionReceived.tryEmit(it) }
         }.onFailure { Log.w(TAG, "reaction side-channel routing failed", it) }
     }
 

--- a/rns-backend-py/src/main/kotlin/network/columba/app/rns/backend/py/PythonRnsLxmf.kt
+++ b/rns-backend-py/src/main/kotlin/network/columba/app/rns/backend/py/PythonRnsLxmf.kt
@@ -28,6 +28,7 @@ import network.columba.app.rns.api.model.MessageReceipt
 import network.columba.app.rns.api.model.PropagationState
 import network.columba.app.rns.api.model.ReceivedMessage
 import network.columba.app.rns.api.util.LxmfFields
+import network.columba.app.rns.api.util.ReactionWireCodec
 import network.columba.app.rns.api.util.hexToBytes
 import network.columba.app.rns.api.util.toHex
 
@@ -169,18 +170,21 @@ class PythonRnsLxmf(
     ): Result<MessageReceipt> =
         pyResult {
             runtime.requireRunning()
-            // Columba reaction payload: LXMF Field 16 carries the small dict
-            // {"reaction_to", "emoji", "sender"} on an otherwise-empty message.
-            val reaction = mapOf(
-                "reaction_to" to targetMessageId,
-                "emoji" to emoji,
-                "sender" to sourceIdentity.hash.toHex(),
-            )
-            val fields = pyDict(mapOf(LxmfFields.FIELD_REACTION to reaction))
+            // Canonical LXMF `fields[0x40] = {0x00: hashBytes, 0x01: emojiBytes}`
+            // on an otherwise-empty message — the reactor is derived from the
+            // message source on receive, so no `sender` is carried. Clean
+            // cutover: we no longer write the legacy `0x10` dict. The shared
+            // `ReactionWireCodec` produces the field map (ByteArray values);
+            // `pyDict` converts it to a Python dict of `bytes`.
+            val reactionFields =
+                ReactionWireCodec.encodeReactionFields(targetMessageId, emoji)
+                    ?: throw IllegalArgumentException(
+                        "Invalid reaction target hash: ${targetMessageId.take(16)}",
+                    )
             dispatchLxmessage(
                 destinationHash = destinationHash,
                 content = "",
-                fields = fields,
+                fields = pyDict(reactionFields),
                 desiredMethod = LXMF_METHOD_OPPORTUNISTIC,
             )
         }


### PR DESCRIPTION
## Summary

Upstream LXMF standardised reply/reaction/comment/continuation fields (`LXMF.py` commit `764758d`, "to be finalized in 1.0.0"). This migrates Columba reactions onto the canonical shape:

```
fields[0x40] = { 0x00: <target LXMessage.hash bytes>,    # REACTION_TO
                 0x01: <reaction content UTF-8 bytes> }  # REACTION_CONTENT
```

The reactor is **no longer carried on the wire** — it's derived from the inbound message's source hash, per the standard.

## Approach

**Clean cutover** (mirrors the `0x30`/`0x31` reply migration): outbound writes `0x40` only; inbound parses `0x40` first and falls back to the legacy string-keyed `fields[0x10] = {reaction_to, emoji, sender}` so reactions from un-upgraded peers still resolve. `0x10` also now sits inside upstream's reserved `0x00`–`0x80` range, so we stop squatting it.

- **New shared `ReactionWireCodec`** (`:rns-api`, same pattern as `TelemeterCodec`) — one encode/decode implementation so the kotlin-native and python-flavor backends can't drift.
- **Send**: both backends write canonical `0x40` via the codec (no legacy `0x10`, no wire `sender`).
- **Receive**: both backends route inbound reactions through the codec (`0x40`-first, `0x10` fallback). The python flavor previously forwarded the raw field dict — it now normalizes like the native backend and derives `sender` from the source hash.

The normalized downstream JSON (`{reaction_to, emoji, sender, source_hash, timestamp}`), the `reactionsJson` DB aggregation, and `MIGRATION_1_2` are **unchanged** — only the wire encode/decode moved.

## Tests

- `ReactionWireCodecTest` (10) — encode shape, canonical round-trip through `AppDataParser`, sender-from-source, lowercasing, multi-codepoint emoji (variation selectors / skin tone / ZWJ family / flags), legacy `0x10` fallback, `0x40` precedence, malformed/no-op inputs.
- Existing `MessagingViewModelTest` / `ReactionMapperTest` / `MessageMapperTest` / `ReactionComponentsTest` stay green (consumer contract preserved).
- Cross-impl conformance (Kotlin pack → Python unpack of the nested `0x40` dict) is covered by a sibling PR on the LXMF-kt port.

## Scope

Comments (`0x41`) and continuations (`0x42`) are **out of scope** here — new features, not a conformance gap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)