### PR TITLE
chore(rns): bump Python fork to 1.3.8

### DIFF
--- a/app/src/main/java/network/columba/app/ui/screens/settings/cards/AboutCard.kt
+++ b/app/src/main/java/network/columba/app/ui/screens/settings/cards/AboutCard.kt
@@ -313,7 +313,7 @@ private fun InfoRow(
 ) {
     // The label keeps its natural width; the value takes the remaining space and
     // is right-aligned. Without the weight, a long value (e.g. the Python
-    // flavor's "Reticulum 1.1.9 (torlando-tech fork)") and the label both claim
+    // flavor's "Reticulum 1.3.8 (torlando-tech fork)") and the label both claim
     // their full intrinsic width and crowd/overlap under SpaceBetween — instead
     // a long value now wraps within its column.
     Row(

--- a/rns-backend-py/PINNED_VERSIONS.md
+++ b/rns-backend-py/PINNED_VERSIONS.md
@@ -17,7 +17,7 @@ moved into the Gradle build script).
 
 | Package | Ref | Pinned to | Notes |
 |---|---|---|---|
-| `rns` (Reticulum) | `git+https://github.com/torlando-tech/Reticulum` | **`99c42fce06bc8afe8cfd0107acd990d8de428013`** (SHA ✓) | RNS 1.1.9 + 4 torlando-tech fork patches. Carries the IFAC autoconnect fix (`866e63f`) and — importantly — the **context-manager ratchet/log file-handle fixes**. Because those fixes are already in this commit, the v0.10.x `python/patches/RNS/` tree is **not restored** (see below). |
+| `rns` (Reticulum) | `git+https://github.com/torlando-tech/Reticulum` | **`817ecc31bd524c6268f816530c5115211b39cffc`** (SHA ✓) | RNS 1.3.8 + 4 torlando-tech fork patches. Carries the socket cleanup, PHY-stats RPC handling, known-destinations migration, and ratchet file-handle fixes. RNS 1.3.8 already includes the equivalent log file-handle fix upstream, so the rebased fork adds no duplicate log change. |
 | `lxmf` (LXMF) | `git+https://github.com/torlando-tech/LXMF` | **`158b771c4c65ff43fd25764b00f5555ea543ab2e`** (SHA ✓) | torlando-tech fork: `set_external_generator()` to bypass Python multiprocessing on Android + `receiving_interface` passed to the delivery callback for opportunistic messages. SHA is the tip of `feature/receiving-interface-capture` as of 2026-05-14; builds as `lxmf-0.9.2`. |
 | `ble-reticulum` | `git+https://github.com/torlando-tech/ble-reticulum.git` | **`07d941304c9a1dc3a8e58087b3b974ff3d229e56`** (SHA ✓) | Provides `BLEInterface` + `bluetooth_driver` that the bundled `ble_modules/` adapters subclass. SHA is the tip of `main` as of 2026-05-14; builds as `ble-reticulum-0.2.2`. |
 | `cryptography` | PyPI | `>=42.0.0` | Range, not pinned — Chaquopy resolves a native wheel for the target ABI. Acceptable: it's a well-tested transitive dep, not a protocol-correctness surface. |
@@ -31,10 +31,10 @@ moved into the Gradle build script).
 context-manager fixes for RNS file-handle leaks (ratchet I/O + the `log()`
 function). They are **not restored** here because:
 
-1. The pinned RNS fork commit `99c42fce` **already includes** those fixes (its
-   changelog explicitly lists "Identity.py / log: use context managers for
-   ratchet file I/O and log writes"). The plan's instruction is to skip the
-   `patches/` tree when the pinned commit already has the fixes — it does.
+1. The pinned RNS fork commit `817ecc31` **already includes** the ratchet I/O
+   context-manager fixes, while upstream RNS 1.3.8 includes the equivalent
+   `log()` context-manager fix. The plan's instruction is to skip the `patches/`
+   tree when the pinned commit already has the fixes — it does.
 2. The patch *deployment* mechanism — `reticulum_wrapper.py::_deploy_rns_patches()`,
    which copied the patched files over the pip-installed RNS at runtime — is
    **not** being restored (the slim-Python design deletes `reticulum_wrapper.py`).

--- a/rns-backend-py/build.gradle.kts
+++ b/rns-backend-py/build.gradle.kts
@@ -57,7 +57,7 @@ android {
         // in PINNED_VERSIONS.md, not the user-facing version line). RNS and LXMF
         // ARE torlando-tech forks of markqvist's upstream; ble-reticulum is
         // torlando-tech's own project, so it carries no "fork" label.
-        buildConfigField("String", "PY_RNS_VERSION", "\"1.1.9 (torlando-tech fork)\"")
+        buildConfigField("String", "PY_RNS_VERSION", "\"1.3.8 (torlando-tech fork)\"")
         buildConfigField("String", "PY_LXMF_VERSION", "\"0.9.2 (torlando-tech fork)\"")
         buildConfigField("String", "PY_BLE_RETICULUM_VERSION", "\"0.2.2\"")
     }
@@ -100,11 +100,12 @@ chaquopy {
 
         pip {
             // Upstream RNS — torlando-tech fork pinned to commit SHA. This commit
-            // already carries the four fork patches incl. the context-manager
-            // ratchet/log file-handle fixes, so the v0.10.x `patches/RNS/` tree
-            // is intentionally NOT restored (its runtime patch-deployer lived in
+            // already carries all four effective fixes. RNS 1.3.8 includes the
+            // log file-handle fix upstream; the fork commit retains the ratchet
+            // file-handle changes, so the v0.10.x `patches/RNS/` tree is
+            // intentionally NOT restored (its runtime patch-deployer lived in
             // the deleted reticulum_wrapper.py — see PINNED_VERSIONS.md).
-            install("git+https://github.com/torlando-tech/Reticulum@99c42fce06bc8afe8cfd0107acd990d8de428013")
+            install("git+https://github.com/torlando-tech/Reticulum@817ecc31bd524c6268f816530c5115211b39cffc")
 
             // Upstream LXMF — torlando-tech fork (external stamp generator +
             // receiving-interface capture). Pinned to the commit SHA at the


### PR DESCRIPTION
## Summary

- pin the Python backend to the torlando-tech Reticulum fork based on upstream RNS 1.3.8
- retain the existing fork fixes without introducing additional fork behavior
- update the displayed RNS version and pinned-version documentation

Reticulum fork commit: `817ecc31bd524c6268f816530c5115211b39cffc`

## Verification

- Reticulum test suite: 36 passed, 1 slow test skipped
- `:rns-backend-py:testDebugUnitTest`
- `:rns-backend-py:assembleDebug`
- Chaquopy resolved and built `rns-1.3.8` directly from the public GitHub commit