### PR TITLE
fix(rns-ipc): inbound attachments out-of-band + stop observer-detach cascade (TransactionTooLargeException)

### DIFF
--- a/rns-api/src/main/aidl/network/columba/app/rns/ipc/callback/IRnsMessageCallback.aidl
+++ b/rns-api/src/main/aidl/network/columba/app/rns/ipc/callback/IRnsMessageCallback.aidl
@@ -4,5 +4,15 @@ package network.columba.app.rns.ipc.callback;
 import network.columba.app.rns.api.model.ReceivedMessage;
 
 oneway interface IRnsMessageCallback {
-    void onMessage(in ReceivedMessage message);
+    // A received message's image/file payload is hex-encoded inside
+    // `ReceivedMessage.fieldsJson`, which makes a received photo several hundred
+    // KB and overflows the ~1 MB shared Binder transaction buffer when marshaled
+    // inline (-> TransactionTooLargeException, which silently detached the
+    // observer and killed all further delivery). When `fieldsJson` is large the
+    // server strips it from `message` (sets it null) and ships it out-of-band as
+    // `fieldsBlob`, a read-only fd over a delete-on-close temp file that
+    // :rns-ipc's FieldsBlob writes on the server and reads on the client; null
+    // means the message is complete inline. Mirrors the send-side attachmentsBlob
+    // on IRnsLxmf.
+    void onMessage(in @nullable ReceivedMessage message, in @nullable ParcelFileDescriptor fieldsBlob);
 }

