### PR TITLE
fix(reactions): reject blank/absent emoji on the legacy 0x10 parse path

### DIFF
--- a/rns-api/src/main/java/network/columba/app/rns/api/util/ReactionWireCodec.kt
+++ b/rns-api/src/main/java/network/columba/app/rns/api/util/ReactionWireCodec.kt
@@ -119,8 +119,11 @@ object ReactionWireCodec {
     /** Legacy `fields[0x10] = {reaction_to, emoji, sender}` (string-keyed). */
     private fun parseLegacy(fields: JSONObject, sourceHashHex: String, timestamp: Long): String? {
         val dict = fields.optJSONObject(FIELD_REACTION_LEGACY_KEY) ?: return null
-        val reactionTo = dict.optString("reaction_to").takeIf { it.isNotBlank() } ?: return null
-        val emoji = dict.optString("emoji")
+        val reactionTo = dict.optString("reaction_to").takeIf { it.isNotBlank() }
+        // Guard a blank/absent emoji (optString returns "" for a missing or null key),
+        // matching parseCanonical — otherwise an empty "" reaction reaches the UI map.
+        val emoji = dict.optString("emoji").takeIf { it.isNotBlank() }
+        if (reactionTo == null || emoji == null) return null
         // Legacy carried the reactor explicitly; fall back to the source hash
         // if an old peer ever omitted it.
         val sender = dict.optString("sender").takeIf { it.isNotBlank() } ?: sourceHashHex

--- a/rns-api/src/test/java/network/columba/app/rns/api/util/ReactionWireCodecTest.kt
+++ b/rns-api/src/test/java/network/columba/app/rns/api/util/ReactionWireCodecTest.kt
@@ -115,6 +115,22 @@ class ReactionWireCodecTest {
     }
 
     @Test
+    fun `legacy 0x10 with blank or absent emoji is rejected`() {
+        // optString returns "" for a missing or null key; a blank emoji must not
+        // become an invisible "" reaction (parity with the canonical path).
+        assertNull(
+            ReactionWireCodec.parseInboundReaction(
+                """{"16":{"reaction_to":"$targetHash","sender":"deadbeef"}}""", sourceHash, 1L,
+            ),
+        )
+        assertNull(
+            ReactionWireCodec.parseInboundReaction(
+                """{"16":{"reaction_to":"$targetHash","emoji":"","sender":"deadbeef"}}""", sourceHash, 1L,
+            ),
+        )
+    }
+
+    @Test
     fun `canonical 0x40 takes precedence over legacy 0x10 when both present`() {
         // Carrier with BOTH a canonical and a (different) legacy reaction.
         val canonical = ReactionWireCodec.encodeReactionFields(targetHash, "🔥")!!


### PR DESCRIPTION
## Summary

Follow-up to the reaction `0x40` migration (#956). `parseCanonical` already rejects a blank reaction content, but `parseLegacy` read `dict.optString("emoji")` unguarded — and `optString` returns `""` for a missing or null key, so a legacy `0x10` frame with an empty/absent emoji produced an invisible `""` reaction out of the codec.

The downstream consumer (`MessagingViewModel.handleIncomingReaction`) already filters empty emoji, so this is **defense-in-depth + parity** with the canonical path, not a live bug — but the codec should be self-consistent on both paths.

## Changes

- `parseLegacy` guards emoji with `takeIf { it.isNotBlank() }`, folded into the existing combined null-check so the function stays at 3 returns (detekt `ReturnCount`).
- New test `legacy 0x10 with blank or absent emoji is rejected` covering both the absent-key and empty-string cases.

`ReactionWireCodecTest` is now 11/11; `:rns-api:detekt` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)