### PR TITLE
fix(rns-ipc): transfer LXMF attachments out-of-band to fix TransactionTooLargeException

### DIFF
--- a/app/src/main/java/network/columba/app/viewmodel/MessagingViewModel.kt
+++ b/app/src/main/java/network/columba/app/viewmodel/MessagingViewModel.kt
@@ -1186,6 +1186,28 @@ class MessagingViewModel
                     val imageFormat = _selectedImageFormat.value
                     val fileAttachments = _selectedFileAttachments.value
 
+                    // Reject pathologically large attachments before sending.
+                    // Attachment bytes now cross to :reticulum out-of-band (a
+                    // ParcelFileDescriptor, so no Binder ~1 MB limit), but they
+                    // still live fully in memory in both processes plus
+                    // Reticulum's Resource buffers — an unbounded file OOMs
+                    // instead of sending. Surface a friendly message rather than
+                    // a buried failure.
+                    val totalAttachmentBytes =
+                        (imageData?.size?.toLong() ?: 0L) + fileAttachments.sumOf { it.sizeBytes.toLong() }
+                    if (totalAttachmentBytes > MAX_ATTACHMENT_TOTAL_BYTES) {
+                        Log.w(
+                            TAG,
+                            "Attachment payload too large to send: $totalAttachmentBytes bytes " +
+                                "(max $MAX_ATTACHMENT_TOTAL_BYTES)",
+                        )
+                        _fileAttachmentError.emit(
+                            "Attachment too large to send (${formatBytesHelper(totalAttachmentBytes)}). " +
+                                "Maximum is ${formatBytesHelper(MAX_ATTACHMENT_TOTAL_BYTES)}.",
+                        )
+                        return@launch
+                    }
+
                     val sanitized = validateAndSanitizeContent(content, imageData, fileAttachments) ?: return@launch
                     val destHashBytes = validateDestinationHash(destinationHash) ?: return@launch
                     val identity =
@@ -1375,7 +1397,7 @@ class MessagingViewModel
                     isFromMe = true,
                     status = "failed",
                     deliveryMethod = deliveryMethodString,
-                    errorMessage = error.message,
+                    errorMessage = friendlyOutboundError(error.message),
                     receivedAt = now,
                 )
             saveMessageToDatabase(destinationHash, currentPeerName, message)
@@ -2489,6 +2511,40 @@ private fun DeliveryMethod.toStorageString(): String =
 private const val OPPORTUNISTIC_MAX_BYTES_HELPER = 295
 private const val OUTGOING_HEX_DIR = "outgoing_hex"
 private const val STREAM_HEX_THRESHOLD = 512 * 1024 // Stream to disk above 512KB to avoid OOM
