### PR TITLE
fix(share-instance): persist hosting toggle + close 37428 listener so hosting survives :reticulum restart

### DIFF
--- a/app/src/main/java/network/columba/app/ColumbaApplication.kt
+++ b/app/src/main/java/network/columba/app/ColumbaApplication.kt
@@ -494,6 +494,7 @@ class ColumbaApplication : Application() {
                         preferOwnInstance = preferOwnInstance,
                         rpcKey = rpcKey,
                         enableTransport = transportNodeEnabled,
+                        shareInstanceHosting = startupConfig.shareInstanceHosting,
                         discoverInterfaces = discoverInterfaces,
                         autoconnectDiscoveredInterfaces = autoconnectDiscoveredCount,
                         autoconnectIfacOnly = startupConfig.autoconnectIfacOnly,
@@ -734,110 +735,6 @@ class ColumbaApplication : Application() {
             }
         } catch (e: Exception) {
             android.util.Log.w("ColumbaApplication", "Failed to register companion devices: ${e.message}")
-        }
-    }
-
-    /**
-     * Initialize the Reticulum service with configuration from the database.
-     * This is called both during normal app startup and when the service needs
-     * reinitialization after being killed by Android and successfully rebound.
-     *
-     * @param rnsCore The RnsCore instance to initialize
-     */
-    private suspend fun initializeReticulumService(rnsCore: RnsCore) {
-        try {
-            android.util.Log.d("ColumbaApplication", "initializeReticulumService: Loading configuration from database...")
-
-            // Load all configuration from database in parallel for faster startup
-            val startupConfig = startupConfigLoader.loadConfig()
-            val enabledInterfaces = startupConfig.interfaces
-            val activeIdentity = startupConfig.identity
-
-            if (activeIdentity != null &&
-                runCatching {
-                    identityRepository.requiresPassword(activeIdentity.identityHash)
-                }.getOrDefault(true)
-            ) {
-                android.util.Log.w(
-                    "ColumbaApplication",
-                    "initializeReticulumService: Active identity ${activeIdentity.identityHash.take(8)}... " +
-                        "is password-protected (or password status unreadable) - skipping init until unlock",
-                )
-                return
-            }
-
-            val preferOwnInstance = startupConfig.preferOwn
-            val rpcKey = startupConfig.rpcKey
-            val transportNodeEnabled = startupConfig.transport
-            val discoverInterfaces = startupConfig.discoverInterfaces
-            val autoconnectDiscoveredCount = startupConfig.autoconnectDiscoveredCount
-            android.util.Log.d("ColumbaApplication", "initializeReticulumService: Loaded ${enabledInterfaces.size} enabled interface(s)")
-            android.util.Log.d(
-                "ColumbaApplication",
-                "initializeReticulumService: Discover interfaces: $discoverInterfaces, autoconnect: $autoconnectDiscoveredCount",
-            )
-
-            val displayName = activeIdentity?.displayName
-            val deliveryKey = decryptDeliveryKey(activeIdentity)
-
-            // Same guard as the cold-start path: don't init with a null key when an
-            // active identity exists, or the native stack silently substitutes a fresh
-            // ephemeral identity.
-            if (activeIdentity != null && deliveryKey == null) {
-                android.util.Log.e(
-                    "ColumbaApplication",
-                    "initializeReticulumService: Active identity ${activeIdentity.identityHash.take(8)}... " +
-                        "present but key decryption returned null - skipping init",
-                )
-                settingsRepository.setNeedsIdentityUnlock(true)
-                return
-            }
-            settingsRepository.setNeedsIdentityUnlock(false)
-
-            // Initialize Reticulum with config from database
-            android.util.Log.d("ColumbaApplication", "initializeReticulumService: Initializing Reticulum...")
-            val config =
-                ReticulumConfig(
-                    storagePath = filesDir.absolutePath + "/reticulum",
-                    enabledInterfaces = enabledInterfaces,
-                    deliveryIdentityKey = deliveryKey,
-                    displayName = displayName,
-                    logLevel = LogLevel.DEBUG,
-                    allowAnonymous = false,
-                    preferOwnInstance = preferOwnInstance,
-                    rpcKey = rpcKey,
-                    enableTransport = transportNodeEnabled,
-                    shareInstanceHosting = startupConfig.shareInstanceHosting,
-                    discoverInterfaces = discoverInterfaces,
-                    autoconnectDiscoveredInterfaces = autoconnectDiscoveredCount,
-                    autoconnectIfacOnly = startupConfig.autoconnectIfacOnly,
-                )
-
-            rnsCore
-                .initialize(config)
-                .onSuccess {
-                    android.util.Log.i("ColumbaApplication", "initializeReticulumService: Reticulum initialized successfully")
-
-                    // networkStatus.collect (set up in onCreate) handles the READY
-                    // notification push.
-
-                    restorePeerIdentities(rnsCore)
-
-                    // Start the message collector and other services after Reticulum is ready
-                    messageCollector.startCollecting()
-                    autoAnnounceManager.start()
-                    identityResolutionManager.start(applicationScope)
-                    propagationNodeManager.start()
-                    telemetryCollectorManager.start()
-                    android.util.Log.d(
-                        "ColumbaApplication",
-                        "initializeReticulumService: MessageCollector, AutoAnnounceManager, IdentityResolutionManager, PropagationNodeManager, TelemetryCollectorManager started",
-                    )
-                }.onFailure { error ->
-                    android.util.Log.e("ColumbaApplication", "initializeReticulumService: Failed to initialize Reticulum: ${error.message}", error)
-                }
-        } catch (e: Exception) {
-            android.util.Log.e("ColumbaApplication", "initializeReticulumService: Error during initialization", e)
         }
     }
 

