### PR TITLE
feat(nomadnet): remember selected page rendering mode across sessions

### DIFF
--- a/app/src/main/java/network/columba/app/repository/SettingsRepository.kt
+++ b/app/src/main/java/network/columba/app/repository/SettingsRepository.kt
@@ -137,6 +137,7 @@ class SettingsRepository
             val MAP_SOURCE_RMSP_ENABLED = booleanPreferencesKey("map_source_rmsp_enabled")
             val MAP_MARKER_DECLUTTER_ENABLED = booleanPreferencesKey("map_marker_declutter_enabled")
             val MAP_STYLE_PREFERENCE = stringPreferencesKey("map_style_preference")
+            val NOMADNET_RENDERING_MODE = stringPreferencesKey("nomadnet_rendering_mode")
             val HTTP_ENABLED_FOR_DOWNLOAD = booleanPreferencesKey("http_enabled_for_download")
 
             // Privacy preferences
@@ -1399,6 +1400,27 @@ class SettingsRepository
         suspend fun saveMapStylePreference(preference: MapStylePreference) {
             context.dataStore.edit { preferences ->
                 preferences[PreferencesKeys.MAP_STYLE_PREFERENCE] = preference.name
+            }
+        }
+
+        /**
+         * Flow of the persisted NomadNet page rendering mode, stored as the enum
+         * name (e.g. "PROPORTIONAL_WRAP"). Emits null when the user has never made
+         * a selection; the consumer maps the name to its RenderingMode enum and
+         * applies its own default. Kept as a raw String here so the repository layer
+         * does not depend on the viewmodel layer where RenderingMode is defined.
+         */
+        val nomadNetRenderingModeFlow: Flow<String?> =
+            context.dataStore.data
+                .map { preferences -> preferences[PreferencesKeys.NOMADNET_RENDERING_MODE] }
+                .distinctUntilChanged()
+
+        /**
+         * Save the NomadNet page rendering mode selection (enum name).
+         */
+        suspend fun saveNomadNetRenderingMode(modeName: String) {
+            context.dataStore.edit { preferences ->
+                preferences[PreferencesKeys.NOMADNET_RENDERING_MODE] = modeName
             }
         }
 

