### PR TITLE
fix(proguard): keep LXST NativeCodec2/NativeOpus for JNI RegisterNatives (COLUMBA-B1/B2)

### DIFF
--- a/app/proguard-rules.pro
+++ b/app/proguard-rules.pro
@@ -38,6 +38,18 @@
     native <methods>;
 }
 
+# LXST Codec2/Opus JNI bridges register their natives from JNI_OnLoad via
+# FindClass + RegisterNatives against a fixed method table. The rule above keeps
+# the NAMES of surviving natives but ALLOWS SHRINKING, and R8 can't trace the
+# capture path (Oboe native callbacks / Chaquopy), so it removed the `encode`
+# native method as unused — RegisterNatives then fails and JNI_OnLoad returns
+# JNI_ERR, crashing outbound calls (Sentry COLUMBA-B1 / COLUMBA-B2). Pin both
+# classes fully so every method in the native table is present. (Also lives in
+# LXST-kt consumer-rules.pro, but columba consumes LXST-kt from JitPack, so the
+# load-bearing copy must be here until that ships.)
+-keep class tech.torlando.lxst.codec.NativeCodec2 { *; }
+-keep class tech.torlando.lxst.codec.NativeOpus { *; }
+
 # ===== Kotlin Coroutines =====
 # Used extensively in service for async operations
 -keepnames class kotlinx.coroutines.internal.MainDispatcherFactory {}

--- a/app/proguard-rules.pro
+++ b/app/proguard-rules.pro
@@ -44,9 +44,12 @@
 # capture path (Oboe native callbacks / Chaquopy), so it removed the `encode`
 # native method as unused — RegisterNatives then fails and JNI_OnLoad returns
 # JNI_ERR, crashing outbound calls (Sentry COLUMBA-B1 / COLUMBA-B2). Pin both
-# classes fully so every method in the native table is present. (Also lives in
-# LXST-kt consumer-rules.pro, but columba consumes LXST-kt from JitPack, so the
-# load-bearing copy must be here until that ships.)
+# classes fully so every method in the native table is present.
+#
+# Do NOT remove these: columba consumes LXST-kt from JitPack, so the app's own
+# R8 config is the authoritative copy. An equivalent keep belongs in LXST-kt's
+# consumer-rules.pro for other consumers, but that is a separate, not-yet-shipped
+# follow-up — these lines must stay regardless of any LXST-kt-side change.
 -keep class tech.torlando.lxst.codec.NativeCodec2 { *; }
 -keep class tech.torlando.lxst.codec.NativeOpus { *; }
 


### PR DESCRIPTION
Fixes `COLUMBA-B1` and `COLUMBA-B2` — same root cause, two surfaces.

## Symptoms
- **B2**: `UnsatisfiedLinkError: JNI_ERR returned from JNI_OnLoad in "…liblxst_codec2_jni.so"` when answering a call.
- **B1**: `NoClassDefFoundError: tech.torlando.lxst.codec.NativeCodec2` — the follow-on error once that class's static init already failed.

Both on a release build (`2.0.0-beta`), during `Telephone.answer → openPipelinesNativeCodec → Codec2 → NativeCodec2.<clinit>`.

## Root cause
`NativeCodec2` (and `NativeOpus`) register their native methods from `JNI_OnLoad` via `FindClass` + `RegisterNatives` against a fixed method table (`create`/`destroy`/`encode`/`decode`/…), returning `JNI_ERR` on any mismatch.

The app's global keep rule is `-keepclasseswithmembernames class * { native <methods>; }` — which keeps the *names* of surviving natives but **allows shrinking**. R8 can't trace the capture/outbound-audio path (it's driven through Oboe native callbacks / Chaquopy, which R8's reachability analysis can't follow), so it **removed the native `encode` method as "unused."** `RegisterNatives` then can't find `encode` on the class → `JNI_OnLoad` returns `JNI_ERR` → crash. `decode`/`create`/etc. survived (reachable via the playback path), which is why only the *encode-triggering* (outbound call) path crashes.

Release-only: debug builds aren't minified, so this never appeared in testing. **Not** a 16 KB-page issue (the `.so` loaded fine; `JNI_OnLoad` ran and *returned* an error) and unrelated to the recent DeadObjectException work.

## Fix
Pin both JNI classes fully so every entry in the native method table is present:

```proguard
-keep class tech.torlando.lxst.codec.NativeCodec2 { *; }
-keep class tech.torlando.lxst.codec.NativeOpus { *; }
```

Placed in `app/proguard-rules.pro` because columba consumes LXST-kt from JitPack, so the app's own R8 config is the load-bearing copy. (The same rule also belongs in LXST-kt's `consumer-rules.pro` for other consumers — a separate library follow-up.)

## Reproduction & verification (R8 output)
A unit test can't capture minification, so this was reproduced and verified via the R8 mapping for the minified release variant:

- **Before**: `usage.txt` lists `NativeCodec2.encode` and `NativeOpus.encode` under removed members.
- **After**: those methods no longer appear in `usage.txt`, and the two `-keep` rules appear in the merged R8 `configuration.txt`.

On-device regression coverage comes from the smoke-test rig answering a call on a minified build.