--- a/rns-host/src/main/kotlin/network/columba/app/rns/host/ReticulumService.kt
+++ b/rns-host/src/main/kotlin/network/columba/app/rns/host/ReticulumService.kt
@@ -429,7 +429,13 @@ class ReticulumService : Service() {
         // onCreate) because in-process service managers (NetworkChangeManager,
         // BleCoordinator) call its `restartAutoInterface` / `announceLxmfDestination`
         // helpers via direct Java calls — A.10 rewires those to use `rnsBackend`.
-        return aidlServer ?: RnsBackendServer(impl = rnsBackend, scope = serviceScope).also {
+        return aidlServer ?: RnsBackendServer(
+            impl = rnsBackend,
+            scope = serviceScope,
+            // Shared app cache (same UID as the UI process) for staging
+            // out-of-band inbound fields blobs; see FieldsBlob / IRnsMessageCallback.
+            cacheDir = cacheDir,
+        ).also {
             aidlServer = it
         }
     }

--- a/rns-ipc/src/main/kotlin/network/columba/app/rns/ipc/FieldsBlob.kt
+++ b/rns-ipc/src/main/kotlin/network/columba/app/rns/ipc/FieldsBlob.kt
@@ -81,12 +81,19 @@ internal object FieldsBlob {
     fun readFromPfd(pfd: ParcelFileDescriptor): String {
         DataInputStream(BufferedInputStream(ParcelFileDescriptor.AutoCloseInputStream(pfd))).use { inp ->
             val magic = inp.readInt()
-            if (magic != MAGIC) throw IOException("Bad fields blob magic: 0x${Integer.toHexString(magic)}")
             val version = inp.readInt()
-            if (version != VERSION) throw IOException("Unsupported fields blob version: $version")
+            if (magic != MAGIC || version != VERSION) {
+                throw IOException(
+                    "Bad fields blob header: magic=0x${Integer.toHexString(magic)} version=$version",
+                )
+            }
+            // Reject a negative or implausibly large length (a corrupt/garbage blob
+            // could carry up to Int.MAX) before allocating, so we fail fast instead
+            // of churning GC/LMK on a doomed multi-GB ByteArray.
             val len = inp.readInt()
-            if (len < 0) throw IOException("Bad fields blob: negative length ($len)")
-            if (len > MAX_FIELDS_BYTES) throw IOException("Bad fields blob: implausible length ($len)")
+            if (len < 0 || len > MAX_FIELDS_BYTES) {
+                throw IOException("Bad fields blob: implausible length ($len)")
+            }
             val bytes = ByteArray(len).also { inp.readFully(it) }
             return String(bytes, Charsets.UTF_8)
         }

--- a/rns-ipc/src/main/kotlin/network/columba/app/rns/ipc/FieldsBlob.kt
+++ b/rns-ipc/src/main/kotlin/network/columba/app/rns/ipc/FieldsBlob.kt
@@ -42,6 +42,14 @@ internal object FieldsBlob {
     private const val VERSION = 1
     private const val TEMP_SUBDIR = "rns-ipc-rx"
 
+    // Sanity ceiling on the declared payload length. A corrupt/garbage blob that
+    // still passes the magic+version check could otherwise carry a length up to
+    // Int.MAX (~2 GB) and trigger a huge ByteArray allocation + GC/LMK churn
+    // before the caller's runCatching fallback. 128 MB is far above any
+    // legitimate hex-encoded fieldsJson — even a maxed ~32 MB attachment doubles
+    // to ~64 MB of hex — yet well under Int.MAX.
+    private const val MAX_FIELDS_BYTES = 128 * 1024 * 1024
+
     /**
      * Serialize [fieldsJson] to a delete-on-close temp file under [cacheDir] and
      * return a read-only [ParcelFileDescriptor] over it. The returned PFD is
@@ -78,6 +86,7 @@ internal object FieldsBlob {
             if (version != VERSION) throw IOException("Unsupported fields blob version: $version")
             val len = inp.readInt()
             if (len < 0) throw IOException("Bad fields blob: negative length ($len)")
+            if (len > MAX_FIELDS_BYTES) throw IOException("Bad fields blob: implausible length ($len)")
             val bytes = ByteArray(len).also { inp.readFully(it) }
             return String(bytes, Charsets.UTF_8)
         }

--- a/rns-ipc/src/main/kotlin/network/columba/app/rns/ipc/FieldsBlob.kt
+++ b/rns-ipc/src/main/kotlin/network/columba/app/rns/ipc/FieldsBlob.kt
@@ -1,0 +1,85 @@
+package network.columba.app.rns.ipc
+
+import android.os.ParcelFileDescriptor
+import java.io.BufferedInputStream
+import java.io.BufferedOutputStream
+import java.io.DataInputStream
+import java.io.DataOutputStream
+import java.io.File
+import java.io.FileOutputStream
+import java.io.IOException
+
+/**
+ * Out-of-band transfer of a received message's `fieldsJson` across the
+ * [network.columba.app.rns.ipc.callback.IRnsMessageCallback] AIDL boundary —
+ * the receive-direction mirror of [AttachmentBlob].
+ *
+ * Inbound LXMF messages carry image/file payloads hex-encoded inside
+ * `ReceivedMessage.fieldsJson`; a received photo makes that string several
+ * hundred KB (hex doubles the byte size), which overflows the ~1 MB shared
+ * Binder transaction buffer when `onMessage` marshals it inline and throws
+ * `android.os.TransactionTooLargeException` in the `:reticulum` process. The
+ * send direction already solved this for outbound attachments (see
+ * [AttachmentBlob]); this is the same trick for the inbound `fieldsJson`.
+ *
+ * Large `fieldsJson` crosses as a read-only [ParcelFileDescriptor] over a
+ * delete-on-close temp file: the server (`:reticulum`) writes it, the client
+ * (UI) streams it back. Both processes share the app UID, so the fd and the
+ * immediately-unlinked inode are shared safely; the client never resolves the
+ * path. Small messages keep riding inline (null PFD) for zero overhead.
+ *
+ * Wire format (big-endian [DataOutputStream]), versioned so a format bump
+ * rejects stale blobs instead of mis-parsing:
+ * ```
+ *   int MAGIC   = 0x4C584D46 ("LXMF")
+ *   int VERSION = 1
+ *   int len                       (UTF-8 byte length of fieldsJson)
+ *   byte[len] fieldsJson          (UTF-8)
+ * ```
+ */
+internal object FieldsBlob {
+    private const val MAGIC = 0x4C584D46 // "LXMF"
+    private const val VERSION = 1
+    private const val TEMP_SUBDIR = "rns-ipc-rx"
+
+    /**
+     * Serialize [fieldsJson] to a delete-on-close temp file under [cacheDir] and
+     * return a read-only [ParcelFileDescriptor] over it. The returned PFD is
+     * owned by the caller, which must close it once the transaction is
+     * delivered — the server's [readFromPfd] reads its own dup.
+     */
+    @Throws(IOException::class)
+    fun writeToPfd(cacheDir: File, fieldsJson: String): ParcelFileDescriptor {
+        val dir = File(cacheDir, TEMP_SUBDIR).apply { mkdirs() }
+        val tempFile = File.createTempFile("lxmf-fields-", ".bin", dir)
+        try {
+            DataOutputStream(BufferedOutputStream(FileOutputStream(tempFile))).use { out ->
+                out.writeInt(MAGIC)
+                out.writeInt(VERSION)
+                val bytes = fieldsJson.toByteArray(Charsets.UTF_8)
+                out.writeInt(bytes.size)
+                out.write(bytes)
+            }
+            return ParcelFileDescriptor.open(tempFile, ParcelFileDescriptor.MODE_READ_ONLY)
+        } finally {
+            // Unlink immediately (delete-on-close): the open fd keeps the inode
+            // alive, so an interrupted delivery leaves nothing on disk.
+            tempFile.delete()
+        }
+    }
+
+    /** Inverse of [writeToPfd]: read the `fieldsJson` back from [pfd] and close it. */
+    @Throws(IOException::class)
+    fun readFromPfd(pfd: ParcelFileDescriptor): String {
+        DataInputStream(BufferedInputStream(ParcelFileDescriptor.AutoCloseInputStream(pfd))).use { inp ->
+            val magic = inp.readInt()
+            if (magic != MAGIC) throw IOException("Bad fields blob magic: 0x${Integer.toHexString(magic)}")
+            val version = inp.readInt()
+            if (version != VERSION) throw IOException("Unsupported fields blob version: $version")
+            val len = inp.readInt()
+            if (len < 0) throw IOException("Bad fields blob: negative length ($len)")
+            val bytes = ByteArray(len).also { inp.readFully(it) }
+            return String(bytes, Charsets.UTF_8)
+        }
+    }
+}

--- a/rns-ipc/src/main/kotlin/network/columba/app/rns/ipc/RnsBackendServer.kt
+++ b/rns-ipc/src/main/kotlin/network/columba/app/rns/ipc/RnsBackendServer.kt
@@ -36,6 +36,9 @@ import network.columba.app.rns.ipc.server.ServerRnsTransportAdmin
 class RnsBackendServer(
     private val impl: RnsBackend,
     private val scope: CoroutineScope,
+    // App cache dir used to stage out-of-band inbound `fieldsJson` blobs
+    // (received images/files) for delivery to the UI process; see [FieldsBlob].
+    private val cacheDir: java.io.File,
 ) : IRnsBackend.Stub() {
     // Lazy server-adapter construction. `synchronized` guards the double-check
     // pattern so two concurrent UI processes (binder dispatch is multi-thread)
@@ -64,7 +67,7 @@ class RnsBackendServer(
 
     override fun getLxmf(cb: IRnsLxmfCallback) {
         val server = lxmfServer ?: synchronized(constructLock) {
-            lxmfServer ?: ServerRnsLxmf(impl.lxmf, scope).also { lxmfServer = it }
+            lxmfServer ?: ServerRnsLxmf(impl.lxmf, scope, cacheDir).also { lxmfServer = it }
         }
         try { cb.onLxmf(server) } catch (_: RemoteException) { /* client dead */ }
     }

--- a/rns-ipc/src/main/kotlin/network/columba/app/rns/ipc/client/ClientRnsLxmf.kt
+++ b/rns-ipc/src/main/kotlin/network/columba/app/rns/ipc/client/ClientRnsLxmf.kt
@@ -1,6 +1,7 @@
 package network.columba.app.rns.ipc.client
 
 import android.os.Bundle
+import android.os.ParcelFileDescriptor
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.channels.awaitClose
@@ -25,6 +26,7 @@ import network.columba.app.rns.api.model.PropagationState
 import network.columba.app.rns.api.model.ReceivedMessage
 import network.columba.app.rns.ipc.AttachmentBlob
 import network.columba.app.rns.ipc.BundleKeys
+import network.columba.app.rns.ipc.FieldsBlob
 import network.columba.app.rns.ipc.IRnsLxmf
 import network.columba.app.rns.ipc.callback.IRnsDeliveryStatusCallback
 import network.columba.app.rns.ipc.callback.IRnsMessageCallback
@@ -132,7 +134,26 @@ internal class ClientRnsLxmf(
 
     override fun observeMessages(): Flow<ReceivedMessage> = callbackFlow {
         val cb = object : IRnsMessageCallback.Stub() {
-            override fun onMessage(message: ReceivedMessage?) { if (message != null) trySend(message) }
+            override fun onMessage(message: ReceivedMessage?, fieldsBlob: ParcelFileDescriptor?) {
+                if (message == null) {
+                    runCatching { fieldsBlob?.close() }
+                    return
+                }
+                // Large messages (received image/file) arrive with fieldsJson
+                // stripped and carried out-of-band; reconstitute it. FieldsBlob
+                // closes the fd on success. On a read failure fall back to the
+                // (fieldsJson-less) message rather than dropping it, and never
+                // leak the fd.
+                val full = if (fieldsBlob != null) {
+                    val fields = runCatching { FieldsBlob.readFromPfd(fieldsBlob) }
+                        .onFailure { runCatching { fieldsBlob.close() } }
+                        .getOrNull()
+                    if (fields != null) message.copy(fieldsJson = fields) else message
+                } else {
+                    message
+                }
+                trySend(full)
+            }
         }
         if (!registerObserverOrClose { remote.registerMessageObserver(cb) }) return@callbackFlow
         awaitClose { runCatching { remote.unregisterMessageObserver(cb) } }

--- a/rns-ipc/src/main/kotlin/network/columba/app/rns/ipc/server/ServerFlowBridge.kt
+++ b/rns-ipc/src/main/kotlin/network/columba/app/rns/ipc/server/ServerFlowBridge.kt
@@ -64,6 +64,7 @@ internal class ObserverHub<T, C : Any>(
                                 // The client process is genuinely gone. Clean up
                                 // now in case the linkToDeath recipient hasn't
                                 // fired yet.
+                                Log.d(TAG, "Observer client is dead; detaching", e)
                                 detach(binder)
                             } catch (e: TransactionTooLargeException) {
                                 // This ONE payload overflowed the Binder buffer;

--- a/rns-ipc/src/main/kotlin/network/columba/app/rns/ipc/server/ServerFlowBridge.kt
+++ b/rns-ipc/src/main/kotlin/network/columba/app/rns/ipc/server/ServerFlowBridge.kt
@@ -1,7 +1,10 @@
 package network.columba.app.rns.ipc.server
 
+import android.os.DeadObjectException
 import android.os.IBinder
 import android.os.RemoteException
+import android.os.TransactionTooLargeException
+import android.util.Log
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.flow.Flow
@@ -41,6 +44,10 @@ internal class ObserverHub<T, C : Any>(
     private var collectorJob: Job? = null
     private val stateLock = Any()
 
+    private companion object {
+        const val TAG = "ObserverHub"
+    }
+
     fun registerObserver(cb: C) {
         val binder = callbackBinder(cb)
         observers[binder] = cb
@@ -53,9 +60,37 @@ internal class ObserverHub<T, C : Any>(
                         for ((binder, observer) in observers.entries.toList()) {
                             try {
                                 emit(observer, value)
-                            } catch (e: RemoteException) {
-                                // Client died between unhook and unregister — clean up now.
+                            } catch (e: DeadObjectException) {
+                                // The client process is genuinely gone. Clean up
+                                // now in case the linkToDeath recipient hasn't
+                                // fired yet.
                                 detach(binder)
+                            } catch (e: TransactionTooLargeException) {
+                                // This ONE payload overflowed the Binder buffer;
+                                // the client is alive and still subscribed.
+                                // Detaching here would silently kill ALL future
+                                // delivery for the session — the client never
+                                // learns it was dropped and never re-registers
+                                // (it subscribes once via a callbackFlow whose
+                                // awaitClose only fires on cancel). That is how a
+                                // single oversized inbound message used to take
+                                // out every subsequent message, including small
+                                // text. Skip this payload and keep the observer;
+                                // large payloads must cross out-of-band (see
+                                // AttachmentBlob), not inline.
+                                Log.e(
+                                    TAG,
+                                    "Observer payload exceeded the Binder transaction " +
+                                        "limit; dropping this message but keeping the " +
+                                        "observer subscribed",
+                                    e,
+                                )
+                            } catch (e: RemoteException) {
+                                // Other transient remote failures: keep the
+                                // observer (genuine death is handled by the
+                                // linkToDeath recipient) so one bad emission can't
+                                // silently end the stream.
+                                Log.w(TAG, "Observer emit failed transiently; keeping observer", e)
                             }
                         }
                     }

--- a/rns-ipc/src/main/kotlin/network/columba/app/rns/ipc/server/ServerRnsLxmf.kt
+++ b/rns-ipc/src/main/kotlin/network/columba/app/rns/ipc/server/ServerRnsLxmf.kt
@@ -209,6 +209,10 @@ internal class ServerRnsLxmf(
         // Comfortably under the ~1 MB Binder async-transaction buffer (so even a
         // few small inline messages queued together stay safe) yet large enough
         // that plain-text messages (null/tiny fieldsJson) always ride inline.
+        // NOTE: measured in chars (String.length), not UTF-8 bytes. fieldsJson is
+        // hex-encoded binary + ASCII JSON, so chars == bytes here; a hypothetical
+        // multi-byte fieldsJson could be up to 4x larger on the wire but still
+        // far under the ~1 MB buffer at this 64 KB threshold.
         const val INLINE_FIELDS_LIMIT = 64 * 1024
     }
 }

--- a/rns-ipc/src/main/kotlin/network/columba/app/rns/ipc/server/ServerRnsLxmf.kt
+++ b/rns-ipc/src/main/kotlin/network/columba/app/rns/ipc/server/ServerRnsLxmf.kt
@@ -2,6 +2,7 @@ package network.columba.app.rns.ipc.server
 
 import android.os.Bundle
 import android.os.ParcelFileDescriptor
+import android.util.Log
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
@@ -14,23 +15,60 @@ import network.columba.app.rns.api.model.ReceivedMessage
 import network.columba.app.rns.api.model.DeliveryStatusUpdate
 import network.columba.app.rns.ipc.AttachmentBlob
 import network.columba.app.rns.ipc.BundleKeys
+import network.columba.app.rns.ipc.FieldsBlob
 import network.columba.app.rns.ipc.IRnsLxmf
 import network.columba.app.rns.ipc.callback.IRnsDeliveryStatusCallback
 import network.columba.app.rns.ipc.callback.IRnsMessageCallback
 import network.columba.app.rns.ipc.callback.IRnsPropagationStateCallback
 import network.columba.app.rns.ipc.callback.IRnsResultCallback
 import network.columba.app.rns.ipc.callback.IRnsStringCallback
+import java.io.File
+import java.io.IOException
 
 internal class ServerRnsLxmf(
     private val impl: RnsLxmf,
     private val scope: CoroutineScope,
+    private val cacheDir: File,
 ) : IRnsLxmf.Stub() {
     private val messageHub = ObserverHub<ReceivedMessage, IRnsMessageCallback>(
         scope = scope,
         upstream = { impl.observeMessages() },
         callbackBinder = { it.asBinder() },
-        emit = { cb, value -> cb.onMessage(value) },
+        emit = { cb, value -> emitMessage(cb, value) },
     )
+
+    /**
+     * Deliver one inbound message to a UI-process observer. A received image/file
+     * is hex-encoded inside [ReceivedMessage.fieldsJson]; when that is large, ship
+     * it out-of-band as a [ParcelFileDescriptor] rather than inline, because an
+     * inline multi-hundred-KB parcel overflows the Binder buffer and throws
+     * `TransactionTooLargeException` (which [ObserverHub] now survives, but the
+     * message would still be lost). Small messages — plain text has null/tiny
+     * `fieldsJson` — stay inline (null blob) at zero overhead.
+     */
+    private fun emitMessage(cb: IRnsMessageCallback, message: ReceivedMessage) {
+        val fields = message.fieldsJson
+        if (fields != null && fields.length > INLINE_FIELDS_LIMIT) {
+            val pfd = try {
+                FieldsBlob.writeToPfd(cacheDir, fields)
+            } catch (e: IOException) {
+                // Staging failed (e.g. disk full). Drop just this message rather
+                // than throwing out of the collector (which would cancel it and
+                // stop all delivery). Keep the observer; the next message is fine.
+                Log.e(TAG, "Failed to stage inbound fields blob; dropping this message", e)
+                return
+            }
+            // onMessage may still throw (RemoteException/TransactionTooLargeException);
+            // let it propagate to ObserverHub, which keeps the observer subscribed.
+            try {
+                cb.onMessage(message.copy(fieldsJson = null), pfd)
+            } finally {
+                pfd.close()
+            }
+        } else {
+            cb.onMessage(message, null)
+        }
+    }
     private val deliveryHub = ObserverHub<DeliveryStatusUpdate, IRnsDeliveryStatusCallback>(
         scope = scope,
         upstream = { impl.observeDeliveryStatus() },
@@ -162,6 +200,16 @@ internal class ServerRnsLxmf(
 
     override fun setIncomingMessageSizeLimit(limitKb: Int) {
         runCatching { impl.setIncomingMessageSizeLimit(limitKb) }
+    }
+
+    private companion object {
+        const val TAG = "ServerRnsLxmf"
+
+        // `fieldsJson` longer than this crosses out-of-band via FieldsBlob.
+        // Comfortably under the ~1 MB Binder async-transaction buffer (so even a
+        // few small inline messages queued together stay safe) yet large enough
+        // that plain-text messages (null/tiny fieldsJson) always ride inline.
+        const val INLINE_FIELDS_LIMIT = 64 * 1024
     }
 }
 

--- a/rns-ipc/src/test/java/network/columba/app/rns/ipc/FieldsBlobTest.kt
+++ b/rns-ipc/src/test/java/network/columba/app/rns/ipc/FieldsBlobTest.kt
@@ -1,0 +1,59 @@
+package network.columba.app.rns.ipc
+
+import android.os.ParcelFileDescriptor
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertThrows
+import org.junit.Rule
+import org.junit.Test
+import org.junit.rules.TemporaryFolder
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import java.io.DataOutputStream
+import java.io.File
+import java.io.FileOutputStream
+import java.io.IOException
+
+/**
+ * Out-of-band inbound `fieldsJson` transfer (the receive-side mirror of
+ * [AttachmentBlob]). Pins the round-trip and the corrupt-length guard.
+ */
+@RunWith(RobolectricTestRunner::class)
+class FieldsBlobTest {
+    @get:Rule val tmp = TemporaryFolder()
+
+    @Test
+    fun `round-trips a large fieldsJson through a PFD unchanged`() {
+        // ~400 KB — comfortably over the inline threshold, the case that used to
+        // overflow the Binder transaction inline.
+        val json = """{"6":"${"ab".repeat(200_000)}"}"""
+        val pfd = FieldsBlob.writeToPfd(tmp.root, json)
+        assertEquals(json, FieldsBlob.readFromPfd(pfd))
+    }
+
+    @Test
+    fun `rejects an implausible declared length instead of allocating it`() {
+        // Hand-craft a blob with a valid magic+version header but an absurd
+        // length, as a corrupt/truncated stream might. readFromPfd must throw
+        // before attempting a multi-GB ByteArray allocation.
+        val f = File(tmp.root, "corrupt.bin")
+        DataOutputStream(FileOutputStream(f)).use { out ->
+            out.writeInt(0x4C584D46) // MAGIC ("LXMF")
+            out.writeInt(1) // VERSION
+            out.writeInt(Int.MAX_VALUE) // implausible length
+        }
+        val pfd = ParcelFileDescriptor.open(f, ParcelFileDescriptor.MODE_READ_ONLY)
+        assertThrows(IOException::class.java) { FieldsBlob.readFromPfd(pfd) }
+    }
+
+    @Test
+    fun `rejects a blob with the wrong magic`() {
+        val f = File(tmp.root, "wrongmagic.bin")
+        DataOutputStream(FileOutputStream(f)).use { out ->
+            out.writeInt(0xDEADBEEF.toInt())
+            out.writeInt(1)
+            out.writeInt(0)
+        }
+        val pfd = ParcelFileDescriptor.open(f, ParcelFileDescriptor.MODE_READ_ONLY)
+        assertThrows(IOException::class.java) { FieldsBlob.readFromPfd(pfd) }
+    }
+}

--- a/rns-ipc/src/test/java/network/columba/app/rns/ipc/RnsBackendIpcRoundTripTest.kt
+++ b/rns-ipc/src/test/java/network/columba/app/rns/ipc/RnsBackendIpcRoundTripTest.kt
@@ -317,7 +317,7 @@ class RnsBackendIpcRoundTripTest {
         val dispatcher = StandardTestDispatcher(testScheduler)
         val serverScope = CoroutineScope(dispatcher + SupervisorJob())
         val clientScope = CoroutineScope(dispatcher + SupervisorJob())
-        val server = RnsBackendServer(fake, serverScope)
+        val server = RnsBackendServer(fake, serverScope, attachmentCacheDir)
         val client = RnsBackendClient(clientScope, attachmentCacheDir)
         client.connect(server)
         return client to server

--- a/rns-ipc/src/test/java/network/columba/app/rns/ipc/server/ObserverHubCascadeTest.kt
+++ b/rns-ipc/src/test/java/network/columba/app/rns/ipc/server/ObserverHubCascadeTest.kt
@@ -1,9 +1,9 @@
 package network.columba.app.rns.ipc.server
 
+import android.os.Binder
 import android.os.DeadObjectException
 import android.os.IBinder
 import android.os.TransactionTooLargeException
-import io.mockk.mockk
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.cancel
@@ -42,7 +42,7 @@ class ObserverHubCascadeTest {
         val hubScope = CoroutineScope(StandardTestDispatcher(testScheduler))
         val upstream = MutableSharedFlow<String>(extraBufferCapacity = 16)
         val delivered = mutableListOf<String>()
-        val cb = FakeCallback(mockk<IBinder>(relaxed = true))
+        val cb = FakeCallback(Binder())
 
         val hub = ObserverHub<String, FakeCallback>(
             scope = hubScope,
@@ -76,7 +76,7 @@ class ObserverHubCascadeTest {
         val hubScope = CoroutineScope(StandardTestDispatcher(testScheduler))
         val upstream = MutableSharedFlow<String>(extraBufferCapacity = 16)
         val delivered = mutableListOf<String>()
-        val cb = FakeCallback(mockk<IBinder>(relaxed = true))
+        val cb = FakeCallback(Binder())
 
         val hub = ObserverHub<String, FakeCallback>(
             scope = hubScope,

--- a/rns-ipc/src/test/java/network/columba/app/rns/ipc/server/ObserverHubCascadeTest.kt
+++ b/rns-ipc/src/test/java/network/columba/app/rns/ipc/server/ObserverHubCascadeTest.kt
@@ -1,0 +1,107 @@
+package network.columba.app.rns.ipc.server
+
+import android.os.DeadObjectException
+import android.os.IBinder
+import android.os.TransactionTooLargeException
+import io.mockk.mockk
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.flow.asSharedFlow
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertEquals
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+
+/**
+ * Regression test for the inbound-message cascade: a single oversized payload
+ * (which the real Binder rejects with [TransactionTooLargeException], a
+ * subclass of [android.os.RemoteException]) must NOT detach the observer.
+ *
+ * Before the fix, [ObserverHub] caught any `RemoteException` as "client died"
+ * and detached the observer. Since the UI subscribes exactly once (a
+ * `callbackFlow` whose `awaitClose` only fires on cancel) it was never told it
+ * had been dropped and never re-registered — so one too-large inbound image
+ * silently killed delivery of EVERY subsequent message, text included, for the
+ * rest of the process's life. See `ServerFlowBridge.ObserverHub`.
+ */
+@OptIn(ExperimentalCoroutinesApi::class)
+@RunWith(RobolectricTestRunner::class)
+class ObserverHubCascadeTest {
+
+    /** Minimal stand-in for an AIDL callback carrying a stable binder identity. */
+    private class FakeCallback(val binder: IBinder)
+
+    @Test
+    fun `oversized emit keeps observer subscribed so later messages still deliver`() = runTest {
+        val hubScope = CoroutineScope(StandardTestDispatcher(testScheduler))
+        val upstream = MutableSharedFlow<String>(extraBufferCapacity = 16)
+        val delivered = mutableListOf<String>()
+        val cb = FakeCallback(mockk<IBinder>(relaxed = true))
+
+        val hub = ObserverHub<String, FakeCallback>(
+            scope = hubScope,
+            upstream = { upstream.asSharedFlow() as Flow<String> },
+            callbackBinder = { it.binder },
+            emit = { _, value ->
+                // Simulate the real Binder behaviour: a too-large payload throws
+                // TransactionTooLargeException; everything else delivers.
+                if (value == "OVERSIZED") throw TransactionTooLargeException()
+                delivered += value
+            },
+        )
+
+        hub.registerObserver(cb)
+        advanceUntilIdle()
+
+        upstream.emit("text-before")
+        advanceUntilIdle()
+        upstream.emit("OVERSIZED") // image too big for the Binder transaction
+        advanceUntilIdle()
+        upstream.emit("text-after") // must still arrive — observer must survive
+        advanceUntilIdle()
+
+        assertEquals(listOf("text-before", "text-after"), delivered)
+
+        hubScope.cancel()
+    }
+
+    @Test
+    fun `dead client still detaches so a genuinely gone observer stops delivery`() = runTest {
+        val hubScope = CoroutineScope(StandardTestDispatcher(testScheduler))
+        val upstream = MutableSharedFlow<String>(extraBufferCapacity = 16)
+        val delivered = mutableListOf<String>()
+        val cb = FakeCallback(mockk<IBinder>(relaxed = true))
+
+        val hub = ObserverHub<String, FakeCallback>(
+            scope = hubScope,
+            upstream = { upstream.asSharedFlow() as Flow<String> },
+            callbackBinder = { it.binder },
+            emit = { _, value ->
+                // A genuinely dead client throws DeadObjectException — that one
+                // SHOULD detach.
+                if (value == "DEAD") throw DeadObjectException()
+                delivered += value
+            },
+        )
+
+        hub.registerObserver(cb)
+        advanceUntilIdle()
+
+        upstream.emit("one")
+        advanceUntilIdle()
+        upstream.emit("DEAD") // client process gone → detach
+        advanceUntilIdle()
+        upstream.emit("two") // observer detached → not delivered
+        advanceUntilIdle()
+
+        assertEquals(listOf("one"), delivered)
+
+        hubScope.cancel()
+    }
+}


### PR DESCRIPTION
## Summary

Two compounding bugs in the `:reticulum` → UI IPC seam meant that receiving an image (or any large message) from a peer:

- never displayed the image, and
- **silently killed delivery of every subsequent message — plain text included — and stopped conversations from updating, until the app was restarted.**

Reproducible iOS → Android: the sender showed messages as delivered (Android's LXMF *did* receive and ack them at the protocol layer), but nothing surfaced in the Android UI after the first oversized image.

## Root cause

**1. Inbound attachments rode inline over Binder.** A received image/file is hex-encoded inside `ReceivedMessage.fieldsJson`. Hex doubles the byte size, so a received photo makes that string several hundred KB. `IRnsMessageCallback.onMessage` marshaled the whole `ReceivedMessage` inline over a `oneway` Binder transaction, overflowing the ~1 MB shared async transaction buffer:

```
E BpBinder: Too large outgoing transaction of 727520 bytes, ... code 1 was sent
```

→ `android.os.TransactionTooLargeException` in the `:reticulum` process. The **send** direction already solved exactly this in #967 (`AttachmentBlob` over a `ParcelFileDescriptor`); the **receive** direction was never converted.

**2. The cascade.** `ObserverHub` (`ServerFlowBridge`) caught that `TransactionTooLargeException` as a plain `RemoteException` and assumed *"client died"* → `detach(binder)`, removing the UI's message observer. But the UI subscribes exactly once (`MessageCollector` collects a `callbackFlow` whose `awaitClose` only fires on cancel), so it was never told it had been dropped and never re-registered. After one too-large image the server's collector had no observers left and stopped — every later message (text included) was silently discarded for the rest of the process's life.

## Fix

- **`ObserverHub` no longer treats a too-large payload as death.** `DeadObjectException` → detach (genuine death; `linkToDeath` already covers it too). `TransactionTooLargeException` / other `RemoteException` → log and **keep the observer subscribed**. One oversized payload can no longer take out the whole stream.
- **Inbound `fieldsJson` crosses out-of-band** when it exceeds 64 KB, via a new `FieldsBlob` (the receive-side mirror of `AttachmentBlob`): `:reticulum` writes it to a delete-on-close temp file in the shared app cache and hands the UI a read-only `ParcelFileDescriptor` (a dup'd fd — a few bytes on the wire); the UI streams it back and reconstitutes the message. The parcel itself stays tiny. Small/text messages keep riding inline at zero overhead.

Only the AIDL callback seam changes (`IRnsMessageCallback.onMessage` gains a nullable `ParcelFileDescriptor`, plus `Server`/`ClientRnsLxmf`), and the app `cacheDir` is threaded through `RnsBackendServer` → `ServerRnsLxmf`. The Kotlin `RnsLxmf` interface and the python/kotlin backends are unchanged — symmetric with #967.

## Testing

- New **`ObserverHubCascadeTest`** — an oversized emit (`TransactionTooLargeException`) keeps the observer subscribed so later messages still deliver; a genuinely dead client (`DeadObjectException`) still detaches.
- Existing `RnsBackendIpcRoundTripTest` still green (AIDL signature update).
- **On device, iOS → Android (python build):** before — the image never arrived and broke all subsequent messaging; after — the image renders, and texts/conversations survive an oversized image either way.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