+
+/**
+ * Defense-in-depth ceiling on the total outbound attachment payload (image +
+ * files). Attachment bytes cross to the `:reticulum` process out-of-band via a
+ * ParcelFileDescriptor, so the Binder ~1 MB transaction limit no longer applies
+ * — but the bytes are still held fully in memory in both processes plus
+ * Reticulum's Resource buffers, so an unbounded file would OOM rather than
+ * send. 32 MB is generous for the mesh use case (large files are slow but
+ * allowed) while staying clear of that cliff. Tune here if needed.
+ */
+internal const val MAX_ATTACHMENT_TOTAL_BYTES = 32L * 1024 * 1024
+
+/** Human-readable byte size for user-facing attachment messages (MB, or KB when small). */
+private fun formatBytesHelper(bytes: Long): String =
+    if (bytes >= 1024L * 1024L) {
+        "%.1f MB".format(bytes / (1024.0 * 1024.0))
+    } else {
+        "%.0f KB".format(bytes / 1024.0)
+    }
+
+/**
+ * Map a raw send-failure message to something a user can act on. The Binder
+ * over-size failure mode (`TransactionTooLargeException`) should no longer
+ * reach here now that attachments transfer out-of-band, but if any residual
+ * inline payload ever overflows the transaction we show "attachment too large"
+ * instead of leaking the raw exception text into the conversation.
+ */
+private fun friendlyOutboundError(raw: String?): String? =
+    when {
+        raw == null -> null
+        raw.contains("TransactionTooLarge", ignoreCase = true) ->
+            "Attachment too large to send. Try a smaller file."
+        else -> raw
+    }
 
 private fun determineDeliveryMethod(
     sanitized: String,

--- a/app/src/main/java/network/columba/app/viewmodel/MessagingViewModel.kt
+++ b/app/src/main/java/network/columba/app/viewmodel/MessagingViewModel.kt
@@ -2523,12 +2523,12 @@ private const val STREAM_HEX_THRESHOLD = 512 * 1024 // Stream to disk above 512K
  */
 internal const val MAX_ATTACHMENT_TOTAL_BYTES = 32L * 1024 * 1024
 
-/** Human-readable byte size for user-facing attachment messages (MB, or KB when small). */
+/** Human-readable byte size for user-facing attachment messages (MB / KB / B). */
 private fun formatBytesHelper(bytes: Long): String =
-    if (bytes >= 1024L * 1024L) {
-        "%.1f MB".format(bytes / (1024.0 * 1024.0))
-    } else {
-        "%.0f KB".format(bytes / 1024.0)
+    when {
+        bytes >= 1024L * 1024L -> "%.1f MB".format(bytes / (1024.0 * 1024.0))
+        bytes >= 1024L -> "%.0f KB".format(bytes / 1024.0)
+        else -> "$bytes B"
     }
 
 /**

--- a/maestro/e2e/single-device/run-large-attachment.sh
+++ b/maestro/e2e/single-device/run-large-attachment.sh
@@ -1,0 +1,68 @@
+#!/usr/bin/env bash
+#
+# run-large-attachment.sh — single-device regression run for the LXMF
+# attachment TransactionTooLargeException fix (PR #967).
+#
+# Stages a multi-MB file in the device's Downloads, looks up the device's own
+# LXMF destination via the debug TestReceiver (so the send resolves locally and
+# reaches handleSendSuccess), then runs send-large-attachment.yaml via the
+# shared run-flow.sh (logcat + before/after screenshots captured).
+#
+# Usage:
+#   run-large-attachment.sh <device-serial> [APP_ID] [SIZE_BYTES]
+#
+# Defaults: APP_ID=network.columba.app.debug (a DEBUG build is required for the
+# TestReceiver self-dest lookup; the attachment fix under test is identical in
+# release). SIZE_BYTES=5528860 (the size from the original crash report).
+#
+# Exit code is the Maestro flow's exit code.
+set -euo pipefail
+
+DEVICE="${1:?usage: run-large-attachment.sh <device-serial> [APP_ID] [SIZE_BYTES]}"
+APP_ID="${2:-network.columba.app.debug}"
+SIZE_BYTES="${3:-5528860}"
+
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+TEST_TAG="COLUMBA_TEST"                                   # TestController.LOGCAT_TAG
+RECEIVER="$APP_ID/network.columba.app.test.TestReceiver"  # debug-only broadcast surface
+FILE_NAME="columba-large-attach-${SIZE_BYTES}.bin"
+DEST_DOWNLOAD="/sdcard/Download/$FILE_NAME"
+MSG_TOKEN="bigfile-$(date +%s)"
+PEER_NAME="Self-LargeAttach"
+
+echo "=== staging ${SIZE_BYTES}-byte file -> $DEVICE:$DEST_DOWNLOAD ==="
+TMP="$(mktemp -d)"; trap 'rm -rf "$TMP"' EXIT
+head -c "$SIZE_BYTES" /dev/urandom > "$TMP/$FILE_NAME"
+adb -s "$DEVICE" push "$TMP/$FILE_NAME" "$DEST_DOWNLOAD"
+# Best-effort: make the file visible to the document picker promptly.
+adb -s "$DEVICE" shell am broadcast -a android.intent.action.MEDIA_SCANNER_SCAN_FILE \
+  -d "file://$DEST_DOWNLOAD" >/dev/null 2>&1 || true
+
+echo "=== launching app + resolving own LXMF dest via TestReceiver ==="
+adb -s "$DEVICE" shell monkey -p "$APP_ID" -c android.intent.category.LAUNCHER 1 >/dev/null 2>&1 || true
+
+SELF_HASH=""
+for attempt in $(seq 1 12); do
+  adb -s "$DEVICE" logcat -c 2>/dev/null || true
+  adb -s "$DEVICE" shell am broadcast -a network.columba.test.GET_DEST -n "$RECEIVER" >/dev/null 2>&1 || true
+  sleep 3
+  # Reply line under COLUMBA_TEST is `dest=<hex>` (or `dest_err reason=not_ready`).
+  SELF_HASH="$(adb -s "$DEVICE" logcat -d -s "$TEST_TAG" 2>/dev/null \
+    | grep -oE 'dest=[0-9a-f]{16,}' | tail -1 | cut -d= -f2 || true)"
+  [ -n "$SELF_HASH" ] && break
+  echo "  ...backend not ready yet (attempt $attempt/12)"
+done
+
+if [ -z "$SELF_HASH" ]; then
+  echo "ERROR: could not resolve own LXMF dest (is this a DEBUG build with a created identity?)" >&2
+  exit 2
+fi
+echo "=== self dest: $SELF_HASH ==="
+
+echo "=== running Maestro flow ==="
+exec "$HERE/../run-flow.sh" "$DEVICE" "$HERE/send-large-attachment.yaml" large-attachment \
+  -e APP_ID="$APP_ID" \
+  -e PEER_HASH="$SELF_HASH" \
+  -e PEER_NAME="$PEER_NAME" \
+  -e FILE_NAME="$FILE_NAME" \
+  -e MSG_TOKEN="$MSG_TOKEN"

--- a/maestro/e2e/single-device/send-large-attachment.yaml
+++ b/maestro/e2e/single-device/send-large-attachment.yaml
@@ -1,0 +1,94 @@
+# single-device/send-large-attachment.yaml
+#
+# Regression guard for the LXMF attachment TransactionTooLargeException.
+#
+# Attachment bytes used to ride INLINE through the oneway AIDL/Binder
+# transaction from the UI process to :reticulum. Binder's ~1 MB shared
+# per-process transaction buffer overflowed on a multi-MB file ->
+# android.os.TransactionTooLargeException, surfaced as a failed send. They now
+# cross out-of-band via a ParcelFileDescriptor (AttachmentBlob), so a multi-MB
+# attachment must send without the overflow surfacing. See PR #967.
+#
+# What it does: open a chat with PEER_HASH/PEER_NAME (the runner points this at
+# the device's OWN LXMF dest, so the send resolves locally and reaches
+# handleSendSuccess -> the file card renders -> a positive assertion is
+# possible on a single device), attach a large file staged in Downloads,
+# send, and assert the file card renders while the Binder-overflow failure text
+# never appears.
+#
+# PREREQUISITES (run-large-attachment.sh does all of this):
+#   - A DEBUG build is installed (release has no TestReceiver, and the runner
+#     uses it only to fetch the self dest; the fix under test is identical).
+#   - A large file (ideally ~5 MB) is already in Downloads as FILE_NAME.
+#   - PEER_HASH is the device's own LXMF destination hash.
+#
+# Params: APP_ID, PEER_HASH, PEER_NAME, FILE_NAME, MSG_TOKEN.
+#
+# NOTE: the SAF document picker (GetContent "*/*") is an EXTERNAL system UI that
+# varies by Android image / OEM. The picker-navigation taps below are marked
+# `optional: true` so the flow tolerates layout differences and falls through to
+# selecting FILE_NAME directly; tune them for your target emulator image if the
+# file isn't found.
+appId: ${APP_ID}
+name: send-large-attachment
+---
+# Open a conversation with the target (self) — leaves us on the MessagingScreen.
+- runFlow:
+    file: ../lib/add-contact-by-hash.yaml
+    env:
+      APP_ID: ${APP_ID}
+      PEER_HASH: ${PEER_HASH}
+      PEER_NAME: ${PEER_NAME}
+
+# Open the attachment panel and choose File (-> SAF GetContent "*/*").
+- tapOn:
+    text: "Attach"            # AttachmentInput button contentDescription
+- extendedWaitUntil:
+    visible: "File"           # AttachmentPanel's File button (text + a11y "File")
+    timeout: 8000
+- tapOn: "File"
+
+# ---- External SAF document picker (system UI; selectors are best-effort) ----
+# Open the roots drawer and the Downloads root if the file isn't already shown,
+# then select it by name. All navigation taps are optional so the flow adapts
+# to whichever document-picker layout the image presents.
+- tapOn:
+    text: "Show roots"
+    optional: true
+- tapOn:
+    text: "Downloads"
+    optional: true
+- scrollUntilVisible:
+    element:
+      text: ${FILE_NAME}
+    direction: DOWN
+    timeout: 20000
+- tapOn:
+    text: ${FILE_NAME}
+
+# Back in the chat: the attachment preview chip shows the picked file.
+- extendedWaitUntil:
+    visible: ${FILE_NAME}
+    timeout: 15000
+
+# Add a tokened body so the sent bubble is unambiguous, then send.
+- tapOn:
+    text: "Type a message..."
+- inputText: ${MSG_TOKEN}
+- hideKeyboard
+- tapOn: "Send message"
+
+# ---- Regression assertions ----
+# Tripwire: if attachment bytes ever ride inline through Binder again, the send
+# fails and the friendly guard (or the raw exception) surfaces this text. It
+# must NOT appear.
+- assertNotVisible:
+    text: ".*[Tt]oo large to send.*"
+- assertNotVisible:
+    text: ".*TransactionTooLarge.*"
+# Positive signal: a successful (past-IPC) send saves the message with its file
+# field, so the file card renders in the conversation.
+- extendedWaitUntil:
+    visible: ${FILE_NAME}
+    timeout: 30000
+- takeScreenshot: large-attachment-sent

--- a/rns-api/src/main/aidl/network/columba/app/rns/ipc/IRnsLxmf.aidl
+++ b/rns-api/src/main/aidl/network/columba/app/rns/ipc/IRnsLxmf.aidl
@@ -8,16 +8,19 @@
 //   - getOutboundPropagationNode (Result<String?>) — uses IRnsStringCallback, not Bundle.
 //   - Result<Unit>        → Bundle.EMPTY
 //
-// File attachments cross AIDL as `List<FileAttachment>` Parcelable wrappers
-// (AIDL has neither Pair nor List<byte[]>). :rns-ipc converts to/from the
-// Kotlin `List<Pair<String, ByteArray>>` shape at the seam. extraFields is a
-// generic Bundle whose keys are stringified LXMF field numbers ("4", "5",
-// "16", …); values are whatever the field accepts (typically byte[] or
-// String). See the per-call documentation for which fields each method writes.
+// Binary attachment payloads (image bytes + file attachments) do NOT ride
+// inline: a Binder transaction caps at ~1 MB shared per process, so a multi-MB
+// file threw TransactionTooLargeException. They cross as a single read-only
+// `ParcelFileDescriptor attachmentsBlob` (a dup'd fd, not the bytes) that
+// :rns-ipc's AttachmentBlob serializes on the client and reads on the server;
+// null means "no binary payload". extraFields is a generic Bundle whose keys
+// are stringified LXMF field numbers ("4", "5", "16", …); values are whatever
+// the field accepts (typically byte[] or String) and are expected to stay small
+// — large binary fields must go through attachmentsBlob, not here. See the
+// per-call documentation for which fields each method writes.
 package network.columba.app.rns.ipc;
 
 import network.columba.app.rns.api.model.DeliveryMethod;
-import network.columba.app.rns.api.model.FileAttachment;
 import network.columba.app.rns.api.model.IconAppearance;
 import network.columba.app.rns.api.model.Identity;
 import network.columba.app.rns.ipc.callback.IRnsDeliveryStatusCallback;
@@ -33,9 +36,7 @@ oneway interface IRnsLxmf {
         in byte[] destinationHash,
         String content,
         in Identity sourceIdentity,
-        in @nullable byte[] imageData,
-        in @nullable String imageFormat,
-        in List<FileAttachment> fileAttachments,
+        in @nullable ParcelFileDescriptor attachmentsBlob,
         in IRnsResultCallback cb);
 
     void sendLxmfMessageWithMethod(
@@ -44,9 +45,7 @@ oneway interface IRnsLxmf {
         in Identity sourceIdentity,
         in DeliveryMethod deliveryMethod,
         boolean tryPropagationOnFail,
-        in @nullable byte[] imageData,
-        in @nullable String imageFormat,
-        in List<FileAttachment> fileAttachments,
+        in @nullable ParcelFileDescriptor attachmentsBlob,
         in @nullable String replyToMessageId,
         in @nullable String replyQuotedContent,
         in @nullable IconAppearance iconAppearance,

--- a/rns-backend-kt/src/main/kotlin/network/columba/app/rns/backend/kt/NativeMessageSender.kt
+++ b/rns-backend-kt/src/main/kotlin/network/columba/app/rns/backend/kt/NativeMessageSender.kt
@@ -134,9 +134,13 @@ internal class NativeMessageSender(
         }
 
         if (!options.fileAttachments.isNullOrEmpty()) {
+            // [[name_str, data_bytes], ...] — filename is a `str` to match upstream
+            // Sideband's `[basename, bytes]` shape (receivers render it via
+            // `str(name)`, so a `bytes` name shows up as its `b'...'` repr). Kept in
+            // lockstep with PythonRnsLxmf.
             fields[LxmfFields.FIELD_FILE_ATTACHMENTS] =
                 options.fileAttachments.map { (name, data) ->
-                    listOf(name.toByteArray(), data)
+                    listOf(name, data)
                 }
         }
 

--- a/rns-backend-py/src/main/kotlin/network/columba/app/rns/backend/py/PythonRnsLxmf.kt
+++ b/rns-backend-py/src/main/kotlin/network/columba/app/rns/backend/py/PythonRnsLxmf.kt
@@ -329,15 +329,14 @@ class PythonRnsLxmf(
         }
 
         if (!fileAttachments.isNullOrEmpty()) {
-            // FIELD_FILE_ATTACHMENTS: [[name_bytes, data_bytes], ...] — byte-identical
-            // to NativeMessageSender (`listOf(name.toByteArray(), data)`), so
-            // cross-backend Columba attachment interop is guaranteed by construction.
-            // Note: upstream Sideband uses a `str` filename (`[basename, bytes]`);
-            // Columba (both backends) uses `bytes`. Columba<->Sideband attachment-
-            // filename interop is a Phase B on-device verification item — not a
-            // wire-shape bug on this backend.
+            // FIELD_FILE_ATTACHMENTS: [[name_str, data_bytes], ...]. The filename is a
+            // `str`, matching upstream Sideband's `[basename, bytes]` shape (and the
+            // sibling FIELD_IMAGE above, which sends its format as a str). Sideband and
+            // older Columba render the name via `str(name)`, so a `bytes` filename
+            // surfaces as its `b'...'` repr on the receiver — sending a `str` is the
+            // interop-correct encoding. Kept in lockstep with NativeMessageSender.
             val attachments = fileAttachments.map { (name, data) ->
-                listOf(name.toByteArray(), data).toPyList()
+                listOf(name, data).toPyList()
             }
             fields[LxmfFields.FIELD_FILE_ATTACHMENTS] = attachments.toPyList()
         }

--- a/rns-host/src/main/kotlin/network/columba/app/rns/host/ReticulumServiceConnection.kt
+++ b/rns-host/src/main/kotlin/network/columba/app/rns/host/ReticulumServiceConnection.kt
@@ -141,7 +141,10 @@ object ReticulumServiceConnection {
                 // stale live reference after the null sentinel.
                 val job = scope.launch {
                     try {
-                        val client = RnsBackendClient(scope)
+                        // cacheDir is shared per-process by the same app/UID; the
+                        // client only needs a writable dir to stage attachment
+                        // PFDs (the server reads the dup'd fd, not the path).
+                        val client = RnsBackendClient(scope, context.cacheDir)
                         client.connect(remote)
                         trySend(client)
                     } catch (e: CancellationException) {

--- a/rns-ipc/src/main/kotlin/network/columba/app/rns/ipc/AttachmentBlob.kt
+++ b/rns-ipc/src/main/kotlin/network/columba/app/rns/ipc/AttachmentBlob.kt
@@ -1,0 +1,152 @@
+package network.columba.app.rns.ipc
+
+import android.os.ParcelFileDescriptor
+import java.io.BufferedInputStream
+import java.io.BufferedOutputStream
+import java.io.DataInputStream
+import java.io.DataOutputStream
+import java.io.File
+import java.io.FileOutputStream
+import java.io.IOException
+
+/**
+ * Out-of-band transfer of LXMF attachment payloads (image bytes + file
+ * attachments) across the [IRnsLxmf] AIDL boundary.
+ *
+ * A Binder transaction caps at ~1 MB shared across the whole process, so
+ * attachment bytes cannot ride inline in the send calls: a multi-MB file threw
+ * `android.os.TransactionTooLargeException` (data parcel size ~5.5 MB) on
+ * v2.0.2-beta when the UI process tried to hand a file to `:reticulum`. Instead
+ * the UI process serializes the payload to a temp file, hands the server a
+ * read-only [ParcelFileDescriptor] (which marshals as a dup'd fd — a handful of
+ * bytes, not the payload), and the server streams it back into memory. Both
+ * ends are the same app/UID, so the fd and the immediately-unlinked temp inode
+ * are shared safely; the server never resolves the path.
+ *
+ * Wire format (big-endian [DataOutputStream]), versioned so a format bump
+ * rejects stale blobs instead of mis-parsing:
+ * ```
+ *   int     MAGIC   = 0x4C584D42 ("LXMB")
+ *   int     VERSION = 1
+ *   int     imageLen        (NO_IMAGE == no image; else byte[imageLen] follows)
+ *   boolean hasFormat       (only present when an image is present)
+ *   utf     imageFormat     (only present when hasFormat)
+ *   int     fileCount
+ *   repeat fileCount: utf name; int dataLen; byte[dataLen] data
+ * ```
+ */
+internal object AttachmentBlob {
+    private const val MAGIC = 0x4C584D42 // "LXMB"
+    private const val VERSION = 1
+    private const val NO_IMAGE = -1
+    private const val TEMP_SUBDIR = "rns-ipc-tx"
+
+    /**
+     * True when there is nothing to transfer. Callers send a null PFD across the
+     * wire and skip temp-file creation entirely, so text-only sends stay
+     * zero-overhead.
+     */
+    fun isEmpty(imageData: ByteArray?, fileAttachments: List<Pair<String, ByteArray>>?): Boolean =
+        imageData == null && fileAttachments.isNullOrEmpty()
+
+    /**
+     * Serialize [imageData] + [fileAttachments] to a temp file under [cacheDir]
+     * and return a read-only [ParcelFileDescriptor] over it, or null when there
+     * is no binary payload. The backing file is unlinked before returning
+     * (delete-on-close): the bytes live only while an open fd references them,
+     * so an interrupted send leaks nothing on disk.
+     *
+     * The returned PFD is owned by the caller, which must close it once the
+     * transaction has been delivered — the server reads its own dup.
+     */
+    @Throws(IOException::class)
+    fun writeToPfd(
+        cacheDir: File,
+        imageData: ByteArray?,
+        imageFormat: String?,
+        fileAttachments: List<Pair<String, ByteArray>>?,
+    ): ParcelFileDescriptor? {
+        if (isEmpty(imageData, fileAttachments)) return null
+
+        val dir = File(cacheDir, TEMP_SUBDIR).apply { mkdirs() }
+        val tempFile = File.createTempFile("lxmf-attach-", ".bin", dir)
+        try {
+            DataOutputStream(BufferedOutputStream(FileOutputStream(tempFile))).use { out ->
+                out.writeInt(MAGIC)
+                out.writeInt(VERSION)
+                if (imageData != null) {
+                    out.writeInt(imageData.size)
+                    out.write(imageData)
+                    val hasFormat = imageFormat != null
+                    out.writeBoolean(hasFormat)
+                    if (hasFormat) out.writeUTF(imageFormat)
+                } else {
+                    out.writeInt(NO_IMAGE)
+                }
+                val files = fileAttachments.orEmpty()
+                out.writeInt(files.size)
+                for ((name, data) in files) {
+                    out.writeUTF(name)
+                    out.writeInt(data.size)
+                    out.write(data)
+                }
+            }
+            return ParcelFileDescriptor.open(tempFile, ParcelFileDescriptor.MODE_READ_ONLY)
+        } finally {
+            // Unlink immediately: our open PFD (and the server's dup, once the
+            // transaction is delivered) keeps the inode alive, so nothing is
+            // left on disk once both ends close.
+            tempFile.delete()
+        }
+    }
+
+    /**
+     * Inverse of [writeToPfd]. Reads the full payload from [pfd] (and closes it)
+     * and returns the reconstructed image + file attachments. A null PFD means
+     * "no binary payload" and yields [Payload.EMPTY].
+     */
+    @Throws(IOException::class)
+    fun readFromPfd(pfd: ParcelFileDescriptor?): Payload {
+        if (pfd == null) return Payload.EMPTY
+        DataInputStream(BufferedInputStream(ParcelFileDescriptor.AutoCloseInputStream(pfd))).use { inp ->
+            val magic = inp.readInt()
+            if (magic != MAGIC) throw IOException("Bad attachment blob magic: 0x${Integer.toHexString(magic)}")
+            val version = inp.readInt()
+            if (version != VERSION) throw IOException("Unsupported attachment blob version: $version")
+
+            val imageLen = inp.readInt()
+            var imageData: ByteArray? = null
+            var imageFormat: String? = null
+            if (imageLen != NO_IMAGE) {
+                imageData = ByteArray(imageLen).also { inp.readFully(it) }
+                if (inp.readBoolean()) imageFormat = inp.readUTF()
+            }
+
+            val fileCount = inp.readInt()
+            val files = ArrayList<Pair<String, ByteArray>>(fileCount)
+            repeat(fileCount) {
+                val name = inp.readUTF()
+                val dataLen = inp.readInt()
+                val data = ByteArray(dataLen).also { inp.readFully(it) }
+                files.add(name to data)
+            }
+            return Payload(imageData, imageFormat, files)
+        }
+    }
+
+    /**
+     * Reconstructed attachment payload. [fileAttachments] is empty (never null)
+     * when no files were sent. Not a `data class` on purpose — it holds a
+     * [ByteArray] and is only ever consumed positionally, so structural equality
+     * would be both wrong and unused.
+     */
+    class Payload(
+        val imageData: ByteArray?,
+        val imageFormat: String?,
+        val fileAttachments: List<Pair<String, ByteArray>>,
+    ) {
+        companion object {
+            val EMPTY = Payload(null, null, emptyList())
+        }
+    }
+}

--- a/rns-ipc/src/main/kotlin/network/columba/app/rns/ipc/AttachmentBlob.kt
+++ b/rns-ipc/src/main/kotlin/network/columba/app/rns/ipc/AttachmentBlob.kt
@@ -114,24 +114,32 @@ internal object AttachmentBlob {
             val version = inp.readInt()
             if (version != VERSION) throw IOException("Unsupported attachment blob version: $version")
 
+            // Lengths come straight off the stream; a corrupt/truncated blob could
+            // carry a negative count. Reject it as a clean IOException rather than
+            // letting ByteArray(-n) / ArrayList(-n) throw NegativeArraySizeException.
             val imageLen = inp.readInt()
             var imageData: ByteArray? = null
             var imageFormat: String? = null
             if (imageLen != NO_IMAGE) {
-                imageData = ByteArray(imageLen).also { inp.readFully(it) }
+                imageData = ByteArray(checkLen(imageLen, "imageLen")).also { inp.readFully(it) }
                 if (inp.readBoolean()) imageFormat = inp.readUTF()
             }
 
-            val fileCount = inp.readInt()
+            val fileCount = checkLen(inp.readInt(), "fileCount")
             val files = ArrayList<Pair<String, ByteArray>>(fileCount)
             repeat(fileCount) {
                 val name = inp.readUTF()
-                val dataLen = inp.readInt()
+                val dataLen = checkLen(inp.readInt(), "dataLen")
                 val data = ByteArray(dataLen).also { inp.readFully(it) }
                 files.add(name to data)
             }
             return Payload(imageData, imageFormat, files)
         }
+    }
+
+    private fun checkLen(value: Int, field: String): Int {
+        if (value < 0) throw IOException("Bad attachment blob: negative $field ($value)")
+        return value
     }
 
     /**

--- a/rns-ipc/src/main/kotlin/network/columba/app/rns/ipc/PairConversions.kt
+++ b/rns-ipc/src/main/kotlin/network/columba/app/rns/ipc/PairConversions.kt
@@ -1,23 +1,20 @@
 package network.columba.app.rns.ipc
 
 import network.columba.app.rns.api.model.AnnounceRestoreEntry
-import network.columba.app.rns.api.model.FileAttachment
 import network.columba.app.rns.api.model.PeerIdentityEntry
 
 /**
  * Conversions between the Kotlin `List<Pair<String, ByteArray>>` shape that
  * the [network.columba.app.rns.api.RnsCore] / [network.columba.app.rns.api.RnsLxmf]
  * interfaces speak and the Parcelable wrapper-list shape AIDL requires
- * (`List<FileAttachment>` / `List<PeerIdentityEntry>` /
- * `List<AnnounceRestoreEntry>`). AIDL can carry neither raw `Pair` nor
- * `List<byte[]>`; the wrappers exist solely to satisfy the marshaller.
+ * (`List<PeerIdentityEntry>` / `List<AnnounceRestoreEntry>`). AIDL can carry
+ * neither raw `Pair` nor `List<byte[]>`; the wrappers exist solely to satisfy
+ * the marshaller.
+ *
+ * LXMF file attachments used to convert through a `FileAttachment` wrapper here
+ * too, but their bytes now cross out-of-band via [AttachmentBlob] (a PFD) to
+ * stay under the Binder transaction limit, so no Pair⇄wrapper hop is needed.
  */
-
-internal fun List<Pair<String, ByteArray>>?.toFileAttachments(): List<FileAttachment> =
-    this?.map { (name, data) -> FileAttachment(name, data) }.orEmpty()
-
-internal fun List<FileAttachment>.toAttachmentPairs(): List<Pair<String, ByteArray>> =
-    map { it.name to it.data }
 
 internal fun List<Pair<String, ByteArray>>.toPeerIdentityEntries(): List<PeerIdentityEntry> =
     map { (hashHex, publicKey) -> PeerIdentityEntry(hashHex, publicKey) }

--- a/rns-ipc/src/main/kotlin/network/columba/app/rns/ipc/RnsBackendClient.kt
+++ b/rns-ipc/src/main/kotlin/network/columba/app/rns/ipc/RnsBackendClient.kt
@@ -28,6 +28,7 @@ import network.columba.app.rns.ipc.client.ClientRnsNomadnet
 import network.columba.app.rns.ipc.client.ClientRnsTelemetry
 import network.columba.app.rns.ipc.client.ClientRnsTelephony
 import network.columba.app.rns.ipc.client.ClientRnsTransportAdmin
+import java.io.File
 import java.util.concurrent.atomic.AtomicBoolean
 import kotlin.coroutines.resume
 
@@ -52,6 +53,13 @@ import kotlin.coroutines.resume
  */
 class RnsBackendClient(
     private val scope: CoroutineScope,
+    /**
+     * App cache dir used by [ClientRnsLxmf] to stage attachment payloads as
+     * temp files before handing the `:reticulum` server a [android.os.ParcelFileDescriptor].
+     * Any writable dir owned by this process works — the server reads the dup'd
+     * fd, never the path.
+     */
+    private val attachmentCacheDir: File,
 ) : RnsBackend {
     private val capabilitiesState = MutableStateFlow(BackendCapabilities.UNKNOWN)
 
@@ -72,7 +80,7 @@ class RnsBackendClient(
      */
     suspend fun connect(remote: IRnsBackend) {
         coreClient = ClientRnsCore(fetchCore(remote), scope)
-        lxmfClient = ClientRnsLxmf(fetchLxmf(remote), scope)
+        lxmfClient = ClientRnsLxmf(fetchLxmf(remote), scope, attachmentCacheDir)
         telephonyClient = ClientRnsTelephony(fetchTelephony(remote), scope)
         telemetryClient = ClientRnsTelemetry(fetchTelemetry(remote), scope)
         nomadnetClient = ClientRnsNomadnet(fetchNomadnet(remote), scope)

--- a/rns-ipc/src/main/kotlin/network/columba/app/rns/ipc/client/ClientRnsLxmf.kt
+++ b/rns-ipc/src/main/kotlin/network/columba/app/rns/ipc/client/ClientRnsLxmf.kt
@@ -2,6 +2,7 @@ package network.columba.app.rns.ipc.client
 
 import android.os.Bundle
 import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.channels.awaitClose
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableSharedFlow
@@ -10,6 +11,7 @@ import kotlinx.coroutines.flow.asSharedFlow
 import kotlinx.coroutines.flow.callbackFlow
 import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.onEach
+import kotlinx.coroutines.withContext
 import network.columba.app.rns.api.RnsError
 import network.columba.app.rns.api.RnsException
 import network.columba.app.rns.api.RnsLxmf
@@ -21,16 +23,19 @@ import network.columba.app.rns.api.model.Identity
 import network.columba.app.rns.api.model.MessageReceipt
 import network.columba.app.rns.api.model.PropagationState
 import network.columba.app.rns.api.model.ReceivedMessage
+import network.columba.app.rns.ipc.AttachmentBlob
 import network.columba.app.rns.ipc.BundleKeys
 import network.columba.app.rns.ipc.IRnsLxmf
 import network.columba.app.rns.ipc.callback.IRnsDeliveryStatusCallback
 import network.columba.app.rns.ipc.callback.IRnsMessageCallback
 import network.columba.app.rns.ipc.callback.IRnsPropagationStateCallback
-import network.columba.app.rns.ipc.toFileAttachments
+import java.io.File
 
 internal class ClientRnsLxmf(
     private val remote: IRnsLxmf,
     private val scope: CoroutineScope,
+    /** App cache dir used to stage attachment blobs before handing the server a PFD. */
+    private val attachmentCacheDir: File,
 ) : RnsLxmf {
     override suspend fun sendLxmfMessage(
         destinationHash: ByteArray,
@@ -40,21 +45,29 @@ internal class ClientRnsLxmf(
         imageFormat: String?,
         fileAttachments: List<Pair<String, ByteArray>>?,
     ): Result<MessageReceipt> = runCatching {
-        val bundle = awaitResult { cb ->
-            remote.sendLxmfMessage(
-                destinationHash,
-                content,
-                sourceIdentity,
-                imageData,
-                imageFormat,
-                fileAttachments.toFileAttachments(),
-                cb,
-            )
+        // Attachment bytes ride out-of-band via a PFD, never inline in the
+        // Binder transaction (see AttachmentBlob). The PFD is ours to close once
+        // the call settles; the server has read its own dup by then.
+        val blob = withContext(Dispatchers.IO) {
+            AttachmentBlob.writeToPfd(attachmentCacheDir, imageData, imageFormat, fileAttachments)
         }
-        bundle.classLoader = MessageReceipt::class.java.classLoader
-        @Suppress("DEPRECATION")
-        bundle.getParcelable<MessageReceipt>(BundleKeys.RECEIPT)
-            ?: throw RnsException(RnsError.Generic("sendLxmfMessage payload missing 'receipt'", null))
+        try {
+            val bundle = awaitResult { cb ->
+                remote.sendLxmfMessage(
+                    destinationHash,
+                    content,
+                    sourceIdentity,
+                    blob,
+                    cb,
+                )
+            }
+            bundle.classLoader = MessageReceipt::class.java.classLoader
+            @Suppress("DEPRECATION")
+            bundle.getParcelable<MessageReceipt>(BundleKeys.RECEIPT)
+                ?: throw RnsException(RnsError.Generic("sendLxmfMessage payload missing 'receipt'", null))
+        } finally {
+            runCatching { blob?.close() }
+        }
     }
 
     override suspend fun sendLxmfMessageWithMethod(
@@ -71,27 +84,35 @@ internal class ClientRnsLxmf(
         iconAppearance: IconAppearance?,
         extraFields: Map<Int, Any>?,
     ): Result<MessageReceipt> = runCatching {
-        val bundle = awaitResult { cb ->
-            remote.sendLxmfMessageWithMethod(
-                destinationHash,
-                content,
-                sourceIdentity,
-                deliveryMethod,
-                tryPropagationOnFail,
-                imageData,
-                imageFormat,
-                fileAttachments.toFileAttachments(),
-                replyToMessageId,
-                replyQuotedContent,
-                iconAppearance,
-                extraFields?.toExtraFieldsBundle(),
-                cb,
-            )
+        // Attachment bytes ride out-of-band via a PFD, never inline in the
+        // Binder transaction (see AttachmentBlob). The PFD is ours to close once
+        // the call settles; the server has read its own dup by then.
+        val blob = withContext(Dispatchers.IO) {
+            AttachmentBlob.writeToPfd(attachmentCacheDir, imageData, imageFormat, fileAttachments)
         }
-        bundle.classLoader = MessageReceipt::class.java.classLoader
-        @Suppress("DEPRECATION")
-        bundle.getParcelable<MessageReceipt>(BundleKeys.RECEIPT)
-            ?: throw RnsException(RnsError.Generic("sendLxmfMessageWithMethod payload missing 'receipt'", null))
+        try {
+            val bundle = awaitResult { cb ->
+                remote.sendLxmfMessageWithMethod(
+                    destinationHash,
+                    content,
+                    sourceIdentity,
+                    deliveryMethod,
+                    tryPropagationOnFail,
+                    blob,
+                    replyToMessageId,
+                    replyQuotedContent,
+                    iconAppearance,
+                    extraFields?.toExtraFieldsBundle(),
+                    cb,
+                )
+            }
+            bundle.classLoader = MessageReceipt::class.java.classLoader
+            @Suppress("DEPRECATION")
+            bundle.getParcelable<MessageReceipt>(BundleKeys.RECEIPT)
+                ?: throw RnsException(RnsError.Generic("sendLxmfMessageWithMethod payload missing 'receipt'", null))
+        } finally {
+            runCatching { blob?.close() }
+        }
     }
 
     override suspend fun sendReaction(

--- a/rns-ipc/src/main/kotlin/network/columba/app/rns/ipc/server/ServerRnsLxmf.kt
+++ b/rns-ipc/src/main/kotlin/network/columba/app/rns/ipc/server/ServerRnsLxmf.kt
@@ -1,15 +1,18 @@
 package network.columba.app.rns.ipc.server
 
 import android.os.Bundle
+import android.os.ParcelFileDescriptor
 import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
 import network.columba.app.rns.api.RnsLxmf
 import network.columba.app.rns.api.model.DeliveryMethod
-import network.columba.app.rns.api.model.FileAttachment
 import network.columba.app.rns.api.model.IconAppearance
 import network.columba.app.rns.api.model.Identity
 import network.columba.app.rns.api.model.PropagationState
 import network.columba.app.rns.api.model.ReceivedMessage
 import network.columba.app.rns.api.model.DeliveryStatusUpdate
+import network.columba.app.rns.ipc.AttachmentBlob
 import network.columba.app.rns.ipc.BundleKeys
 import network.columba.app.rns.ipc.IRnsLxmf
 import network.columba.app.rns.ipc.callback.IRnsDeliveryStatusCallback
@@ -17,7 +20,6 @@ import network.columba.app.rns.ipc.callback.IRnsMessageCallback
 import network.columba.app.rns.ipc.callback.IRnsPropagationStateCallback
 import network.columba.app.rns.ipc.callback.IRnsResultCallback
 import network.columba.app.rns.ipc.callback.IRnsStringCallback
-import network.columba.app.rns.ipc.toAttachmentPairs
 
 internal class ServerRnsLxmf(
     private val impl: RnsLxmf,
@@ -46,18 +48,20 @@ internal class ServerRnsLxmf(
         destinationHash: ByteArray,
         content: String,
         sourceIdentity: Identity,
-        imageData: ByteArray?,
-        imageFormat: String?,
-        fileAttachments: MutableList<FileAttachment>,
+        attachmentsBlob: ParcelFileDescriptor?,
         cb: IRnsResultCallback,
     ) = dispatch(cb, scope) {
+        // Read the out-of-band attachment payload back into memory (fast local
+        // temp-file read just staged by the client; see AttachmentBlob). Runs on
+        // the dispatch coroutine, so it never blocks a Binder thread.
+        val payload = withContext(Dispatchers.IO) { AttachmentBlob.readFromPfd(attachmentsBlob) }
         val receipt = impl.sendLxmfMessage(
             destinationHash,
             content,
             sourceIdentity,
-            imageData,
-            imageFormat,
-            fileAttachments.toAttachmentPairs().takeIf { it.isNotEmpty() },
+            payload.imageData,
+            payload.imageFormat,
+            payload.fileAttachments.takeIf { it.isNotEmpty() },
         ).getOrThrow()
         Bundle().apply { putParcelable(BundleKeys.RECEIPT, receipt) }
     }
@@ -68,24 +72,26 @@ internal class ServerRnsLxmf(
         sourceIdentity: Identity,
         deliveryMethod: DeliveryMethod,
         tryPropagationOnFail: Boolean,
-        imageData: ByteArray?,
-        imageFormat: String?,
-        fileAttachments: MutableList<FileAttachment>,
+        attachmentsBlob: ParcelFileDescriptor?,
         replyToMessageId: String?,
         replyQuotedContent: String?,
         iconAppearance: IconAppearance?,
         extraFields: Bundle?,
         cb: IRnsResultCallback,
     ) = dispatch(cb, scope) {
+        // Read the out-of-band attachment payload back into memory (fast local
+        // temp-file read just staged by the client; see AttachmentBlob). Runs on
+        // the dispatch coroutine, so it never blocks a Binder thread.
+        val payload = withContext(Dispatchers.IO) { AttachmentBlob.readFromPfd(attachmentsBlob) }
         val receipt = impl.sendLxmfMessageWithMethod(
             destinationHash,
             content,
             sourceIdentity,
             deliveryMethod,
             tryPropagationOnFail,
-            imageData,
-            imageFormat,
-            fileAttachments.toAttachmentPairs().takeIf { it.isNotEmpty() },
+            payload.imageData,
+            payload.imageFormat,
+            payload.fileAttachments.takeIf { it.isNotEmpty() },
             replyToMessageId,
             replyQuotedContent,
             iconAppearance,

--- a/rns-ipc/src/test/java/network/columba/app/rns/ipc/RnsBackendIpcRoundTripTest.kt
+++ b/rns-ipc/src/test/java/network/columba/app/rns/ipc/RnsBackendIpcRoundTripTest.kt
@@ -51,6 +51,8 @@ import network.columba.app.rns.api.model.ReceivedPacket
 import network.columba.app.rns.api.model.ReticulumConfig
 import network.columba.app.rns.api.model.VoiceCallState
 import kotlinx.coroutines.flow.Flow
+import org.junit.After
+import org.junit.Assert.assertArrayEquals
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertTrue
 import org.junit.Before
@@ -76,9 +78,18 @@ import org.robolectric.RobolectricTestRunner
 class RnsBackendIpcRoundTripTest {
     private lateinit var fake: FakeRnsBackend
 
+    // Scratch dir for ClientRnsLxmf's out-of-band attachment PFD staging.
+    private lateinit var attachmentCacheDir: java.io.File
+
     @Before
     fun setUp() {
         fake = FakeRnsBackend()
+        attachmentCacheDir = java.nio.file.Files.createTempDirectory("rns-ipc-attach-test").toFile()
+    }
+
+    @After
+    fun tearDown() {
+        attachmentCacheDir.deleteRecursively()
     }
 
     @Test
@@ -230,6 +241,74 @@ class RnsBackendIpcRoundTripTest {
         assertEquals(flipped, client.capabilities.value)
     }
 
+    @Test
+    fun `large file attachment and image survive the send round trip via out-of-band PFD`() = runTest {
+        val (client, _) = buildClientAndServer()
+        advanceUntilIdle()
+
+        // 3 MB — well past Binder's ~1 MB transaction cap, the size that threw
+        // TransactionTooLargeException when attachment bytes rode inline. The
+        // non-trivial byte patterns let assertArrayEquals catch any truncation
+        // or framing slip in AttachmentBlob.
+        val bigFile = ByteArray(3 * 1024 * 1024) { (it % 251).toByte() }
+        val image = ByteArray(700 * 1024) { (it % 97).toByte() }
+        val identity = Identity(hash = ByteArray(16), publicKey = ByteArray(32), privateKey = null)
+
+        val result = client.lxmf.sendLxmfMessageWithMethod(
+            destinationHash = ByteArray(16) { 0x11 },
+            content = "here is a file",
+            sourceIdentity = identity,
+            deliveryMethod = DeliveryMethod.DIRECT,
+            tryPropagationOnFail = false,
+            imageData = image,
+            imageFormat = "jpg",
+            fileAttachments = listOf("report.pdf" to bigFile),
+            replyToMessageId = null,
+            replyQuotedContent = null,
+            iconAppearance = null,
+            extraFields = null,
+        )
+        advanceUntilIdle()
+
+        assertTrue("send should succeed", result.isSuccess)
+        assertEquals("here is a file", fake.lxmf.lastContent)
+        assertEquals("jpg", fake.lxmf.lastImageFormat)
+        assertArrayEquals("image bytes must survive the PFD round trip", image, fake.lxmf.lastImageData)
+        val files = fake.lxmf.lastFileAttachments
+        assertEquals(1, files?.size)
+        assertEquals("report.pdf", files?.first()?.first)
+        assertArrayEquals("3 MB file must survive the PFD round trip", bigFile, files?.first()?.second)
+    }
+
+    @Test
+    fun `text-only send sends a null attachment blob`() = runTest {
+        val (client, _) = buildClientAndServer()
+        advanceUntilIdle()
+
+        val identity = Identity(hash = ByteArray(16), publicKey = ByteArray(32), privateKey = null)
+        val result = client.lxmf.sendLxmfMessageWithMethod(
+            destinationHash = ByteArray(16) { 0x22 },
+            content = "no attachments here",
+            sourceIdentity = identity,
+            deliveryMethod = DeliveryMethod.DIRECT,
+            tryPropagationOnFail = false,
+            imageData = null,
+            imageFormat = null,
+            fileAttachments = null,
+            replyToMessageId = null,
+            replyQuotedContent = null,
+            iconAppearance = null,
+            extraFields = null,
+        )
+        advanceUntilIdle()
+
+        assertTrue("send should succeed", result.isSuccess)
+        assertEquals("no attachments here", fake.lxmf.lastContent)
+        assertEquals(null, fake.lxmf.lastImageData)
+        // Server maps an empty payload back to null file attachments.
+        assertEquals(null, fake.lxmf.lastFileAttachments)
+    }
+
     private suspend fun TestScope.buildClientAndServer(): Pair<RnsBackend, RnsBackendServer> {
         // Single shared scheduler so advanceUntilIdle() drains both halves of
         // the round trip. Separate jobs so we can cancel scopes independently
@@ -239,7 +318,7 @@ class RnsBackendIpcRoundTripTest {
         val serverScope = CoroutineScope(dispatcher + SupervisorJob())
         val clientScope = CoroutineScope(dispatcher + SupervisorJob())
         val server = RnsBackendServer(fake, serverScope)
-        val client = RnsBackendClient(clientScope)
+        val client = RnsBackendClient(clientScope, attachmentCacheDir)
         client.connect(server)
         return client to server
     }
@@ -337,6 +416,30 @@ private class FakeRnsLxmf : RnsLxmf {
     private val deliveryStatus: MutableSharedFlow<DeliveryStatusUpdate> = MutableSharedFlow(extraBufferCapacity = 8)
     private val propagation: MutableSharedFlow<PropagationState> = MutableSharedFlow(extraBufferCapacity = 8)
 
+    // Last-send capture so tests can assert exactly what reached the backend
+    // after crossing the AIDL seam (the attachment payload travels out-of-band
+    // through a PFD, so byte-for-byte fidelity is what we're verifying).
+    @Volatile var lastContent: String? = null
+    @Volatile var lastImageData: ByteArray? = null
+    @Volatile var lastImageFormat: String? = null
+    @Volatile var lastFileAttachments: List<Pair<String, ByteArray>>? = null
+
+    private fun recordAndAck(
+        content: String,
+        imageData: ByteArray?,
+        imageFormat: String?,
+        fileAttachments: List<Pair<String, ByteArray>>?,
+        destinationHash: ByteArray,
+    ): Result<MessageReceipt> {
+        lastContent = content
+        lastImageData = imageData
+        lastImageFormat = imageFormat
+        lastFileAttachments = fileAttachments
+        return Result.success(
+            MessageReceipt(messageHash = ByteArray(0), timestamp = 0L, destinationHash = destinationHash),
+        )
+    }
+
     override suspend fun sendLxmfMessage(
         destinationHash: ByteArray,
         content: String,
@@ -344,7 +447,8 @@ private class FakeRnsLxmf : RnsLxmf {
         imageData: ByteArray?,
         imageFormat: String?,
         fileAttachments: List<Pair<String, ByteArray>>?,
-    ): Result<MessageReceipt> = Result.failure(NotImplementedError())
+    ): Result<MessageReceipt> =
+        recordAndAck(content, imageData, imageFormat, fileAttachments, destinationHash)
 
     override suspend fun sendLxmfMessageWithMethod(
         destinationHash: ByteArray,
@@ -359,7 +463,8 @@ private class FakeRnsLxmf : RnsLxmf {
         replyQuotedContent: String?,
         iconAppearance: IconAppearance?,
         extraFields: Map<Int, Any>?,
-    ): Result<MessageReceipt> = Result.failure(NotImplementedError())
+    ): Result<MessageReceipt> =
+        recordAndAck(content, imageData, imageFormat, fileAttachments, destinationHash)
 
     override suspend fun sendReaction(
         destinationHash: ByteArray,

--- a/tests/interop/test_file.py
+++ b/tests/interop/test_file.py
@@ -36,7 +36,7 @@ def test_file_columba_to_sideband(interop, attach_bytes):
     attachments = file_attachments(msg.fields)
     assert len(attachments) == 1
     name, data = attachments[0]
-    assert name == b"attach.txt"
+    assert name == "attach.txt"
     assert data == attach_bytes
 
 

--- a/tests/interop/verify.py
+++ b/tests/interop/verify.py
@@ -49,16 +49,18 @@ def image_format(fields: dict) -> str:
     return fmt.decode("utf-8") if isinstance(fmt, (bytes, bytearray)) else fmt
 
 
-def file_attachments(fields: dict) -> list[tuple[bytes, bytes]]:
-    """`FIELD_FILE_ATTACHMENTS` is `[[name_bytes, data_bytes], …]`. Coerce
-    both elements to `bytes` so test asserts don't have to care about
-    Chaquopy jarray vs python bytes."""
+def file_attachments(fields: dict) -> list[tuple[str, bytes]]:
+    """`FIELD_FILE_ATTACHMENTS` is `[[name_str, data_bytes], …]` — the filename
+    is a `str`, matching Sideband's `[basename, bytes]` shape. Coerce the name to
+    `str` (decoding defensively if a peer still sends bytes) and the data to
+    `bytes`, so asserts don't have to care about Chaquopy jarray vs python bytes."""
     raw = fields[FIELD_FILE_ATTACHMENTS]
     out = []
     for entry in raw:
         if isinstance(entry, (list, tuple)) and len(entry) >= 2:
             n, d = entry[0], entry[1]
-            out.append((bytes(n), bytes(d)))
+            name = n.decode("utf-8", "replace") if isinstance(n, (bytes, bytearray)) else str(n)
+            out.append((name, bytes(d)))
     return out
 
 


### PR DESCRIPTION
## Problem

`android.os.TransactionTooLargeException` (data parcel size ~5.5 MB) when sending a file attachment, reported on v2.0.2-beta (Galaxy Z Fold 7).

Reticulum runs in a separate `:reticulum` process. Sending marshals the message across a `oneway` AIDL/Binder transaction (`ClientRnsLxmf` → `ServerRnsLxmf`), and `IRnsLxmf.aidl` carried the attachment bytes **inline** (`byte[] imageData` + `List<FileAttachment>` whose `data` is inline). Binder's transaction buffer is ~1 MB **shared per process**, so a multi-MB file overflows it. The exception is caught at `ClientAidlBridge` and surfaced as a *failed send*. It's deterministic for any large attachment on any device — the Fold 7 was incidental. Images squeaked by only because they're capped at 512 KB; file attachments were explicitly uncapped.

## Fix

Attachment payloads now cross via a single read-only `ParcelFileDescriptor` instead of inline bytes:

- New `AttachmentBlob` serializes image + files to a **delete-on-close** temp file in the app cache dir, opens a read-only PFD, and unlinks immediately. The fd marshals as a handful of bytes; the server streams it back into memory. Same app UID ⇒ the fd and the unlinked inode are shared safely; the server never resolves the path.
- Blob write/read run on `Dispatchers.IO`, so the multi-MB copy never touches the main thread (StrictMode-clean — confirmed on-device).
- The Kotlin `RnsLxmf` interface and the reticulum-kt / python backends are **unchanged** — only the AIDL seam changes (`IRnsLxmf` + `Client`/`ServerRnsLxmf`).

**Guard (defense-in-depth):** a friendly 32 MB pre-send ceiling (OOM protection — the bytes live fully in memory in both processes plus Reticulum's Resource buffers) and mapping any residual Binder-overflow failure to a clear "attachment too large" message instead of leaking the raw exception.

## Also fixed: Field 5 attachment filename interop

Surfaced once large-file sends worked: `FIELD_FILE_ATTACHMENTS` encoded the filename as msgpack **bytes** (`name.toByteArray()`) in both backends. Sideband and older Columba render the name via `str(name)`, so a bytes filename shows up as its `b'…'` repr on the receiver (the data half was fine). Now sent as a **`str`**, matching Sideband's `[basename, bytes]` shape and the sibling `FIELD_IMAGE` encoding, kept in lockstep across `PythonRnsLxmf` + `NativeMessageSender`. The interop round-trip test is updated to assert the str shape.

## Verification

- `:rns-ipc` round-trip test sends a 3 MB file + 700 KB image **byte-for-byte** through the PFD, plus a text-only→null-blob case (detekt clean across touched modules; existing `MessagingViewModelTest` green).
- New Maestro regression flow `maestro/e2e/single-device/send-large-attachment.yaml` (+ `run-large-attachment.sh`) — UI-level guard. *Authored against existing conventions; the SAF-picker steps are `optional:` and may need a tuning pass on first emulator run.*
- **On a physical Galaxy Z Fold 7** (the reported device): a 5.27 MB file now **sends and delivers end-to-end** with no `TransactionTooLargeException`, and the filename renders as `eridanus-kotlin-0.1.10.apk` (not `b'…'`) on a Columba v0.10.10 peer.

## Notes

- The IPC unit test uses an *in-process* stub that bypasses real Binder, so it proves serialization fidelity but not the Binder limit itself — hence the on-device check.
- **Out of scope / pre-existing:** on-device testing surfaced a separate `AuthenticationError: digest sent was rejected` from Reticulum's shared-instance RPC when multiple Columba variants (release + debug + kt) run their python RNS simultaneously. Unrelated to this change; it blocks *any* send while the instances coexist (stopping the extra variants clears it).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