--- a/app/src/main/java/network/columba/app/service/InterfaceConfigManager.kt
+++ b/app/src/main/java/network/columba/app/service/InterfaceConfigManager.kt
@@ -26,6 +26,7 @@ import network.columba.app.rns.api.RnsTransportAdmin
 import network.columba.app.rns.host.ReticulumService
 import network.columba.app.service.manager.InterfaceTransportObserver
 import network.columba.app.rns.host.manager.filterByTransport
+import network.columba.app.rns.host.persistence.ReticulumConfigSnapshot
 import javax.inject.Inject
 import javax.inject.Singleton
 
@@ -372,7 +373,7 @@ class InterfaceConfigManager
                             // field changed via Apply & Restart (e.g. shareInstanceHosting)
                             // silently reverts the next time the OS reaps and START_STICKY-
                             // restarts the :reticulum process from the stale snapshot.
-                            network.columba.app.rns.host.persistence.ReticulumConfigSnapshot.write(
+                            ReticulumConfigSnapshot.write(
                                 context = context,
                                 config = config,
                                 identityHashHex = activeIdentity?.identityHash,

--- a/app/src/main/java/network/columba/app/service/InterfaceConfigManager.kt
+++ b/app/src/main/java/network/columba/app/service/InterfaceConfigManager.kt
@@ -365,6 +365,18 @@ class InterfaceConfigManager
                         .initialize(config)
                         .onSuccess {
                             Log.d(TAG, "✓ Reticulum initialized successfully")
+
+                            // Refresh the persisted snapshot with the config we just
+                            // applied. Without this, the snapshot only ever reflects
+                            // ColumbaApplication.onCreate's cold-start config — so any
+                            // field changed via Apply & Restart (e.g. shareInstanceHosting)
+                            // silently reverts the next time the OS reaps and START_STICKY-
+                            // restarts the :reticulum process from the stale snapshot.
+                            network.columba.app.rns.host.persistence.ReticulumConfigSnapshot.write(
+                                context = context,
+                                config = config,
+                                identityHashHex = activeIdentity?.identityHash,
+                            )
                         }.onFailure { error ->
                             // The outer finally clears is_applying_config — keep the flag set
                             // here so any stale ACTION_STOP redelivery during the in-flight

--- a/app/src/test/java/network/columba/app/service/InterfaceConfigManagerTest.kt
+++ b/app/src/test/java/network/columba/app/service/InterfaceConfigManagerTest.kt
@@ -12,6 +12,8 @@ import io.mockk.coVerifyOrder
 import io.mockk.every
 import io.mockk.just
 import io.mockk.mockk
+import io.mockk.mockkObject
+import io.mockk.unmockkObject
 import io.mockk.verify
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
@@ -32,6 +34,7 @@ import network.columba.app.repository.SettingsRepository
 import network.columba.app.rns.api.model.BatteryProfile
 import network.columba.app.rns.api.RnsCore
 import network.columba.app.rns.api.RnsTransportAdmin
+import network.columba.app.rns.host.persistence.ReticulumConfigSnapshot
 import org.junit.After
 import org.junit.Assert.assertTrue
 import org.junit.Before
@@ -142,6 +145,16 @@ class InterfaceConfigManagerTest {
         coEvery { rnsCore.shutdown() } returns Result.success(Unit)
         coEvery { rnsCore.initialize(any()) } returns Result.success(Unit)
 
+        // applyInterfaceChanges() refreshes the persisted snapshot on the
+        // initialize() success path. ReticulumConfigSnapshot.write() does real
+        // Android Parcel + file I/O, which isn't on the JVM unit-test classpath
+        // (Parcel.obtain() throws "not mocked"), so stub the object to a no-op —
+        // same boundary-mocking the rest of this test already does for Context.
+        // The snapshot's own serialization is covered elsewhere; here we only
+        // care about the manager's orchestration.
+        mockkObject(ReticulumConfigSnapshot)
+        every { ReticulumConfigSnapshot.write(any(), any(), any()) } just Runs
+
         // Setup manager mocks (start/stop methods)
         every { messageCollector.stopCollecting() } just Runs
         every { messageCollector.startCollecting() } just Runs
@@ -175,6 +188,7 @@ class InterfaceConfigManagerTest {
     @After
     fun tearDown() {
         Dispatchers.resetMain()
+        unmockkObject(ReticulumConfigSnapshot)
         clearAllMocks()
     }
 

--- a/app/src/test/java/network/columba/app/service/InterfaceConfigManagerTest.kt
+++ b/app/src/test/java/network/columba/app/service/InterfaceConfigManagerTest.kt
@@ -282,6 +282,39 @@ class InterfaceConfigManagerTest {
         }
 
     @Test
+    fun `applyInterfaceChanges - refreshes config snapshot on successful initialization`() =
+        runTest {
+            // When
+            val result = manager.applyInterfaceChanges()
+
+            // Then: Should succeed
+            assertTrue("applyInterfaceChanges should succeed", result.isSuccess)
+
+            // And: the persisted snapshot is refreshed so a later OS-driven
+            // :reticulum restart self-inits from the just-applied config rather
+            // than a stale one. This is the core behavioral fix — assert it
+            // explicitly so the call can't be silently dropped.
+            verify { ReticulumConfigSnapshot.write(any(), any(), any()) }
+        }
+
+    @Test
+    fun `applyInterfaceChanges - does not write snapshot when initialization fails`() =
+        runTest {
+            // Given: initialize() fails
+            coEvery { rnsCore.initialize(any()) } returns
+                Result.failure(RuntimeException("init failed"))
+
+            // When
+            val result = manager.applyInterfaceChanges()
+
+            // Then: apply fails and the snapshot is NOT refreshed — a stale-but-
+            // valid snapshot is preferable to one reflecting a config that never
+            // came up. Guards that the write stays gated on the onSuccess path.
+            assertTrue("applyInterfaceChanges should fail", result.isFailure)
+            verify(exactly = 0) { ReticulumConfigSnapshot.write(any(), any(), any()) }
+        }
+
+    @Test
     fun `applyInterfaceChanges - managers stopped before collectors and started after`() =
         runTest {
             // When

--- a/app/src/test/java/network/columba/app/service/InterfaceConfigManagerTest.kt
+++ b/app/src/test/java/network/columba/app/service/InterfaceConfigManagerTest.kt
@@ -72,7 +72,9 @@ class InterfaceConfigManagerTest {
     private lateinit var sharedPrefs: SharedPreferences
     private lateinit var sharedPrefsEditor: SharedPreferences.Editor
 
-    @Suppress("NoRelaxedMocks") // Android Context and SharedPreferences require relaxed mocks
+    // NoRelaxedMocks: Android Context and SharedPreferences require relaxed mocks.
+    // LongMethod: setup configures mock stubs for InterfaceConfigManager's 15+ dependencies.
+    @Suppress("NoRelaxedMocks", "LongMethod")
     @Before
     fun setup() {
         Dispatchers.setMain(testDispatcher)

--- a/rns-backend-py/src/main/python/event_bridge.py
+++ b/rns-backend-py/src/main/python/event_bridge.py
@@ -403,6 +403,28 @@ def reset_reticulum_for_restart():
                         RNS.LOG_DEBUG,
                     )
 
+    # Shared-instance TCP listener (port 37428). When share_instance=yes,
+    # upstream's LocalServerInterface binds via BackboneInterface.add_listener,
+    # which stashes the listening socket in the *global*
+    # BackboneInterface.listener_filenos dict — NOT in an interface's .socket /
+    # .server attribute, so the per-interface close loop above never sees it.
+    # That socket is normally closed by exit_handler() ->
+    # Transport.detach_interfaces() -> BackboneInterface.deregister_listeners();
+    # but PythonRnsRuntime.stop() swallows exit_handler() failures, and if it
+    # threw before detach the 37428 listener leaks. A leaked listener makes the
+    # NEXT in-process start()'s SharedInstanceProbe connect to our OWN socket
+    # and silently demote us from host to client (self-detection). Close it here
+    # unconditionally — reset_reticulum_for_restart() runs in stop()'s own
+    # runCatching, independent of exit_handler(). Idempotent: deregister_listeners()
+    # no-ops once listener_filenos is already cleared (the normal exit_handler()
+    # path), so this only has an effect when exit_handler() failed to run it.
+    try:
+        import RNS.Interfaces.BackboneInterface as _backbone
+        _backbone.BackboneInterface.deregister_listeners()
+        print("event_bridge.reset: deregistered BackboneInterface listeners (shared-instance 37428)", flush=True)
+    except Exception as e:  # noqa: BLE001
+        print(f"event_bridge.reset: BackboneInterface.deregister_listeners FAILED: {type(e).__name__}: {e}", flush=True)
+
     # Reticulum singleton + one-shot exit guards. Without the __instance reset
     # the next Reticulum() raises OSError; without the *_ran resets a second
     # exit_handler() would no-op and skip interface detach + persist.


### PR DESCRIPTION
Two related fixes so **Share Instance** hosting reliably survives a `:reticulum` restart.

---

## Fix 1 — persist `shareInstanceHosting` (the reported bug)

### Problem
The hosting toggle would silently stop hosting after the OS reaped and `START_STICKY`-restarted the `:reticulum` process — observed as *"hosting disabled in reality, toggle still on"* after suspending and reopening the app.

### Root cause
The live cold-start config built in `ColumbaApplication.onCreate` **omitted `shareInstanceHosting`**, so it defaulted to `false`. That config both drove the live init *and* was written to the self-init snapshot (`ReticulumConfigSnapshot`). The correct value lived only in a sibling `initializeReticulumService()` that had **no callers** (dead code).

Chain:
1. `onCreate` came up not hosting (flag dropped → `false`).
2. The snapshot recorded `shareInstanceHosting=false`.
3. An **Apply & Restart** (`InterfaceConfigManager`) *did* host correctly (reads DataStore) — which is why it appeared to work at first — but it never refreshed the snapshot.
4. The next OS-driven `:reticulum` restart rehydrated from the **stale snapshot** → `share_instance = No` while the DataStore-backed toggle still read enabled.

### Changes
- **`ColumbaApplication.onCreate`** — pass `shareInstanceHosting` into the auto-init `ReticulumConfig`. Fixes both the live cold-start instance and the snapshot it writes.
- **`InterfaceConfigManager.applyInterfaceChanges`** — refresh the snapshot after a successful `initialize()`, so runtime toggle changes survive the next FGS restart (applies to *any* field the Apply path changes, not just hosting).
- **Delete the unreferenced `initializeReticulumService()`** so the two init paths can't drift again.

`ReticulumConfig` is `@Parcelize`, so the snapshot already round-trips the field (snapshot `VERSION` was bumped to 2 when it was added). With the flag set, `RnsConfigFile` renders `share_instance = Yes` + `shared_instance_type = tcp` and binds TCP 37428.

---

## Fix 2 — close the 37428 listener on restart teardown (self-detection hardening)

### Problem
`reset_reticulum_for_restart()` closes per-interface sockets but missed the shared-instance TCP listener (port 37428). With `share_instance = yes`, upstream's `LocalServerInterface` binds via `BackboneInterface.add_listener`, which stores the listening socket in the **global** `BackboneInterface.listener_filenos` dict — not in an interface's `.socket`/`.server` attribute — so the per-interface close loop never touches it.

That socket is normally closed by `exit_handler() → Transport.detach_interfaces() → BackboneInterface.deregister_listeners()`. But `PythonRnsRuntime.stop()` wraps `exit_handler()` in a failure-swallowing `runCatching`; if it throws before detach, the 37428 listener **leaks**. A leaked listener makes the next in-process `start()`'s `SharedInstanceProbe` connect to our *own* socket and silently demote host → client (self-detection).

### Change
- **`event_bridge.reset_reticulum_for_restart()`** now calls `BackboneInterface.deregister_listeners()` best-effort. It runs in `stop()`'s own `runCatching`, independent of `exit_handler()`, and is idempotent (no-op once `listener_filenos` is already cleared by the normal `exit_handler()` path), so it only has effect when `exit_handler()` failed.

Current restart paths kill the `:reticulum` process (process death releases the fd), so this is **defense-in-depth** that closes the latent landmine for any in-process `shutdown()`→`initialize()` restart. The demotion itself is already observable via `describeRnsMode` (`"HOSTING CONFLICT"`) and the `isHostingShareInstanceConflict` UI.

---

## Notes
- The `share_instance = joinShareInstance || hostShareInstance` logic in `RnsConfigFile` is correct and unchanged — verified against upstream RNS (`share_instance` is a single gate; first-to-bind elects master vs client).

## Verification
- `:app:compileNoSentryPythonBackendDebugKotlin` → BUILD SUCCESSFUL.
- `python3 -m py_compile event_bridge.py` → OK.
- On-device ground truth (after build): with the toggle on, following a suspend/resume cycle, dump the `:reticulum` process's `files/reticulum/config` via `run-as` — it should now show `share_instance = Yes` + `shared_instance_type = tcp`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
