### PR TITLE
fix: default new AutoInterface to Wi-Fi only

### DIFF
--- a/app/src/main/java/network/columba/app/ui/components/InterfaceConfigDialog.kt
+++ b/app/src/main/java/network/columba/app/ui/components/InterfaceConfigDialog.kt
@@ -178,7 +178,7 @@ fun InterfaceConfigDialog(
                         // showing the selector would be misleading.
                         if (configState.networkRestrictionApplies) {
                             NetworkRestrictionSelector(
-                                selectedRestriction = configState.networkRestriction,
+                                selectedRestriction = configState.effectiveNetworkRestriction,
                                 onRestrictionChange = {
                                     onConfigUpdate(configState.copy(networkRestriction = it))
                                 },

--- a/app/src/main/java/network/columba/app/viewmodel/InterfaceManagementViewModel.kt
+++ b/app/src/main/java/network/columba/app/viewmodel/InterfaceManagementViewModel.kt
@@ -141,7 +141,9 @@ data class InterfaceConfigState(
     // Network transport restriction: "any", "wifi_only", or "cellular_only".
     // Stored as a string (matching the JSON wire form) so the existing copy()-based
     // dialog plumbing keeps working without an enum import for every screen.
-    val networkRestriction: String = NetworkRestriction.ANY.value,
+    // Null is the untouched sentinel. Save resolves it to the active type's default,
+    // while edit state and explicit selector choices remain non-null.
+    val networkRestriction: String? = null,
     // Validation
     val nameError: String? = null,
     val targetHostError: String? = null,
@@ -172,7 +174,14 @@ data class InterfaceConfigState(
             "RNode" -> connectionMode == "tcp"
             else -> true
         }
+
+    /** Restriction shown before the user makes an explicit selection. */
+    val effectiveNetworkRestriction: String
+        get() = networkRestriction ?: defaultNetworkRestriction(type).value
 }
+
+private fun defaultNetworkRestriction(type: String): NetworkRestriction =
+    if (type == "AutoInterface") NetworkRestriction.WIFI_ONLY else NetworkRestriction.ANY
 
 /**
  * ViewModel for managing Reticulum network interface configurations.
@@ -1033,9 +1042,10 @@ class InterfaceManagementViewModel
         private fun configStateToInterfaceConfig(state: InterfaceConfigState): InterfaceConfig {
             // Per-type defaults: AutoInterface defaults to WIFI_ONLY (UDP multicast on
             // cellular is meaningless), all other types default to ANY.
-            val defaultRestriction =
-                if (state.type == "AutoInterface") NetworkRestriction.WIFI_ONLY else NetworkRestriction.ANY
-            val restriction = NetworkRestriction.fromValue(state.networkRestriction) ?: defaultRestriction
+            val defaultRestriction = defaultNetworkRestriction(state.type)
+            val restriction =
+                state.networkRestriction?.let(NetworkRestriction::fromValue)
+                    ?: defaultRestriction
             return when (state.type) {
                 "AutoInterface" ->
                     InterfaceConfig.AutoInterface(

--- a/app/src/test/java/network/columba/app/ui/components/InterfaceConfigDialogTest.kt
+++ b/app/src/test/java/network/columba/app/ui/components/InterfaceConfigDialogTest.kt
@@ -2,10 +2,14 @@ package network.columba.app.ui.components
 
 import android.app.Application
 import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.assertIsNotSelected
+import androidx.compose.ui.test.assertIsSelected
 import androidx.compose.ui.test.junit4.createComposeRule
 import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.performClick
 import network.columba.app.test.RegisterComponentActivityRule
 import network.columba.app.viewmodel.InterfaceConfigState
+import org.junit.Assert.assertNull
 import org.junit.Rule
 import org.junit.Test
 import org.junit.rules.RuleChain
@@ -23,6 +27,45 @@ class InterfaceConfigDialogTest {
     val ruleChain: RuleChain = RuleChain.outerRule(registerActivityRule).around(composeRule)
 
     val composeTestRule get() = composeRule
+
+    @Test
+    fun `fresh AutoInterface selector displays wifi only without persisting a choice`() {
+        val configState = InterfaceConfigState()
+
+        composeTestRule.setContent {
+            InterfaceConfigDialog(
+                configState = configState,
+                isEditing = false,
+                onDismiss = {},
+                onSave = {},
+                onConfigUpdate = {},
+            )
+        }
+
+        composeTestRule.onNodeWithText("Advanced Options").performClick()
+        composeTestRule.onNodeWithText("Wi-Fi only").assertIsSelected()
+        composeTestRule.onNodeWithText("Any").assertIsNotSelected()
+        assertNull(configState.networkRestriction)
+    }
+
+    @Test
+    fun `explicit Any selector state displays Any`() {
+        val configState = InterfaceConfigState(networkRestriction = "any")
+
+        composeTestRule.setContent {
+            InterfaceConfigDialog(
+                configState = configState,
+                isEditing = false,
+                onDismiss = {},
+                onSave = {},
+                onConfigUpdate = {},
+            )
+        }
+
+        composeTestRule.onNodeWithText("Advanced Options").performClick()
+        composeTestRule.onNodeWithText("Any").assertIsSelected()
+        composeTestRule.onNodeWithText("Wi-Fi only").assertIsNotSelected()
+    }
 
     // ========== TCPServerFields UI Tests ==========
 

--- a/app/src/test/java/network/columba/app/viewmodel/InterfaceManagementViewModelNetworkRestrictionTest.kt
+++ b/app/src/test/java/network/columba/app/viewmodel/InterfaceManagementViewModelNetworkRestrictionTest.kt
@@ -1,0 +1,268 @@
+@file:Suppress("InjectDispatcher")
+
+package network.columba.app.viewmodel
+
+import androidx.arch.core.executor.testing.InstantTaskExecutorRule
+import androidx.lifecycle.viewModelScope
+import io.mockk.clearAllMocks
+import io.mockk.coEvery
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.slot
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.test.setMain
+import network.columba.app.data.database.entity.InterfaceEntity
+import network.columba.app.data.model.BleConnectionsState
+import network.columba.app.data.repository.BleStatusRepository
+import network.columba.app.repository.InterfaceRepository
+import network.columba.app.rns.api.BackendCapabilities
+import network.columba.app.rns.api.RnsBackend
+import network.columba.app.rns.api.RnsTransportAdmin
+import network.columba.app.rns.api.model.InterfaceConfig
+import network.columba.app.rns.api.model.NetworkRestriction
+import network.columba.app.rns.host.manager.CurrentTransport
+import network.columba.app.service.InterfaceConfigManager
+import network.columba.app.service.manager.InterfaceTransportObserver
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class InterfaceManagementViewModelNetworkRestrictionTest {
+    @get:Rule
+    val instantExecutorRule = InstantTaskExecutorRule()
+
+    private val testDispatcher = StandardTestDispatcher()
+    private lateinit var interfaceRepository: InterfaceRepository
+    private lateinit var configManager: InterfaceConfigManager
+    private lateinit var bleStatusRepository: BleStatusRepository
+    private lateinit var transportAdmin: RnsTransportAdmin
+    private lateinit var transportObserver: InterfaceTransportObserver
+    private lateinit var rnsBackend: RnsBackend
+    private lateinit var viewModel: InterfaceManagementViewModel
+
+    @Before
+    fun setup() {
+        Dispatchers.setMain(testDispatcher)
+        InterfaceManagementViewModel.ioDispatcher = testDispatcher
+        InterfaceManagementViewModel.enableStatusPolling = false
+
+        interfaceRepository = mockk()
+        every { interfaceRepository.allInterfaceEntities } returns flowOf(emptyList())
+        every { interfaceRepository.enabledInterfaceCount } returns flowOf(0)
+        every { interfaceRepository.totalInterfaceCount } returns flowOf(0)
+        every { interfaceRepository.enabledInterfaces } returns flowOf(emptyList())
+
+        configManager = mockk()
+        every { configManager.checkAndClearPendingChanges() } returns false
+
+        bleStatusRepository = mockk()
+        every { bleStatusRepository.getConnectedPeersFlow() } returns
+            flowOf(BleConnectionsState.Success(emptyList()))
+
+        transportAdmin = mockk()
+        every { transportAdmin.interfaceStatusFlow } returns MutableSharedFlow()
+        every { transportAdmin.debugInfoFlow } returns MutableSharedFlow()
+        coEvery { transportAdmin.isDiscoveryEnabled() } returns false
+        coEvery { transportAdmin.getDiscoveredInterfaces() } returns emptyList()
+        coEvery { transportAdmin.getDebugInfo() } returns emptyMap()
+        coEvery { transportAdmin.reloadInterfaces(any()) } returns Unit
+
+        transportObserver = mockk()
+        every { transportObserver.snapshotTransport() } returns CurrentTransport.WIFI_LIKE
+        every { transportObserver.currentTransport } returns MutableStateFlow(CurrentTransport.WIFI_LIKE)
+
+        rnsBackend = mockk()
+        every { rnsBackend.capabilities } returns
+            MutableStateFlow(
+                BackendCapabilities.UNKNOWN.copy(
+                    interfaces = BackendCapabilities.InterfaceCaps(hotReloadInterfaces = true),
+                ),
+            )
+
+        viewModel =
+            InterfaceManagementViewModel(
+                interfaceRepository,
+                configManager,
+                bleStatusRepository,
+                transportAdmin,
+                transportObserver,
+                rnsBackend,
+            )
+    }
+
+    @After
+    fun tearDown() {
+        viewModel.viewModelScope.cancel()
+        Dispatchers.resetMain()
+        InterfaceManagementViewModel.ioDispatcher = Dispatchers.IO
+        InterfaceManagementViewModel.enableStatusPolling = true
+        clearAllMocks()
+    }
+
+    @Test
+    fun `fresh add state uses an untouched restriction sentinel`() =
+        runTest {
+            advanceUntilIdle()
+
+            viewModel.showAddDialog()
+
+            assertEquals("AutoInterface", viewModel.configState.value.type)
+            assertNull(viewModel.configState.value.networkRestriction)
+        }
+
+    @Test
+    fun `fresh AutoInterface save defaults to wifi only`() =
+        runTest {
+            val savedConfig = slot<InterfaceConfig>()
+            coEvery { interfaceRepository.insertInterface(capture(savedConfig)) } returns 1L
+            advanceUntilIdle()
+
+            viewModel.showAddDialog()
+            viewModel.updateConfigState { it.copy(name = "Auto Test") }
+            viewModel.saveInterface()
+            advanceUntilIdle()
+
+            val saved = savedConfig.captured as InterfaceConfig.AutoInterface
+            assertEquals(NetworkRestriction.WIFI_ONLY, saved.networkRestriction)
+        }
+
+    @Test
+    fun `explicit Any selection on AutoInterface remains Any`() =
+        runTest {
+            val savedConfig = slot<InterfaceConfig>()
+            coEvery { interfaceRepository.insertInterface(capture(savedConfig)) } returns 1L
+            advanceUntilIdle()
+
+            viewModel.showAddDialog()
+            viewModel.updateConfigState {
+                it.copy(
+                    name = "Auto Any",
+                    networkRestriction = NetworkRestriction.ANY.value,
+                )
+            }
+            viewModel.saveInterface()
+            advanceUntilIdle()
+
+            val saved = savedConfig.captured as InterfaceConfig.AutoInterface
+            assertEquals(NetworkRestriction.ANY, saved.networkRestriction)
+        }
+
+    @Test
+    fun `fresh TCPClient save defaults to Any`() =
+        runTest {
+            val savedConfig = slot<InterfaceConfig>()
+            coEvery { interfaceRepository.insertInterface(capture(savedConfig)) } returns 1L
+            advanceUntilIdle()
+
+            viewModel.showAddDialog()
+            viewModel.updateConfigState {
+                it.copy(
+                    name = "TCP Test",
+                    type = "TCPClient",
+                    targetHost = "example.com",
+                )
+            }
+            viewModel.saveInterface()
+            advanceUntilIdle()
+
+            val saved = savedConfig.captured as InterfaceConfig.TCPClient
+            assertEquals(NetworkRestriction.ANY, saved.networkRestriction)
+        }
+
+    @Test
+    fun `editing configured Any AutoInterface round trips Any`() =
+        runTest {
+            val entity = autoEntity(id = 41L, name = "Configured Any")
+            every { interfaceRepository.entityToConfig(entity) } returns
+                InterfaceConfig.AutoInterface(
+                    name = entity.name,
+                    networkRestriction = NetworkRestriction.ANY,
+                )
+            val savedConfig = slot<InterfaceConfig>()
+            coEvery { interfaceRepository.updateInterface(entity.id, capture(savedConfig)) } returns Unit
+            advanceUntilIdle()
+
+            viewModel.showEditDialog(entity)
+            assertEquals(NetworkRestriction.ANY.value, viewModel.configState.value.networkRestriction)
+            viewModel.saveInterface()
+            advanceUntilIdle()
+
+            val saved = savedConfig.captured as InterfaceConfig.AutoInterface
+            assertEquals(NetworkRestriction.ANY, saved.networkRestriction)
+        }
+
+    @Test
+    fun `editing legacy AutoInterface default round trips wifi only`() =
+        runTest {
+            val entity = autoEntity(id = 42L, name = "Legacy Auto")
+            every { interfaceRepository.entityToConfig(entity) } returns
+                InterfaceConfig.AutoInterface(name = entity.name)
+            val savedConfig = slot<InterfaceConfig>()
+            coEvery { interfaceRepository.updateInterface(entity.id, capture(savedConfig)) } returns Unit
+            advanceUntilIdle()
+
+            viewModel.showEditDialog(entity)
+            assertEquals(NetworkRestriction.WIFI_ONLY.value, viewModel.configState.value.networkRestriction)
+            viewModel.saveInterface()
+            advanceUntilIdle()
+
+            val saved = savedConfig.captured as InterfaceConfig.AutoInterface
+            assertEquals(NetworkRestriction.WIFI_ONLY, saved.networkRestriction)
+        }
+
+    @Test
+    fun `type switching preserves untouched sentinel and opening a new dialog resets explicit selection`() =
+        runTest {
+            advanceUntilIdle()
+
+            viewModel.showAddDialog()
+            assertEquals(NetworkRestriction.WIFI_ONLY.value, viewModel.configState.value.effectiveNetworkRestriction)
+
+            viewModel.updateConfigState { it.copy(type = "TCPClient") }
+            assertNull(viewModel.configState.value.networkRestriction)
+            assertEquals(NetworkRestriction.ANY.value, viewModel.configState.value.effectiveNetworkRestriction)
+
+            viewModel.updateConfigState { it.copy(type = "AutoInterface") }
+            assertNull(viewModel.configState.value.networkRestriction)
+            assertEquals(NetworkRestriction.WIFI_ONLY.value, viewModel.configState.value.effectiveNetworkRestriction)
+
+            viewModel.updateConfigState {
+                it.copy(networkRestriction = NetworkRestriction.ANY.value)
+            }
+            assertEquals(NetworkRestriction.ANY.value, viewModel.configState.value.networkRestriction)
+            assertEquals(NetworkRestriction.ANY.value, viewModel.configState.value.effectiveNetworkRestriction)
+
+            viewModel.updateConfigState { it.copy(type = "TCPClient") }
+            viewModel.updateConfigState { it.copy(type = "AutoInterface") }
+            assertEquals(NetworkRestriction.ANY.value, viewModel.configState.value.networkRestriction)
+
+            viewModel.showAddDialog()
+            assertNull(viewModel.configState.value.networkRestriction)
+            assertEquals(NetworkRestriction.WIFI_ONLY.value, viewModel.configState.value.effectiveNetworkRestriction)
+        }
+
+    private fun autoEntity(
+        id: Long,
+        name: String,
+    ) = InterfaceEntity(
+        id = id,
+        name = name,
+        type = "AutoInterface",
+        enabled = true,
+        configJson = "{}",
+        displayOrder = 0,
+    )
+}


### PR DESCRIPTION
## Summary

Ports the still-valid behavior from stale draft #904 onto current `main`.

Fresh AutoInterface configurations now present and save **Wi-Fi only** as their untouched default. An explicit user selection of **Any** remains distinguishable from untouched state and round-trips correctly. Existing and legacy AutoInterface rows preserve their persisted/model defaults, while unrelated interface types retain **Any**.

Replaces #904 and addresses #899.

## Changes

- Preserve an untouched network-restriction sentinel in `InterfaceConfigState`.
- Resolve the effective default by interface type for display and persistence.
- Keep explicit `Any` selections distinct from untouched defaults.
- Add regression coverage for fresh, edited, legacy, explicit-selection, type-switching, unrelated-interface, and Compose-dialog behavior.

## Verification

- `:app:testNoSentryKotlinBackendDebugUnitTest` focused ViewModel and dialog tests — **passed**
- `ktlintCheck detekt --continue` — **BUILD SUCCESSFUL**
- `git diff --check` — **clean**
- Independent read-only review of commit `e617efda6ed207b710cf9e53629ef313a3a9fe46` — **no findings**

## Notes

This is a clean one-commit port based on `main` at `2f324af5428ab206d420e72893209ab3fb77571a`; it does not reuse the stale draft branch history.
