### PR TITLE
fix(rns-ipc): guard all observer registrations against dead backend (COLUMBA-B0)

### DIFF
--- a/rns-ipc/src/main/kotlin/network/columba/app/rns/ipc/client/ClientAidlBridge.kt
+++ b/rns-ipc/src/main/kotlin/network/columba/app/rns/ipc/client/ClientAidlBridge.kt
@@ -3,6 +3,8 @@ package network.columba.app.rns.ipc.client
 import android.os.Bundle
 import android.os.DeadObjectException
 import android.os.RemoteException
+import android.util.Log
+import kotlinx.coroutines.channels.ProducerScope
 import kotlinx.coroutines.suspendCancellableCoroutine
 import network.columba.app.rns.api.RnsError
 import network.columba.app.rns.api.RnsException
@@ -224,6 +226,34 @@ internal suspend inline fun awaitNullableByteArray(
 internal inline fun <T> Bundle.unwrap(extract: Bundle.() -> T): Result<T> =
     runCatching { extract() }.recoverCatching {
         throw RnsException(RnsError.Generic("Failed to extract result payload: ${it.message}", it.stackTraceToString()))
+    }
+
+private const val OBSERVER_TAG = "ClientRnsObserver"
+
+/**
+ * Register an AIDL observer from inside a [kotlinx.coroutines.flow.callbackFlow]
+ * producer, guarding the cross-process call against a dead `:reticulum` backend.
+ *
+ * If the backend process is dead at registration time the call throws
+ * [RemoteException] (DeadObjectException). Unguarded, that escapes the producer
+ * and crashes the collecting coroutine — Sentry COLUMBA-AZ (networkStatus),
+ * COLUMBA-B0 (telemetry), and every other observer-backed flow share the
+ * hazard. On failure the producer is closed gracefully (no exception
+ * propagated), so the bound-service layer's `flatMapLatest` re-subscribes once
+ * the backend rebinds.
+ *
+ * @return true if registration succeeded; false if the backend was dead — in
+ *   which case the flow is already closed and the caller should
+ *   `return@callbackFlow` to skip the awaitClose unregister.
+ */
+internal inline fun ProducerScope<*>.registerObserverOrClose(register: () -> Unit): Boolean =
+    try {
+        register()
+        true
+    } catch (e: RemoteException) {
+        Log.w(OBSERVER_TAG, "observer registration failed; :reticulum backend dead", e)
+        close()
+        false
     }
 
 internal fun remoteToRnsException(e: RemoteException): RnsException =

--- a/rns-ipc/src/main/kotlin/network/columba/app/rns/ipc/client/ClientAidlBridge.kt
+++ b/rns-ipc/src/main/kotlin/network/columba/app/rns/ipc/client/ClientAidlBridge.kt
@@ -242,6 +242,13 @@ private const val OBSERVER_TAG = "ClientRnsObserver"
  * propagated), so the bound-service layer's `flatMapLatest` re-subscribes once
  * the backend rebinds.
  *
+ * Closing **without** the cause is deliberate — do NOT change this to
+ * `close(e)`. Most of these observers are collected via `.launchIn(scope)`
+ * with no `.catch`, so `close(e)` would re-throw the [RemoteException] into
+ * that collector and reintroduce the exact uncaught-coroutine crash this
+ * guards against. The dead-backend signal is intentionally dropped here; the
+ * rebind path is what restores the stream.
+ *
  * @return true if registration succeeded; false if the backend was dead — in
  *   which case the flow is already closed and the caller should
  *   `return@callbackFlow` to skip the awaitClose unregister.

--- a/rns-ipc/src/main/kotlin/network/columba/app/rns/ipc/client/ClientRnsCore.kt
+++ b/rns-ipc/src/main/kotlin/network/columba/app/rns/ipc/client/ClientRnsCore.kt
@@ -184,7 +184,7 @@ internal class ClientRnsCore(
         val cb = object : IRnsPacketCallback.Stub() {
             override fun onPacket(packet: ReceivedPacket?) { if (packet != null) trySend(packet) }
         }
-        remote.registerPacketObserver(cb)
+        if (!registerObserverOrClose { remote.registerPacketObserver(cb) }) return@callbackFlow
         awaitClose { runCatching { remote.unregisterPacketObserver(cb) } }
     }
 