--- a/app/src/main/java/network/columba/app/viewmodel/NomadNetBrowserViewModel.kt
+++ b/app/src/main/java/network/columba/app/viewmodel/NomadNetBrowserViewModel.kt
@@ -104,6 +104,9 @@ class NomadNetBrowserViewModel
                 val restored =
                     try {
                         RenderingMode.fromName(settingsRepository.nomadNetRenderingModeFlow.first())
+                    } catch (e: kotlinx.coroutines.CancellationException) {
+                        // Normal ViewModel teardown cancels the read; preserve the cancellation contract.
+                        throw e
                     } catch (e: Exception) {
                         // DataStore I/O failure or corruption: fall back to the default rather than crash.
                         Log.w(TAG, "Failed to read persisted rendering mode; using default", e)

--- a/app/src/main/java/network/columba/app/viewmodel/NomadNetBrowserViewModel.kt
+++ b/app/src/main/java/network/columba/app/viewmodel/NomadNetBrowserViewModel.kt
@@ -12,6 +12,7 @@ import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharedFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
 import network.columba.app.micron.MicronDocument
@@ -19,6 +20,7 @@ import network.columba.app.micron.MicronElement
 import network.columba.app.micron.MicronParser
 import network.columba.app.nomadnet.NomadNetPageCache
 import network.columba.app.nomadnet.PartialManager
+import network.columba.app.repository.SettingsRepository
 import network.columba.app.rns.api.RnsNomadnet
 import org.json.JSONObject
 import javax.inject.Inject
@@ -30,6 +32,7 @@ class NomadNetBrowserViewModel
     constructor(
         private val nomadnet: RnsNomadnet,
         private val pageCache: NomadNetPageCache,
+        private val settingsRepository: SettingsRepository,
     ) : ViewModel() {
         companion object {
             private const val TAG = "NomadNetBrowserVM"
@@ -66,6 +69,12 @@ class NomadNetBrowserViewModel
             MONOSPACE_SCROLL,
             MONOSPACE_ZOOM,
             PROPORTIONAL_WRAP,
+            ;
+
+            companion object {
+                /** Maps a persisted enum name back to a RenderingMode, defaulting when absent/unknown. */
+                fun fromName(name: String?): RenderingMode = entries.firstOrNull { it.name == name } ?: MONOSPACE_SCROLL
+            }
         }
 
         private data class HistoryEntry(
@@ -83,6 +92,21 @@ class NomadNetBrowserViewModel
 
         private val _renderingMode = MutableStateFlow(RenderingMode.MONOSPACE_SCROLL)
         val renderingMode: StateFlow<RenderingMode> = _renderingMode.asStateFlow()
+
+        // Guards the async startup restore from clobbering a selection the user
+        // makes before the persisted value has been read back.
+        @Volatile
+        private var renderingModeUserSelected = false
+
+        init {
+            // Restore the user's last-selected rendering mode so it persists across sessions.
+            viewModelScope.launch {
+                val restored = RenderingMode.fromName(settingsRepository.nomadNetRenderingModeFlow.first())
+                if (!renderingModeUserSelected) {
+                    _renderingMode.value = restored
+                }
+            }
+        }
 
         private val _isIdentified = MutableStateFlow(false)
         val isIdentified: StateFlow<Boolean> = _isIdentified.asStateFlow()
@@ -495,7 +519,10 @@ class NomadNetBrowserViewModel
         }
 
         fun setRenderingMode(mode: RenderingMode) {
+            renderingModeUserSelected = true
             _renderingMode.value = mode
+            // Persist so the choice is remembered for future sessions and other sites.
+            viewModelScope.launch { settingsRepository.saveNomadNetRenderingMode(mode.name) }
         }
 
         fun identifyToNode() {

--- a/app/src/main/java/network/columba/app/viewmodel/NomadNetBrowserViewModel.kt
+++ b/app/src/main/java/network/columba/app/viewmodel/NomadNetBrowserViewModel.kt
@@ -101,7 +101,14 @@ class NomadNetBrowserViewModel
         init {
             // Restore the user's last-selected rendering mode so it persists across sessions.
             viewModelScope.launch {
-                val restored = RenderingMode.fromName(settingsRepository.nomadNetRenderingModeFlow.first())
+                val restored =
+                    try {
+                        RenderingMode.fromName(settingsRepository.nomadNetRenderingModeFlow.first())
+                    } catch (e: Exception) {
+                        // DataStore I/O failure or corruption: fall back to the default rather than crash.
+                        Log.w(TAG, "Failed to read persisted rendering mode; using default", e)
+                        RenderingMode.MONOSPACE_SCROLL
+                    }
                 if (!renderingModeUserSelected) {
                     _renderingMode.value = restored
                 }

--- a/app/src/test/java/network/columba/app/viewmodel/NomadNetBrowserViewModelTest.kt
+++ b/app/src/test/java/network/columba/app/viewmodel/NomadNetBrowserViewModelTest.kt
@@ -17,12 +17,14 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.async
 import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.test.UnconfinedTestDispatcher
 import kotlinx.coroutines.test.advanceUntilIdle
 import kotlinx.coroutines.test.resetMain
 import kotlinx.coroutines.test.runTest
 import kotlinx.coroutines.test.setMain
 import network.columba.app.nomadnet.NomadNetPageCache
+import network.columba.app.repository.SettingsRepository
 import network.columba.app.rns.api.RnsNomadnet
 import network.columba.app.rns.api.model.NomadnetPageResult
 import org.junit.After
@@ -46,6 +48,7 @@ class NomadNetBrowserViewModelTest {
     private val testDispatcher = UnconfinedTestDispatcher()
     private lateinit var protocol: RnsNomadnet
     private lateinit var pageCache: NomadNetPageCache
+    private lateinit var settingsRepository: SettingsRepository
     private lateinit var viewModel: NomadNetBrowserViewModel
 
     private val nodeHash = "abcdef01234567890abcdef012345678"
@@ -56,10 +59,14 @@ class NomadNetBrowserViewModelTest {
         Dispatchers.setMain(testDispatcher)
         protocol = mockk()
         pageCache = mockk()
+        settingsRepository = mockk()
         every { pageCache.put(any(), any(), any(), any()) } just Runs
         coEvery { protocol.cancelNomadnetPageRequest() } just Runs
         coEvery { protocol.getNomadnetRequestStatus() } returns ""
-        viewModel = NomadNetBrowserViewModel(protocol, pageCache)
+        // No persisted rendering mode by default; individual tests can override.
+        every { settingsRepository.nomadNetRenderingModeFlow } returns flowOf(null)
+        coEvery { settingsRepository.saveNomadNetRenderingMode(any()) } just Runs
+        viewModel = NomadNetBrowserViewModel(protocol, pageCache, settingsRepository)
     }
 
     @Suppress("SleepInsteadOfDelay")
@@ -483,6 +490,41 @@ class NomadNetBrowserViewModelTest {
 
         assertEquals(NomadNetBrowserViewModel.RenderingMode.PROPORTIONAL_WRAP, viewModel.renderingMode.value)
     }
+
+    @Test
+    fun `setRenderingMode persists the selection`() =
+        runTest(testDispatcher) {
+            viewModel.setRenderingMode(NomadNetBrowserViewModel.RenderingMode.MONOSPACE_ZOOM)
+            advanceUntilIdle()
+
+            coVerify { settingsRepository.saveNomadNetRenderingMode("MONOSPACE_ZOOM") }
+        }
+
+    @Test
+    fun `init restores the persisted rendering mode`() =
+        runTest(testDispatcher) {
+            every { settingsRepository.nomadNetRenderingModeFlow } returns flowOf("PROPORTIONAL_WRAP")
+
+            val restoredViewModel = NomadNetBrowserViewModel(protocol, pageCache, settingsRepository)
+            advanceUntilIdle()
+
+            assertEquals(
+                NomadNetBrowserViewModel.RenderingMode.PROPORTIONAL_WRAP,
+                restoredViewModel.renderingMode.value,
+            )
+        }
+
+    @Test
+    fun `init falls back to default when no rendering mode persisted`() =
+        runTest(testDispatcher) {
+            // setUp already stubs nomadNetRenderingModeFlow to flowOf(null)
+            advanceUntilIdle()
+
+            assertEquals(
+                NomadNetBrowserViewModel.RenderingMode.MONOSPACE_SCROLL,
+                viewModel.renderingMode.value,
+            )
+        }
 
     // ── identifyToNode ──
 

--- a/app/src/test/java/network/columba/app/viewmodel/NomadNetBrowserViewModelTest.kt
+++ b/app/src/test/java/network/columba/app/viewmodel/NomadNetBrowserViewModelTest.kt
@@ -495,10 +495,14 @@ class NomadNetBrowserViewModelTest {
     @Test
     fun `setRenderingMode persists the selection`() =
         runTest(testDispatcher) {
+            val savedMode = slot<String>()
+            coEvery { settingsRepository.saveNomadNetRenderingMode(capture(savedMode)) } just Runs
+
             viewModel.setRenderingMode(NomadNetBrowserViewModel.RenderingMode.MONOSPACE_ZOOM)
             advanceUntilIdle()
 
-            coVerify { settingsRepository.saveNomadNetRenderingMode("MONOSPACE_ZOOM") }
+            // Asserts the production enum→name conversion that gets persisted, not just the call.
+            assertEquals("MONOSPACE_ZOOM", savedMode.captured)
         }
 
     @Test

--- a/app/src/test/java/network/columba/app/viewmodel/NomadNetBrowserViewModelTest.kt
+++ b/app/src/test/java/network/columba/app/viewmodel/NomadNetBrowserViewModelTest.kt
@@ -16,6 +16,7 @@ import io.mockk.verify
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.async
+import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.test.UnconfinedTestDispatcher
@@ -523,6 +524,30 @@ class NomadNetBrowserViewModelTest {
             assertEquals(
                 NomadNetBrowserViewModel.RenderingMode.MONOSPACE_SCROLL,
                 viewModel.renderingMode.value,
+            )
+        }
+
+    @Test
+    fun `init restore does not clobber a selection made before the read completes`() =
+        runTest(testDispatcher) {
+            // A flow whose emission we control, so the init read stays suspended until we choose.
+            val controllableFlow = MutableSharedFlow<String?>()
+            every { settingsRepository.nomadNetRenderingModeFlow } returns controllableFlow
+
+            // init launches and suspends on first() because nothing has been emitted yet.
+            val racingViewModel = NomadNetBrowserViewModel(protocol, pageCache, settingsRepository)
+
+            // User picks a mode before the persisted value has been read back.
+            racingViewModel.setRenderingMode(NomadNetBrowserViewModel.RenderingMode.MONOSPACE_ZOOM)
+
+            // The persisted value finally arrives, resuming the init coroutine.
+            controllableFlow.emit("PROPORTIONAL_WRAP")
+            advanceUntilIdle()
+
+            // The guard must keep the user's selection, not the late-arriving persisted value.
+            assertEquals(
+                NomadNetBrowserViewModel.RenderingMode.MONOSPACE_ZOOM,
+                racingViewModel.renderingMode.value,
             )
         }
 


### PR DESCRIPTION
Closes #868

## Problem
The NomadNet browser's page rendering mode (Monospace scroll / Monospace zoom / Proportional wrap) was held only in-memory and reset to **Monospace (scroll)** on every launch. Users on small screens who prefer **Proportional (wrap)** had to re-select it for every site, every session.

Per the issue discussion, the chosen approach is to **remember the selection** (global, not per-site).

## Change
- **`SettingsRepository`** — new `nomadnet_rendering_mode` DataStore key, with `nomadNetRenderingModeFlow: Flow<String?>` and `saveNomadNetRenderingMode(modeName)`. The mode is stored as its enum *name* (raw `String`) so the repository layer doesn't take a dependency on the viewmodel layer where `RenderingMode` is defined — mirroring the existing `MapStylePreference` / `BatteryProfile` patterns.
- **`NomadNetBrowserViewModel`** — injects `SettingsRepository`, restores the saved mode on `init`, and persists on `setRenderingMode`. Added a `RenderingMode.fromName()` companion helper that defaults safely on absent/unknown values. A `@Volatile` guard prevents the async startup restore from clobbering a selection the user makes during the brief read window.

No UI changes needed — the existing dropdown already drives `setRenderingMode`, so it now persists automatically.

## Tests
Added three unit tests to `NomadNetBrowserViewModelTest`:
- `setRenderingMode persists the selection`
- `init restores the persisted rendering mode`
- `init falls back to default when no rendering mode persisted`

All `NomadNetBrowserViewModelTest` tests pass (`:app:testNoSentryKotlinBackendDebugUnitTest`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)