### PR TITLE
deps: bump reticulum-kt v0.0.22 + LXMF-kt v0.0.14 — land columba#1004 path-request fix

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -20,8 +20,8 @@ coil = "2.7.0"
 desugarJdkLibs = "2.1.5"
 
 # JitPack-published libraries (formerly git submodules)
-reticulumKt = "v0.0.21"
-lxmfKt = "v0.0.13"
+reticulumKt = "v0.0.22"
+lxmfKt = "v0.0.14"
 lxstKt = "v0.0.4"
 
 [libraries]

--- a/rns-backend-kt/src/main/kotlin/network/columba/app/rns/backend/kt/NativeRnsBackendImpl.kt
+++ b/rns-backend-kt/src/main/kotlin/network/columba/app/rns/backend/kt/NativeRnsBackendImpl.kt
@@ -1,16 +1,46 @@
 package network.columba.app.rns.backend.kt
 
+import android.util.Log
+import androidx.room.Room
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.SharedFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asSharedFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.isActive
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
+import network.columba.app.rns.api.model.AnnounceEvent
+import network.columba.app.rns.api.model.BatteryProfile
 import network.columba.app.rns.api.model.CallState
 import network.columba.app.rns.api.model.ConversationLinkResult
 import network.columba.app.rns.api.model.DeliveryMethod
 import network.columba.app.rns.api.model.DeliveryStatusUpdate
+import network.columba.app.rns.api.model.DestinationType
+import network.columba.app.rns.api.model.Direction
 import network.columba.app.rns.api.model.DiscoveredInterface
 import network.columba.app.rns.api.model.FailedInterface
 import network.columba.app.rns.api.model.IconAppearance
+import network.columba.app.rns.api.model.LinkEvent
+import network.columba.app.rns.api.model.LinkSpeedProbeResult
+import network.columba.app.rns.api.model.LinkStatus
 import network.columba.app.rns.api.model.LocationTelemetry
 import network.columba.app.rns.api.model.MessageReceipt
+import network.columba.app.rns.api.model.NetworkStatus
+import network.columba.app.rns.api.model.NodeType
+import network.columba.app.rns.api.model.PacketReceipt
+import network.columba.app.rns.api.model.PacketType
 import network.columba.app.rns.api.model.PropagationState
 import network.columba.app.rns.api.model.ReceivedMessage
+import network.columba.app.rns.api.model.ReceivedPacket
+import network.columba.app.rns.api.model.ReticulumConfig
 import network.columba.app.rns.api.model.VoiceCallState
 import network.columba.app.rns.api.util.AppDataParser
 import network.columba.app.rns.api.util.Aspects
@@ -19,37 +49,7 @@ import network.columba.app.rns.api.util.ReactionWireCodec
 import network.columba.app.rns.api.util.hexToBytes
 import network.columba.app.rns.api.util.isUserVisibleChatMessage
 import network.columba.app.rns.api.util.toHex
-
-import android.util.Log
-import androidx.room.Room
-import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.SupervisorJob
-import kotlinx.coroutines.cancel
-import kotlinx.coroutines.delay
-import kotlinx.coroutines.isActive
-import kotlinx.coroutines.flow.Flow
-import kotlinx.coroutines.flow.MutableSharedFlow
-import kotlinx.coroutines.flow.MutableStateFlow
-import kotlinx.coroutines.flow.SharedFlow
-import kotlinx.coroutines.flow.StateFlow
-import kotlinx.coroutines.flow.asSharedFlow
-import kotlinx.coroutines.flow.asStateFlow
-import kotlinx.coroutines.launch
-import kotlinx.coroutines.withContext
-import network.columba.app.rns.api.model.AnnounceEvent
-import network.columba.app.rns.api.model.BatteryProfile
-import network.columba.app.rns.api.model.DestinationType
-import network.columba.app.rns.api.model.Direction
-import network.columba.app.rns.api.model.LinkEvent
-import network.columba.app.rns.api.model.LinkSpeedProbeResult
-import network.columba.app.rns.api.model.LinkStatus
-import network.columba.app.rns.api.model.NetworkStatus
-import network.columba.app.rns.api.model.NodeType
-import network.columba.app.rns.api.model.PacketReceipt
-import network.columba.app.rns.api.model.PacketType
-import network.columba.app.rns.api.model.ReceivedPacket
-import network.columba.app.rns.api.model.ReticulumConfig
+import network.columba.app.rns.backend.kt.BuildConfig
 import network.reticulum.Reticulum
 import network.reticulum.common.DestinationDirection
 import network.reticulum.lxmf.LXMRouter
@@ -57,7 +57,6 @@ import network.reticulum.lxmf.LXMessage
 import network.reticulum.transport.Transport
 import org.json.JSONObject
 import org.msgpack.core.MessagePack
-import network.columba.app.rns.backend.kt.BuildConfig
 import network.columba.app.rns.api.model.Destination as ColumbaDestination
 import network.columba.app.rns.api.model.Identity as ColumbaIdentity
 import network.columba.app.rns.api.model.Link as ColumbaLink