@@ -210,7 +210,7 @@ internal class ClientRnsCore(
         val cb = object : IRnsLinkEventCallback.Stub() {
             override fun onLinkEvent(event: LinkEvent?) { if (event != null) trySend(event) }
         }
-        remote.registerLinkObserver(cb)
+        if (!registerObserverOrClose { remote.registerLinkObserver(cb) }) return@callbackFlow
         awaitClose { runCatching { remote.unregisterLinkObserver(cb) } }
     }
 
@@ -279,7 +279,7 @@ internal class ClientRnsCore(
         val cb = object : IRnsAnnounceCallback.Stub() {
             override fun onAnnounce(event: AnnounceEvent?) { if (event != null) trySend(event) }
         }
-        remote.registerAnnounceObserver(cb)
+        if (!registerObserverOrClose { remote.registerAnnounceObserver(cb) }) return@callbackFlow
         awaitClose { runCatching { remote.unregisterAnnounceObserver(cb) } }
     }
 

--- a/rns-ipc/src/main/kotlin/network/columba/app/rns/ipc/client/ClientRnsLxmf.kt
+++ b/rns-ipc/src/main/kotlin/network/columba/app/rns/ipc/client/ClientRnsLxmf.kt
@@ -113,7 +113,7 @@ internal class ClientRnsLxmf(
         val cb = object : IRnsMessageCallback.Stub() {
             override fun onMessage(message: ReceivedMessage?) { if (message != null) trySend(message) }
         }
-        remote.registerMessageObserver(cb)
+        if (!registerObserverOrClose { remote.registerMessageObserver(cb) }) return@callbackFlow
         awaitClose { runCatching { remote.unregisterMessageObserver(cb) } }
     }
 
@@ -121,7 +121,7 @@ internal class ClientRnsLxmf(
         val cb = object : IRnsDeliveryStatusCallback.Stub() {
             override fun onDeliveryStatus(update: DeliveryStatusUpdate?) { if (update != null) trySend(update) }
         }
-        remote.registerDeliveryStatusObserver(cb)
+        if (!registerObserverOrClose { remote.registerDeliveryStatusObserver(cb) }) return@callbackFlow
         awaitClose { runCatching { remote.unregisterDeliveryStatusObserver(cb) } }
     }
 
@@ -185,7 +185,7 @@ internal class ClientRnsLxmf(
                     if (state != null) trySend(state)
                 }
             }
-            remote.registerPropagationStateObserver(cb)
+            if (!registerObserverOrClose { remote.registerPropagationStateObserver(cb) }) return@callbackFlow
             awaitClose { runCatching { remote.unregisterPropagationStateObserver(cb) } }
         }.onEach { propagationShared.emit(it) }.launchIn(scope)
     }

--- a/rns-ipc/src/main/kotlin/network/columba/app/rns/ipc/client/ClientRnsNomadnet.kt
+++ b/rns-ipc/src/main/kotlin/network/columba/app/rns/ipc/client/ClientRnsNomadnet.kt
@@ -64,7 +64,7 @@ internal class ClientRnsNomadnet(
             val cb = object : IRnsStringEventCallback.Stub() {
                 override fun onString(value: String?) { if (value != null) trySend(value) }
             }
-            remote.registerRequestStatusObserver(cb)
+            if (!registerObserverOrClose { remote.registerRequestStatusObserver(cb) }) return@callbackFlow
             awaitClose { runCatching { remote.unregisterRequestStatusObserver(cb) } }
         }.onEach { statusState.value = it }.launchIn(scope)
 
@@ -72,7 +72,7 @@ internal class ClientRnsNomadnet(
             val cb = object : IRnsFloatEventCallback.Stub() {
                 override fun onFloat(value: Float) { trySend(value) }
             }
-            remote.registerDownloadProgressObserver(cb)
+            if (!registerObserverOrClose { remote.registerDownloadProgressObserver(cb) }) return@callbackFlow
             awaitClose { runCatching { remote.unregisterDownloadProgressObserver(cb) } }
         }.onEach { progressState.value = it }.launchIn(scope)
 

--- a/rns-ipc/src/main/kotlin/network/columba/app/rns/ipc/client/ClientRnsTelemetry.kt
+++ b/rns-ipc/src/main/kotlin/network/columba/app/rns/ipc/client/ClientRnsTelemetry.kt
@@ -94,7 +94,7 @@ internal class ClientRnsTelemetry(
                     if (payload != null) trySend(payload)
                 }
             }
