### PR TITLE
refactor(delivery): sealed DeliveryState + shared DeliveryRetryPolicy replace the stringly delivery contract

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -1,0 +1,70 @@
+# Columba Domain Glossary
+
+Names for the concepts this codebase is built around. When code, docs, or
+architecture discussions need one of these concepts, use the term defined
+here — don't invent a synonym.
+
+## Message delivery
+
+### DeliveryState
+
+The lifecycle of an outbound LXMF message, from optimistic creation through
+terminal success or failure. A closed vocabulary, modeled as the sealed
+interface `network.columba.app.rns.api.model.DeliveryState`:
+
+| State | Meaning | Rendered |
+|---|---|---|
+| `Pending` | Handed to the router, awaiting an outcome | ○ |
+| `Sent` | Transmitted, no proof yet (legacy initial state, Room column default) | ✓ |
+| `Delivered` | Delivery proof received from the recipient | ✓✓ |
+| `Propagated` | Stored on the configured propagation node; recipient will fetch it | ✓ |
+| `RetryingViaPropagation` | Direct delivery failed; rebuilt as PROPAGATED and re-routed via relay | ✓ |
+| `Failed` | Delivery failed with no retry remaining | ! |
+
+Rules that travel with the concept:
+
+- **Terminal success never degrades** (Issue #257): `Sent`, `Propagated`,
+  and `Delivered` never transition to `Failed`; `Delivered` never
+  transitions to anything. LXMF can fire spurious failure callbacks after
+  a success confirmation — consumers must guard, and the guard lives with
+  the type (`isTerminalSuccess`).
+- **The string form is a persistence contract.** Room stores
+  `encode()`-produced strings (`"pending"`, `"sent"`, …) in
+  `MessageEntity.status`; the maestro logcat harness greps their uppercased
+  forms. Old databases are an open string set, so `decode()` is nullable —
+  null means "unrecognized legacy value", rendered as the neutral
+  presentation.
+
+### DeliveryMethod
+
+How a send is routed — a different axis than DeliveryState, modeled as
+`network.columba.app.rns.api.model.DeliveryMethod`:
+
+- `OPPORTUNISTIC` — single packet, no link required; small messages.
+- `DIRECT` — link-based delivery with retries; supports large messages.
+- `PROPAGATED` — delivered via a relay (propagation node) for offline
+  recipients.
+
+**Trap:** the word "propagated" appears in both vocabularies. As a *method*
+it means "route via relay"; as a *state* it means "the relay accepted it".
+Success for a PROPAGATED-method send is the `Propagated` state (✓), not
+`Delivered` (✓✓) — the relay holding a message is a weaker promise than a
+recipient acknowledging it.
+
+### Propagation node
+
+A relay in the Reticulum mesh that stores LXMF messages for recipients who
+are offline, until they fetch them. The configured outbound propagation node
+is a precondition for the `RetryingViaPropagation` fallback (the Sideband
+retry pattern: try direct, on failure rebuild as PROPAGATED and re-route).
+
+## Backends
+
+### RnsBackend seam
+
+The interface (`:rns-api`) between the app and the Reticulum protocol stack.
+Two adapters implement it: the Python flavor (`:rns-backend-py`, upstream
+RNS/LXMF via Chaquopy) and the native flavor (`:rns-backend-kt`,
+reticulum-kt). Both emit `DeliveryStatusUpdate(messageHash, state, timestamp)`
+carrying a `DeliveryState` — the states above are the seam's contract, not
+per-backend inventions.

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -58,6 +58,17 @@ are offline, until they fetch them. The configured outbound propagation node
 is a precondition for the `RetryingViaPropagation` fallback (the Sideband
 retry pattern: try direct, on failure rebuild as PROPAGATED and re-route).
 
+### DeliveryRetryPolicy
+
+The shared *decision* half of the Sideband retry pattern
+(`network.columba.app.rns.api.util.DeliveryRetryPolicy`): retry via
+propagation iff the sender opted in, the message's desired method isn't
+already PROPAGATED (that flip is what terminates the loop after one retry),
+and a propagation node is configured. Both backend adapters consult this one
+predicate; only the *mechanism* (rebuilding the live LXMessage and
+re-submitting it) stays flavor-local, because it manipulates flavor-owned
+router/message objects.
+
 ## Backends
 
 ### RnsBackend seam

--- a/app/src/debug/java/network/columba/app/test/TestController.kt
+++ b/app/src/debug/java/network/columba/app/test/TestController.kt
@@ -116,10 +116,11 @@ object TestController {
         }
         deliveryJob = scope.launch {
             rnsLxmf!!.observeDeliveryStatus().collect { upd ->
-                // DeliveryStatusUpdate.messageHash is already a hex string;
-                // status is one of "delivered" | "failed" | "retrying_propagated"
+                // DeliveryStatusUpdate.messageHash is already a hex string.
+                // encode() keeps the exact legacy strings the maestro harness
+                // greps for (e.g. DELIVERED, RETRYING_PROPAGATED).
                 val idHex = upd.messageHash
-                val stateName = upd.status.uppercase()
+                val stateName = upd.state.encode().uppercase()
                 synchronized(deliveryLock) { deliveryStates[idHex] = stateName }
                 Log.i(LOGCAT_TAG, "msg_state id=$idHex state=$stateName")
             }

--- a/app/src/main/java/network/columba/app/service/MessageCollector.kt
+++ b/app/src/main/java/network/columba/app/service/MessageCollector.kt
@@ -18,6 +18,7 @@ import network.columba.app.data.repository.IdentityRepository
 import network.columba.app.notifications.NotificationHelper
 import network.columba.app.rns.api.RnsCore
 import network.columba.app.rns.api.RnsLxmf
+import network.columba.app.rns.api.model.DeliveryState
 import network.columba.app.rns.host.util.PeerNameResolver
 import java.util.concurrent.ConcurrentHashMap
 import javax.inject.Inject
@@ -213,7 +214,7 @@ class MessageCollector
                                 // Use sender's timestamp for display; receivedAt for sort ordering
                                 timestamp = receivedMessage.timestamp,
                                 isFromMe = false,
-                                status = "delivered",
+                                status = DeliveryState.Delivered.encode(),
                                 // LXMF attachments
                                 fieldsJson = receivedMessage.fieldsJson,
                                 // Routing info (hop count and receiving interface)

--- a/app/src/main/java/network/columba/app/ui/model/MessageMapper.kt
+++ b/app/src/main/java/network/columba/app/ui/model/MessageMapper.kt
@@ -7,6 +7,7 @@ import android.util.Log
 import androidx.compose.ui.graphics.ImageBitmap
 import androidx.compose.ui.graphics.asImageBitmap
 import network.columba.app.data.repository.Message
+import network.columba.app.rns.api.model.DeliveryState
 import network.columba.app.util.FileUtils
 import network.columba.app.util.ImageUtils
 import org.json.JSONArray
@@ -62,7 +63,7 @@ fun Message.toMessageUi(): MessageUi {
         content = content,
         timestamp = timestamp,
         isFromMe = isFromMe,
-        status = status,
+        status = DeliveryState.decode(status),
         decodedImage = cachedImage,
         hasImageAttachment = hasImage,
         fileAttachments = fileAttachmentsList,

--- a/app/src/main/java/network/columba/app/ui/model/MessageUi.kt
+++ b/app/src/main/java/network/columba/app/ui/model/MessageUi.kt
@@ -2,6 +2,7 @@ package network.columba.app.ui.model
 
 import androidx.compose.runtime.Immutable
 import androidx.compose.ui.graphics.ImageBitmap
+import network.columba.app.rns.api.model.DeliveryState
 
 /**
  * UI model for messages with pre-decoded images and file attachments.
@@ -21,7 +22,12 @@ data class MessageUi(
     val content: String,
     val timestamp: Long,
     val isFromMe: Boolean,
-    val status: String,
+    /**
+     * Delivery lifecycle state. Null when the persisted status string is
+     * unrecognized (old databases are an open string set) — renderers show
+     * the neutral/unknown presentation for null.
+     */
+    val status: DeliveryState?,
     /**
      * Pre-decoded image bitmap. If the message contains an LXMF image field (type 6),
      * it's decoded asynchronously and cached in ImageCache.
@@ -61,7 +67,7 @@ data class MessageUi(
      */
     val deliveryMethod: String? = null,
     /**
-     * Error message if delivery failed (when status == "failed").
+     * Error message if delivery failed (when status == DeliveryState.Failed).
      * Null for successful deliveries or messages without errors.
      */
     val errorMessage: String? = null,

--- a/app/src/main/java/network/columba/app/ui/screens/MessageDetailScreen.kt
+++ b/app/src/main/java/network/columba/app/ui/screens/MessageDetailScreen.kt
@@ -44,6 +44,7 @@ import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
+import network.columba.app.rns.api.model.DeliveryState
 import network.columba.app.ui.util.getInterfaceInfo
 import network.columba.app.ui.util.getRssiInfo
 import network.columba.app.ui.util.getSnrInfo
@@ -182,7 +183,7 @@ fun MessageDetailScreen(
                     }
 
                     // Error card (only if failed and has error message)
-                    if (msg.status == "failed" && !msg.errorMessage.isNullOrBlank()) {
+                    if (msg.status == DeliveryState.Failed && !msg.errorMessage.isNullOrBlank()) {
                         MessageInfoCard(
                             icon = Icons.Default.Error,
                             iconTint = MaterialTheme.colorScheme.error,
@@ -340,9 +341,9 @@ private data class StatusInfo(
 )
 
 @Composable
-private fun getStatusInfo(status: String): StatusInfo =
+private fun getStatusInfo(status: DeliveryState?): StatusInfo =
     when (status) {
-        "delivered" ->
+        DeliveryState.Delivered ->
             StatusInfo(
                 icon = Icons.Default.CheckCircle,
                 // Green
@@ -350,21 +351,24 @@ private fun getStatusInfo(status: String): StatusInfo =
                 text = "Delivered",
                 subtitle = "Message was successfully delivered to recipient",
             )
-        "failed" ->
+        DeliveryState.Failed ->
             StatusInfo(
                 icon = Icons.Default.Error,
                 color = MaterialTheme.colorScheme.error,
                 text = "Failed",
                 subtitle = "Message delivery failed",
             )
-        "pending" ->
+        DeliveryState.Pending ->
             StatusInfo(
                 icon = Icons.Default.HourglassEmpty,
                 color = MaterialTheme.colorScheme.tertiary,
                 text = "Pending",
                 subtitle = "Waiting for delivery confirmation",
             )
-        else ->
+        // Sent / Propagated / RetryingViaPropagation / unknown-legacy all
+        // rendered as the generic "Sent" card, matching the historical
+        // else-branch behavior.
+        DeliveryState.Sent, DeliveryState.Propagated, DeliveryState.RetryingViaPropagation, null ->
             StatusInfo(
                 icon = Icons.AutoMirrored.Filled.Send,
                 color = MaterialTheme.colorScheme.primary,

--- a/app/src/main/java/network/columba/app/ui/screens/MessagingScreen.kt
+++ b/app/src/main/java/network/columba/app/ui/screens/MessagingScreen.kt
@@ -166,6 +166,7 @@ import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 import network.columba.app.R
+import network.columba.app.rns.api.model.DeliveryState
 import network.columba.app.service.SyncProgress
 import network.columba.app.service.SyncResult
 import network.columba.app.ui.components.AttachmentPanel
@@ -1889,7 +1890,7 @@ fun MessageBubble(
                                 hapticFeedback.performHapticFeedback(HapticFeedbackType.LongPress)
                                 scope.launch {
                                     val bitmap = graphicsLayer.toImageBitmap()
-                                    onLongPress(message.id, isFromMe, message.status == "failed", bitmap, bubbleX, bubbleY, bubbleWidth, bubbleHeight)
+                                    onLongPress(message.id, isFromMe, message.status == DeliveryState.Failed, bitmap, bubbleX, bubbleY, bubbleWidth, bubbleHeight)
                                 }
                             },
                             indication = null,
@@ -2001,7 +2002,7 @@ fun MessageBubble(
                                     hapticFeedback.performHapticFeedback(HapticFeedbackType.LongPress)
                                     scope.launch {
                                         val bitmap = graphicsLayer.toImageBitmap()
-                                        onLongPress(message.id, isFromMe, message.status == "failed", bitmap, bubbleX, bubbleY, bubbleWidth, bubbleHeight)
+                                        onLongPress(message.id, isFromMe, message.status == DeliveryState.Failed, bitmap, bubbleX, bubbleY, bubbleWidth, bubbleHeight)
                                     }
                                 },
                                 // Disable ripple - we use scale animation instead
@@ -2940,23 +2941,23 @@ private fun formatFileSize(bytes: Long): String =
     }
 
 /**
- * Get the status icon character for a message status.
+ * Get the status icon character for a message delivery state.
  *
- * @param status The message status string
- * @return Unicode character representing the status:
- *   - "○" (hollow circle) for pending - message created, waiting to send
- *   - "✓" (single check) for sent/retrying_propagated/propagated - transmitted or stored on relay
- *   - "✓✓" (double check) for delivered - delivered and acknowledged by recipient
- *   - "!" (exclamation) for failed - delivery failed
+ * @param status The delivery state (null = unrecognized legacy DB value)
+ * @return Unicode character representing the state:
+ *   - "○" (hollow circle) for Pending - message created, waiting to send
+ *   - "✓" (single check) for Sent/RetryingViaPropagation/Propagated - transmitted or stored on relay
+ *   - "✓✓" (double check) for Delivered - delivered and acknowledged by recipient
+ *   - "!" (exclamation) for Failed - delivery failed
  *   - "" (empty) for unknown status
  */
-internal fun getMessageStatusIcon(status: String): String =
+internal fun getMessageStatusIcon(status: DeliveryState?): String =
     when (status) {
-        "pending" -> "○"
-        "sent", "retrying_propagated", "propagated" -> "✓"
-        "delivered" -> "✓✓"
-        "failed" -> "!"
-        else -> ""
+        DeliveryState.Pending -> "○"
+        DeliveryState.Sent, DeliveryState.RetryingViaPropagation, DeliveryState.Propagated -> "✓"
+        DeliveryState.Delivered -> "✓✓"
+        DeliveryState.Failed -> "!"
+        null -> ""
     }
 
 @Composable

--- a/app/src/main/java/network/columba/app/viewmodel/MessagingViewModel.kt
+++ b/app/src/main/java/network/columba/app/viewmodel/MessagingViewModel.kt
@@ -16,6 +16,7 @@ import network.columba.app.data.repository.ReceivedLocationRepository
 import network.columba.app.repository.SettingsRepository
 import network.columba.app.rns.api.model.Identity
 import network.columba.app.rns.api.model.DeliveryMethod
+import network.columba.app.rns.api.model.DeliveryState
 import network.columba.app.rns.api.RnsCore
 import network.columba.app.rns.api.RnsLxmf
 import network.columba.app.rns.api.RnsTransportAdmin
@@ -780,7 +781,7 @@ class MessagingViewModel
                 try {
                     rnsLxmf.observeDeliveryStatus().collect { update ->
                         try {
-                            Log.d(TAG, "Delivery status update: ${update.messageHash.take(16)}... -> ${update.status}")
+                            Log.d(TAG, "Delivery status update: ${update.messageHash.take(16)}... -> ${update.state.encode()}")
                             handleDeliveryStatusUpdate(update)
                         } catch (e: Exception) {
                             Log.e(TAG, "Error handling delivery status update", e)
@@ -870,21 +871,23 @@ class MessagingViewModel
                 }
 
                 if (message != null) {
-                    // Guard: 'delivered' is terminal — never regress to any other state.
+                    val currentState = DeliveryState.decode(message.status)
+
+                    // Guard: Delivered is terminal — never regress to any other state.
                     // LXMF may fire spurious failure/sent callbacks after delivery confirmation,
-                    // which can trigger propagation retries that overwrite 'delivered' with 'propagated'.
-                    if (message.status == "delivered" && update.status != "delivered") {
+                    // which can trigger propagation retries that overwrite Delivered with Propagated.
+                    if (currentState == DeliveryState.Delivered && update.state != DeliveryState.Delivered) {
                         Log.w(
                             TAG,
-                            "Blocking status regression from 'delivered' to '${update.status}' " +
+                            "Blocking status regression from 'delivered' to '${update.state.encode()}' " +
                                 "for message ${update.messageHash.take(16)}...",
                         )
                         return
                     }
 
-                    // Guard: Don't degrade from terminal success states to failed (Issue #257 fix)
+                    // Guard: Don't degrade from terminal success states to Failed (Issue #257 fix)
                     // This provides defense-in-depth in case Python layer misses the spurious callback
-                    if (update.status == "failed" && isTerminalSuccessStatus(message.status)) {
+                    if (update.state == DeliveryState.Failed && currentState?.isTerminalSuccess == true) {
                         Log.w(
                             TAG,
                             "Blocking status degradation from '${message.status}' to 'failed' " +
@@ -894,10 +897,10 @@ class MessagingViewModel
                     }
 
                     // Update status
-                    conversationRepository.updateMessageStatus(update.messageHash, update.status)
+                    conversationRepository.updateMessageStatus(update.messageHash, update.state.encode())
 
                     // When retrying via propagation, also update the delivery method
-                    if (update.status == "retrying_propagated") {
+                    if (update.state == DeliveryState.RetryingViaPropagation) {
                         conversationRepository.updateMessageDeliveryDetails(
                             update.messageHash,
                             deliveryMethod = "propagated",
@@ -907,21 +910,21 @@ class MessagingViewModel
 
                     // Record peer activity when delivery proof is received
                     // This proves the peer was recently online and received our message
-                    if (update.status == "delivered") {
+                    if (update.state == DeliveryState.Delivered) {
                         conversationLinkManager.recordPeerActivity(message.conversationHash, update.timestamp)
                     }
 
                     // Enrich sentInterface on a terminal-success state — the
                     // routing table still reflects the actual send path. For
-                    // DIRECT/OPPORTUNISTIC this fires on "delivered"; for
-                    // PROPAGATED on "propagated" (the propagation-node-accepted
+                    // DIRECT/OPPORTUNISTIC this fires on Delivered; for
+                    // PROPAGATED on Propagated (the propagation-node-accepted
                     // analogue). Failed / retrying paths carry too much routing
                     // ambiguity to produce accurate interface data.
-                    if (update.status == "delivered" || update.status == "propagated") {
+                    if (update.state == DeliveryState.Delivered || update.state == DeliveryState.Propagated) {
                         enrichSentInterfaceOnDelivery(message, update.messageHash)
                     }
 
-                    Log.d(TAG, "Updated message ${update.messageHash.take(16)}... status to ${update.status}")
+                    Log.d(TAG, "Updated message ${update.messageHash.take(16)}... status to ${update.state.encode()}")
                 } else {
                     Log.w(TAG, "Delivery status update for unknown message after $maxRetries retries: ${update.messageHash.take(16)}...")
                 }
@@ -1012,15 +1015,6 @@ class MessagingViewModel
                 Log.e(TAG, "Error handling incoming reaction: ${e.message}", e)
             }
         }
-
-        /**
-         * Check if a message status represents a terminal success state.
-         * Terminal success states should never degrade to "failed" (Issue #257 fix).
-         *
-         * @param status The current message status
-         * @return true if this is a terminal success status that shouldn't be degraded
-         */
-        private fun isTerminalSuccessStatus(status: String): Boolean = status in setOf("sent", "propagated", "delivered")
 
         private suspend fun saveMessageToDatabase(
             peerHash: String,
@@ -1368,7 +1362,7 @@ class MessagingViewModel
                     content = sanitized,
                     timestamp = receipt.timestamp,
                     isFromMe = true,
-                    status = "pending",
+                    status = DeliveryState.Pending.encode(),
                     fieldsJson = fieldsJson,
                     deliveryMethod = deliveryMethodString,
                     replyToMessageId = replyToMessageId,
@@ -1395,7 +1389,7 @@ class MessagingViewModel
                     content = sanitized,
                     timestamp = now,
                     isFromMe = true,
-                    status = "failed",
+                    status = DeliveryState.Failed.encode(),
                     deliveryMethod = deliveryMethodString,
                     errorMessage = friendlyOutboundError(error.message),
                     receivedAt = now,
@@ -2278,7 +2272,7 @@ class MessagingViewModel
                     }
 
                     // Only retry failed messages
-                    if (failedMessage.status != "failed") {
+                    if (DeliveryState.decode(failedMessage.status) != DeliveryState.Failed) {
                         Log.w(TAG, "Message $messageId is not failed (status: ${failedMessage.status}), skipping retry")
                         return@launch
                     }
@@ -2314,7 +2308,7 @@ class MessagingViewModel
                     Log.d(TAG, "Retrying message via $deliveryMethod delivery")
 
                     // Mark message as pending before sending
-                    conversationRepository.updateMessageStatus(messageId, "pending")
+                    conversationRepository.updateMessageStatus(messageId, DeliveryState.Pending.encode())
 
                     // Send the message
                     val result =
@@ -2341,7 +2335,7 @@ class MessagingViewModel
                         }.onFailure { error ->
                             Log.e(TAG, "Retry failed: ${error.message}", error)
                             // Mark as failed again with the error message
-                            conversationRepository.updateMessageStatus(messageId, "failed")
+                            conversationRepository.updateMessageStatus(messageId, DeliveryState.Failed.encode())
                             conversationRepository.updateMessageDeliveryDetails(
                                 messageId,
                                 deliveryMethod = null,
@@ -2352,7 +2346,7 @@ class MessagingViewModel
                     Log.e(TAG, "Error retrying message", e)
                     // Restore failed status
                     try {
-                        conversationRepository.updateMessageStatus(messageId, "failed")
+                        conversationRepository.updateMessageStatus(messageId, DeliveryState.Failed.encode())
                     } catch (e2: Exception) {
                         Log.e(TAG, "Error restoring failed status", e2)
                     }

--- a/app/src/test/java/network/columba/app/test/MessageDetailTestFixtures.kt
+++ b/app/src/test/java/network/columba/app/test/MessageDetailTestFixtures.kt
@@ -1,5 +1,6 @@
 package network.columba.app.test
 
+import network.columba.app.rns.api.model.DeliveryState
 import network.columba.app.ui.model.MessageUi
 
 /**
@@ -36,7 +37,7 @@ object MessageDetailTestFixtures {
             content = config.content,
             timestamp = config.timestamp,
             isFromMe = config.isFromMe,
-            status = config.status,
+            status = DeliveryState.decode(config.status),
             decodedImage = null,
             deliveryMethod = config.deliveryMethod,
             errorMessage = config.errorMessage,

--- a/app/src/test/java/network/columba/app/test/MessagingTestFixtures.kt
+++ b/app/src/test/java/network/columba/app/test/MessagingTestFixtures.kt
@@ -1,6 +1,7 @@
 package network.columba.app.test
 
 import network.columba.app.data.repository.Announce
+import network.columba.app.rns.api.model.DeliveryState
 import network.columba.app.ui.model.MessageUi
 import network.columba.app.ui.model.ReplyPreviewUi
 
@@ -31,7 +32,7 @@ object MessagingTestFixtures {
         content = content,
         timestamp = timestamp,
         isFromMe = true,
-        status = status,
+        status = DeliveryState.decode(status),
         decodedImage = null,
         deliveryMethod = deliveryMethod,
         errorMessage = errorMessage,
@@ -48,7 +49,7 @@ object MessagingTestFixtures {
         content = content,
         timestamp = timestamp,
         isFromMe = false,
-        status = "delivered",
+        status = DeliveryState.Delivered,
         decodedImage = null,
         deliveryMethod = null,
         errorMessage = null,
@@ -69,7 +70,7 @@ object MessagingTestFixtures {
     ) = createSentMessage(
         id = id,
         content = content,
-        status = "delivered",
+        status = DeliveryState.Delivered,
     )
 
     fun createFailedMessage(
@@ -166,7 +167,7 @@ object MessagingTestFixtures {
         content = content,
         timestamp = System.currentTimeMillis(),
         isFromMe = false,
-        status = "delivered",
+        status = DeliveryState.Delivered,
         decodedImage = null,
         hasImageAttachment = true,
         fieldsJson = """{"6": "ffd8ffe0"}""", // Needs async loading
@@ -188,7 +189,7 @@ object MessagingTestFixtures {
         content = content,
         timestamp = System.currentTimeMillis(),
         isFromMe = false,
-        status = "delivered",
+        status = DeliveryState.Delivered,
         decodedImage = decodedImage,
         hasImageAttachment = true,
         fieldsJson = null, // Image already cached, no need for JSON
@@ -292,7 +293,7 @@ object MessagingTestFixtures {
         content = content,
         timestamp = timestamp,
         isFromMe = isFromMe,
-        status = if (isFromMe) "sent" else "delivered",
+        status = if (isFromMe) DeliveryState.Sent else DeliveryState.Delivered,
         decodedImage = null,
         deliveryMethod = if (isFromMe) "direct" else null,
         errorMessage = null,
@@ -317,7 +318,7 @@ object MessagingTestFixtures {
         content = content,
         timestamp = timestamp,
         isFromMe = isFromMe,
-        status = if (isFromMe) "sent" else "delivered",
+        status = if (isFromMe) DeliveryState.Sent else DeliveryState.Delivered,
         decodedImage = null,
         deliveryMethod = if (isFromMe) "direct" else null,
         errorMessage = null,
@@ -368,7 +369,7 @@ object MessagingTestFixtures {
         content = content,
         timestamp = timestamp,
         isFromMe = isFromMe,
-        status = status ?: if (isFromMe) "sent" else "delivered",
+        status = status?.let { DeliveryState.decode(it) } ?: if (isFromMe) DeliveryState.Sent else DeliveryState.Delivered,
         decodedImage = null,
         hasImageAttachment = true,
         imageData = imageData,
@@ -394,7 +395,7 @@ object MessagingTestFixtures {
         content = content,
         timestamp = timestamp,
         isFromMe = isFromMe,
-        status = if (isFromMe) "sent" else "delivered",
+        status = if (isFromMe) DeliveryState.Sent else DeliveryState.Delivered,
         decodedImage = null,
         hasImageAttachment = true,
         imageData = imageData,
@@ -421,7 +422,7 @@ object MessagingTestFixtures {
         content = content,
         timestamp = timestamp,
         isFromMe = isFromMe,
-        status = if (isFromMe) "sent" else "delivered",
+        status = if (isFromMe) DeliveryState.Sent else DeliveryState.Delivered,
         decodedImage = null,
         hasImageAttachment = true,
         imageData = imageData,

--- a/app/src/test/java/network/columba/app/test/MessagingTestFixtures.kt
+++ b/app/src/test/java/network/columba/app/test/MessagingTestFixtures.kt
@@ -70,7 +70,7 @@ object MessagingTestFixtures {
     ) = createSentMessage(
         id = id,
         content = content,
-        status = DeliveryState.Delivered,
+        status = "delivered",
     )
 
     fun createFailedMessage(

--- a/app/src/test/java/network/columba/app/ui/model/MessageMapperTest.kt
+++ b/app/src/test/java/network/columba/app/ui/model/MessageMapperTest.kt
@@ -4,6 +4,7 @@ import android.app.Application
 import android.graphics.Bitmap
 import androidx.compose.ui.graphics.asImageBitmap
 import network.columba.app.data.repository.Message
+import network.columba.app.rns.api.model.DeliveryState
 import org.junit.After
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
@@ -51,7 +52,7 @@ class MessageMapperTest {
         assertEquals("test-id", result.id)
         assertEquals("Hello world", result.content)
         assertTrue(result.isFromMe)
-        assertEquals("delivered", result.status)
+        assertEquals(DeliveryState.Delivered, result.status)
     }
 
     @Test
@@ -848,7 +849,7 @@ class MessageMapperTest {
         assertEquals("Complete message content", result.content)
         assertEquals(1700000000000L, result.timestamp)
         assertTrue(result.isFromMe)
-        assertEquals("delivered", result.status)
+        assertEquals(DeliveryState.Delivered, result.status)
         assertNull(result.decodedImage)
         assertFalse(result.hasImageAttachment)
         assertNull(result.fieldsJson)
@@ -868,7 +869,7 @@ class MessageMapperTest {
 
         val result = message.toMessageUi()
 
-        assertEquals("failed", result.status)
+        assertEquals(DeliveryState.Failed, result.status)
         assertEquals("Network timeout", result.errorMessage)
     }
 
@@ -2094,7 +2095,7 @@ class MessageMapperTest {
                 content = "",
                 timestamp = 0L,
                 isFromMe = true,
-                status = "delivered",
+                status = DeliveryState.Delivered,
                 isAnimatedImage = true,
                 imageData = byteArrayOf(1, 2, 3),
                 hasFileAttachments = false,
@@ -2112,7 +2113,7 @@ class MessageMapperTest {
                 content = "Hello!",
                 timestamp = 0L,
                 isFromMe = true,
-                status = "delivered",
+                status = DeliveryState.Delivered,
                 isAnimatedImage = true,
                 imageData = byteArrayOf(1, 2, 3),
             )
@@ -2129,7 +2130,7 @@ class MessageMapperTest {
                 content = "",
                 timestamp = 0L,
                 isFromMe = true,
-                status = "delivered",
+                status = DeliveryState.Delivered,
                 isAnimatedImage = false,
                 imageData = byteArrayOf(1, 2, 3),
             )
@@ -2146,7 +2147,7 @@ class MessageMapperTest {
                 content = "",
                 timestamp = 0L,
                 isFromMe = true,
-                status = "delivered",
+                status = DeliveryState.Delivered,
                 isAnimatedImage = true,
                 imageData = null,
             )
@@ -2163,7 +2164,7 @@ class MessageMapperTest {
                 content = "",
                 timestamp = 0L,
                 isFromMe = true,
-                status = "delivered",
+                status = DeliveryState.Delivered,
                 isAnimatedImage = true,
                 imageData = byteArrayOf(1, 2, 3),
                 hasFileAttachments = true,
@@ -2181,7 +2182,7 @@ class MessageMapperTest {
                 content = "",
                 timestamp = 0L,
                 isFromMe = true,
-                status = "delivered",
+                status = DeliveryState.Delivered,
                 isAnimatedImage = true,
                 imageData = byteArrayOf(1, 2, 3),
                 replyPreview =
@@ -2204,7 +2205,7 @@ class MessageMapperTest {
                 content = "   \n\t  ",
                 timestamp = 0L,
                 isFromMe = true,
-                status = "delivered",
+                status = DeliveryState.Delivered,
                 isAnimatedImage = true,
                 imageData = byteArrayOf(1, 2, 3),
             )
@@ -2223,7 +2224,7 @@ class MessageMapperTest {
                 content = "",
                 timestamp = 0L,
                 isFromMe = false,
-                status = "delivered",
+                status = DeliveryState.Delivered,
                 fieldsJson = null,
             )
 
@@ -2239,7 +2240,7 @@ class MessageMapperTest {
                 content = "",
                 timestamp = 0L,
                 isFromMe = false,
-                status = "delivered",
+                status = DeliveryState.Delivered,
                 fieldsJson = """{"16": {"reply_to": "some_id"}}""",
             )
 
@@ -2255,7 +2256,7 @@ class MessageMapperTest {
                 content = "",
                 timestamp = 0L,
                 isFromMe = false,
-                status = "delivered",
+                status = DeliveryState.Delivered,
                 fieldsJson = """{"16": {"pending_file_notification": {"original_message_id": "abc"}}}""",
             )
 
@@ -2273,7 +2274,7 @@ class MessageMapperTest {
                 content = "",
                 timestamp = 0L,
                 isFromMe = false,
-                status = "delivered",
+                status = DeliveryState.Delivered,
                 fieldsJson = null,
             )
 
@@ -2289,7 +2290,7 @@ class MessageMapperTest {
                 content = "",
                 timestamp = 0L,
                 isFromMe = false,
-                status = "delivered",
+                status = DeliveryState.Delivered,
                 fieldsJson = """{"16": {"pending_file_notification": {}}}""",
             )
 
@@ -2305,7 +2306,7 @@ class MessageMapperTest {
                 content = "",
                 timestamp = 0L,
                 isFromMe = false,
-                status = "delivered",
+                status = DeliveryState.Delivered,
                 fieldsJson = """{"16": {"superseded":true}}""",
             )
 
@@ -2321,7 +2322,7 @@ class MessageMapperTest {
                 content = "",
                 timestamp = 0L,
                 isFromMe = false,
-                status = "delivered",
+                status = DeliveryState.Delivered,
                 fieldsJson = """{"16": {"superseded":false}}""",
             )
 
@@ -2339,7 +2340,7 @@ class MessageMapperTest {
                 content = "",
                 timestamp = 0L,
                 isFromMe = false,
-                status = "delivered",
+                status = DeliveryState.Delivered,
                 fieldsJson = """{"16": {"reply_to": "id"}}""",
             )
 
@@ -2355,7 +2356,7 @@ class MessageMapperTest {
                 content = "",
                 timestamp = 0L,
                 isFromMe = false,
-                status = "delivered",
+                status = DeliveryState.Delivered,
                 fieldsJson = null,
             )
 
@@ -2371,7 +2372,7 @@ class MessageMapperTest {
                 content = "",
                 timestamp = 0L,
                 isFromMe = false,
-                status = "delivered",
+                status = DeliveryState.Delivered,
                 fieldsJson =
                     """{"16": {"pending_file_notification": {"original_message_id": "abc123", """ +
                         """"filename": "report.pdf", "file_count": 3, "total_size": 1048576}}}""",
@@ -2394,7 +2395,7 @@ class MessageMapperTest {
                 content = "",
                 timestamp = 0L,
                 isFromMe = false,
-                status = "delivered",
+                status = DeliveryState.Delivered,
                 fieldsJson = """{"16": {"pending_file_notification": {}}}""",
             )
 
@@ -2415,7 +2416,7 @@ class MessageMapperTest {
                 content = "",
                 timestamp = 0L,
                 isFromMe = false,
-                status = "delivered",
+                status = DeliveryState.Delivered,
                 fieldsJson = """{"16": {"pending_file_notification": "invalid"}}""",
             )
 
@@ -2431,7 +2432,7 @@ class MessageMapperTest {
                 content = "",
                 timestamp = 0L,
                 isFromMe = false,
-                status = "delivered",
+                status = DeliveryState.Delivered,
                 fieldsJson = """{"6": "image_hex"}""",
             )
 
@@ -2449,7 +2450,7 @@ class MessageMapperTest {
                 content = "",
                 timestamp = 0L,
                 isFromMe = false,
-                status = "delivered",
+                status = DeliveryState.Delivered,
                 fieldsJson = "pending_file_notification not valid json {{{",
             )
 

--- a/app/src/test/java/network/columba/app/ui/model/MessageUiTest.kt
+++ b/app/src/test/java/network/columba/app/ui/model/MessageUiTest.kt
@@ -1,5 +1,6 @@
 package network.columba.app.ui.model
 
+import network.columba.app.rns.api.model.DeliveryState
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
 import org.junit.Test
@@ -32,7 +33,7 @@ class MessageUiTest {
             content = content,
             timestamp = System.currentTimeMillis(),
             isFromMe = true,
-            status = "sent",
+            status = DeliveryState.Sent,
             isAnimatedImage = isAnimatedImage,
             imageData = imageData,
             hasFileAttachments = hasFileAttachments,
@@ -376,7 +377,7 @@ class MessageUiTest {
                 content = "Minimal message",
                 timestamp = 0L,
                 isFromMe = false,
-                status = "pending",
+                status = DeliveryState.Pending,
             )
 
         assertFalse(message.isMediaOnlyMessage)
@@ -424,7 +425,7 @@ class MessageUiTest {
                 content = "LOL look at this!",
                 timestamp = System.currentTimeMillis(),
                 isFromMe = true,
-                status = "delivered",
+                status = DeliveryState.Delivered,
                 isAnimatedImage = true,
                 imageData = byteArrayOf(0x47, 0x49, 0x46),
                 hasImageAttachment = true,

--- a/app/src/test/java/network/columba/app/ui/screens/MessageBubbleTest.kt
+++ b/app/src/test/java/network/columba/app/ui/screens/MessageBubbleTest.kt
@@ -7,6 +7,7 @@ import androidx.compose.ui.test.junit4.createComposeRule
 import androidx.compose.ui.test.onNodeWithContentDescription
 import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.performClick
+import network.columba.app.rns.api.model.DeliveryState
 import network.columba.app.test.MessagingTestFixtures
 import network.columba.app.test.RegisterComponentActivityRule
 import network.columba.app.ui.model.MessageUi
@@ -173,7 +174,7 @@ class MessageBubbleTest {
         content = content,
         timestamp = System.currentTimeMillis(),
         isFromMe = isFromMe,
-        status = if (isFromMe) "delivered" else "received",
+        status = if (isFromMe) DeliveryState.Delivered else null,
         decodedImage = null, // No actual image (simulates missing attachment)
         hasImageAttachment = true, // But message originally had an image
         deliveryMethod = null,

--- a/app/src/test/java/network/columba/app/ui/screens/MessageStatusIconTest.kt
+++ b/app/src/test/java/network/columba/app/ui/screens/MessageStatusIconTest.kt
@@ -1,18 +1,20 @@
 package network.columba.app.ui.screens
 
+import network.columba.app.rns.api.model.DeliveryState
 import org.junit.Assert.assertEquals
 import org.junit.Test
 
 /**
  * Unit tests for message status icon logic in MessagingScreen.
  *
- * Tests the visual indicator for message delivery status:
- * - pending: hollow circle (○) - message created, waiting to send
- * - sent: single check (✓) - transmitted to network
- * - retrying_propagated: single check (✓) - retrying via propagation node
- * - propagated: single check (✓) - stored on propagation relay
- * - delivered: double check (✓✓) - delivered and acknowledged
- * - failed: exclamation (!) - delivery failed
+ * Tests the visual indicator for message delivery state:
+ * - Pending: hollow circle (○) - message created, waiting to send
+ * - Sent: single check (✓) - transmitted to network
+ * - RetryingViaPropagation: single check (✓) - retrying via propagation node
+ * - Propagated: single check (✓) - stored on propagation relay
+ * - Delivered: double check (✓✓) - delivered and acknowledged
+ * - Failed: exclamation (!) - delivery failed
+ * - null (unrecognized legacy DB string): empty
  */
 class MessageStatusIconTest {
     // ==========================================
@@ -21,7 +23,7 @@ class MessageStatusIconTest {
 
     @Test
     fun `pending status shows hollow circle`() {
-        assertEquals("○", getMessageStatusIcon("pending"))
+        assertEquals("○", getMessageStatusIcon(DeliveryState.Pending))
     }
 
     // ==========================================
@@ -30,7 +32,7 @@ class MessageStatusIconTest {
 
     @Test
     fun `sent status shows single checkmark`() {
-        assertEquals("✓", getMessageStatusIcon("sent"))
+        assertEquals("✓", getMessageStatusIcon(DeliveryState.Sent))
     }
 
     // ==========================================
@@ -39,19 +41,19 @@ class MessageStatusIconTest {
 
     @Test
     fun `retrying_propagated status shows single checkmark`() {
-        assertEquals("✓", getMessageStatusIcon("retrying_propagated"))
+        assertEquals("✓", getMessageStatusIcon(DeliveryState.RetryingViaPropagation))
     }
 
     @Test
     fun `propagated status shows single checkmark`() {
-        assertEquals("✓", getMessageStatusIcon("propagated"))
+        assertEquals("✓", getMessageStatusIcon(DeliveryState.Propagated))
     }
 
     @Test
     fun `sent and retrying_propagated and propagated have same icon`() {
-        val sentIcon = getMessageStatusIcon("sent")
-        assertEquals(sentIcon, getMessageStatusIcon("retrying_propagated"))
-        assertEquals(sentIcon, getMessageStatusIcon("propagated"))
+        val sentIcon = getMessageStatusIcon(DeliveryState.Sent)
+        assertEquals(sentIcon, getMessageStatusIcon(DeliveryState.RetryingViaPropagation))
+        assertEquals(sentIcon, getMessageStatusIcon(DeliveryState.Propagated))
     }
 
     // ==========================================
@@ -60,7 +62,7 @@ class MessageStatusIconTest {
 
     @Test
     fun `delivered status shows double checkmark`() {
-        assertEquals("✓✓", getMessageStatusIcon("delivered"))
+        assertEquals("✓✓", getMessageStatusIcon(DeliveryState.Delivered))
     }
 
     // ==========================================
@@ -69,7 +71,7 @@ class MessageStatusIconTest {
 
     @Test
     fun `failed status shows exclamation`() {
-        assertEquals("!", getMessageStatusIcon("failed"))
+        assertEquals("!", getMessageStatusIcon(DeliveryState.Failed))
     }
 
     // ==========================================
@@ -77,18 +79,18 @@ class MessageStatusIconTest {
     // ==========================================
 
     @Test
-    fun `unknown status shows empty string`() {
-        assertEquals("", getMessageStatusIcon("unknown"))
+    fun `unknown legacy status decodes to null and shows empty string`() {
+        assertEquals("", getMessageStatusIcon(DeliveryState.decode("unknown")))
     }
 
     @Test
-    fun `empty status shows empty string`() {
-        assertEquals("", getMessageStatusIcon(""))
+    fun `empty legacy status decodes to null and shows empty string`() {
+        assertEquals("", getMessageStatusIcon(DeliveryState.decode("")))
     }
 
     @Test
-    fun `null-like status shows empty string`() {
-        assertEquals("", getMessageStatusIcon("null"))
+    fun `null state shows empty string`() {
+        assertEquals("", getMessageStatusIcon(null))
     }
 
     // ==========================================
@@ -97,10 +99,10 @@ class MessageStatusIconTest {
 
     @Test
     fun `status icons are distinct for main states`() {
-        val pending = getMessageStatusIcon("pending")
-        val sent = getMessageStatusIcon("sent")
-        val delivered = getMessageStatusIcon("delivered")
-        val failed = getMessageStatusIcon("failed")
+        val pending = getMessageStatusIcon(DeliveryState.Pending)
+        val sent = getMessageStatusIcon(DeliveryState.Sent)
+        val delivered = getMessageStatusIcon(DeliveryState.Delivered)
+        val failed = getMessageStatusIcon(DeliveryState.Failed)
 
         // All main states should have distinct icons
         val icons = setOf(pending, sent, delivered, failed)
@@ -109,17 +111,17 @@ class MessageStatusIconTest {
 
     @Test
     fun `normal delivery flow has correct icon progression`() {
-        // Normal flow: pending -> sent -> delivered
-        assertEquals("○", getMessageStatusIcon("pending"))
-        assertEquals("✓", getMessageStatusIcon("sent"))
-        assertEquals("✓✓", getMessageStatusIcon("delivered"))
+        // Normal flow: Pending -> Sent -> Delivered
+        assertEquals("○", getMessageStatusIcon(DeliveryState.Pending))
+        assertEquals("✓", getMessageStatusIcon(DeliveryState.Sent))
+        assertEquals("✓✓", getMessageStatusIcon(DeliveryState.Delivered))
     }
 
     @Test
     fun `propagation fallback flow has correct icon progression`() {
-        // Propagation fallback: pending -> retrying_propagated -> delivered
-        assertEquals("○", getMessageStatusIcon("pending"))
-        assertEquals("✓", getMessageStatusIcon("retrying_propagated"))
-        assertEquals("✓✓", getMessageStatusIcon("delivered"))
+        // Propagation fallback: Pending -> RetryingViaPropagation -> Delivered
+        assertEquals("○", getMessageStatusIcon(DeliveryState.Pending))
+        assertEquals("✓", getMessageStatusIcon(DeliveryState.RetryingViaPropagation))
+        assertEquals("✓✓", getMessageStatusIcon(DeliveryState.Delivered))
     }
 }

--- a/app/src/test/java/network/columba/app/viewmodel/MessagingViewModelTest.kt
+++ b/app/src/test/java/network/columba/app/viewmodel/MessagingViewModelTest.kt
@@ -17,6 +17,7 @@ import network.columba.app.data.repository.ReceivedLocationRepository
 import network.columba.app.data.repository.ReplyPreview
 import network.columba.app.repository.SettingsRepository
 import network.columba.app.rns.api.model.Identity
+import network.columba.app.rns.api.model.DeliveryState
 import network.columba.app.rns.api.model.DeliveryStatusUpdate
 import network.columba.app.rns.api.model.MessageReceipt
 import network.columba.app.rns.api.RnsCore
@@ -1065,7 +1066,7 @@ class MessagingViewModelTest {
                     deliveryStatusFlow.emit(
                         DeliveryStatusUpdate(
                             messageHash = testMessageHash,
-                            status = "retrying_propagated",
+                            state = DeliveryState.RetryingViaPropagation,
                             timestamp = System.currentTimeMillis(),
                         ),
                     )
@@ -1139,7 +1140,7 @@ class MessagingViewModelTest {
                     deliveryStatusFlow.emit(
                         DeliveryStatusUpdate(
                             messageHash = testMessageHash,
-                            status = "delivered",
+                            state = DeliveryState.Delivered,
                             timestamp = System.currentTimeMillis(),
                         ),
                     )
@@ -1211,7 +1212,7 @@ class MessagingViewModelTest {
                     deliveryStatusFlow.emit(
                         DeliveryStatusUpdate(
                             messageHash = testMessageHash,
-                            status = "failed",
+                            state = DeliveryState.Failed,
                             timestamp = System.currentTimeMillis(),
                         ),
                     )
@@ -1271,7 +1272,7 @@ class MessagingViewModelTest {
                     deliveryStatusFlow.emit(
                         DeliveryStatusUpdate(
                             messageHash = unknownMessageHash,
-                            status = "delivered",
+                            state = DeliveryState.Delivered,
                             timestamp = System.currentTimeMillis(),
                         ),
                     )
@@ -1345,7 +1346,7 @@ class MessagingViewModelTest {
                     deliveryStatusFlow.emit(
                         DeliveryStatusUpdate(
                             messageHash = testMessageHash,
-                            status = "failed",
+                            state = DeliveryState.Failed,
                             timestamp = System.currentTimeMillis(),
                         ),
                     )
@@ -1412,7 +1413,7 @@ class MessagingViewModelTest {
                     deliveryStatusFlow.emit(
                         DeliveryStatusUpdate(
                             messageHash = testMessageHash,
-                            status = "failed",
+                            state = DeliveryState.Failed,
                             timestamp = System.currentTimeMillis(),
                         ),
                     )
@@ -1479,7 +1480,7 @@ class MessagingViewModelTest {
                     deliveryStatusFlow.emit(
                         DeliveryStatusUpdate(
                             messageHash = testMessageHash,
-                            status = "failed",
+                            state = DeliveryState.Failed,
                             timestamp = System.currentTimeMillis(),
                         ),
                     )
@@ -1546,7 +1547,7 @@ class MessagingViewModelTest {
                     deliveryStatusFlow.emit(
                         DeliveryStatusUpdate(
                             messageHash = testMessageHash,
-                            status = "failed",
+                            state = DeliveryState.Failed,
                             timestamp = System.currentTimeMillis(),
                         ),
                     )
@@ -1613,7 +1614,7 @@ class MessagingViewModelTest {
                     deliveryStatusFlow.emit(
                         DeliveryStatusUpdate(
                             messageHash = testMessageHash,
-                            status = "delivered",
+                            state = DeliveryState.Delivered,
                             timestamp = System.currentTimeMillis(),
                         ),
                     )
@@ -1678,7 +1679,7 @@ class MessagingViewModelTest {
                     deliveryStatusFlow.emit(
                         DeliveryStatusUpdate(
                             messageHash = testMessageHash,
-                            status = "propagated",
+                            state = DeliveryState.Propagated,
                             timestamp = System.currentTimeMillis(),
                         ),
                     )
@@ -1739,7 +1740,7 @@ class MessagingViewModelTest {
                     deliveryStatusFlow.emit(
                         DeliveryStatusUpdate(
                             messageHash = testMessageHash,
-                            status = "retrying_propagated",
+                            state = DeliveryState.RetryingViaPropagation,
                             timestamp = System.currentTimeMillis(),
                         ),
                     )
@@ -1800,7 +1801,7 @@ class MessagingViewModelTest {
                     deliveryStatusFlow.emit(
                         DeliveryStatusUpdate(
                             messageHash = testMessageHash,
-                            status = "sent",
+                            state = DeliveryState.Sent,
                             timestamp = System.currentTimeMillis(),
                         ),
                     )

--- a/data/src/main/java/network/columba/app/data/repository/ConversationRepository.kt
+++ b/data/src/main/java/network/columba/app/data/repository/ConversationRepository.kt
@@ -683,7 +683,9 @@ class ConversationRepository
             val activeIdentity = localIdentityDao.getActiveIdentitySync() ?: return
             val oldMessage = messageDao.getMessageById(oldMessageId, activeIdentity.identityHash) ?: return
 
-            // Create new message with updated ID
+            // Create new message with updated ID. The literal is the encoded
+            // form of DeliveryState.Pending (:rns-api) — :data sits below that
+            // module, so the string can't reference the codec here.
             val newMessage = oldMessage.copy(id = newMessageId, status = "pending")
 
             // Delete old and insert new atomically would require @Transaction,

--- a/rns-api/src/main/java/network/columba/app/rns/api/model/DeliveryState.kt
+++ b/rns-api/src/main/java/network/columba/app/rns/api/model/DeliveryState.kt
@@ -1,0 +1,101 @@
+package network.columba.app.rns.api.model
+
+import android.os.Parcelable
+import kotlinx.parcelize.Parcelize
+
+/**
+ * Delivery lifecycle of an outbound LXMF message, from optimistic creation
+ * through terminal success or failure.
+ *
+ * This is the closed vocabulary that used to live as magic strings
+ * (`"pending"`, `"sent"`, …) matched by hand across both backends and the
+ * UI. Every consumer `when` over this type is exhaustive, so adding a state
+ * is a compile error at each consumer instead of a silently-dropped status.
+ *
+ * Not to be confused with [DeliveryMethod] (how a send is routed:
+ * opportunistic / direct / propagated). [Propagated] here is a *state* —
+ * "stored on the relay node" — the success analogue of a PROPAGATED-method
+ * send, where [Delivered] means "acknowledged by the recipient" for a
+ * DIRECT/OPPORTUNISTIC send.
+ *
+ * The string form survives only at persistence/log boundaries via
+ * [encode]/[decode]; Room keeps storing the legacy strings so existing
+ * databases need no migration.
+ */
+sealed interface DeliveryState : Parcelable {
+    /**
+     * Terminal-success states must never degrade to [Failed] (Issue #257):
+     * LXMF can fire spurious failure callbacks after a success confirmation.
+     */
+    val isTerminalSuccess: Boolean
+        get() = this is Sent || this is Propagated || this is Delivered
+
+    /** Outbound message handed to the router, awaiting a delivery outcome. */
+    @Parcelize
+    data object Pending : DeliveryState
+
+    /**
+     * Transmitted, no proof yet. Legacy initial state (and the Room column
+     * default) predating [Pending]; still counts as terminal success.
+     */
+    @Parcelize
+    data object Sent : DeliveryState
+
+    /** Delivery proof received from the recipient (rendered ✓✓). */
+    @Parcelize
+    data object Delivered : DeliveryState
+
+    /**
+     * Stored on the configured propagation node (rendered ✓). The relay
+     * holds the message for the recipient to fetch — success for a
+     * PROPAGATED-method send, weaker than [Delivered].
+     */
+    @Parcelize
+    data object Propagated : DeliveryState
+
+    /**
+     * Direct delivery failed; the backend rebuilt the message as PROPAGATED
+     * and re-routed it via the relay (the Sideband retry pattern). A second
+     * failure surfaces as [Failed].
+     */
+    @Parcelize
+    data object RetryingViaPropagation : DeliveryState
+
+    /** Delivery failed with no retry remaining. */
+    @Parcelize
+    data object Failed : DeliveryState
+
+    /**
+     * Stable string form for the Room `status` column and logcat contracts
+     * (the maestro harness greps these, uppercased). The values are the
+     * pre-existing legacy strings — do not change them.
+     */
+    fun encode(): String =
+        when (this) {
+            Pending -> "pending"
+            Sent -> "sent"
+            Delivered -> "delivered"
+            Propagated -> "propagated"
+            RetryingViaPropagation -> "retrying_propagated"
+            Failed -> "failed"
+        }
+
+    companion object {
+        /**
+         * Inverse of [encode]. Returns null for unrecognized values (old
+         * databases are an open string set); callers render null as the
+         * neutral/unknown presentation, matching the historical `else`
+         * branches.
+         */
+        fun decode(raw: String): DeliveryState? =
+            when (raw) {
+                "pending" -> Pending
+                "sent" -> Sent
+                "delivered" -> Delivered
+                "propagated" -> Propagated
+                "retrying_propagated" -> RetryingViaPropagation
+                "failed" -> Failed
+                else -> null
+            }
+    }
+}

--- a/rns-api/src/main/java/network/columba/app/rns/api/model/DeliveryStatusUpdate.kt
+++ b/rns-api/src/main/java/network/columba/app/rns/api/model/DeliveryStatusUpdate.kt
@@ -5,11 +5,15 @@ import kotlinx.parcelize.Parcelize
 
 /**
  * Delivery status update for a sent LXMF message.
+ *
+ * Backends emit the backend-originated subset of [DeliveryState]:
+ * [DeliveryState.Delivered], [DeliveryState.Propagated],
+ * [DeliveryState.RetryingViaPropagation], and [DeliveryState.Failed].
+ * ([DeliveryState.Pending]/[DeliveryState.Sent] are UI-originated.)
  */
 @Parcelize
 data class DeliveryStatusUpdate(
     val messageHash: String,
-    /** Status: "delivered", "failed", or "retrying_propagated" (direct failed, retrying via propagation). */
-    val status: String,
+    val state: DeliveryState,
     val timestamp: Long,
 ) : Parcelable

--- a/rns-api/src/main/java/network/columba/app/rns/api/util/DeliveryRetryPolicy.kt
+++ b/rns-api/src/main/java/network/columba/app/rns/api/util/DeliveryRetryPolicy.kt
@@ -1,0 +1,35 @@
+package network.columba.app.rns.api.util
+
+/**
+ * The shared try-propagation-on-fail retry decision (the Sideband pattern):
+ * when a DIRECT/OPPORTUNISTIC delivery fails, rebuild the message as
+ * PROPAGATED and re-route it via the configured propagation node instead of
+ * reporting failure. Mirrors Sideband's `core.message_notification` retry
+ * block (`Sideband/sbapp/sideband/core.py:4440`).
+ *
+ * Both backend adapters consult this one predicate; only the *mechanism*
+ * (rebuilding the live LXMessage and re-submitting it to the router) stays
+ * flavor-local, because it manipulates flavor-owned router/message objects
+ * (upstream Python LXMF vs lxmf-kt).
+ *
+ * "Give up after one retry" is encoded by the desired-method flip: the retry
+ * rebuilds the message with desired method PROPAGATED, so when that attempt
+ * fails too, [shouldRetryViaPropagation] is false and the failure is
+ * reported for real — matching upstream's single-retry behaviour.
+ */
+object DeliveryRetryPolicy {
+    /**
+     * @param tryPropagationOnFail the caller opted into the fallback at send
+     *   time (per-message; also implies the original method wasn't PROPAGATED)
+     * @param desiredMethodIsPropagated the message's *current* desired method
+     *   is PROPAGATED — true on the failure that follows a retry, which is
+     *   what terminates the loop
+     * @param propagationNodeConfigured an outbound propagation node is set;
+     *   without one there is nothing to fall back to
+     */
+    fun shouldRetryViaPropagation(
+        tryPropagationOnFail: Boolean,
+        desiredMethodIsPropagated: Boolean,
+        propagationNodeConfigured: Boolean,
+    ): Boolean = tryPropagationOnFail && !desiredMethodIsPropagated && propagationNodeConfigured
+}

--- a/rns-api/src/test/java/network/columba/app/rns/api/ParcelRoundTripTest.kt
+++ b/rns-api/src/test/java/network/columba/app/rns/api/ParcelRoundTripTest.kt
@@ -4,6 +4,8 @@ import android.os.Parcel
 import android.os.Parcelable
 import network.columba.app.rns.api.model.AnnounceRestoreEntry
 import network.columba.app.rns.api.model.CallState
+import network.columba.app.rns.api.model.DeliveryState
+import network.columba.app.rns.api.model.DeliveryStatusUpdate
 import network.columba.app.rns.api.model.FileAttachment
 import network.columba.app.rns.api.model.InterfaceConfig
 import network.columba.app.rns.api.model.Link
@@ -297,6 +299,26 @@ class ParcelRoundTripTest {
         val original = AnnounceRestoreEntry("cafef00d", ByteArray(64) { (it * 2).toByte() })
         val restored = roundTripViaFramework(original)
         assertEquals(original, restored)
+    }
+
+    // ==================== DeliveryStatusUpdate ====================
+
+    @Test
+    fun `DeliveryStatusUpdate round-trips every DeliveryState across the AIDL boundary`() {
+        val states =
+            listOf(
+                DeliveryState.Pending,
+                DeliveryState.Sent,
+                DeliveryState.Delivered,
+                DeliveryState.Propagated,
+                DeliveryState.RetryingViaPropagation,
+                DeliveryState.Failed,
+            )
+        for (state in states) {
+            val original = DeliveryStatusUpdate("deadbeef".repeat(4), state, 1_700_000_000_000L)
+            val restored = roundTripViaFramework(original)
+            assertEquals(original, restored)
+        }
     }
 
     // ==================== Helpers ====================

--- a/rns-api/src/test/java/network/columba/app/rns/api/model/DeliveryStateTest.kt
+++ b/rns-api/src/test/java/network/columba/app/rns/api/model/DeliveryStateTest.kt
@@ -1,0 +1,68 @@
+package network.columba.app.rns.api.model
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * Unit tests for the [DeliveryState] codec and its terminal-success policy.
+ *
+ * The encoded strings are a persistence contract: Room databases created
+ * before the sealed type existed contain exactly these values, and the
+ * maestro logcat harness greps their uppercased forms. Changing any encoded
+ * value is a breaking change — these tests pin them.
+ */
+class DeliveryStateTest {
+    private val allStates =
+        listOf(
+            DeliveryState.Pending,
+            DeliveryState.Sent,
+            DeliveryState.Delivered,
+            DeliveryState.Propagated,
+            DeliveryState.RetryingViaPropagation,
+            DeliveryState.Failed,
+        )
+
+    @Test
+    fun `encode produces the legacy persistence strings`() {
+        assertEquals("pending", DeliveryState.Pending.encode())
+        assertEquals("sent", DeliveryState.Sent.encode())
+        assertEquals("delivered", DeliveryState.Delivered.encode())
+        assertEquals("propagated", DeliveryState.Propagated.encode())
+        assertEquals("retrying_propagated", DeliveryState.RetryingViaPropagation.encode())
+        assertEquals("failed", DeliveryState.Failed.encode())
+    }
+
+    @Test
+    fun `decode inverts encode for every state`() {
+        for (state in allStates) {
+            assertEquals(state, DeliveryState.decode(state.encode()))
+        }
+    }
+
+    @Test
+    fun `encoded forms are pairwise distinct`() {
+        assertEquals(allStates.size, allStates.map { it.encode() }.toSet().size)
+    }
+
+    @Test
+    fun `decode returns null for unrecognized legacy values`() {
+        assertNull(DeliveryState.decode("unknown"))
+        assertNull(DeliveryState.decode(""))
+        assertNull(DeliveryState.decode("received"))
+        // Decoding is exact; case variants are not valid persisted forms.
+        assertNull(DeliveryState.decode("Delivered"))
+    }
+
+    @Test
+    fun `terminal success covers sent, propagated, delivered (Issue 257)`() {
+        assertTrue(DeliveryState.Sent.isTerminalSuccess)
+        assertTrue(DeliveryState.Propagated.isTerminalSuccess)
+        assertTrue(DeliveryState.Delivered.isTerminalSuccess)
+        assertFalse(DeliveryState.Pending.isTerminalSuccess)
+        assertFalse(DeliveryState.RetryingViaPropagation.isTerminalSuccess)
+        assertFalse(DeliveryState.Failed.isTerminalSuccess)
+    }
+}

--- a/rns-api/src/test/java/network/columba/app/rns/api/util/DeliveryRetryPolicyTest.kt
+++ b/rns-api/src/test/java/network/columba/app/rns/api/util/DeliveryRetryPolicyTest.kt
@@ -1,0 +1,35 @@
+package network.columba.app.rns.api.util
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+/**
+ * Truth table for the shared try-propagation-on-fail decision. Both backend
+ * adapters route their failure callbacks through this predicate, so these
+ * cases pin the retry semantics for the python and kotlin flavors at once.
+ */
+class DeliveryRetryPolicyTest {
+    @Test
+    fun `retries only when opted in, not already propagated, and a node is configured`() {
+        // (tryPropagationOnFail, desiredMethodIsPropagated, propagationNodeConfigured) -> decision
+        val cases =
+            listOf(
+                Triple(true, false, true) to true, // the one retry case
+                Triple(true, false, false) to false, // no node -> plain failure
+                Triple(true, true, true) to false, // already retried (method flipped) -> give up
+                Triple(true, true, false) to false,
+                Triple(false, false, true) to false, // caller never opted in
+                Triple(false, false, false) to false,
+                Triple(false, true, true) to false,
+                Triple(false, true, false) to false,
+            )
+        for ((inputs, expected) in cases) {
+            val (optIn, isPropagated, nodeConfigured) = inputs
+            assertEquals(
+                "shouldRetryViaPropagation($optIn, $isPropagated, $nodeConfigured)",
+                expected,
+                DeliveryRetryPolicy.shouldRetryViaPropagation(optIn, isPropagated, nodeConfigured),
+            )
+        }
+    }
+}

--- a/rns-backend-kt/src/main/kotlin/network/columba/app/rns/backend/kt/NativeMessageSender.kt
+++ b/rns-backend-kt/src/main/kotlin/network/columba/app/rns/backend/kt/NativeMessageSender.kt
@@ -2,6 +2,7 @@ package network.columba.app.rns.backend.kt
 
 import network.columba.app.rns.api.model.ConversationLinkResult
 import network.columba.app.rns.api.model.DeliveryMethod
+import network.columba.app.rns.api.model.DeliveryState
 import network.columba.app.rns.api.model.DeliveryStatusUpdate
 import network.columba.app.rns.api.model.DiscoveredInterface
 import network.columba.app.rns.api.model.FailedInterface
@@ -203,20 +204,20 @@ internal class NativeMessageSender(
             // callback runs). Distinguish by method, not state — checking state
             // alone risks misclassifying a future direct path that briefly
             // transitions through SENT before DELIVERED.
-            val status =
+            val state =
                 if (msg.method == NativeDeliveryMethod.PROPAGATED ||
                     msg.desiredMethod == NativeDeliveryMethod.PROPAGATED
                 ) {
-                    "propagated"
+                    DeliveryState.Propagated
                 } else {
-                    "delivered"
+                    DeliveryState.Delivered
                 }
             Log.i(
                 TAG,
-                "Delivery callback for $hash -> $status (state=${msg.state}, method=${msg.method}, desired=${msg.desiredMethod})",
+                "Delivery callback for $hash -> ${state.encode()} (state=${msg.state}, method=${msg.method}, desired=${msg.desiredMethod})",
             )
             deliveryStatusFlow.tryEmit(
-                DeliveryStatusUpdate(hash, status, System.currentTimeMillis()),
+                DeliveryStatusUpdate(hash, state, System.currentTimeMillis()),
             )
         }
         message.failedCallback = failedCallback@{ msg ->
@@ -229,7 +230,7 @@ internal class NativeMessageSender(
             ) {
                 Log.i(TAG, "${currentMethod ?: lxmfMethod} delivery failed for $hash, falling back to PROPAGATED")
                 deliveryStatusFlow.tryEmit(
-                    DeliveryStatusUpdate(hash, "retrying_propagated", System.currentTimeMillis()),
+                    DeliveryStatusUpdate(hash, DeliveryState.RetryingViaPropagation, System.currentTimeMillis()),
                 )
                 msg.desiredMethod = NativeDeliveryMethod.PROPAGATED
                 msg.state = network.reticulum.lxmf.MessageState.OUTBOUND
@@ -241,7 +242,7 @@ internal class NativeMessageSender(
             }
 
             deliveryStatusFlow.tryEmit(
-                DeliveryStatusUpdate(hash, "failed", System.currentTimeMillis()),
+                DeliveryStatusUpdate(hash, DeliveryState.Failed, System.currentTimeMillis()),
             )
         }
     }

--- a/rns-backend-kt/src/main/kotlin/network/columba/app/rns/backend/kt/NativeMessageSender.kt
+++ b/rns-backend-kt/src/main/kotlin/network/columba/app/rns/backend/kt/NativeMessageSender.kt
@@ -17,6 +17,7 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.launch
 import network.reticulum.common.DestinationDirection
+import network.columba.app.rns.api.util.DeliveryRetryPolicy
 import network.columba.app.rns.api.util.LxmfFields
 import network.columba.app.rns.api.util.hexToBytes
 import network.columba.app.rns.api.util.toHex
@@ -224,9 +225,14 @@ internal class NativeMessageSender(
             val hash = msg.hash?.toHex() ?: return@failedCallback
             val currentMethod = msg.desiredMethod
 
-            if (tryPropagationOnFail &&
-                currentMethod != NativeDeliveryMethod.PROPAGATED &&
-                router.getActivePropagationNode() != null
+            // Decision is the shared DeliveryRetryPolicy (same predicate the
+            // python flavor applies in PythonEventBridge.handleLxmfFailure);
+            // only the rebuild-and-resubmit mechanism below is lxmf-kt-local.
+            if (DeliveryRetryPolicy.shouldRetryViaPropagation(
+                    tryPropagationOnFail = tryPropagationOnFail,
+                    desiredMethodIsPropagated = currentMethod == NativeDeliveryMethod.PROPAGATED,
+                    propagationNodeConfigured = router.getActivePropagationNode() != null,
+                )
             ) {
                 Log.i(TAG, "${currentMethod ?: lxmfMethod} delivery failed for $hash, falling back to PROPAGATED")
                 deliveryStatusFlow.tryEmit(

--- a/rns-backend-kt/src/main/kotlin/network/columba/app/rns/backend/kt/NativeRnsBackendImpl.kt
+++ b/rns-backend-kt/src/main/kotlin/network/columba/app/rns/backend/kt/NativeRnsBackendImpl.kt
@@ -3,6 +3,7 @@ package network.columba.app.rns.backend.kt
 import network.columba.app.rns.api.model.CallState
 import network.columba.app.rns.api.model.ConversationLinkResult
 import network.columba.app.rns.api.model.DeliveryMethod
+import network.columba.app.rns.api.model.DeliveryState
 import network.columba.app.rns.api.model.DeliveryStatusUpdate
 import network.columba.app.rns.api.model.DiscoveredInterface
 import network.columba.app.rns.api.model.FailedInterface
@@ -429,7 +430,7 @@ class NativeRnsBackendImpl(
 
         router!!.registerFailedDeliveryCallback { message ->
             val hash = message.hash?.toHex() ?: return@registerFailedDeliveryCallback
-            _deliveryStatus.tryEmit(DeliveryStatusUpdate(hash, "failed", System.currentTimeMillis()))
+            _deliveryStatus.tryEmit(DeliveryStatusUpdate(hash, DeliveryState.Failed, System.currentTimeMillis()))
         }
 
         return identity

--- a/rns-backend-py/src/main/kotlin/network/columba/app/rns/backend/py/ChaquopyRnsBackend.kt
+++ b/rns-backend-py/src/main/kotlin/network/columba/app/rns/backend/py/ChaquopyRnsBackend.kt
@@ -70,7 +70,23 @@ class ChaquopyRnsBackend(
     val runtime: PythonRnsRuntime = PythonRnsRuntime(appContext)
 
     /** Shared upstream-callback → SharedFlow translation layer. */
-    val events: PythonEventBridge = PythonEventBridge()
+    val events: PythonEventBridge = PythonEventBridge(
+        // Flavor-local mechanism for the shared DeliveryRetryPolicy decision:
+        // both calls operate on event_bridge.py's `_outbound_messages`
+        // registry of parked LXMessages. Invoked from the failure-callback
+        // thread (already inside Python), so the reentrant callAttr is safe.
+        outboundRetry = object : PythonEventBridge.OutboundRetryMechanism {
+            override fun resubmitViaPropagation(messageHash: String): Boolean =
+                runCatching {
+                    runtime.eventBridge.callAttr("resubmit_as_propagated", messageHash)
+                        ?.toJava(Boolean::class.javaObjectType) == true
+                }.getOrDefault(false)
+
+            override fun discardOutbound(messageHash: String) {
+                runCatching { runtime.eventBridge.callAttr("discard_outbound", messageHash) }
+            }
+        },
+    )
 
     private val coreImpl = PythonRnsCore(runtime, events)
     private val lxmfImpl = PythonRnsLxmf(runtime, events)

--- a/rns-backend-py/src/main/kotlin/network/columba/app/rns/backend/py/PythonEventBridge.kt
+++ b/rns-backend-py/src/main/kotlin/network/columba/app/rns/backend/py/PythonEventBridge.kt
@@ -17,6 +17,7 @@ import network.columba.app.rns.api.model.NodeType
 import network.columba.app.rns.api.model.ReceivedMessage
 import network.columba.app.rns.api.model.ReceivedPacket
 import network.columba.app.rns.api.util.AppDataParser
+import network.columba.app.rns.api.util.DeliveryRetryPolicy
 import network.columba.app.rns.api.util.isUserVisibleChatMessage
 import network.columba.app.rns.api.util.LxmfFields
 import network.columba.app.rns.api.util.ReactionWireCodec
@@ -47,7 +48,29 @@ import org.json.JSONObject
  * `NativeRnsBackendImpl`.
  */
 @ReflectivelyKept // Python (event_bridge.py) calls this via Chaquopy reflection — R8 must not strip/rename it
-class PythonEventBridge {
+class PythonEventBridge(
+    /**
+     * Mechanism half of the try-propagation-on-fail retry. The *decision*
+     * is the shared [DeliveryRetryPolicy]; when [handleLxmfFailure] decides
+     * to retry, this hook performs the flavor-local rebuild-and-resubmit
+     * (`event_bridge.resubmit_as_propagated`). Null only in tests.
+     */
+    private val outboundRetry: OutboundRetryMechanism? = null,
+) {
+    /**
+     * Flavor-local mechanism for the shared retry decision — implemented by
+     * [ChaquopyRnsBackend] over `event_bridge.py`'s `_outbound_messages`
+     * registry. Both calls pop the parked LXMessage, so exactly one of them
+     * must be invoked per failure event.
+     */
+    interface OutboundRetryMechanism {
+        /** Rebuild the parked message as PROPAGATED and re-route it. False = couldn't (caller reports failure). */
+        fun resubmitViaPropagation(messageHash: String): Boolean
+
+        /** Drop the parked message after a final, no-retry failure. */
+        fun discardOutbound(messageHash: String)
+    }
+
     private companion object {
         const val TAG = "PythonEventBridge"
 
@@ -134,18 +157,6 @@ class PythonEventBridge {
      * Attached per-LXMessage by [PythonRnsLxmf], not via `register_callbacks`.
      */
     val onLxmfDelivered = PyEventCallback { payload -> handleLxmfDelivered(payload) }
-
-    /**
-     * Outbound try-propagation-on-fail retry sink: `attach_lxmessage_callbacks`
-     * fires this when a DIRECT/OPPORTUNISTIC send fails AND
-     * `try_propagation_on_fail` was set on the message AND a propagation node
-     * is configured — the Sideband pattern that escalates the message to a
-     * PROPAGATED re-`handle_outbound` instead of reporting failure. Surfaces
-     * as `DeliveryState.RetryingViaPropagation` on the delivery-status flow,
-     * matching `NativeMessageSender.installDeliveryCallbacks` on the kotlin
-     * backend so the UI need not branch on backend.
-     */
-    val onLxmfRetryingPropagated = PyEventCallback { payload -> handleLxmfRetryingPropagated(payload) }
 
     /**
      * Packet observation is a low-traffic diagnostic surface; upstream RNS
@@ -437,12 +448,35 @@ class PythonEventBridge {
     // shared codec — no JSON intermediate, no `event_bridge.py` side
     // assembly. Reactions still go through `routeReactionSideChannel`.
 
+    /**
+     * Applies the shared [DeliveryRetryPolicy] to a flattened outbound
+     * failure (the decision `NativeMessageSender.installDeliveryCallbacks`
+     * makes inline on the kotlin flavor). On retry, the flavor-local
+     * [outboundRetry] mechanism rebuilds the parked LXMessage as PROPAGATED
+     * python-side and this emits [DeliveryState.RetryingViaPropagation];
+     * otherwise the parked message is discarded and this emits
+     * [DeliveryState.Failed].
+     */
     private fun handleLxmfFailure(payload: PyObject) {
         runCatching {
+            val hash = payload.dictStr("hash").orEmpty()
+            val shouldRetry =
+                DeliveryRetryPolicy.shouldRetryViaPropagation(
+                    tryPropagationOnFail = payload.dictBool("try_propagation_on_fail"),
+                    desiredMethodIsPropagated = payload.dictBool("desired_method_is_propagated"),
+                    propagationNodeConfigured = payload.dictBool("propagation_node_configured"),
+                )
+            val state =
+                if (shouldRetry && outboundRetry?.resubmitViaPropagation(hash) == true) {
+                    DeliveryState.RetryingViaPropagation
+                } else {
+                    outboundRetry?.discardOutbound(hash)
+                    DeliveryState.Failed
+                }
             _deliveryStatus.tryEmit(
                 DeliveryStatusUpdate(
-                    messageHash = payload.dictStr("hash").orEmpty(),
-                    state = DeliveryState.Failed,
+                    messageHash = hash,
+                    state = state,
                     timestamp = System.currentTimeMillis(),
                 ),
             )
@@ -474,21 +508,6 @@ class PythonEventBridge {
                 ),
             )
         }.onFailure { Log.e(TAG, "lxmf delivered translation failed", it) }
-    }
-
-    private fun handleLxmfRetryingPropagated(payload: PyObject) {
-        runCatching {
-            // Mirrors NativeMessageSender.installDeliveryCallbacks — same
-            // state the kotlin backend emits when a DIRECT send fails and
-            // falls back to PROPAGATED.
-            _deliveryStatus.tryEmit(
-                DeliveryStatusUpdate(
-                    messageHash = payload.dictStr("hash").orEmpty(),
-                    state = DeliveryState.RetryingViaPropagation,
-                    timestamp = System.currentTimeMillis(),
-                ),
-            )
-        }.onFailure { Log.e(TAG, "lxmf retrying-propagated translation failed", it) }
     }
 
     private fun handlePacket(payload: PyObject) {

--- a/rns-backend-py/src/main/kotlin/network/columba/app/rns/backend/py/PythonEventBridge.kt
+++ b/rns-backend-py/src/main/kotlin/network/columba/app/rns/backend/py/PythonEventBridge.kt
@@ -7,6 +7,7 @@ import kotlinx.coroutines.flow.SharedFlow
 import kotlinx.coroutines.flow.asSharedFlow
 import network.columba.app.rns.api.annotation.ReflectivelyKept
 import network.columba.app.rns.api.model.AnnounceEvent
+import network.columba.app.rns.api.model.DeliveryState
 import network.columba.app.rns.api.model.DeliveryStatusUpdate
 import network.columba.app.rns.api.model.IconAppearance
 import network.columba.app.rns.api.model.Identity
@@ -140,7 +141,7 @@ class PythonEventBridge {
      * `try_propagation_on_fail` was set on the message AND a propagation node
      * is configured — the Sideband pattern that escalates the message to a
      * PROPAGATED re-`handle_outbound` instead of reporting failure. Surfaces
-     * as `status = "retrying_propagated"` on the delivery-status flow,
+     * as `DeliveryState.RetryingViaPropagation` on the delivery-status flow,
      * matching `NativeMessageSender.installDeliveryCallbacks` on the kotlin
      * backend so the UI need not branch on backend.
      */
@@ -441,7 +442,7 @@ class PythonEventBridge {
             _deliveryStatus.tryEmit(
                 DeliveryStatusUpdate(
                     messageHash = payload.dictStr("hash").orEmpty(),
-                    status = "failed",
+                    state = DeliveryState.Failed,
                     timestamp = System.currentTimeMillis(),
                 ),
             )
@@ -459,16 +460,16 @@ class PythonEventBridge {
             // misrepresenting the actual delivery promise.
             val method = payload.dictInt("method") ?: -1
             val desired = payload.dictInt("desired_method") ?: -1
-            val status =
+            val state =
                 if (method == LXMF_METHOD_PROPAGATED || desired == LXMF_METHOD_PROPAGATED) {
-                    "propagated"
+                    DeliveryState.Propagated
                 } else {
-                    "delivered"
+                    DeliveryState.Delivered
                 }
             _deliveryStatus.tryEmit(
                 DeliveryStatusUpdate(
                     messageHash = payload.dictStr("hash").orEmpty(),
-                    status = status,
+                    state = state,
                     timestamp = System.currentTimeMillis(),
                 ),
             )
@@ -478,12 +479,12 @@ class PythonEventBridge {
     private fun handleLxmfRetryingPropagated(payload: PyObject) {
         runCatching {
             // Mirrors NativeMessageSender.installDeliveryCallbacks — same
-            // `retrying_propagated` status string the kotlin backend emits
-            // when a DIRECT send fails and falls back to PROPAGATED.
+            // state the kotlin backend emits when a DIRECT send fails and
+            // falls back to PROPAGATED.
             _deliveryStatus.tryEmit(
                 DeliveryStatusUpdate(
                     messageHash = payload.dictStr("hash").orEmpty(),
-                    status = "retrying_propagated",
+                    state = DeliveryState.RetryingViaPropagation,
                     timestamp = System.currentTimeMillis(),
                 ),
             )

--- a/rns-backend-py/src/main/kotlin/network/columba/app/rns/backend/py/PythonRnsLxmf.kt
+++ b/rns-backend-py/src/main/kotlin/network/columba/app/rns/backend/py/PythonRnsLxmf.kt
@@ -147,12 +147,12 @@ class PythonRnsLxmf(
                 extraFields = extraFields,
             )
             // tryPropagationOnFail mirrors Sideband's `try_propagation_on_fail`
-            // pattern: tag the LXMessage so the failure callback (in
-            // `event_bridge.attach_lxmessage_callbacks`) rebuilds it as
-            // PROPAGATED and re-routes through `handle_outbound` instead of
-            // reporting failure. Upstream LXMF does not do the fallback
-            // itself — the retry lives in the Python side of event_bridge so
-            // it has direct access to the live LXMessage / LXMRouter.
+            // pattern: tag the LXMessage so its failure surfaces with the
+            // state the shared DeliveryRetryPolicy needs. The retry *decision*
+            // lives in Kotlin (PythonEventBridge.handleLxmfFailure); only the
+            // rebuild-as-PROPAGATED *mechanism* stays in event_bridge.py
+            // (`resubmit_as_propagated`), because it has direct access to the
+            // live LXMessage / LXMRouter.
             dispatchLxmessage(
                 destinationHash = destinationHash,
                 content = content,
@@ -235,16 +235,15 @@ class PythonRnsLxmf(
         //
         // `try_propagation_on_fail` only applies when the caller picked a
         // non-PROPAGATED method AND a propagation node is configured — the
-        // event_bridge helper re-checks both before doing the retry dance,
-        // but we skip wiring the retry hook for PROPAGATED sends here too so
-        // the LXMessage isn't tagged unnecessarily.
+        // shared DeliveryRetryPolicy re-checks both at failure time, but we
+        // skip wiring the retry hook for PROPAGATED sends here too so the
+        // LXMessage isn't tagged unnecessarily.
         val tryPropagation = tryPropagationOnFail && desiredMethod != LXMF_METHOD_PROPAGATED
         runtime.eventBridge.callAttr(
             "attach_lxmessage_callbacks",
             lxmessage,
             events.onLxmfDelivered,
             events.onLxmfFailure,
-            events.onLxmfRetryingPropagated,
             tryPropagation,
         )
 

--- a/rns-backend-py/src/main/python/event_bridge.py
+++ b/rns-backend-py/src/main/python/event_bridge.py
@@ -330,6 +330,10 @@ def reset_reticulum_for_restart():
     print("event_bridge.reset: ENTER", flush=True)
     sys.stdout.flush()
 
+    # Parked outbound messages reference the dying router — a resubmit after
+    # restart would re-route through dead state, so drop them.
+    _outbound_messages.clear()
+
     reticulum = RNS.Reticulum
     transport = RNS.Transport
 
@@ -1288,11 +1292,19 @@ def make_link_packet_handler(on_packet):
 
 # --- Per-LXMessage outbound delivery / failure -----------------------------
 
+# Outbound LXMessages awaiting a Kotlin retry decision, keyed by hex hash.
+# `_failed` registers the live message here before flattening the failure to
+# Kotlin; `PythonEventBridge.handleLxmfFailure` applies the shared
+# `DeliveryRetryPolicy` and calls back into `resubmit_as_propagated` (retry)
+# or `discard_outbound` (final failure), both of which pop the entry.
+# `_delivered` pops defensively in case a spurious failure registered first.
+_outbound_messages = {}
+
+
 def attach_lxmessage_callbacks(
     lxmessage,
     on_delivered,
     on_failed,
-    on_retrying_propagated=None,
     try_propagation_on_fail=False,
 ):
     """Wire per-LXMessage delivery + failure callbacks for an outbound message.
@@ -1307,28 +1319,24 @@ def attach_lxmessage_callbacks(
     message it sends — without it the Kotlin side never learns a sent message
     was delivered or failed, so the delivery-status flow stays silent (no
     delivery proofs surface in the UI). Success vs failure is implied by which
-    Kotlin `PyEventCallback` fires; the payload is a flat `{hash}` dict.
+    Kotlin `PyEventCallback` fires.
 
-    **try_propagation_on_fail (Sideband pattern)** — when set, the LXMessage
-    is tagged so the failed-callback rebuilds it as PROPAGATED and re-routes
-    it through `LXMRouter.handle_outbound` instead of reporting failure. This
-    mirrors Sideband's `core.message_notification` retry block (see
-    `Sideband/sbapp/sideband/core.py:4440`) and the `release/v0.10.x`
-    `reticulum_wrapper._on_message_failed` port. The retry fires
-    `on_retrying_propagated` (so the UI can show "retrying via propagation"
-    status); the second failure — after the propagation retry attempt — fires
-    `on_failed` for real, mirroring upstream's "give up after one retry"
-    behaviour. Requires a configured outbound propagation node; falls through
-    to plain failure when none is set.
+    **try_propagation_on_fail (Sideband pattern)** — the *decision* to retry
+    a failed DIRECT send via the propagation node lives in shared Kotlin
+    (`DeliveryRetryPolicy` in `:rns-api`, applied by
+    `PythonEventBridge.handleLxmfFailure` — the same predicate
+    `NativeMessageSender` consults on the kotlin flavor). This side only
+    flattens the failure with the state the policy needs and parks the live
+    LXMessage in `_outbound_messages` so a Kotlin retry decision can invoke
+    `resubmit_as_propagated`. The *mechanism* stays here because it
+    manipulates the live upstream LXMessage/LXMRouter.
     """
     def _delivered(msg):
         msg_hash_hex = _hex(getattr(msg, "hash", None))
+        _outbound_messages.pop(msg_hash_hex, None)
         # Carry method + desired_method through so the Kotlin side can
         # distinguish PROPAGATED (success means "stored on the relay")
         # from DIRECT/OPPORTUNISTIC (success means "ack from recipient").
-        # NativeMessageSender on the kotlin backend does the same split via
-        # NativeDeliveryMethod; the python flavor must surface enough state
-        # for PythonEventBridge.handleLxmfDelivered to make the same call.
         # Without these fields a PROPAGATED success gets stamped "delivered"
         # in the UI (✓✓) instead of "propagated" (✓).
         method = getattr(msg, "method", None)
@@ -1346,50 +1354,26 @@ def attach_lxmessage_callbacks(
         _emit(on_delivered, payload)
 
     def _failed(msg):
-        # Sideband pattern: if try_propagation_on_fail was set on the message
-        # AND we haven't already retried AND a propagation node is configured,
-        # rebuild as PROPAGATED and re-submit through the router. Otherwise
-        # report failure to Kotlin.
-        if (
-            getattr(msg, "try_propagation_on_fail", False)
-            and not getattr(msg, "_columba_propagation_retry_attempted", False)
-            and _lxmf_router is not None
-            and getattr(_lxmf_router, "outbound_propagation_node", None) is not None
-            and getattr(msg, "desired_method", None) != LXMF.LXMessage.PROPAGATED
-        ):
-            msg._columba_propagation_retry_attempted = True
-            # Clear retry flag so a second failure doesn't loop.
-            msg.try_propagation_on_fail = False
-            # Sideband resets the upstream-LXMF send-state for a fresh try as
-            # PROPAGATED. Skipping any of these wedges the send: stale packed
-            # bytes, stale propagation stamp, or a non-zero delivery_attempts
-            # count would short-circuit upstream's outbound state machine.
-            msg.delivery_attempts = 0
-            msg.packed = None
-            msg.propagation_packed = None
-            msg.propagation_stamp = None
-            msg.defer_propagation_stamp = True
-            msg.desired_method = LXMF.LXMessage.PROPAGATED
-            try:
-                _lxmf_router.handle_outbound(msg)
-                _emit(on_retrying_propagated, {"hash": _hex(getattr(msg, "hash", None))})
-                RNS.log(
-                    "event_bridge: DIRECT delivery failed, retrying via propagation node",
-                    RNS.LOG_DEBUG,
-                )
-                return
-            except Exception as e:  # noqa: BLE001
-                RNS.log(
-                    f"event_bridge: propagation retry failed: {e}",
-                    RNS.LOG_ERROR,
-                )
-                # Fall through to plain failure reporting.
+        # Flatten the failure with everything DeliveryRetryPolicy needs and
+        # park the live message for a possible resubmit. No decision here.
+        msg_hash_hex = _hex(getattr(msg, "hash", None))
+        _outbound_messages[msg_hash_hex] = msg
+        payload = {
+            "hash": msg_hash_hex,
+            "try_propagation_on_fail": bool(getattr(msg, "try_propagation_on_fail", False)),
+            "desired_method_is_propagated": (
+                getattr(msg, "desired_method", None) == LXMF.LXMessage.PROPAGATED
+            ),
+            "propagation_node_configured": (
+                _lxmf_router is not None
+                and getattr(_lxmf_router, "outbound_propagation_node", None) is not None
+            ),
+        }
+        _emit(on_failed, payload)
 
-        _emit(on_failed, {"hash": _hex(getattr(msg, "hash", None))})
-
-    # Tag the LXMessage so the failed callback can see the intent. Upstream
+    # Tag the LXMessage so the failure payload can carry the intent. Upstream
     # Sideband uses this same attribute; LXMF does not read it itself, so the
-    # tag is benign on stock upstream and only consumed by this callback.
+    # tag is benign on stock upstream.
     if try_propagation_on_fail:
         try:
             lxmessage.try_propagation_on_fail = True
@@ -1401,6 +1385,60 @@ def attach_lxmessage_callbacks(
 
     lxmessage.register_delivery_callback(_delivered)
     lxmessage.register_failed_callback(_failed)
+
+
+def resubmit_as_propagated(msg_hash_hex):
+    """Rebuild a failed outbound LXMessage as PROPAGATED and re-route it.
+
+    Mechanism half of the Sideband try-propagation-on-fail pattern — the
+    decision half is `DeliveryRetryPolicy` in `:rns-api`, applied by
+    `PythonEventBridge.handleLxmfFailure`, which calls this when it decides
+    to retry. Returns True when the message was re-submitted (the caller
+    then emits `RetryingViaPropagation`), False when it wasn't (unknown
+    hash, router gone, already retried, or `handle_outbound` raised — the
+    caller emits `Failed`).
+    """
+    msg = _outbound_messages.pop(msg_hash_hex, None)
+    if msg is None or _lxmf_router is None:
+        return False
+    if getattr(msg, "_columba_propagation_retry_attempted", False):
+        return False
+    msg._columba_propagation_retry_attempted = True
+    # Clear retry flag so a second failure doesn't loop.
+    msg.try_propagation_on_fail = False
+    # Sideband resets the upstream-LXMF send-state for a fresh try as
+    # PROPAGATED. Skipping any of these wedges the send: stale packed
+    # bytes, stale propagation stamp, or a non-zero delivery_attempts
+    # count would short-circuit upstream's outbound state machine.
+    msg.delivery_attempts = 0
+    msg.packed = None
+    msg.propagation_packed = None
+    msg.propagation_stamp = None
+    msg.defer_propagation_stamp = True
+    msg.desired_method = LXMF.LXMessage.PROPAGATED
+    try:
+        _lxmf_router.handle_outbound(msg)
+        RNS.log(
+            "event_bridge: DIRECT delivery failed, retrying via propagation node",
+            RNS.LOG_DEBUG,
+        )
+        return True
+    except Exception as e:  # noqa: BLE001
+        RNS.log(
+            f"event_bridge: propagation retry failed: {e}",
+            RNS.LOG_ERROR,
+        )
+        return False
+
+
+def discard_outbound(msg_hash_hex):
+    """Drop a parked outbound LXMessage after a final (no-retry) failure.
+
+    Called by `PythonEventBridge.handleLxmfFailure` when `DeliveryRetryPolicy`
+    decides against a propagation retry, so `_outbound_messages` doesn't leak
+    references to dead messages.
+    """
+    _outbound_messages.pop(msg_hash_hex, None)
 
 
 # --- Accessors for the per-object callbacks -------------------------------

--- a/rns-host/src/main/kotlin/network/columba/app/rns/host/persistence/ServicePersistenceManager.kt
+++ b/rns-host/src/main/kotlin/network/columba/app/rns/host/persistence/ServicePersistenceManager.kt
@@ -9,6 +9,7 @@ import network.columba.app.data.db.entity.MessageEntity
 import network.columba.app.data.db.entity.PeerIdentityEntity
 import network.columba.app.data.util.HashUtils
 import network.columba.app.data.util.TextSanitizer
+import network.columba.app.rns.api.model.DeliveryState
 import network.columba.app.rns.host.di.ServiceDatabaseProvider
 import network.columba.app.rns.host.util.PeerNameResolver
 import kotlinx.coroutines.CoroutineScope
@@ -296,7 +297,7 @@ class ServicePersistenceManager(
                     content = sanitizedContent,
                     timestamp = timestamp,
                     isFromMe = false,
-                    status = "delivered",
+                    status = DeliveryState.Delivered.encode(),
                     isRead = false,
                     fieldsJson = fieldsJson,
                     replyToMessageId = replyToMessageId,


### PR DESCRIPTION
The delivery status of an outbound LXMF message was an open set of magic
strings ("delivered", "failed", "retrying_propagated", ...) produced
independently by both backend flavors and hand-matched at 20+ consumer
sites across the app — and the try-propagation-on-fail retry logic behind
those strings was implemented twice (event_bridge.py and
NativeMessageSender), kept in sync only by "kept in lockstep" comments.
A typo or a new state added to one backend silently no-oped in the UI.

This PR lands both slices of the delivery-state deepening.

## Slice 1 — typed seam (representation only, no behavior change)

- New sealed interface `DeliveryState` in `:rns-api` (Pending, Sent,
  Delivered, Propagated, RetryingViaPropagation, Failed) with the
  Issue #257 terminal-success policy as a property and an
  `encode()`/`decode()` codec pinning the legacy persistence strings.
- `DeliveryStatusUpdate.status: String` → `state: DeliveryState`. The
  parcelable crosses AIDL whole, so no marshalling changes.
- Both backend emit sites (PythonEventBridge, NativeMessageSender,
  NativeRnsBackendImpl) emit typed states.
- All app consumers (MessagingViewModel guards, MessageUi, MessageMapper,
  MessagingScreen, MessageDetailScreen, MessageCollector,
  ServicePersistenceManager, TestController) switch to exhaustive whens;
  `isTerminalSuccessStatus` in the ViewModel is replaced by
  `DeliveryState.isTerminalSuccess`.
- Room keeps storing the legacy strings (no migration); `decode()` is
  nullable for unrecognized legacy values, rendered as the historical
  else-branch presentation.

## Slice 2 — shared retry decision (de-duplicates the Sideband pattern)

Planned as "a state machine in :rns-host", it landed as a decision/
mechanism split instead — the backends can't depend on `:rns-host`, and
the rebuild-and-resubmit mechanism must stay flavor-local because it
manipulates flavor-owned router/message objects:

- New `DeliveryRetryPolicy` in `:rns-api` — the one shared predicate
  ("retry via propagation iff opted in, not already PROPAGATED, node
  configured"), consulted by both flavors. A truth-table test pins the
  semantics, including the give-up-after-one-retry rule encoded by the
  desired-method flip.
- `event_bridge.py` loses the decision: `_failed` now only flattens the
  failure and parks the live LXMessage in an `_outbound_messages`
  registry; new mechanism-only `resubmit_as_propagated` /
  `discard_outbound` functions do the flavor-local surgery.
  `reset_reticulum_for_restart` clears the registry.
- `PythonEventBridge.handleLxmfFailure` applies the policy and drives the
  mechanism through an injected `OutboundRetryMechanism` hook wired in
  `ChaquopyRnsBackend`; the separate retrying-propagated event sink is
  gone.
- `NativeMessageSender` consults the same policy; its lxmf-kt rebuild
  mechanism is unchanged.

## Docs & tests

- `CONTEXT.md` seeds the domain glossary: DeliveryState, DeliveryMethod,
  DeliveryRetryPolicy, propagation node, and the "propagated"
  method-vs-state trap.
- New `DeliveryStateTest` (codec + legacy decode) and
  `DeliveryRetryPolicyTest` (truth table); `ParcelRoundTripTest` covers
  every state across the AIDL boundary.

## Verification

`:rns-api`, `:rns-ipc`, `:rns-backend-kt`, `:rns-backend-py`, and
`:rns-host` (kotlinBackend) unit tests green; the six affected `:app`
test classes pass (490 tests, 0 failures) with full `:app` main+test
compilation proving the exhaustiveness migration; `event_bridge.py`
py_compile clean. Not covered here: an on-device send-with-propagation-
node smoke test of the Python retry mechanism.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BZ3PvF8KzApTXFYTfabv1b