### PR TITLE
Fix: pan short NomadNet pages from anywhere in the viewport (#681)

### DIFF
--- a/app/src/main/java/network/columba/app/ui/screens/NomadNetBrowserScreen.kt
+++ b/app/src/main/java/network/columba/app/ui/screens/NomadNetBrowserScreen.kt
@@ -477,22 +477,34 @@ fun NomadNetBrowserScreen(
                         ) {
                             // Subtract horizontal padding (8.dp * 2) so lines fill viewport
                             val viewportLineWidth = maxWidth - 16.dp
+                            // Viewport size in px, captured here before verticalScroll /
+                            // horizontalScroll unbound the constraints to Infinity.
+                            val viewportWidthPx = constraints.maxWidth
+                            val viewportHeightPx = constraints.maxHeight
                             Column(
                                 modifier =
                                     Modifier
-                                        // fillMaxSize forces minHeight/minWidth = viewport into
-                                        // the scroll node's child constraints, so the scrollable
-                                        // (gesture-catching) area always fills the viewport even
-                                        // when the page is shorter than the screen. Without it the
-                                        // scroll node wraps the content and drags in the blank area
-                                        // below short pages are ignored (issue #681).
-                                        .fillMaxSize()
                                         .verticalScroll(rememberScrollState())
                                         .horizontalScroll(rememberScrollState())
                                         .layout { measurable, constraints ->
                                             val placeable = measurable.measure(constraints)
-                                            val scaledWidth = (placeable.width * zoomScale).roundToInt()
-                                            val scaledHeight = (placeable.height * zoomScale).roundToInt()
+                                            // Report a scrollable area no smaller than the
+                                            // viewport so the whole screen catches pan gestures
+                                            // even when the page is shorter than the screen
+                                            // (issue #681). Clamping the reported size — rather
+                                            // than forcing the content to fill via fillMaxSize —
+                                            // keeps the scroll extent tied to the real (scaled)
+                                            // content height, so a short page is neither
+                                            // scrollable into blank space when zoomed in nor
+                                            // dead-zoned when zoomed out.
+                                            val scaledWidth =
+                                                (placeable.width * zoomScale)
+                                                    .roundToInt()
+                                                    .coerceAtLeast(viewportWidthPx)
+                                            val scaledHeight =
+                                                (placeable.height * zoomScale)
+                                                    .roundToInt()
+                                                    .coerceAtLeast(viewportHeightPx)
                                             layout(scaledWidth, scaledHeight) {
                                                 placeable.placeRelativeWithLayer(0, 0) {
                                                     scaleX = zoomScale

--- a/app/src/main/java/network/columba/app/ui/screens/NomadNetBrowserScreen.kt
+++ b/app/src/main/java/network/columba/app/ui/screens/NomadNetBrowserScreen.kt
@@ -480,6 +480,13 @@ fun NomadNetBrowserScreen(
                             Column(
                                 modifier =
                                     Modifier
+                                        // fillMaxSize forces minHeight/minWidth = viewport into
+                                        // the scroll node's child constraints, so the scrollable
+                                        // (gesture-catching) area always fills the viewport even
+                                        // when the page is shorter than the screen. Without it the
+                                        // scroll node wraps the content and drags in the blank area
+                                        // below short pages are ignored (issue #681).
+                                        .fillMaxSize()
                                         .verticalScroll(rememberScrollState())
                                         .horizontalScroll(rememberScrollState())
                                         .layout { measurable, constraints ->


### PR DESCRIPTION
Fixes #681.

## Problem
NomadNet pages that are shorter than the screen can only be panned/scrolled by dragging on the content itself — dragging in the blank area below the content does nothing.

## Root cause
In `NomadNetBrowserScreen.kt`, the `MONOSPACE_SCROLL` rendering mode (the only mode with free vertical + horizontal finger panning) puts the page content in a `Column` with `.verticalScroll().horizontalScroll()` but no minimum size.

Compose's scroll node measures its child with unbounded height/width but reports its **own** size as `childSize.coerceAtMost(maxConstraint)`. So when a page is shorter than the viewport, the scroll container shrinks to wrap the content, and the empty region below it falls outside the node — touches there never reach the pan gesture handler. (The other rendering modes use a `LazyColumn` with `.fillMaxSize()`, which is why they were unaffected.)

## Fix
Clamp the **reported** size of the existing `.layout` zoom block to at least the viewport, using the viewport pixel size captured from `BoxWithConstraints` before the scroll modifiers unbind the constraints:

```kotlin
val scaledWidth  = (placeable.width  * zoomScale).roundToInt().coerceAtLeast(viewportWidthPx)
val scaledHeight = (placeable.height * zoomScale).roundToInt().coerceAtLeast(viewportHeightPx)
```

This makes the scroll node always report at least the viewport size, so the whole screen catches pan gestures even for short pages — while the scroll *extent* still tracks the real (scaled) content size.

An earlier revision forced the content to fill via `.fillMaxSize()`, but that inflated the measured content to the viewport height, so `scaledHeight = viewport × zoomScale` let a short page scroll a full viewport into blank space when zoomed in. Clamping the reported size instead avoids that and handles every zoom level correctly:

- **zoom = 1×:** reported size == viewport → fills, no over-scroll.
- **zoom > 1× (short page):** scaled content stays small → clamped to viewport → no scroll into blank space.
- **zoom < 1×:** scaled content small → clamped to viewport → no dead zone below the content.
- **tall pages:** scaled content exceeds the viewport → scroll normally.

## Testing
- `:app:compileNoSentryPythonBackendDebugKotlin` builds clean (only pre-existing deprecation warnings).
- Installed the debug build on a Galaxy Z Fold 7 and confirmed short pages now pan from anywhere in the viewport.

🤖 Generated with [Claude Code](https://claude.com/claude-code)