-            remote.registerTelemetryObserver(cb)
+            if (!registerObserverOrClose { remote.registerTelemetryObserver(cb) }) return@callbackFlow
             awaitClose { runCatching { remote.unregisterTelemetryObserver(cb) } }
         }.onEach { locationTelemetryShared.emit(it) }.launchIn(scope)
     }

--- a/rns-ipc/src/main/kotlin/network/columba/app/rns/ipc/client/ClientRnsTelephony.kt
+++ b/rns-ipc/src/main/kotlin/network/columba/app/rns/ipc/client/ClientRnsTelephony.kt
@@ -54,7 +54,7 @@ internal class ClientRnsTelephony(
             val cb = object : IRnsCallStateCallback.Stub() {
                 override fun onState(state: CallState?) { if (state != null) trySend(state) }
             }
-            remote.registerCallStateObserver(cb)
+            if (!registerObserverOrClose { remote.registerCallStateObserver(cb) }) return@callbackFlow
             awaitClose { runCatching { remote.unregisterCallStateObserver(cb) } }
         }.onEach { callStateState.value = it }.launchIn(scope)
 
@@ -69,7 +69,7 @@ internal class ClientRnsTelephony(
             val cb = object : IRnsNullableStringEventCallback.Stub() {
                 override fun onString(value: String?) { trySend(value) }
             }
-            remote.registerRemoteIdentityObserver(cb)
+            if (!registerObserverOrClose { remote.registerRemoteIdentityObserver(cb) }) return@callbackFlow
             awaitClose { runCatching { remote.unregisterRemoteIdentityObserver(cb) } }
         }.onEach { remoteIdentityState.value = it }.launchIn(scope)
 
@@ -108,7 +108,7 @@ internal class ClientRnsTelephony(
             val cb = object : IRnsBoolEventCallback.Stub() {
                 override fun onBool(value: Boolean) { trySend(value) }
             }
-            register(cb)
+            if (!registerObserverOrClose { register(cb) }) return@callbackFlow
             awaitClose { runCatching { unregister(cb) } }
         }.onEach { state.value = it }.launchIn(scope)
     }

