### PR TITLE
fix(location): restore precise location for sharing — drop merged FINE maxSdkVersion cap (#855)

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -39,7 +39,17 @@
     <!-- Location permissions for BLE scanning (Android 6-11) and Map feature (all versions) -->
     <!-- Android 12+ requires both FINE and COARSE if requesting FINE -->
     <uses-permission android:name="android.permission.ACCESS_COARSE_LOCATION" />
-    <uses-permission android:name="android.permission.ACCESS_FINE_LOCATION" />
+    <!--
+        reticulum-kt's rns-android manifest declares ACCESS_FINE_LOCATION with
+        android:maxSdkVersion="32" (for legacy pre-Android-12 BLE-scan location).
+        Manifest-merged into the app, that cap strips fine location on API 33+,
+        so on modern devices there is no "Use precise location" toggle and every
+        position is coarse — kilometres off (issue #855). tools:remove drops the
+        merged cap so precise location works on all API levels.
+    -->
+    <uses-permission
+        android:name="android.permission.ACCESS_FINE_LOCATION"
+        tools:remove="android:maxSdkVersion" />
     <uses-permission android:name="android.permission.ACCESS_BACKGROUND_LOCATION" />
 
     <!-- Declare BLE hardware feature (optional but recommended) -->

--- a/app/src/main/java/network/columba/app/MainActivity.kt
+++ b/app/src/main/java/network/columba/app/MainActivity.kt
@@ -1069,6 +1069,8 @@ fun ColumbaNavigation(
         network.columba.app.ui.components.PreciseLocationPermissionPrompt(
             locationPrecisionRadius = settingsState.locationPrecisionRadius,
             enabled = !settingsState.isLoading && onboardingState.hasCompletedOnboarding,
+            dismissed = settingsState.preciseLocationPromptDismissed,
+            onDismiss = { settingsViewModel.dismissPreciseLocationPrompt() },
         )
         Surface(
             modifier = Modifier.fillMaxSize(),

--- a/app/src/main/java/network/columba/app/MainActivity.kt
+++ b/app/src/main/java/network/columba/app/MainActivity.kt
@@ -1061,6 +1061,15 @@ fun ColumbaNavigation(
     }
 
     ColumbaTheme(selectedTheme = settingsState.selectedTheme) {
+        // Prompt for precise location when the user has chosen precise sharing
+        // but only approximate access is granted. Fires on app start, after a
+        // settings import, and when precision is changed to Precise — all
+        // surface as the precision setting (issue #855). Hosted inside
+        // ColumbaTheme so the sheet matches the app's light/dark theme.
+        network.columba.app.ui.components.PreciseLocationPermissionPrompt(
+            locationPrecisionRadius = settingsState.locationPrecisionRadius,
+            enabled = !settingsState.isLoading && onboardingState.hasCompletedOnboarding,
+        )
         Surface(
             modifier = Modifier.fillMaxSize(),
             color = MaterialTheme.colorScheme.background,

--- a/app/src/main/java/network/columba/app/repository/SettingsRepository.kt
+++ b/app/src/main/java/network/columba/app/repository/SettingsRepository.kt
@@ -125,6 +125,7 @@ class SettingsRepository
             val LOCATION_SHARING_ENABLED = booleanPreferencesKey("location_sharing_enabled")
             val DEFAULT_SHARING_DURATION = stringPreferencesKey("default_sharing_duration")
             val LOCATION_PRECISION_RADIUS = intPreferencesKey("location_precision_radius")
+            val PRECISE_LOCATION_PROMPT_DISMISSED = booleanPreferencesKey("precise_location_prompt_dismissed")
 
             // Incoming message size limit
             val INCOMING_MESSAGE_SIZE_LIMIT_KB = intPreferencesKey("incoming_message_size_limit_kb")
@@ -1335,6 +1336,31 @@ class SettingsRepository
         suspend fun saveLocationPrecisionRadius(radiusMeters: Int) {
             context.dataStore.edit { preferences ->
                 preferences[PreferencesKeys.LOCATION_PRECISION_RADIUS] = radiusMeters
+                // Re-arm the precise-location prompt whenever the user (re)selects
+                // Precise (0): a fresh "I want precise" intent should re-prompt even
+                // after a prior "Not Now" dismissal (issue #855).
+                if (radiusMeters == 0) {
+                    preferences[PreferencesKeys.PRECISE_LOCATION_PROMPT_DISMISSED] = false
+                }
+            }
+        }
+
+        /**
+         * Whether the user dismissed the precise-location prompt ("Not Now").
+         * Persisted so the prompt doesn't reappear on every cold start; re-armed
+         * when Precise is (re)selected (see [saveLocationPrecisionRadius]).
+         * Defaults to false (not dismissed).
+         */
+        val preciseLocationPromptDismissedFlow: Flow<Boolean> =
+            context.dataStore.data
+                .map { preferences ->
+                    preferences[PreferencesKeys.PRECISE_LOCATION_PROMPT_DISMISSED] ?: false
+                }.distinctUntilChanged()
+
+        /** Persist that the user dismissed the precise-location prompt. */
+        suspend fun savePreciseLocationPromptDismissed(dismissed: Boolean) {
+            context.dataStore.edit { preferences ->
+                preferences[PreferencesKeys.PRECISE_LOCATION_PROMPT_DISMISSED] = dismissed
             }
         }
 

--- a/app/src/main/java/network/columba/app/repository/SettingsRepository.kt
+++ b/app/src/main/java/network/columba/app/repository/SettingsRepository.kt
@@ -1335,11 +1335,14 @@ class SettingsRepository
          */
         suspend fun saveLocationPrecisionRadius(radiusMeters: Int) {
             context.dataStore.edit { preferences ->
+                val previousRadius = preferences[PreferencesKeys.LOCATION_PRECISION_RADIUS] ?: 0
                 preferences[PreferencesKeys.LOCATION_PRECISION_RADIUS] = radiusMeters
-                // Re-arm the precise-location prompt whenever the user (re)selects
-                // Precise (0): a fresh "I want precise" intent should re-prompt even
-                // after a prior "Not Now" dismissal (issue #855).
-                if (radiusMeters == 0) {
+                // Re-arm the precise-location prompt only on a real transition INTO
+                // Precise (0) — a fresh "I want precise" intent should re-prompt even
+                // after a prior "Not Now". Idempotent re-saves of an already-Precise
+                // value (e.g. a settings import/restore that preserves radius 0) must
+                // NOT silently undo a prior dismissal (issue #855).
+                if (radiusMeters == 0 && previousRadius != 0) {
                     preferences[PreferencesKeys.PRECISE_LOCATION_PROMPT_DISMISSED] = false
                 }
             }

--- a/app/src/main/java/network/columba/app/ui/components/PreciseLocationPermissionPrompt.kt
+++ b/app/src/main/java/network/columba/app/ui/components/PreciseLocationPermissionPrompt.kt
@@ -17,11 +17,13 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.platform.LocalContext
+import androidx.core.app.ActivityCompat
 import network.columba.app.util.LocationPermissionManager
 
 /**
  * Prompts the user to grant *precise* (fine) location when they've chosen
- * precise location sharing but the OS has only granted approximate access.
+ * precise location sharing but the OS has only granted approximate access (or
+ * none at all).
  *
  * The trigger is [locationPrecisionRadius] being "Precise"
  * ([LocationPermissionManager.PRECISE_PRECISION_RADIUS]) while fine location is
@@ -30,22 +32,33 @@ import network.columba.app.util.LocationPermissionManager
  * precision picker, observing it here covers all three cases (issue #855)
  * without a persistent map banner.
  *
- * Tapping "Enable Precise Location" re-requests `FINE`+`COARSE`. On a fresh
- * grant that surfaces the system dialog; but once the user has already settled
- * on **Approximate**, Android no longer shows the in-app precise-upgrade dialog
- * and the request returns denied with no UI. In that case we fall back to the
- * app's settings page, where "Use precise location" can be turned on manually —
- * otherwise the prompt would re-appear forever with no way to act on it.
+ * Dismissals persist: tapping "Not Now" calls [onDismiss] to set [dismissed],
+ * so the prompt does not reappear on every cold start. It re-arms when the user
+ * next (re)selects Precise — `SettingsRepository.saveLocationPrecisionRadius`
+ * clears the persisted flag for radius 0.
+ *
+ * Tapping "Enable Precise Location" re-requests `FINE`+`COARSE`. If the request
+ * returns without `FINE` and Android will no longer show the in-app dialog
+ * ([ActivityCompat.shouldShowRequestPermissionRationale] is false — the user
+ * already settled on Approximate, or permanently denied), it falls back to the
+ * app's settings page. If the rationale is still true (a plain decline that can
+ * be re-prompted next time), it just closes.
  *
  * @param locationPrecisionRadius persisted precision radius (0 = precise)
  * @param enabled gate so the prompt only fires once the main UI is up
  *   (onboarding complete, settings loaded) — never during splash/onboarding
+ * @param dismissed persisted "Not Now" state; suppresses the prompt until the
+ *   user next selects Precise
+ * @param onDismiss persist a dismissal (called when the user taps "Not Now" or
+ *   swipes the sheet away)
  */
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun PreciseLocationPermissionPrompt(
     locationPrecisionRadius: Int,
     enabled: Boolean,
+    dismissed: Boolean,
+    onDismiss: () -> Unit,
 ) {
     val context = LocalContext.current
     var showSheet by remember { mutableStateOf(false) }
@@ -59,18 +72,26 @@ fun PreciseLocationPermissionPrompt(
             val fineGranted =
                 grants[Manifest.permission.ACCESS_FINE_LOCATION] == true ||
                     LocationPermissionManager.hasFineLocationPermission(context)
-            if (!fineGranted) {
-                // Android won't surface the in-app precise-upgrade dialog once
-                // the user has settled on Approximate — the request returns
-                // without UI. Guide them to the app's settings page to turn on
-                // "Use precise location" manually (issue #855).
+            // Only route to app settings when Android will NOT show the in-app
+            // dialog again: shouldShowRequestPermissionRationale == false with FINE
+            // still missing means the dialog is suppressed (user settled on
+            // Approximate, or permanently denied), so settings is the only
+            // recourse. When it's true, this was a plain decline that can be
+            // re-prompted next time — just close the sheet (issue #855).
+            if (!fineGranted &&
+                !ActivityCompat.shouldShowRequestPermissionRationale(
+                    context.findActivity(),
+                    Manifest.permission.ACCESS_FINE_LOCATION,
+                )
+            ) {
                 context.openPreciseLocationSettings()
             }
         }
 
-    LaunchedEffect(locationPrecisionRadius, enabled) {
+    LaunchedEffect(locationPrecisionRadius, enabled, dismissed) {
         showSheet =
             enabled &&
+            !dismissed &&
             LocationPermissionManager.needsPreciseLocationUpgrade(
                 precisionRadiusMeters = locationPrecisionRadius,
                 hasFineLocation = LocationPermissionManager.hasFineLocationPermission(context),
@@ -79,7 +100,12 @@ fun PreciseLocationPermissionPrompt(
 
     if (showSheet) {
         LocationPermissionBottomSheet(
-            onDismiss = { showSheet = false },
+            onDismiss = {
+                showSheet = false
+                // Persist so the prompt doesn't reappear on every cold start;
+                // it re-arms when the user next selects Precise (issue #855).
+                onDismiss()
+            },
             onRequestPermissions = {
                 showSheet = false
                 permissionLauncher.launch(

--- a/app/src/main/java/network/columba/app/ui/components/PreciseLocationPermissionPrompt.kt
+++ b/app/src/main/java/network/columba/app/ui/components/PreciseLocationPermissionPrompt.kt
@@ -41,17 +41,21 @@ import network.columba.app.util.LocationPermissionManager
  * `ON_RESUME` so granting/revoking precise from system settings while the app
  * is backgrounded is reflected when the user returns.
  *
- * Dismissals persist: tapping "Not Now" calls [onDismiss] to set [dismissed],
- * so the prompt does not reappear on every cold start. It re-arms when the user
- * next (re)selects Precise — `SettingsRepository.saveLocationPrecisionRadius`
+ * Dismissals persist: tapping "Not Now", swiping the sheet away, or finishing the
+ * precise-permission request without granting `FINE` calls [onDismiss] to set
+ * [dismissed], so the prompt does not reappear on every cold start. It re-arms when
+ * the user next (re)selects Precise — `SettingsRepository.saveLocationPrecisionRadius`
  * clears the persisted flag on a transition into radius 0.
  *
- * Tapping "Enable Precise Location" re-requests `FINE`+`COARSE`. If the request
- * returns without `FINE` and Android will no longer show the in-app dialog
- * ([ActivityCompat.shouldShowRequestPermissionRationale] is false — already
- * settled on Approximate, or permanently denied), it falls back to the app's
- * settings page. If the rationale is still true (a plain decline that can be
- * re-prompted next time), it just closes.
+ * Tapping "Enable Precise Location" re-requests `FINE`+`COARSE`. Any outcome that
+ * doesn't grant `FINE` (plain decline, Approximate-only, or permanent denial)
+ * settles the interaction by persisting a dismissal, so the sheet re-arms only when
+ * the user next selects Precise. This also stops the `ON_RESUME` that the closing
+ * system chooser delivers from immediately re-showing the sheet (issue #855). When
+ * Android will additionally no longer show the in-app dialog
+ * ([ActivityCompat.shouldShowRequestPermissionRationale] is false — settled on
+ * Approximate, or permanently denied), it also routes to the app's settings page as
+ * the only remaining way to enable precise access.
  *
  * @param locationPrecisionRadius persisted precision radius (0 = precise)
  * @param enabled gate so the prompt only fires once the main UI is up
@@ -87,6 +91,15 @@ fun PreciseLocationPermissionPrompt(
         onDispose { lifecycleOwner.lifecycle.removeObserver(observer) }
     }
 
+    // Local guard bridging the window between the permission-launcher callback
+    // deciding to dismiss and the persisted [dismissed] flag propagating back.
+    // On Android 12+ the precise-location chooser closing delivers an ON_RESUME
+    // (which bumps resumeKey) in the same frame the callback runs; without this
+    // guard the resume-driven LaunchedEffect re-evaluates needsPreciseLocationUpgrade
+    // (still true) and re-shows the sheet before onDismiss() takes effect, trapping
+    // the user in a loop (issue #855).
+    var pendingDismiss by remember { mutableStateOf(false) }
+
     val permissionLauncher =
         rememberLauncherForActivityResult(
             contract = ActivityResultContracts.RequestMultiplePermissions(),
@@ -95,25 +108,41 @@ fun PreciseLocationPermissionPrompt(
             val fineGranted =
                 grants[Manifest.permission.ACCESS_FINE_LOCATION] == true ||
                     LocationPermissionManager.hasFineLocationPermission(context)
-            // Only route to app settings when Android will NOT show the in-app
-            // dialog again: shouldShowRequestPermissionRationale == false with FINE
-            // still missing means the dialog is suppressed (settled on Approximate,
-            // or permanently denied), so settings is the only recourse. A plain
-            // decline (rationale true) can be re-prompted — just close (issue #855).
-            if (!fineGranted &&
-                !ActivityCompat.shouldShowRequestPermissionRationale(
-                    context.findActivity(),
-                    Manifest.permission.ACCESS_FINE_LOCATION,
-                )
-            ) {
-                context.openPreciseLocationSettings()
+            if (!fineGranted) {
+                // The Enable flow finished without precise access (plain decline,
+                // Approximate-only, or permanent denial). Settle the interaction:
+                // persist a dismissal so the prompt re-arms only when the user next
+                // selects Precise, and set pendingDismiss so the ON_RESUME the closing
+                // system chooser delivers can't re-show the sheet before that flag
+                // propagates back (issue #855).
+                pendingDismiss = true
+                onDismiss()
+                // Additionally route to app settings only when Android will NOT show
+                // the in-app dialog again: shouldShowRequestPermissionRationale ==
+                // false with FINE still missing means the dialog is suppressed
+                // (settled on Approximate, or permanently denied), so settings is the
+                // only remaining recourse. A plain decline (rationale true) can be
+                // re-prompted next time the user re-selects Precise.
+                if (!ActivityCompat.shouldShowRequestPermissionRationale(
+                        context.findActivity(),
+                        Manifest.permission.ACCESS_FINE_LOCATION,
+                    )
+                ) {
+                    context.openPreciseLocationSettings()
+                }
             }
         }
 
-    LaunchedEffect(locationPrecisionRadius, enabled, dismissed, resumeKey) {
+    // Clear the local guard once the persisted dismissal state settles — true after
+    // a non-grant (suppression handed back to [dismissed]), or false again when the
+    // user re-selects Precise and re-arms the prompt (issue #855).
+    LaunchedEffect(dismissed) { pendingDismiss = false }
+
+    LaunchedEffect(locationPrecisionRadius, enabled, dismissed, pendingDismiss, resumeKey) {
         showSheet =
             enabled &&
             !dismissed &&
+            !pendingDismiss &&
             LocationPermissionManager.needsPreciseLocationUpgrade(
                 precisionRadiusMeters = locationPrecisionRadius,
                 hasFineLocation = LocationPermissionManager.hasFineLocationPermission(context),

--- a/app/src/main/java/network/columba/app/ui/components/PreciseLocationPermissionPrompt.kt
+++ b/app/src/main/java/network/columba/app/ui/components/PreciseLocationPermissionPrompt.kt
@@ -11,13 +11,20 @@ import androidx.activity.result.contract.ActivityResultContracts
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.rememberModalBottomSheetState
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableIntStateOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.res.stringResource
 import androidx.core.app.ActivityCompat
+import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.LifecycleEventObserver
+import androidx.lifecycle.compose.LocalLifecycleOwner
+import network.columba.app.R
 import network.columba.app.util.LocationPermissionManager
 
 /**
@@ -30,19 +37,21 @@ import network.columba.app.util.LocationPermissionManager
  * missing. Because the persisted precision setting is the single value that
  * changes on app start, on settings import, and when the user edits the
  * precision picker, observing it here covers all three cases (issue #855)
- * without a persistent map banner.
+ * without a persistent map banner. The state is also re-evaluated on every
+ * `ON_RESUME` so granting/revoking precise from system settings while the app
+ * is backgrounded is reflected when the user returns.
  *
  * Dismissals persist: tapping "Not Now" calls [onDismiss] to set [dismissed],
  * so the prompt does not reappear on every cold start. It re-arms when the user
  * next (re)selects Precise — `SettingsRepository.saveLocationPrecisionRadius`
- * clears the persisted flag for radius 0.
+ * clears the persisted flag on a transition into radius 0.
  *
  * Tapping "Enable Precise Location" re-requests `FINE`+`COARSE`. If the request
  * returns without `FINE` and Android will no longer show the in-app dialog
- * ([ActivityCompat.shouldShowRequestPermissionRationale] is false — the user
- * already settled on Approximate, or permanently denied), it falls back to the
- * app's settings page. If the rationale is still true (a plain decline that can
- * be re-prompted next time), it just closes.
+ * ([ActivityCompat.shouldShowRequestPermissionRationale] is false — already
+ * settled on Approximate, or permanently denied), it falls back to the app's
+ * settings page. If the rationale is still true (a plain decline that can be
+ * re-prompted next time), it just closes.
  *
  * @param locationPrecisionRadius persisted precision radius (0 = precise)
  * @param enabled gate so the prompt only fires once the main UI is up
@@ -61,8 +70,22 @@ fun PreciseLocationPermissionPrompt(
     onDismiss: () -> Unit,
 ) {
     val context = LocalContext.current
+    val lifecycleOwner = LocalLifecycleOwner.current
     var showSheet by remember { mutableStateOf(false) }
     val sheetState = rememberModalBottomSheetState()
+
+    // Bump on every foreground transition so the sheet state is refreshed when
+    // the user returns after granting/revoking fine location in system settings
+    // (none of the other keys would change to reflect that) — issue #855.
+    var resumeKey by remember { mutableIntStateOf(0) }
+    DisposableEffect(lifecycleOwner) {
+        val observer =
+            LifecycleEventObserver { _, event ->
+                if (event == Lifecycle.Event.ON_RESUME) resumeKey++
+            }
+        lifecycleOwner.lifecycle.addObserver(observer)
+        onDispose { lifecycleOwner.lifecycle.removeObserver(observer) }
+    }
 
     val permissionLauncher =
         rememberLauncherForActivityResult(
@@ -74,10 +97,9 @@ fun PreciseLocationPermissionPrompt(
                     LocationPermissionManager.hasFineLocationPermission(context)
             // Only route to app settings when Android will NOT show the in-app
             // dialog again: shouldShowRequestPermissionRationale == false with FINE
-            // still missing means the dialog is suppressed (user settled on
-            // Approximate, or permanently denied), so settings is the only
-            // recourse. When it's true, this was a plain decline that can be
-            // re-prompted next time — just close the sheet (issue #855).
+            // still missing means the dialog is suppressed (settled on Approximate,
+            // or permanently denied), so settings is the only recourse. A plain
+            // decline (rationale true) can be re-prompted — just close (issue #855).
             if (!fineGranted &&
                 !ActivityCompat.shouldShowRequestPermissionRationale(
                     context.findActivity(),
@@ -88,7 +110,7 @@ fun PreciseLocationPermissionPrompt(
             }
         }
 
-    LaunchedEffect(locationPrecisionRadius, enabled, dismissed) {
+    LaunchedEffect(locationPrecisionRadius, enabled, dismissed, resumeKey) {
         showSheet =
             enabled &&
             !dismissed &&
@@ -114,7 +136,7 @@ fun PreciseLocationPermissionPrompt(
             },
             sheetState = sheetState,
             rationale = LocationPermissionManager.getPreciseLocationRationale(),
-            primaryActionLabel = "Enable Precise Location",
+            primaryActionLabel = stringResource(R.string.enable_precise_location),
         )
     }
 }
@@ -138,7 +160,7 @@ private fun Context.openPreciseLocationSettings() {
         Toast
             .makeText(
                 this,
-                "Open Permissions → Location and turn on \"Use precise location\".",
+                getString(R.string.precise_location_settings_hint),
                 Toast.LENGTH_LONG,
             ).show()
     }

--- a/app/src/main/java/network/columba/app/ui/components/PreciseLocationPermissionPrompt.kt
+++ b/app/src/main/java/network/columba/app/ui/components/PreciseLocationPermissionPrompt.kt
@@ -1,0 +1,119 @@
+package network.columba.app.ui.components
+
+import android.Manifest
+import android.content.Context
+import android.content.Intent
+import android.net.Uri
+import android.provider.Settings
+import android.widget.Toast
+import androidx.activity.compose.rememberLauncherForActivityResult
+import androidx.activity.result.contract.ActivityResultContracts
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.rememberModalBottomSheetState
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.platform.LocalContext
+import network.columba.app.util.LocationPermissionManager
+
+/**
+ * Prompts the user to grant *precise* (fine) location when they've chosen
+ * precise location sharing but the OS has only granted approximate access.
+ *
+ * The trigger is [locationPrecisionRadius] being "Precise"
+ * ([LocationPermissionManager.PRECISE_PRECISION_RADIUS]) while fine location is
+ * missing. Because the persisted precision setting is the single value that
+ * changes on app start, on settings import, and when the user edits the
+ * precision picker, observing it here covers all three cases (issue #855)
+ * without a persistent map banner.
+ *
+ * Tapping "Enable Precise Location" re-requests `FINE`+`COARSE`. On a fresh
+ * grant that surfaces the system dialog; but once the user has already settled
+ * on **Approximate**, Android no longer shows the in-app precise-upgrade dialog
+ * and the request returns denied with no UI. In that case we fall back to the
+ * app's settings page, where "Use precise location" can be turned on manually —
+ * otherwise the prompt would re-appear forever with no way to act on it.
+ *
+ * @param locationPrecisionRadius persisted precision radius (0 = precise)
+ * @param enabled gate so the prompt only fires once the main UI is up
+ *   (onboarding complete, settings loaded) — never during splash/onboarding
+ */
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun PreciseLocationPermissionPrompt(
+    locationPrecisionRadius: Int,
+    enabled: Boolean,
+) {
+    val context = LocalContext.current
+    var showSheet by remember { mutableStateOf(false) }
+    val sheetState = rememberModalBottomSheetState()
+
+    val permissionLauncher =
+        rememberLauncherForActivityResult(
+            contract = ActivityResultContracts.RequestMultiplePermissions(),
+        ) { grants ->
+            showSheet = false
+            val fineGranted =
+                grants[Manifest.permission.ACCESS_FINE_LOCATION] == true ||
+                    LocationPermissionManager.hasFineLocationPermission(context)
+            if (!fineGranted) {
+                // Android won't surface the in-app precise-upgrade dialog once
+                // the user has settled on Approximate — the request returns
+                // without UI. Guide them to the app's settings page to turn on
+                // "Use precise location" manually (issue #855).
+                context.openPreciseLocationSettings()
+            }
+        }
+
+    LaunchedEffect(locationPrecisionRadius, enabled) {
+        showSheet =
+            enabled &&
+            LocationPermissionManager.needsPreciseLocationUpgrade(
+                precisionRadiusMeters = locationPrecisionRadius,
+                hasFineLocation = LocationPermissionManager.hasFineLocationPermission(context),
+            )
+    }
+
+    if (showSheet) {
+        LocationPermissionBottomSheet(
+            onDismiss = { showSheet = false },
+            onRequestPermissions = {
+                showSheet = false
+                permissionLauncher.launch(
+                    LocationPermissionManager.getRequiredPermissions().toTypedArray(),
+                )
+            },
+            sheetState = sheetState,
+            rationale = LocationPermissionManager.getPreciseLocationRationale(),
+            primaryActionLabel = "Enable Precise Location",
+        )
+    }
+}
+
+/**
+ * Open this app's system settings so the user can enable "Use precise
+ * location". There is no direct intent to the precise toggle, so we open the
+ * app-details page and hint at the path with a toast.
+ */
+private fun Context.openPreciseLocationSettings() {
+    val opened =
+        runCatching {
+            startActivity(
+                Intent(
+                    Settings.ACTION_APPLICATION_DETAILS_SETTINGS,
+                    Uri.fromParts("package", packageName, null),
+                ).addFlags(Intent.FLAG_ACTIVITY_NEW_TASK),
+            )
+        }.isSuccess
+    if (opened) {
+        Toast
+            .makeText(
+                this,
+                "Open Permissions → Location and turn on \"Use precise location\".",
+                Toast.LENGTH_LONG,
+            ).show()
+    }
+}

--- a/app/src/main/java/network/columba/app/util/LocationPermissionManager.kt
+++ b/app/src/main/java/network/columba/app/util/LocationPermissionManager.kt
@@ -191,19 +191,20 @@ object LocationPermissionManager {
 
     /**
      * Rationale shown when prompting a user who has selected precise location
-     * sharing but only granted approximate access (issue #855).
+     * sharing but doesn't hold precise (fine) access — whether that's
+     * approximate-only or no location permission at all (issue #855).
      */
     fun getPreciseLocationRationale(): String {
         return buildString {
             appendLine(
-                "Location sharing is set to Precise, but Columba currently only has approximate " +
+                "Location sharing is set to Precise, but Columba doesn't have precise " +
                     "location access.",
             )
             appendLine()
             appendLine(
-                "Approximate location is rounded to an area a kilometre or more across, so the position " +
-                    "you share will be off by that much. Enable precise location for accurate sharing, or " +
-                    "set a coarser precision in Location Sharing settings if that's intended.",
+                "Without it, a shared position is unavailable or only approximate — off by a " +
+                    "kilometre or more. Enable precise location for accurate sharing, or set a " +
+                    "coarser precision in Location Sharing settings if that's intended.",
             )
         }
     }

--- a/app/src/main/java/network/columba/app/util/LocationPermissionManager.kt
+++ b/app/src/main/java/network/columba/app/util/LocationPermissionManager.kt
@@ -18,6 +18,15 @@ import androidx.core.content.ContextCompat
  */
 object LocationPermissionManager {
     /**
+     * The location-precision radius (metres) that means "Precise" — exact GPS,
+     * no coarsening. Mirrors the `PRECISE` preset in the Location Sharing
+     * settings card. When the user has chosen this, the app needs
+     * [Manifest.permission.ACCESS_FINE_LOCATION]; only-approximate access
+     * yields positions kilometres off (issue #855).
+     */
+    const val PRECISE_PRECISION_RADIUS = 0
+
+    /**
      * Result of permission check.
      */
     sealed class PermissionStatus {
@@ -81,6 +90,25 @@ object LocationPermissionManager {
             Manifest.permission.ACCESS_FINE_LOCATION,
         ) == PackageManager.PERMISSION_GRANTED
     }
+
+    /**
+     * Whether to prompt the user to upgrade to precise (fine) location.
+     *
+     * True when the Location Sharing precision is set to "Precise"
+     * ([PRECISE_PRECISION_RADIUS]) but only approximate location is currently
+     * granted — the state behind issue #855, where shared/telemetry positions
+     * land kilometres away because the OS is withholding GPS. When the user has
+     * deliberately chosen an approximate radius (>0) no upgrade is needed.
+     *
+     * @param precisionRadiusMeters persisted location-precision radius
+     *   (0 = precise; >0 = coarsen to that radius)
+     * @param hasFineLocation whether [Manifest.permission.ACCESS_FINE_LOCATION]
+     *   is currently granted (see [hasFineLocationPermission])
+     */
+    fun needsPreciseLocationUpgrade(
+        precisionRadiusMeters: Int,
+        hasFineLocation: Boolean,
+    ): Boolean = precisionRadiusMeters == PRECISE_PRECISION_RADIUS && !hasFineLocation
 
     /**
      * Whether this Android version requires explicit background location permission.
@@ -157,6 +185,25 @@ object LocationPermissionManager {
             appendLine(
                 "Columba will not and can not share your location with anyone until you actively " +
                     "send it to someone. Your location is always encrypted safely over Reticulum.",
+            )
+        }
+    }
+
+    /**
+     * Rationale shown when prompting a user who has selected precise location
+     * sharing but only granted approximate access (issue #855).
+     */
+    fun getPreciseLocationRationale(): String {
+        return buildString {
+            appendLine(
+                "Location sharing is set to Precise, but Columba currently only has approximate " +
+                    "location access.",
+            )
+            appendLine()
+            appendLine(
+                "Approximate location is rounded to an area a kilometre or more across, so the position " +
+                    "you share will be off by that much. Enable precise location for accurate sharing, or " +
+                    "set a coarser precision in Location Sharing settings if that's intended.",
             )
         }
     }

--- a/app/src/main/java/network/columba/app/viewmodel/SettingsViewModel.kt
+++ b/app/src/main/java/network/columba/app/viewmodel/SettingsViewModel.kt
@@ -149,6 +149,7 @@ data class SettingsState(
     val activeSharingSessions: List<network.columba.app.service.SharingSession> = emptyList(),
     val defaultSharingDuration: String = "ONE_HOUR",
     val locationPrecisionRadius: Int = 0,
+    val preciseLocationPromptDismissed: Boolean = false,
     // Notifications state
     val notificationsEnabled: Boolean = true,
     // Privacy state
@@ -1913,6 +1914,11 @@ class SettingsViewModel
                 }
             }
             viewModelScope.launch {
+                settingsRepository.preciseLocationPromptDismissedFlow.collect { dismissed ->
+                    _state.update { it.copy(preciseLocationPromptDismissed = dismissed) }
+                }
+            }
+            viewModelScope.launch {
                 settingsRepository.incomingMessageSizeLimitKbFlow.collect { limitKb ->
                     _state.update { it.copy(incomingMessageSizeLimitKb = limitKb) }
                 }
@@ -2003,6 +2009,13 @@ class SettingsViewModel
                 Log.d(TAG, "Location precision radius set to: ${radiusMeters}m")
                 // Send immediate update to all active sharing recipients with new precision
                 locationSharingManager.sendImmediateUpdate()
+            }
+        }
+
+        /** Persist that the user dismissed the precise-location prompt ("Not Now"). */
+        fun dismissPreciseLocationPrompt() {
+            viewModelScope.launch {
+                settingsRepository.savePreciseLocationPromptDismissed(true)
             }
         }
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -30,4 +30,8 @@
     <string name="view_interface_details">View interface details</string>
     <string name="interface_actions">Interface actions</string>
     <string name="edit_interface">Edit interface</string>
+
+    <!-- Precise location permission prompt (issue #855) -->
+    <string name="enable_precise_location">Enable Precise Location</string>
+    <string name="precise_location_settings_hint">Open Permissions → Location and turn on \"Use precise location\".</string>
 </resources>

--- a/app/src/test/java/network/columba/app/repository/SettingsRepositoryTest.kt
+++ b/app/src/test/java/network/columba/app/repository/SettingsRepositoryTest.kt
@@ -1628,4 +1628,32 @@ class SettingsRepositoryTest {
                 cancelAndIgnoreRemainingEvents()
             }
         }
+
+    @Test
+    fun saveLocationPrecisionRadius_transitionIntoPrecise_reArmsDismissedPrompt() =
+        runTest {
+            // Approximate radius with the precise-prompt dismissed.
+            repository.saveLocationPrecisionRadius(1000)
+            repository.savePreciseLocationPromptDismissed(true)
+            assertTrue(repository.preciseLocationPromptDismissedFlow.first())
+
+            // A real transition INTO Precise (0) re-arms the prompt (issue #855).
+            repository.saveLocationPrecisionRadius(0)
+
+            assertFalse(repository.preciseLocationPromptDismissedFlow.first())
+        }
+
+    @Test
+    fun saveLocationPrecisionRadius_reSavingPrecise_keepsDismissal() =
+        runTest {
+            // Already Precise and dismissed (e.g. a settings import preserving 0).
+            repository.saveLocationPrecisionRadius(0)
+            repository.savePreciseLocationPromptDismissed(true)
+            assertTrue(repository.preciseLocationPromptDismissedFlow.first())
+
+            // An idempotent re-save of Precise must NOT clear the dismissal (issue #855).
+            repository.saveLocationPrecisionRadius(0)
+
+            assertTrue(repository.preciseLocationPromptDismissedFlow.first())
+        }
 }

--- a/app/src/test/java/network/columba/app/util/LocationPermissionManagerTest.kt
+++ b/app/src/test/java/network/columba/app/util/LocationPermissionManagerTest.kt
@@ -177,6 +177,47 @@ class LocationPermissionManagerTest {
         assertTrue(rationale.contains("peer-to-peer"))
     }
 
+    // ========== needsPreciseLocationUpgrade Tests (issue #855) ==========
+
+    @Test
+    fun `needsPreciseLocationUpgrade true when precise selected but fine not granted`() {
+        assertTrue(
+            LocationPermissionManager.needsPreciseLocationUpgrade(
+                precisionRadiusMeters = LocationPermissionManager.PRECISE_PRECISION_RADIUS,
+                hasFineLocation = false,
+            ),
+        )
+    }
+
+    @Test
+    fun `needsPreciseLocationUpgrade false when precise selected and fine granted`() {
+        assertFalse(
+            LocationPermissionManager.needsPreciseLocationUpgrade(
+                precisionRadiusMeters = LocationPermissionManager.PRECISE_PRECISION_RADIUS,
+                hasFineLocation = true,
+            ),
+        )
+    }
+
+    @Test
+    fun `needsPreciseLocationUpgrade false when approximate radius chosen even without fine`() {
+        // User deliberately picked a coarse radius — no precise upgrade needed.
+        assertFalse(LocationPermissionManager.needsPreciseLocationUpgrade(100, hasFineLocation = false))
+        assertFalse(LocationPermissionManager.needsPreciseLocationUpgrade(1000, hasFineLocation = false))
+        assertFalse(LocationPermissionManager.needsPreciseLocationUpgrade(10000, hasFineLocation = true))
+    }
+
+    // ========== getPreciseLocationRationale Tests ==========
+
+    @Test
+    fun `getPreciseLocationRationale mentions precise and approximate`() {
+        val rationale = LocationPermissionManager.getPreciseLocationRationale()
+
+        assertTrue(rationale.isNotEmpty())
+        assertTrue(rationale.contains("Precise"))
+        assertTrue(rationale.contains("approximate"))
+    }
+
     // ========== isLocationSupported Tests ==========
 
     @Test

--- a/app/src/test/java/network/columba/app/viewmodel/SettingsViewModelIncomingMessageLimitTest.kt
+++ b/app/src/test/java/network/columba/app/viewmodel/SettingsViewModelIncomingMessageLimitTest.kt
@@ -183,6 +183,7 @@ class SettingsViewModelIncomingMessageLimitTest {
         every { settingsRepository.locationSharingEnabledFlow } returns MutableStateFlow(false)
         every { settingsRepository.defaultSharingDurationFlow } returns MutableStateFlow("ONE_HOUR")
         every { settingsRepository.locationPrecisionRadiusFlow } returns MutableStateFlow(0)
+        every { settingsRepository.preciseLocationPromptDismissedFlow } returns MutableStateFlow(false)
         every { settingsRepository.imageCompressionPresetFlow } returns MutableStateFlow(network.columba.app.data.model.ImageCompressionPreset.AUTO)
         every { settingsRepository.telemetryCollectorEnabledFlow } returns MutableStateFlow(false)
         every { settingsRepository.telemetryCollectorAddressFlow } returns MutableStateFlow<String?>(null)

--- a/app/src/test/java/network/columba/app/viewmodel/SettingsViewModelTest.kt
+++ b/app/src/test/java/network/columba/app/viewmodel/SettingsViewModelTest.kt
@@ -190,6 +190,7 @@ class SettingsViewModelTest {
         every { settingsRepository.locationSharingEnabledFlow } returns flowOf(false)
         every { settingsRepository.defaultSharingDurationFlow } returns flowOf("ONE_HOUR")
         every { settingsRepository.locationPrecisionRadiusFlow } returns flowOf(0)
+        every { settingsRepository.preciseLocationPromptDismissedFlow } returns flowOf(false)
         every { settingsRepository.tryPropagationOnFailFlow } returns flowOf(false)
         every { settingsRepository.autoSelectPropagationNodeFlow } returns flowOf(false)
         every { settingsRepository.mapSourceHttpEnabledFlow } returns flowOf(true)


### PR DESCRIPTION
## Summary

Fixes #855: shared/displayed location is several kilometres off and "stuck," with no "Use precise location" option in system settings. This is the root-cause fix plus a complementary UX nudge.

## Root cause

`reticulum-kt`'s `rns-android` library manifest declares `ACCESS_FINE_LOCATION` with `android:maxSdkVersion="32"` (legacy pre-Android-12 BLE-scan location). The manifest merger applies that cap to Columba's own FINE permission, so on **API ≥ 33** the OS never sees a fine-location request:

- no "Use precise location" toggle in Settings,
- the app can never obtain GPS → every position is the coarse ~1–3 km approximate fix.

This is why it appeared at the **0.10.10 → 1.0 switch to reticulum-kt** (the old RNS/Python build never pulled `rns-android`) and reproduces on **both** backends: `rns-android` is on both flavors' classpaths via the shared `:rns-host` module (`api(libs.rns.android)`), and manifest merging is classpath-based regardless of which backend's code runs.

**Fix:** `tools:remove="android:maxSdkVersion"` on the app's `ACCESS_FINE_LOCATION` declaration drops the merged cap. Verified on an Android 16 device — the merged manifest no longer caps FINE, the device now lists `ACCESS_FINE_LOCATION` among requested permissions, and the precise toggle appears.

## Precise-permission prompt (complementary)

The manifest fix lets new grants default to Precise, but existing users already on Approximate would silently keep sharing coarse positions. So when Location Sharing precision is "Precise" yet only approximate location is granted, prompt the user to enable precise. It's driven off the persisted precision setting — the single value that changes on app start, settings import, and editing the precision picker — so one observer covers all three with **no map banner**. Falls back to the app's location-settings page when Android won't re-show the in-app precise dialog (i.e. once the user has settled on Approximate).

## Tests

Unit tests for the precise-upgrade decision + rationale. `:app:testNoSentryKotlinBackendDebugUnitTest` and `:app:detekt` pass.

## Follow-up (not in this PR)

`rns-android` (reticulum-kt) shouldn't ship a FINE `maxSdkVersion` cap that leaks into consumers — worth fixing upstream so other apps aren't bitten.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