@@ -108,6 +107,7 @@ class NativeRnsBackendImpl(
     network.columba.app.rns.api.RnsTransportAdmin {
     companion object {
         private const val TAG = "NativeReticulumProtocol"
+
         // Upstream LXMF FIELD_CUSTOM_META — see NativeTelemetryHandler /
         // LocationTelemetry.COLUMBA_META_FIELD_ID. 0xFD is the documented
         // app-extension point; 0x70 was a non-canonical invention.
@@ -310,7 +310,9 @@ class NativeRnsBackendImpl(
     override val callState: StateFlow<CallState> = _callState.asStateFlow()
 
     private val callCoordinator: tech.torlando.lxst.core.CallCoordinator
-        get() = tech.torlando.lxst.core.CallCoordinator.getInstance()
+        get() =
+            tech.torlando.lxst.core.CallCoordinator
+                .getInstance()
 
     override val remoteIdentity: StateFlow<String?>
         get() = callCoordinator.remoteIdentity
@@ -570,19 +572,7 @@ class NativeRnsBackendImpl(
                 dozeThrottleMultiplier = 1.0f
                 Log.i(TAG, "Initializing native Reticulum stack")
 
-                // Heads-up if another RNS instance is on the device.
-                // reticulum-kt does not currently speak shared-instance RPC
-                // (the python flavor does); the warning makes a future
-                // multicast collision diagnosable instead of mysterious.
-                if (network.columba.app.rns.api.util.SharedInstanceProbe.shouldShareInstance(config)) {
-                    Log.w(
-                        TAG,
-                        "Another RNS instance detected on 127.0.0.1:" +
-                            "${network.columba.app.rns.api.util.SharedInstanceProbe.DEFAULT_PORT}; " +
-                            "reticulum-kt doesn't currently speak shared-instance RPC, so native " +
-                            "interfaces may collide. Consider preferOwnInstance=true or stopping the other RNS app.",
-                    )
-                }
+                warnIfOtherRnsInstance(config)
 
                 initializePersistentStores(config.storagePath)
 
@@ -741,6 +731,25 @@ class NativeRnsBackendImpl(
             }
         }
 
+    /**
+     * Heads-up if another RNS instance is on the device. reticulum-kt does not
+     * currently speak shared-instance RPC (the python flavor does); the warning
+     * makes a future multicast collision diagnosable instead of mysterious.
+     */
+    private fun warnIfOtherRnsInstance(config: ReticulumConfig) {
+        if (network.columba.app.rns.api.util.SharedInstanceProbe
+                .shouldShareInstance(config)
+        ) {
+            Log.w(
+                TAG,
+                "Another RNS instance detected on 127.0.0.1:" +
+                    "${network.columba.app.rns.api.util.SharedInstanceProbe.DEFAULT_PORT}; " +
+                    "reticulum-kt doesn't currently speak shared-instance RPC, so native " +
+                    "interfaces may collide. Consider preferOwnInstance=true or stopping the other RNS app.",
+            )
+        }
+    }
+
     // ==================== Phase 1: Announce Handling ====================
 
     private fun registerAnnounceHandlers() {
@@ -757,6 +766,10 @@ class NativeRnsBackendImpl(
                     hops: Int,
                     receivingInterfaceName: String?,
                     matchedAspect: String?,
+                    // Added to RichAnnounceHandler in reticulum-kt v0.0.22 (conformance
+                    // work). Columba's announce handling doesn't need the announce-packet
+                    // hash, but the override must match the interface signature.
+                    announcePacketHash: ByteArray?,
                 ): Boolean {
                     if (matchedAspect == null) return false // unknown aspect — not an app we handle
                     handleAnnounce(matchedAspect, destinationHash, announcedIdentity, appData, hops, receivingInterfaceName)
@@ -1347,19 +1360,20 @@ class NativeRnsBackendImpl(
      */
     private fun startPropagationPoll() {
         propagationPollJob?.cancel()
-        propagationPollJob = scope.launch(Dispatchers.IO) {
-            val r = router ?: return@launch
-            try {
-                while (isActive) {
-                    val snap = readPropagationState(r)
-                    _propagationStateFlow.tryEmit(snap)
-                    if (snap.state >= PropagationState.STATE_COMPLETE) break
-                    kotlinx.coroutines.delay(PROPAGATION_POLL_INTERVAL_MS)
+        propagationPollJob =
+            scope.launch(Dispatchers.IO) {
+                val r = router ?: return@launch
+                try {
+                    while (isActive) {
+                        val snap = readPropagationState(r)
+                        _propagationStateFlow.tryEmit(snap)
+                        if (snap.state >= PropagationState.STATE_COMPLETE) break
+                        kotlinx.coroutines.delay(PROPAGATION_POLL_INTERVAL_MS)
+                    }
+                } finally {
+                    propagationPollJob = null
                 }
-            } finally {
-                propagationPollJob = null
             }
-        }
     }
 
     // ==================== Phase 2: Reactions & Telemetry Stubs ====================
@@ -1406,7 +1420,8 @@ class NativeRnsBackendImpl(
         // peers consume is byte-identical across both Columba backends.
         val fields = mutableMapOf<Int, Any>()
         fields[LxmfFields.FIELD_TELEMETRY] =
-            network.columba.app.rns.api.util.TelemeterCodec.packLocationTelemetry(telemetry)
+            network.columba.app.rns.api.util.TelemeterCodec
+                .packLocationTelemetry(telemetry)
         network.columba.app.rns.api.util.TelemeterCodec.packColumbaMeta(telemetry)?.let {
             fields[FIELD_COLUMBA_META] = it
         }
@@ -1432,7 +1447,8 @@ class NativeRnsBackendImpl(
         // first-request null to 0 so we never ship int(None) into the list.
         // See TelemeterCodec.telemetryRequestTimebaseSeconds. (#927)
         val timebaseSeconds =
-            network.columba.app.rns.api.util.TelemeterCodec.telemetryRequestTimebaseSeconds(timebase)
+            network.columba.app.rns.api.util.TelemeterCodec
+                .telemetryRequestTimebaseSeconds(timebase)
         val commands =
             listOf(
                 mapOf(
@@ -2022,12 +2038,13 @@ class NativeRnsBackendImpl(
 
     private fun setupNativeTelephone(identity: NativeIdentity) {
         val ctx = appContext ?: return
-        val manager = NativeCallManager(
-            context = ctx,
-            deliveryIdentity = identity,
-            transport = callTransport,
-            callPrivacyBridge = callPrivacyBridge,
-        )
+        val manager =
+            NativeCallManager(
+                context = ctx,
+                deliveryIdentity = identity,
+                transport = callTransport,
+                callPrivacyBridge = callPrivacyBridge,
+            )
         manager.setup()
         callManager = manager
         // Wire the AIDL master-toggle hook now that the manager exists.
@@ -2253,11 +2270,9 @@ class NativeRnsBackendImpl(
     // future helpers — for now we acknowledge the call by reporting
     // `entries.size` so call sites that block on a real count don't spin.
 
-    override suspend fun restorePeerIdentities(peerIdentities: List<Pair<String, ByteArray>>): Result<Int> =
-        Result.success(peerIdentities.size)
+    override suspend fun restorePeerIdentities(peerIdentities: List<Pair<String, ByteArray>>): Result<Int> = Result.success(peerIdentities.size)
 
-    override suspend fun restoreAnnounceIdentities(announces: List<Pair<String, ByteArray>>): Result<Int> =
-        Result.success(announces.size)
+    override suspend fun restoreAnnounceIdentities(announces: List<Pair<String, ByteArray>>): Result<Int> = Result.success(announces.size)
 
     // ==================== RnsTransportAdmin: RNode + BLE diagnostics ====================
 


### PR DESCRIPTION
Lands the **columba#1004** fix in the app by bumping to the released library tags.

The Kotlin backend now requests a path before establishing a link to a destination that has been silent since the app opened — so DIRECT delivery links establish and the **second checkmark** arrives, instead of failing over to PROPAGATED (single ✓).

## Changes
- `reticulumKt`: `v0.0.21` → **`v0.0.22`** (the reticulum-kt half of #1004: unconditional `requestPath`, honest `hasPath`, `Link.activatedAt` — plus the conformance-bridge Phase 1–5 work that merged upstream).
- `lxmfKt`: `v0.0.13` → **`v0.0.14`** (the LXMF-kt half: DIRECT delivery path requests).
- **Adapt `NativeRnsBackendImpl`'s `RichAnnounceHandler` override**: reticulum-kt `v0.0.22` added a trailing `announcePacketHash: ByteArray?` parameter to `handleAnnounceWithContext`. Columba doesn't use it, but the override must match the new signature. (Not part of #1004 itself — an unavoidable adaptation to the API that rode in with the conformance work.)

## Verification
- Kotlin-backend variant **compiles** against the real `v0.0.22` / `v0.0.14` tags; `rns-backend-kt` unit tests green.
- **LXST-kt `v0.0.4` confirmed compatible** with reticulum-kt `v0.0.22` — no realignment needed.
- **End-to-end on two Android emulators + a local `rnsd` transport hub**: a fresh app with no path to a silent destination emits a path request → the hub answers with a `PATH_RESPONSE` → a DIRECT link establishes → the message delivers with a proof (✓✓). Reproduced for both DIRECT and OPPORTUNISTIC; `state=DELIVERED` confirmed via the debug TestReceiver.

Closes out the user-reported behaviour in #1004 (links to never-announced destinations + the missing second checkmark). Leaving the issue open for you to verify/close.

---
Authored with assistance from `claude-opus-4-8` (Claude Code), on behalf of the repo owner (torlando-tech).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