--- a/rns-ipc/src/main/kotlin/network/columba/app/rns/ipc/client/ClientRnsTransportAdmin.kt
+++ b/rns-ipc/src/main/kotlin/network/columba/app/rns/ipc/client/ClientRnsTransportAdmin.kt
@@ -113,7 +113,7 @@ internal class ClientRnsTransportAdmin(
     init {
         callbackFlow<Unit> {
             val cb = object : IRnsUnitEventCallback.Stub() { override fun onEvent() { trySend(Unit) } }
-            remote.registerInterfaceStatusChangedObserver(cb)
+            if (!registerObserverOrClose { remote.registerInterfaceStatusChangedObserver(cb) }) return@callbackFlow
             awaitClose { runCatching { remote.unregisterInterfaceStatusChangedObserver(cb) } }
         }.onEach { interfaceStatusChangedShared.emit(it) }.launchIn(scope)
 
@@ -153,7 +153,7 @@ internal class ClientRnsTransportAdmin(
         val cb = object : IRnsStringEventCallback.Stub() {
             override fun onString(value: String?) { if (value != null) trySend(value) }
         }
-        register(cb)
+        if (!registerObserverOrClose { register(cb) }) return@callbackFlow
         awaitClose { runCatching { unregister(cb) } }
     }
 

--- a/rns-ipc/src/test/java/network/columba/app/rns/ipc/client/ClientRnsTelemetryObserverTest.kt
+++ b/rns-ipc/src/test/java/network/columba/app/rns/ipc/client/ClientRnsTelemetryObserverTest.kt
@@ -1,0 +1,68 @@
+package network.columba.app.rns.ipc.client
+
+import android.os.DeadObjectException
+import io.mockk.Runs
+import io.mockk.every
+import io.mockk.just
+import io.mockk.mockk
+import kotlinx.coroutines.CoroutineExceptionHandler
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.cancel
+import network.columba.app.rns.ipc.IRnsTelemetry
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNull
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.TimeUnit
+import java.util.concurrent.atomic.AtomicReference
+
+/**
+ * Regression guard for Sentry COLUMBA-B0 — the telemetry sibling of COLUMBA-AZ.
+ *
+ * [ClientRnsTelemetry]'s init block registers a telemetry observer via an AIDL
+ * call inside a `callbackFlow`. If the `:reticulum` backend is dead at
+ * registration the call throws [DeadObjectException]; unguarded it escapes the
+ * producer and crashes the collecting coroutine. The shared
+ * `registerObserverOrClose` guard must catch it and close the flow gracefully so
+ * nothing reaches the scope's [CoroutineExceptionHandler]. This exercises that
+ * shared guard through a real client site; it fails on the unguarded code and
+ * passes once the registration is routed through the guard.
+ */
+@RunWith(RobolectricTestRunner::class)
+class ClientRnsTelemetryObserverTest {
+
+    @Test
+    fun deadRemoteDuringObserverRegistration_isHandledNotCrashed() {
+        val caught = AtomicReference<Throwable?>(null)
+        val latch = CountDownLatch(1)
+        val handler = CoroutineExceptionHandler { _, t ->
+            caught.set(t)
+            latch.countDown()
+        }
+        val scope = CoroutineScope(SupervisorJob() + Dispatchers.Unconfined + handler)
+
+        // Explicit stubs (no relaxed mock) for exactly the init calls: the
+        // observer registration throws (the crash trigger); unregister is a no-op.
+        val remote = mockk<IRnsTelemetry>()
+        every { remote.registerTelemetryObserver(any()) } throws
+            DeadObjectException("Transaction failed on small parcel; remote process probably died")
+        every { remote.unregisterTelemetryObserver(any()) } just Runs
+
+        // Construct the real production object — its init block registers the observer.
+        ClientRnsTelemetry(remote, scope)
+
+        // Block the full window for any (unexpected) escape to reach the handler.
+        val escaped = latch.await(500, TimeUnit.MILLISECONDS)
+        scope.cancel()
+
+        assertFalse(
+            "DeadObjectException must NOT escape to the coroutine scope (reproduces COLUMBA-B0)",
+            escaped,
+        )
+        assertNull("No throwable should reach the coroutine exception handler", caught.get())
+    }
+}


### PR DESCRIPTION
Fixes `COLUMBA-B0` — and the entire class of `DeadObjectException` crashes it belongs to.

## Background

PR #962 (COLUMBA-AZ) guarded `ClientRnsCore`'s `networkStatus` observer. But an audit shows **every other `ClientRns*` observer** registered inside a `callbackFlow` had the identical unguarded AIDL call:

```kotlin
remote.registerXObserver(cb)   // throws DeadObjectException if :reticulum is dead → escapes producer → crash
```

When the `:reticulum` backend process is dead at registration time (OOM-killed on low-end devices — same Galaxy S5 / low-memory profile as COLUMBA-AZ), the call throws, escapes the `callbackFlow` producer, and crashes the collecting coroutine (fatal, uncaught).

`COLUMBA-B0` is the **telemetry** instance (`ClientRnsTelemetry.registerTelemetryObserver`). Still latent at time of writing: `observePackets`, `observeLinks`, `observeAnnounces`, `observeMessages`, `observeDeliveryStatus`, propagation state, all four telephony bool observers + call-state + remote-identity, both nomadnet observers, and the four transport-admin observers — i.e. COLUMBA-B1…Bn waiting to happen.

## Fix

A single shared helper in `ClientAidlBridge`:

```kotlin
internal inline fun ProducerScope<*>.registerObserverOrClose(register: () -> Unit): Boolean
```

It runs the registration, catches `RemoteException`, logs it, and **closes the `callbackFlow` gracefully** (no exception propagated). The bound-service layer's `flatMapLatest` re-subscribes once the backend rebinds — consistent with the existing recovery design.

Routed **all 13 direct sites + the 2 parameterized helpers** (`registerBoolObserver`, `stringEventFlow`) through it. `networkStatus` keeps its bespoke guard since it must emit `NetworkStatus.ERROR` rather than just close.

## Test

`ClientRnsTelemetryObserverTest` (Robolectric) constructs the real `ClientRnsTelemetry` with a mock `IRnsTelemetry` whose registration throws `DeadObjectException`, and asserts nothing escapes to the coroutine scope. It exercises the shared guard through a real client site — verified **red** without the guard, **green** with it. (The COLUMBA-AZ `ClientRnsCoreNetworkObserverTest` continues to cover the custom networkStatus guard.)
