### PR TITLE
Match Sideband's LXMF telemetry-request command: epoch-seconds timebase + collector flag (#927)

### DIFF
--- a/rns-api/src/main/java/network/columba/app/rns/api/RnsTelemetry.kt
+++ b/rns-api/src/main/java/network/columba/app/rns/api/RnsTelemetry.kt
@@ -49,7 +49,10 @@ interface RnsTelemetry {
      *
      * @param destinationHash Destination hash bytes (16 bytes identity hash) of the collector
      * @param sourceIdentity Identity of the sender
-     * @param timebase Optional Unix timestamp (milliseconds) to request telemetry since
+     * @param timebase Optional last-request time in epoch **milliseconds** to request
+     *   telemetry since. The backend converts this to epoch **seconds** before it goes
+     *   on the wire — Sideband's FIELD_COMMANDS telemetry-request timebase is seconds
+     *   (#927). Null (no prior request) means "all available history".
      * @param isCollectorRequest True if requesting from a collector (default)
      * @return Result containing MessageReceipt or failure
      */

--- a/rns-api/src/main/java/network/columba/app/rns/api/util/TelemeterCodec.kt
+++ b/rns-api/src/main/java/network/columba/app/rns/api/util/TelemeterCodec.kt
@@ -10,10 +10,11 @@ import kotlin.math.round
 /**
  * Single source of truth for the Sideband-compatible Telemeter wire
  * format (LXMF `FIELD_TELEMETRY` payload) + Columba's `FIELD_CUSTOM_META`
- * extras. Both backends — Kotlin-native (`rns-backend-kt`) and Python-
- * Chaquopy (`rns-backend-py`) — route through this codec so there's
- * exactly one implementation of the bit-format both apps interoperate
- * over.
+ * extras, plus the `FIELD_COMMANDS` telemetry-request timebase units
+ * ([telemetryRequestTimebaseSeconds]). Both backends — Kotlin-native
+ * (`rns-backend-kt`) and Python-Chaquopy (`rns-backend-py`) — route
+ * through this codec so there's exactly one implementation of the
+ * bit-format both apps interoperate over.
  *
  * Wire-format reference: `Sideband/sbapp/sideband/sense.py`'s
  * `Telemeter.packed()` / `Telemeter.from_packed()`:
@@ -191,6 +192,28 @@ object TelemeterCodec {
         } catch (_: Exception) {
             null
         }
+
+    /**
+     * Convert a last-request time in epoch **milliseconds** (Columba tracks
+     * telemetry request times with `System.currentTimeMillis()`) to the epoch
+     * **seconds** timebase that rides in an LXMF `FIELD_COMMANDS` telemetry
+     * request — `{0x01: [timebase, isCollectorRequest]}`. Both backends route
+     * through here so the request units can't drift from the data units packed
+     * by [packLocationTelemetry] (likewise seconds).
+     *
+     * Sideband reads this field as seconds: `timebase = int(command_timebase)`
+     * then `list_telemetry(after=timebase)` against second-resolution
+     * `{"utc": int(time.time())}` telemetry stamps (Sideband `core.py:5259`,
+     * `sense.py:328`). A milliseconds value read as seconds points the request
+     * ~58000 AD, so collectors return no telemetry and RCH additionally crashes
+     * in `datetime.fromtimestamp` ("year 58337 is out of range").
+     *
+     * Null (the first request, no stored time) maps to 0 — epoch, i.e. "all
+     * available history". 0 is a valid wire value; a literal null would crash
+     * collectors via `int(None)`. (#927)
+     */
+    fun telemetryRequestTimebaseSeconds(lastRequestMillis: Long?): Long =
+        (lastRequestMillis ?: 0L) / 1000L
 
     // ---- msgpack value helpers ---------------------------------------
     // Type-routing packer/unpacker for the polymorphic SID_LOCATION list

--- a/rns-api/src/test/java/network/columba/app/rns/api/util/TelemeterCodecTest.kt
+++ b/rns-api/src/test/java/network/columba/app/rns/api/util/TelemeterCodecTest.kt
@@ -1,0 +1,48 @@
+package network.columba.app.rns.api.util
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * Coverage for [TelemeterCodec.telemetryRequestTimebaseSeconds] — the LXMF
+ * `FIELD_COMMANDS` telemetry-request timebase, which must go on the wire in
+ * epoch SECONDS to interop with Sideband/RCH.
+ *
+ * Regression guard for #927: the timebase was previously shipped in epoch
+ * MILLISECONDS, which collectors read as seconds (`int(command_timebase)` /
+ * `datetime.fromtimestamp`) — landing ~58000 AD ("year 58337 is out of
+ * range") so RCH crashed and Sideband returned no telemetry.
+ */
+class TelemeterCodecTest {
+    // 1_779_580_800_000 ms == 1_779_580_800 s, a ~2026 instant.
+    private val millis2026 = 1_779_580_800_000L
+    private val seconds2026 = 1_779_580_800L
+
+    @Test
+    fun `converts last-request millis to wire seconds`() {
+        assertEquals(seconds2026, TelemeterCodec.telemetryRequestTimebaseSeconds(millis2026))
+    }
+
+    @Test
+    fun `wire value is seconds-magnitude, not the raw millis that crashed collectors`() {
+        val wire = TelemeterCodec.telemetryRequestTimebaseSeconds(millis2026)
+        assertNotEquals(millis2026, wire)
+        // 253_402_300_800 == year-9999 in epoch seconds. The #927 millis value
+        // blew past this and crashed Python's datetime.fromtimestamp; a correct
+        // seconds value sits far below it.
+        assertTrue("timebase $wire still looks like millis", wire < 253_402_300_800L)
+    }
+
+    @Test
+    fun `null first request maps to 0 - all history, never a null on the wire`() {
+        // Sideband does int(timebase); a literal null would crash via int(None).
+        assertEquals(0L, TelemeterCodec.telemetryRequestTimebaseSeconds(null))
+    }
+
+    @Test
+    fun `zero stays zero`() {
+        assertEquals(0L, TelemeterCodec.telemetryRequestTimebaseSeconds(0L))
+    }
+}

--- a/rns-backend-kt/src/main/kotlin/network/columba/app/rns/backend/kt/NativeRnsBackendImpl.kt
+++ b/rns-backend-kt/src/main/kotlin/network/columba/app/rns/backend/kt/NativeRnsBackendImpl.kt
@@ -1427,10 +1427,16 @@ class NativeRnsBackendImpl(
         timebase: Long?,
         isCollectorRequest: Boolean,
     ): Result<MessageReceipt> {
+        // Timebase rides the wire in epoch SECONDS (Sideband-interop) but
+        // arrives here in millis; the shared converter also maps the
+        // first-request null to 0 so we never ship int(None) into the list.
+        // See TelemeterCodec.telemetryRequestTimebaseSeconds. (#927)
+        val timebaseSeconds =
+            network.columba.app.rns.api.util.TelemeterCodec.telemetryRequestTimebaseSeconds(timebase)
         val commands =
             listOf(
                 mapOf(
-                    0x01 to listOf(timebase, isCollectorRequest),
+                    0x01 to listOf(timebaseSeconds, isCollectorRequest),
                 ),
             )
         return sendLxmfMessageWithMethod(

--- a/rns-backend-py/src/main/kotlin/network/columba/app/rns/backend/py/PythonRnsTelemetry.kt
+++ b/rns-backend-py/src/main/kotlin/network/columba/app/rns/backend/py/PythonRnsTelemetry.kt
@@ -118,8 +118,13 @@ class PythonRnsTelemetry(
             // command-dict shape `{0x01: timebase}` (Sideband's
             // `_COMMAND_TELEMETRY_REQUEST`) was verified live against a
             // Fold 7 host ↔ S21 member pair in commit `61598cf1`.
+            // Timebase rides the wire in epoch SECONDS (Sideband-interop) but
+            // arrives here in millis; the shared converter also maps the
+            // first-request null to 0. See
+            // [TelemeterCodec.telemetryRequestTimebaseSeconds]. (#927)
+            val timebaseSeconds = TelemeterCodec.telemetryRequestTimebaseSeconds(timebase)
             val commandList = listOf(
-                mapOf(0x01 to (timebase ?: 0L)).toPyDict(),
+                mapOf(0x01 to timebaseSeconds).toPyDict(),
             ).toPyList()
             val fields = buildFieldsDict {
                 putRaw(LxmfFields.FIELD_COMMANDS, commandList)

--- a/rns-backend-py/src/main/kotlin/network/columba/app/rns/backend/py/PythonRnsTelemetry.kt
+++ b/rns-backend-py/src/main/kotlin/network/columba/app/rns/backend/py/PythonRnsTelemetry.kt
@@ -112,20 +112,28 @@ class PythonRnsTelemetry(
     ): Result<MessageReceipt> =
         pyResult {
             runtime.requireRunning()
-            // A telemetry request is an LXMF FIELD_COMMANDS frame. Upstream
-            // Sideband encodes this as a list of command dicts; the collector
-            // replies with FIELD_TELEMETRY_STREAM since `timebase`. The
-            // command-dict shape `{0x01: timebase}` (Sideband's
-            // `_COMMAND_TELEMETRY_REQUEST`) was verified live against a
-            // Fold 7 host ↔ S21 member pair in commit `61598cf1`.
+            // LXMF FIELD_COMMANDS telemetry request. Match Sideband's
+            // canonical shape `{0x01: [timebase, is_collector_request]}`
+            // (core.py:1358) — identical to the native backend. Sideband also
+            // accepts the legacy scalar `{0x01: timebase}`, but its old-format
+            // fallback hardcodes is_collector_request=True (core.py:5254-5256),
+            // so the scalar silently drops `isCollectorRequest`; the list form
+            // honors it (e.g. a non-collector "just send your own telemetry"
+            // request). Shape live-verified Fold 7 ↔ S21 in commit `61598cf1`.
+            //
             // Timebase rides the wire in epoch SECONDS (Sideband-interop) but
             // arrives here in millis; the shared converter also maps the
             // first-request null to 0. See
             // [TelemeterCodec.telemetryRequestTimebaseSeconds]. (#927)
             val timebaseSeconds = TelemeterCodec.telemetryRequestTimebaseSeconds(timebase)
-            val commandList = listOf(
-                mapOf(0x01 to timebaseSeconds).toPyDict(),
-            ).toPyList()
+            // Build the inner [timebase, isCollectorRequest] as a real Python
+            // list before nesting: a raw Kotlin List value would reach umsgpack
+            // as a non-iterable Java proxy (see PythonExt.toPyList). toPyDict
+            // passes the already-built PyObject value through unchanged.
+            val command = mapOf(
+                0x01 to listOf<Any>(timebaseSeconds, isCollectorRequest).toPyList(),
+            ).toPyDict()
+            val commandList = listOf(command).toPyList()
             val fields = buildFieldsDict {
                 putRaw(LxmfFields.FIELD_COMMANDS, commandList)
             }


### PR DESCRIPTION
## Summary

Fixes #927. Aligns Columba's LXMF `FIELD_COMMANDS` telemetry request with Sideband (the reference) on **two** points: the timebase **units** and the command **shape** / collector flag.

### 1. Timebase units — milliseconds → seconds (the reported crash)
Columba sent the request timebase in epoch **milliseconds**; Sideband's wire format is epoch **seconds**. A normal 2026 millisecond value (~1.78e12) read as seconds points ~58000 AD:
- **RCH** crashes in `datetime.fromtimestamp` → `ValueError: year 58337 is out of range` (the reported error).
- **Sideband** doesn't crash, but `list_telemetry(after=<future>)` matches nothing, so the collector silently returns zero telemetry.

Columba already divides telemetry-**data** timestamps by 1000 at the wire boundary (`TelemeterCodec.packLocationTelemetry`); only the request **timebase** was missed.

### 2. Command shape — match Sideband's canonical list, honor `isCollectorRequest`
Sideband always sends the 2-element list `{0x01: [timebase, is_collector_request]}` (`core.py:1358`). The flag selects two distinct request semantics on the receiver (`core.py:5251-5266`):
- `true` → responder acts as a **collector** and returns **all** known objects since `timebase`;
- `false` → responder returns **only its own** latest telemetry.

The **native** backend already sent the list (matches Sideband). The **Python** backend sent the legacy scalar `{0x01: timebase}`, which Sideband's old-format fallback hardcodes to `is_collector_request=True` (`core.py:5254-5256`) — so it **silently dropped** the `isCollectorRequest` argument. Both backends now send the canonical list.

### Verified against the Sideband source (`~/repos/Sideband`)
- Send shape: `core.py:1357-1358` `{TELEMETRY_REQUEST: [request_timebase, is_collector_request]}` (timebase from `:1343` `now = time.time()`, seconds)
- Receive: `core.py:5252` `command[...][0]` / `:5253` `[...][1]` → `:5259` `int(command_timebase)` → `:5305` `list_telemetry(after=timebase)`
- Telemetry **data** stamps are seconds too: `sense.py:155` `SID_TIME = int(time.time())`, `sense.py:328` `{"utc": int(time.time())}`

## Fix

| File | Change |
|---|---|
| `rns-api/…/util/TelemeterCodec.kt` | New `telemetryRequestTimebaseSeconds(ms?)` converter (single source of truth) + KDoc citing the Sideband lines |
| `rns-backend-py/…/PythonRnsTelemetry.kt` | Route timebase through the converter; **send the canonical list shape** `{0x01: [seconds, isCollectorRequest]}` (was the legacy scalar that dropped the flag) |
| `rns-backend-kt/…/NativeRnsBackendImpl.kt` | Route through the converter; **also fixes a latent crash** — it previously put a literal `null` into the list on the first request, which crashes the collector via `int(None)`. `null → 0` now ("all history"). |
| `rns-api/…/RnsTelemetry.kt` | KDoc corrected (was documented as "milliseconds" on the wire) |
| `rns-api/…/util/TelemeterCodecTest.kt` | **New** — 4 regression tests, all exercising the production converter |

## Testing
- `:rns-api:testDebugUnitTest` (`TelemeterCodecTest`) — 4/4 pass
- `:rns-backend-kt:testDebugUnitTest` — pass
- `:rns-backend-py:compileDebugKotlin` — compiles

All four `sendTelemetryRequest` call sites originate the timebase in milliseconds (`TelemetryCollectorManager` via `System.currentTimeMillis()`); the IPC forwarders only marshal it, so the conversion runs **exactly once** at the backend wire boundary (no double-divide). The Python wire path (Chaquopy + upstream umsgpack) isn't JVM-unit-testable — the list shape mirrors the native backend's already-working shape and is best confirmed by on-device smoke.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
