### PR TITLE
chore(deps): bump LXST-kt to v0.0.4 (JNI keep for NativeCodec2/NativeOpus)

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -21,7 +21,7 @@ coil = "2.7.0"
 # JitPack-published libraries (formerly git submodules)
 reticulumKt = "v0.0.20"
 lxmfKt = "v0.0.13"
-lxstKt = "v0.0.3"
+lxstKt = "v0.0.4"
 
 [libraries]
 # JitPack-published Reticulum/LXMF/LXST stack (migrated from git submodules)


### PR DESCRIPTION
Bumps `lxstKt` v0.0.3 → v0.0.4, which ships the `consumer-rules.pro` keep for `NativeCodec2`/`NativeOpus` (LXST-kt PR #14) so R8 can't shrink the JNI `RegisterNatives` methods at the library level.

v0.0.4 contains **only** that change relative to v0.0.3 (verified: single commit on LXST-kt main since the tag). JitPack build of v0.0.4 confirmed (POM resolves).

Complements the app-side keep in #964 (COLUMBA-B1/B2). Both stay — columba consumes LXST-kt from JitPack, so the app-side rule is the authoritative copy; this just covers the library for other consumers and as defense in depth.