### PR TITLE
fix(rns-ipc): guard network-status observer registration against dead backend

### DIFF
--- a/rns-host/src/main/kotlin/network/columba/app/rns/host/ReticulumServiceConnection.kt
+++ b/rns-host/src/main/kotlin/network/columba/app/rns/host/ReticulumServiceConnection.kt
@@ -5,6 +5,7 @@ import android.content.Context
 import android.content.Intent
 import android.content.ServiceConnection
 import android.os.IBinder
+import android.os.RemoteException
 import android.util.Log
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CoroutineScope
@@ -78,12 +79,61 @@ object ReticulumServiceConnection {
      */
     fun bind(context: Context, scope: CoroutineScope): Flow<RnsBackend?> = callbackFlow {
         var connectJob: Job? = null
+        // The binder we currently hold a death link on, plus its recipient, so
+        // the link can be dropped on reconnect/teardown (avoids leaking
+        // recipients across rebinds). Mutated from the main-thread connection
+        // callbacks; read from the binder-thread recipient via an identity guard.
+        var linkedBinder: IBinder? = null
+        var deathRecipient: IBinder.DeathRecipient? = null
+
+        fun unlinkDeath() {
+            val binder = linkedBinder
+            val recipient = deathRecipient
+            if (binder != null && recipient != null) {
+                runCatching { binder.unlinkToDeath(recipient, 0) }
+            }
+            linkedBinder = null
+            deathRecipient = null
+        }
 
         val connection = object : ServiceConnection {
             override fun onServiceConnected(name: ComponentName?, service: IBinder?) {
-                val remote = service?.let { IRnsBackend.Stub.asInterface(it) }
+                if (service == null) {
+                    Log.w(TAG, "onServiceConnected delivered a null binder")
+                    return
+                }
+                val remote = IRnsBackend.Stub.asInterface(service)
                 if (remote == null) {
                     Log.w(TAG, "onServiceConnected delivered a binder that is not IRnsBackend")
+                    return
+                }
+                // Link a death recipient to the new binder. binderDied() fires
+                // promptly off a binder thread — often before the main-thread
+                // onServiceDisconnected lands, which lags on low-end devices (the
+                // Sentry COLUMBA-AZ repro device: 2 cores, low memory). It only
+                // emits null so awaitBound() callers suspend through the gap and
+                // stop invoking the dead binder; the rebind itself stays owned by
+                // onServiceDisconnected/onBindingDied to avoid a double-rebind.
+                unlinkDeath()
+                val recipient = IBinder.DeathRecipient {
+                    // Identity guard: ignore a stale fire for a binder we've
+                    // already replaced on a newer onServiceConnected.
+                    if (linkedBinder === service) {
+                        Log.w(TAG, "binderDied — :reticulum process died; emitting null")
+                        connectJob?.cancel()
+                        connectJob = null
+                        trySend(null)
+                    }
+                }
+                try {
+                    service.linkToDeath(recipient, 0)
+                    linkedBinder = service
+                    deathRecipient = recipient
+                } catch (e: RemoteException) {
+                    // Binder already dead at link time — the exact race COLUMBA-AZ
+                    // hit. Treat as disconnected and let the rebind path recover.
+                    Log.w(TAG, "linkToDeath failed; binder already dead", e)
+                    trySend(null)
                     return
                 }
                 connectJob?.cancel()
@@ -102,6 +152,7 @@ object ReticulumServiceConnection {
 
             override fun onServiceDisconnected(name: ComponentName?) {
                 Log.w(TAG, "Service disconnected; awaiting reconnect (emitting null)")
+                unlinkDeath()
                 connectJob?.cancel()
                 connectJob = null
                 // Punch-list item 10: emit null so downstream awaitBound() suspends
@@ -112,6 +163,7 @@ object ReticulumServiceConnection {
 
             override fun onBindingDied(name: ComponentName?) {
                 Log.w(TAG, "onBindingDied from $name — binding will need rebind")
+                unlinkDeath()
                 connectJob?.cancel()
                 connectJob = null
                 trySend(null)
@@ -152,6 +204,7 @@ object ReticulumServiceConnection {
 
         awaitClose {
             connectJob?.cancel()
+            unlinkDeath()
             try {
                 context.unbindService(connection)
             } catch (e: IllegalArgumentException) {

--- a/rns-host/src/main/kotlin/network/columba/app/rns/host/ReticulumServiceConnection.kt
+++ b/rns-host/src/main/kotlin/network/columba/app/rns/host/ReticulumServiceConnection.kt
@@ -79,7 +79,11 @@ object ReticulumServiceConnection {
      *   `ApplicationScope`).
      */
     fun bind(context: Context, scope: CoroutineScope): Flow<RnsBackend?> = callbackFlow {
-        var connectJob: Job? = null
+        // connectJob is mutated from the main-thread connection callbacks AND
+        // the binder-thread death recipient, so it needs the same atomic
+        // happens-before treatment as the link refs below (getAndSet swaps the
+        // job and cancels the previous one in one step).
+        val connectJob = AtomicReference<Job?>(null)
         // The binder we currently hold a death link on, plus its recipient, so
         // the link can be dropped on reconnect/teardown (avoids leaking
         // recipients across rebinds). AtomicReference, not plain var: written on
@@ -120,8 +124,7 @@ object ReticulumServiceConnection {
                     // already replaced on a newer onServiceConnected.
                     if (linkedBinder.get() === service) {
                         Log.w(TAG, "binderDied — :reticulum process died; emitting null")
-                        connectJob?.cancel()
-                        connectJob = null
+                        connectJob.getAndSet(null)?.cancel()
                         trySend(null)
                     }
                 }
@@ -143,8 +146,7 @@ object ReticulumServiceConnection {
                     trySend(null)
                     return
                 }
-                connectJob?.cancel()
-                connectJob = scope.launch {
+                val job = scope.launch {
                     try {
                         val client = RnsBackendClient(scope)
                         client.connect(remote)
@@ -155,13 +157,13 @@ object ReticulumServiceConnection {
                         Log.e(TAG, "Failed to connect RnsBackendClient", e)
                     }
                 }
+                connectJob.getAndSet(job)?.cancel()
             }
 
             override fun onServiceDisconnected(name: ComponentName?) {
                 Log.w(TAG, "Service disconnected; awaiting reconnect (emitting null)")
                 unlinkDeath()
-                connectJob?.cancel()
-                connectJob = null
+                connectJob.getAndSet(null)?.cancel()
                 // Punch-list item 10: emit null so downstream awaitBound() suspends
                 // until a fresh onServiceConnected lands, instead of resolving
                 // immediately against the dead binder still cached in the StateFlow.
@@ -171,8 +173,7 @@ object ReticulumServiceConnection {
             override fun onBindingDied(name: ComponentName?) {
                 Log.w(TAG, "onBindingDied from $name — binding will need rebind")
                 unlinkDeath()
-                connectJob?.cancel()
-                connectJob = null
+                connectJob.getAndSet(null)?.cancel()
                 trySend(null)
                 // Re-bind so Android delivers a fresh onServiceConnected once the
                 // next :reticulum process is up. Without this, onBindingDied is
@@ -210,7 +211,7 @@ object ReticulumServiceConnection {
         }
 
         awaitClose {
-            connectJob?.cancel()
+            connectJob.getAndSet(null)?.cancel()
             unlinkDeath()
             try {
                 context.unbindService(connection)

--- a/rns-host/src/main/kotlin/network/columba/app/rns/host/ReticulumServiceConnection.kt
+++ b/rns-host/src/main/kotlin/network/columba/app/rns/host/ReticulumServiceConnection.kt
@@ -7,6 +7,7 @@ import android.content.ServiceConnection
 import android.os.IBinder
 import android.os.RemoteException
 import android.util.Log
+import java.util.concurrent.atomic.AtomicReference
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Job
@@ -81,19 +82,18 @@ object ReticulumServiceConnection {
         var connectJob: Job? = null
         // The binder we currently hold a death link on, plus its recipient, so
         // the link can be dropped on reconnect/teardown (avoids leaking
-        // recipients across rebinds). Mutated from the main-thread connection
-        // callbacks; read from the binder-thread recipient via an identity guard.
-        var linkedBinder: IBinder? = null
-        var deathRecipient: IBinder.DeathRecipient? = null
+        // recipients across rebinds). AtomicReference, not plain var: written on
+        // the main-thread connection callbacks but read from the binder-thread
+        // death recipient's identity guard, so it needs a happens-before edge.
+        val linkedBinder = AtomicReference<IBinder?>(null)
+        val deathRecipient = AtomicReference<IBinder.DeathRecipient?>(null)
 
         fun unlinkDeath() {
-            val binder = linkedBinder
-            val recipient = deathRecipient
+            val binder = linkedBinder.getAndSet(null)
+            val recipient = deathRecipient.getAndSet(null)
             if (binder != null && recipient != null) {
                 runCatching { binder.unlinkToDeath(recipient, 0) }
             }
-            linkedBinder = null
-            deathRecipient = null
         }
 
         val connection = object : ServiceConnection {
@@ -118,20 +118,27 @@ object ReticulumServiceConnection {
                 val recipient = IBinder.DeathRecipient {
                     // Identity guard: ignore a stale fire for a binder we've
                     // already replaced on a newer onServiceConnected.
-                    if (linkedBinder === service) {
+                    if (linkedBinder.get() === service) {
                         Log.w(TAG, "binderDied — :reticulum process died; emitting null")
                         connectJob?.cancel()
                         connectJob = null
                         trySend(null)
                     }
                 }
+                // Publish the refs BEFORE linkToDeath: if the binder dies in the
+                // window around registration, the recipient's identity guard must
+                // already see this binder, or the null emission is silently
+                // dropped — defeating the fast path for the very COLUMBA-AZ race.
+                linkedBinder.set(service)
+                deathRecipient.set(recipient)
                 try {
                     service.linkToDeath(recipient, 0)
-                    linkedBinder = service
-                    deathRecipient = recipient
                 } catch (e: RemoteException) {
                     // Binder already dead at link time — the exact race COLUMBA-AZ
-                    // hit. Treat as disconnected and let the rebind path recover.
+                    // hit. Roll back the refs we just published and treat as
+                    // disconnected; the rebind path recovers.
+                    linkedBinder.set(null)
+                    deathRecipient.set(null)
                     Log.w(TAG, "linkToDeath failed; binder already dead", e)
                     trySend(null)
                     return

--- a/rns-host/src/main/kotlin/network/columba/app/rns/host/ReticulumServiceConnection.kt
+++ b/rns-host/src/main/kotlin/network/columba/app/rns/host/ReticulumServiceConnection.kt
@@ -134,18 +134,11 @@ object ReticulumServiceConnection {
                 // dropped — defeating the fast path for the very COLUMBA-AZ race.
                 linkedBinder.set(service)
                 deathRecipient.set(recipient)
-                try {
-                    service.linkToDeath(recipient, 0)
-                } catch (e: RemoteException) {
-                    // Binder already dead at link time — the exact race COLUMBA-AZ
-                    // hit. Roll back the refs we just published and treat as
-                    // disconnected; the rebind path recovers.
-                    linkedBinder.set(null)
-                    deathRecipient.set(null)
-                    Log.w(TAG, "linkToDeath failed; binder already dead", e)
-                    trySend(null)
-                    return
-                }
+                // Store the connect job BEFORE linkToDeath, too: otherwise a
+                // binderDied() firing in the window after registration but before
+                // the job is stored finds no job to cancel, and a connect() that
+                // completed before the death notification would trySend(client) a
+                // stale live reference after the null sentinel.
                 val job = scope.launch {
                     try {
                         val client = RnsBackendClient(scope)
@@ -158,6 +151,19 @@ object ReticulumServiceConnection {
                     }
                 }
                 connectJob.getAndSet(job)?.cancel()
+                try {
+                    service.linkToDeath(recipient, 0)
+                } catch (e: RemoteException) {
+                    // Binder already dead at link time — the exact race COLUMBA-AZ
+                    // hit. Roll back: cancel the job we just stored, clear the
+                    // refs, and treat as disconnected; the rebind path recovers.
+                    connectJob.getAndSet(null)?.cancel()
+                    linkedBinder.set(null)
+                    deathRecipient.set(null)
+                    Log.w(TAG, "linkToDeath failed; binder already dead", e)
+                    trySend(null)
+                    return
+                }
             }
 
             override fun onServiceDisconnected(name: ComponentName?) {

--- a/rns-host/src/test/kotlin/network/columba/app/rns/host/ReticulumServiceConnectionDeathTest.kt
+++ b/rns-host/src/test/kotlin/network/columba/app/rns/host/ReticulumServiceConnectionDeathTest.kt
@@ -1,0 +1,80 @@
+package network.columba.app.rns.host
+
+import android.content.ComponentName
+import android.os.IBinder
+import app.cash.turbine.test
+import io.mockk.Runs
+import io.mockk.every
+import io.mockk.just
+import io.mockk.mockk
+import io.mockk.slot
+import io.mockk.verify
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import kotlinx.coroutines.test.runTest
+import network.columba.app.rns.ipc.IRnsBackend
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.RuntimeEnvironment
+import org.robolectric.Shadows.shadowOf
+import org.robolectric.annotation.Config
+
+/**
+ * Hardening for Sentry COLUMBA-AZ: the UI->host binding links a death recipient
+ * to the `:reticulum` binder so process death is detected promptly (off a binder
+ * thread) even when the main-thread [android.content.ServiceConnection] callbacks
+ * lag — the situation on the low-end repro device. The recipient emits a `null`
+ * backend (so `awaitBound()` callers suspend through the gap instead of invoking
+ * the dead binder); the rebind itself stays owned by onServiceDisconnected/
+ * onBindingDied to avoid a double-rebind.
+ */
+@RunWith(RobolectricTestRunner::class)
+@Config(sdk = [34])
+class ReticulumServiceConnectionDeathTest {
+
+    @OptIn(ExperimentalCoroutinesApi::class)
+    @Test
+    fun binderDeath_linksRecipientAndEmitsNull() = runTest(UnconfinedTestDispatcher()) {
+        val app = RuntimeEnvironment.getApplication()
+        // Separate scope for the client-connect job so its (deliberately
+        // never-resolving, relaxed-mock) fetch doesn't entangle the test scope.
+        val bindScope = CoroutineScope(SupervisorJob() + UnconfinedTestDispatcher(testScheduler))
+
+        ReticulumServiceConnection.bind(app, bindScope).test {
+            val connection = shadowOf(app).boundServiceConnections.firstOrNull()
+            assertNotNull("bind() should register a ServiceConnection via bindService", connection)
+
+            val backend = mockk<IRnsBackend>(relaxed = true)
+            val binder = mockk<IBinder>(relaxed = true)
+            // asInterface() returns this local interface directly.
+            every { binder.queryLocalInterface(any()) } returns backend
+            val recipientSlot = slot<IBinder.DeathRecipient>()
+            every { binder.linkToDeath(capture(recipientSlot), 0) } just Runs
+            every { binder.unlinkToDeath(any(), 0) } returns true
+
+            // Deliver a live binder, exactly as Android would.
+            connection!!.onServiceConnected(ComponentName(app, "ReticulumService"), binder)
+
+            // The fix wires a death recipient onto the delivered binder.
+            verify { binder.linkToDeath(any(), 0) }
+            assertTrue("a DeathRecipient should be linked on connect", recipientSlot.isCaptured)
+
+            // Simulate the :reticulum process dying (binder thread callback).
+            recipientSlot.captured.binderDied()
+
+            // Death must surface as a null backend, not a crash or a stale live ref.
+            assertNull("binderDied should emit a null backend", awaitItem())
+
+            cancelAndIgnoreRemainingEvents()
+        }
+
+        bindScope.cancel()
+    }
+}

--- a/rns-host/src/test/kotlin/network/columba/app/rns/host/ReticulumServiceConnectionDeathTest.kt
+++ b/rns-host/src/test/kotlin/network/columba/app/rns/host/ReticulumServiceConnectionDeathTest.kt
@@ -51,9 +51,13 @@ class ReticulumServiceConnectionDeathTest {
             val connection = shadowOf(app).boundServiceConnections.firstOrNull()
             assertNotNull("bind() should register a ServiceConnection via bindService", connection)
 
-            val backend = mockk<IRnsBackend>(relaxed = true)
-            val binder = mockk<IBinder>(relaxed = true)
-            // asInterface() returns this local interface directly.
+            // Explicit stubs (no relaxed mock) for exactly the calls the connect
+            // path makes: asInterface() resolves the backend; RnsBackendClient.connect
+            // fetches the core sub-interface (left unresolved — we only exercise the
+            // death wiring, not a full connect); the binder is linked/unlinked.
+            val backend = mockk<IRnsBackend>()
+            every { backend.getCore(any()) } just Runs
+            val binder = mockk<IBinder>()
             every { binder.queryLocalInterface(any()) } returns backend
             val recipientSlot = slot<IBinder.DeathRecipient>()
             every { binder.linkToDeath(capture(recipientSlot), 0) } just Runs

--- a/rns-ipc/src/main/kotlin/network/columba/app/rns/ipc/client/ClientRnsCore.kt
+++ b/rns-ipc/src/main/kotlin/network/columba/app/rns/ipc/client/ClientRnsCore.kt
@@ -73,7 +73,8 @@ internal class ClientRnsCore(
                 // Surface the unavailability and close the flow gracefully; the
                 // bound-service layer recreates this ClientRnsCore (fresh observer)
                 // on rebind. Mirrors the snapshot path, which already catches here.
-                trySend(NetworkStatus.ERROR("RNS backend process unavailable"))
+                // The cause is carried into the ERROR so it isn't swallowed.
+                trySend(NetworkStatus.ERROR("RNS backend process unavailable: ${e.message}"))
                 close()
                 return@callbackFlow
             }

--- a/rns-ipc/src/main/kotlin/network/columba/app/rns/ipc/client/ClientRnsCore.kt
+++ b/rns-ipc/src/main/kotlin/network/columba/app/rns/ipc/client/ClientRnsCore.kt
@@ -1,5 +1,6 @@
 package network.columba.app.rns.ipc.client
 
+import android.os.RemoteException
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.channels.awaitClose
 import kotlinx.coroutines.flow.Flow
@@ -60,7 +61,22 @@ internal class ClientRnsCore(
             val cb = object : IRnsNetworkStatusCallback.Stub() {
                 override fun onStatus(status: NetworkStatus?) { if (status != null) trySend(status) }
             }
-            remote.registerNetworkStatusObserver(cb)
+            try {
+                remote.registerNetworkStatusObserver(cb)
+            } catch (e: RemoteException) {
+                // The :reticulum backend process can die in the window between
+                // onServiceConnected handing back this proxy and this coroutine
+                // running (OOM/restart), so the observer registration is the one
+                // remote call that races process death. An unguarded throw here
+                // escapes the callbackFlow into the collecting coroutine and crashes
+                // the UI (Sentry COLUMBA-AZ: DeadObjectException, a RemoteException).
+                // Surface the unavailability and close the flow gracefully; the
+                // bound-service layer recreates this ClientRnsCore (fresh observer)
+                // on rebind. Mirrors the snapshot path, which already catches here.
+                trySend(NetworkStatus.ERROR("RNS backend process unavailable"))
+                close()
+                return@callbackFlow
+            }
             awaitClose { runCatching { remote.unregisterNetworkStatusObserver(cb) } }
         }.onEach { networkStatusState.value = it }.launchIn(scope)
 

--- a/rns-ipc/src/test/java/network/columba/app/rns/ipc/client/ClientRnsCoreNetworkObserverTest.kt
+++ b/rns-ipc/src/test/java/network/columba/app/rns/ipc/client/ClientRnsCoreNetworkObserverTest.kt
@@ -1,7 +1,9 @@
 package network.columba.app.rns.ipc.client
 
 import android.os.DeadObjectException
+import io.mockk.Runs
 import io.mockk.every
+import io.mockk.just
 import io.mockk.mockk
 import kotlinx.coroutines.CoroutineExceptionHandler
 import kotlinx.coroutines.CoroutineScope
@@ -50,9 +52,14 @@ class ClientRnsCoreNetworkObserverTest {
         // coroutine; Unconfined so init's launches run eagerly/inline.
         val scope = CoroutineScope(SupervisorJob() + Dispatchers.Unconfined + handler)
 
-        val remote = mockk<IRnsCore>(relaxed = true)
+        // Explicit stubs (no relaxed mock) for exactly the calls ClientRnsCore.init
+        // makes: the observer registration throws (the crash trigger); the snapshot
+        // read and unregister are no-ops.
+        val remote = mockk<IRnsCore>()
         every { remote.registerNetworkStatusObserver(any()) } throws
             DeadObjectException("Transaction failed on small parcel; remote process probably died")
+        every { remote.unregisterNetworkStatusObserver(any()) } just Runs
+        every { remote.getCurrentNetworkStatus(any()) } just Runs
 
         // Construct the real production object — its init block performs the registration.
         val core = ClientRnsCore(remote, scope)

--- a/rns-ipc/src/test/java/network/columba/app/rns/ipc/client/ClientRnsCoreNetworkObserverTest.kt
+++ b/rns-ipc/src/test/java/network/columba/app/rns/ipc/client/ClientRnsCoreNetworkObserverTest.kt
@@ -57,13 +57,10 @@ class ClientRnsCoreNetworkObserverTest {
         // Construct the real production object — its init block performs the registration.
         val core = ClientRnsCore(remote, scope)
 
-        // Give any (unexpected) escape a moment to surface on the handler.
+        // Block the full window for any (unexpected) escape to surface on the
+        // handler. This also lets the Unconfined callbackFlow settle to its
+        // terminal ERROR emission, so the value read below is deterministic.
         val escaped = latch.await(500, TimeUnit.MILLISECONDS)
-        // Let the StateFlow settle to its terminal ERROR emission.
-        val deadline = System.currentTimeMillis() + 2000
-        while (core.networkStatus.value !is NetworkStatus.ERROR && System.currentTimeMillis() < deadline) {
-            Thread.sleep(20)
-        }
         scope.cancel()
 
         assertFalse(

--- a/rns-ipc/src/test/java/network/columba/app/rns/ipc/client/ClientRnsCoreNetworkObserverTest.kt
+++ b/rns-ipc/src/test/java/network/columba/app/rns/ipc/client/ClientRnsCoreNetworkObserverTest.kt
@@ -1,0 +1,80 @@
+package network.columba.app.rns.ipc.client
+
+import android.os.DeadObjectException
+import io.mockk.every
+import io.mockk.mockk
+import kotlinx.coroutines.CoroutineExceptionHandler
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.cancel
+import network.columba.app.rns.api.model.NetworkStatus
+import network.columba.app.rns.ipc.IRnsCore
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.TimeUnit
+import java.util.concurrent.atomic.AtomicReference
+
+/**
+ * Regression guard for Sentry COLUMBA-AZ.
+ *
+ * The `:reticulum` backend process can die in the window between `onServiceConnected`
+ * handing [ClientRnsCore] a proxy and its init block registering the network-status
+ * observer. The registration is the one remote call in this client that races process
+ * death; an unguarded `remote.registerNetworkStatusObserver()` throws [DeadObjectException]
+ * (a `RemoteException`) that escapes the `callbackFlow` producer and crashes the
+ * collecting coroutine.
+ *
+ * Reproduced first against the unguarded code (the exception reached the scope's
+ * [CoroutineExceptionHandler]); this asserts the FIXED behavior: the failure is caught,
+ * nothing escapes to the handler, and `networkStatus` surfaces ERROR instead of crashing.
+ * This test fails on the pre-fix code and passes once the registration is guarded.
+ */
+@RunWith(RobolectricTestRunner::class)
+class ClientRnsCoreNetworkObserverTest {
+
+    @Test
+    fun deadRemoteDuringObserverRegistration_isHandledNotCrashed() {
+        val caught = AtomicReference<Throwable?>(null)
+        val latch = CountDownLatch(1)
+        val handler = CoroutineExceptionHandler { _, t ->
+            caught.set(t)
+            latch.countDown()
+        }
+        // SupervisorJob so the snapshot coroutine isn't cancelled by the observer
+        // coroutine; Unconfined so init's launches run eagerly/inline.
+        val scope = CoroutineScope(SupervisorJob() + Dispatchers.Unconfined + handler)
+
+        val remote = mockk<IRnsCore>(relaxed = true)
+        every { remote.registerNetworkStatusObserver(any()) } throws
+            DeadObjectException("Transaction failed on small parcel; remote process probably died")
+
+        // Construct the real production object — its init block performs the registration.
+        val core = ClientRnsCore(remote, scope)
+
+        // Give any (unexpected) escape a moment to surface on the handler.
+        val escaped = latch.await(500, TimeUnit.MILLISECONDS)
+        // Let the StateFlow settle to its terminal ERROR emission.
+        val deadline = System.currentTimeMillis() + 2000
+        while (core.networkStatus.value !is NetworkStatus.ERROR && System.currentTimeMillis() < deadline) {
+            Thread.sleep(20)
+        }
+        scope.cancel()
+
+        assertFalse(
+            "DeadObjectException must NOT escape to the coroutine scope after the fix " +
+                "(escaped throwable: ${caught.get()})",
+            escaped,
+        )
+        assertNull("No throwable should reach the coroutine exception handler", caught.get())
+        assertTrue(
+            "networkStatus should surface ERROR when the backend is unavailable, was ${core.networkStatus.value}",
+            core.networkStatus.value is NetworkStatus.ERROR,
+        )
+    }
+}


### PR DESCRIPTION
Fixes the COLUMBA-AZ crash, plus a defense-in-depth hardening for the underlying race. Two commits.

## 1. The crash — guard the observer registration (`rns-ipc`)

`ClientRnsCore.init` registered the network-status observer with an **unguarded** AIDL call inside a `callbackFlow`:

```kotlin
remote.registerNetworkStatusObserver(cb)   // ClientRnsCore.kt:63 — no try/catch
```

When the `:reticulum` backend process is dead in the window between `onServiceConnected` handing back the proxy and this coroutine running, the call throws `DeadObjectException` (a `RemoteException`). With no `try/catch` and no `.catch` on the chain (consumed via `.launchIn(scope)`), it escaped the producer and crashed the collecting coroutine — a **fatal uncaught crash**.

It was the **only** remote call in the IPC client layer without `RemoteException` handling; the sibling snapshot path (`awaitNetworkStatus`) in the same `init` block already caught it.

**Crash signature (COLUMBA-AZ):**
```
DeadObjectException: Transaction failed on small parcel; remote process probably died
  ClientRnsCore$1.invokeSuspend(ClientRnsCore.kt:63)
    → IRnsCore$Stub$Proxy.registerNetworkStatusObserver → BinderProxy.transact (native)
  via CallbackFlowBuilder.collectTo on a Default dispatcher worker
  mechanism: UncaughtExceptionHandler · level: fatal · handled: no
```

The reporting device explains *why* the remote was dead: a low-end handset (`device.class: low`, ~1.7 GB RAM, Android 11, battery 6%). On such devices the system OOM-kills the `:reticulum` foreground service while the UI still holds the proxy. Seen on `2.0.0-beta`, production.

**Fix:** guard the registration — on `RemoteException`, surface `NetworkStatus.ERROR` and `close()` the flow gracefully instead of crashing; the bound-service layer recreates `ClientRnsCore` (fresh observer) on rebind.

## 2. Hardening — death recipient on the UI→host binder (`rns-host`)

UI-side death detection relied solely on the main-thread `ServiceConnection` callbacks (`onServiceDisconnected`/`onBindingDied`), which are best-effort and **lag on exactly the low-end device profile that crashed**. During the lag the binder is dead but no rebind has fired, widening the dead-binder window.

`ReticulumServiceConnection` now links an `IBinder.DeathRecipient` to the host binder in `onServiceConnected`. It fires promptly off a binder thread and emits a `null` backend so `awaitBound()` callers suspend through the gap. The rebind stays owned by `onServiceDisconnected`/`onBindingDied` (no double-rebind); an identity guard ignores stale fires for a replaced binder; the link is dropped on reconnect/disconnect/teardown; and `linkToDeath` throwing (binder already dead at link time) also emits `null`.

## Tests

Both changes are TDD'd with Robolectric, each verified **red before / green after**:
- `ClientRnsCoreNetworkObserverTest` — constructs the real `ClientRnsCore` with a mock `IRnsCore` whose registration throws `DeadObjectException`; asserts the exception is handled (no escape to the coroutine scope) and `networkStatus` reports `ERROR`.
- `ReticulumServiceConnectionDeathTest` — drives a real `onServiceConnected` with a mock binder, captures the linked recipient, fires `binderDied()`, and asserts a `null` emission.
