### PR TITLE
fix: classify active default-network transport

### DIFF
--- a/app/src/main/java/network/columba/app/service/manager/InterfaceTransportObserver.kt
+++ b/app/src/main/java/network/columba/app/service/manager/InterfaceTransportObserver.kt
@@ -108,18 +108,14 @@ class InterfaceTransportObserver
                         }
                     }
                 }
+            // Refresh the construction-time seed before registration. Registration may
+            // synchronously or asynchronously dispatch a newer default-network callback;
+            // no snapshot write may occur after that callback or it could overwrite the
+            // coherent callback result with stale transport A while `lastTransport` is B.
+            _currentTransport.value = currentTransportOf(connectivityManager)
             try {
                 connectivityManager.registerDefaultNetworkCallback(cb)
                 callback = cb
-                // Seed the reactive view at start() so the StateFlow's initial value
-                // reflects reality before the first capability callback fires. Without
-                // this, collectors that subscribe between start() and the first callback
-                // would briefly observe NONE even on a Wi-Fi-connected device. We do NOT
-                // touch `lastTransport` here — leaving it null preserves the
-                // "first callback always emits a transition" contract that
-                // `applyTransport()` relies on (boot-on-cellular drops a wifi-only
-                // AutoInterface immediately, not on the first carrier change).
-                _currentTransport.value = currentTransportOf(connectivityManager)
                 Log.d(TAG, "Transport observer started")
             } catch (e: Exception) {
                 Log.e(TAG, "Failed to register transport observer", e)

--- a/app/src/main/java/network/columba/app/service/manager/InterfaceTransportObserver.kt
+++ b/app/src/main/java/network/columba/app/service/manager/InterfaceTransportObserver.kt
@@ -4,7 +4,6 @@ import android.content.Context
 import android.net.ConnectivityManager
 import android.net.Network
 import android.net.NetworkCapabilities
-import android.net.NetworkRequest
 import android.util.Log
 import dagger.hilt.android.qualifiers.ApplicationContext
 import kotlinx.coroutines.CancellationException
@@ -57,6 +56,7 @@ class InterfaceTransportObserver
         }
 
         private var callback: ConnectivityManager.NetworkCallback? = null
+        private var currentDefaultNetwork: Network? = null
 
         @Volatile
         private var lastTransport: CurrentTransport? = null
@@ -88,30 +88,28 @@ class InterfaceTransportObserver
             }
             val cb =
                 object : ConnectivityManager.NetworkCallback() {
+                    override fun onAvailable(network: Network) {
+                        currentDefaultNetwork = network
+                    }
+
                     override fun onCapabilitiesChanged(
                         network: Network,
                         networkCapabilities: NetworkCapabilities,
                     ) {
-                        // The callback fires for every network matching NET_CAPABILITY_INTERNET,
-                        // not just the default route — classify by activeNetwork so a cellular
-                        // backup network's capability update doesn't masquerade as a transport
-                        // change while Wi-Fi is still the default.
-                        applyTransport(snapshotTransport(), scope)
+                        if (network == currentDefaultNetwork) {
+                            applyTransport(currentTransportOf(networkCapabilities), scope)
+                        }
                     }
 
                     override fun onLost(network: Network) {
-                        if (connectivityManager.activeNetwork == null) {
+                        if (network == currentDefaultNetwork) {
+                            currentDefaultNetwork = null
                             applyTransport(CurrentTransport.NONE, scope)
                         }
                     }
                 }
-            val request =
-                NetworkRequest
-                    .Builder()
-                    .addCapability(NetworkCapabilities.NET_CAPABILITY_INTERNET)
-                    .build()
             try {
-                connectivityManager.registerNetworkCallback(request, cb)
+                connectivityManager.registerDefaultNetworkCallback(cb)
                 callback = cb
                 // Seed the reactive view at start() so the StateFlow's initial value
                 // reflects reality before the first capability callback fires. Without
@@ -140,6 +138,7 @@ class InterfaceTransportObserver
                 }
             }
             callback = null
+            currentDefaultNetwork = null
             lastTransport = null
             reloadJob?.cancel()
             reloadJob = null

--- a/app/src/main/java/network/columba/app/ui/screens/InterfaceManagementUtils.kt
+++ b/app/src/main/java/network/columba/app/ui/screens/InterfaceManagementUtils.kt
@@ -165,6 +165,7 @@ fun InterfaceEntity.restrictionView(currentTransport: CurrentTransport): Interfa
     return when {
         restriction == NetworkRestriction.ANY -> InterfaceRestrictionView.NotApplicable
         currentTransport == CurrentTransport.NONE -> InterfaceRestrictionView.NoNetwork(restriction)
+        currentTransport == CurrentTransport.UNKNOWN -> InterfaceRestrictionView.Blocked(restriction)
         restrictionMatchesTransport(restriction, currentTransport) -> InterfaceRestrictionView.Allowed(restriction)
         else -> InterfaceRestrictionView.Blocked(restriction)
     }

--- a/app/src/main/java/network/columba/app/viewmodel/InterfaceManagementViewModel.kt
+++ b/app/src/main/java/network/columba/app/viewmodel/InterfaceManagementViewModel.kt
@@ -68,8 +68,9 @@ data class InterfaceManagementState(
     val discoveredStaleCount: Int = 0,
     val isDiscoveryEnabled: Boolean = false,
     // The device's current transport class — drives the "this interface is paused
-    // because you're on cellular" indicator on each card. `NONE` means either no
-    // active default network or that the observer hasn't seen its first callback yet.
+    // because you're on cellular" indicator on each card. `NONE` means no active
+    // default network; `UNKNOWN` means a live default route that Android couldn't
+    // classify as Wi-Fi/Ethernet or cellular.
     val currentTransport: CurrentTransport = CurrentTransport.NONE,
 )
 

--- a/app/src/test/java/network/columba/app/service/manager/InterfaceTransportObserverTest.kt
+++ b/app/src/test/java/network/columba/app/service/manager/InterfaceTransportObserverTest.kt
@@ -92,6 +92,32 @@ class InterfaceTransportObserverTest {
         }
 
     @Test
+    fun `registration callback cannot be overwritten by an older startup snapshot`() =
+        runTest {
+            val oldNetwork = mockk<Network>()
+            val newNetwork = mockk<Network>()
+            val oldCaps = wifiCaps()
+            val newCaps = cellularCaps()
+            every { connectivityManager.getActiveNetwork() } returns oldNetwork
+            every { connectivityManager.getNetworkCapabilities(oldNetwork) } returns oldCaps
+            every { interfaceRepository.enabledInterfaces } returns flowOf(sampleConfigs())
+            every { connectivityManager.registerDefaultNetworkCallback(any()) } answers {
+                firstArg<ConnectivityManager.NetworkCallback>().apply {
+                    onAvailable(newNetwork)
+                    onCapabilitiesChanged(newNetwork, newCaps)
+                }
+                Unit
+            }
+
+            observer.start(testScope.backgroundScope)
+
+            assertEquals(CurrentTransport.CELLULAR, observer.currentTransport.value)
+            coVerify(timeout = 5_000, exactly = 1) {
+                transportAdmin.reloadInterfaces(any())
+            }
+        }
+
+    @Test
     fun `first default capabilities trigger filtering and reload`() =
         runTest {
             val defaultNetwork = mockk<Network>()

--- a/app/src/test/java/network/columba/app/service/manager/InterfaceTransportObserverTest.kt
+++ b/app/src/test/java/network/columba/app/service/manager/InterfaceTransportObserverTest.kt
@@ -190,7 +190,9 @@ class InterfaceTransportObserverTest {
             observer.start(testScope.backgroundScope)
             callbackSlot.captured.onAvailable(wifiNetwork)
             callbackSlot.captured.onCapabilitiesChanged(wifiNetwork, wifiCaps)
-            advanceUntilIdle()
+            coVerify(timeout = 5_000, exactly = 1) {
+                transportAdmin.reloadInterfaces(any())
+            }
 
             callbackSlot.captured.onLost(wifiNetwork)
             advanceUntilIdle()

--- a/app/src/test/java/network/columba/app/service/manager/InterfaceTransportObserverTest.kt
+++ b/app/src/test/java/network/columba/app/service/manager/InterfaceTransportObserverTest.kt
@@ -1,0 +1,312 @@
+package network.columba.app.service.manager
+
+import android.content.Context
+import android.net.ConnectivityManager
+import android.net.Network
+import android.net.NetworkCapabilities
+import io.mockk.Runs
+import io.mockk.clearAllMocks
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.every
+import io.mockk.just
+import io.mockk.mockk
+import io.mockk.slot
+import io.mockk.verify
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.TestScope
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.test.setMain
+import network.columba.app.repository.InterfaceRepository
+import network.columba.app.rns.api.RnsTransportAdmin
+import network.columba.app.rns.api.model.InterfaceConfig
+import network.columba.app.rns.api.model.NetworkRestriction
+import network.columba.app.rns.host.manager.CurrentTransport
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class InterfaceTransportObserverTest {
+    private val testDispatcher = StandardTestDispatcher()
+    private lateinit var testScope: TestScope
+
+    private lateinit var context: Context
+    private lateinit var connectivityManager: ConnectivityManager
+    private lateinit var interfaceRepository: InterfaceRepository
+    private lateinit var transportAdmin: RnsTransportAdmin
+    private lateinit var observer: InterfaceTransportObserver
+
+    private val callbackSlot = slot<ConnectivityManager.NetworkCallback>()
+
+    @Before
+    fun setup() {
+        Dispatchers.setMain(testDispatcher)
+        testScope = TestScope(testDispatcher)
+
+        context = mockk()
+        connectivityManager = mockk()
+        interfaceRepository = mockk()
+        transportAdmin = mockk()
+
+        every { context.getSystemService(Context.CONNECTIVITY_SERVICE) } returns connectivityManager
+        every { connectivityManager.getActiveNetwork() } returns null
+        coEvery { transportAdmin.reloadInterfaces(any()) } just Runs
+        every { connectivityManager.unregisterNetworkCallback(any<ConnectivityManager.NetworkCallback>()) } just Runs
+
+        observer =
+            InterfaceTransportObserver(
+                context = context,
+                interfaceRepository = interfaceRepository,
+                transportAdmin = transportAdmin,
+            )
+    }
+
+    @After
+    fun tearDown() {
+        Dispatchers.resetMain()
+        clearAllMocks()
+    }
+
+    @Test
+    fun `start registers default network callback and seeds from snapshot`() =
+        runTest {
+            val activeNetwork = mockk<Network>()
+            val caps = wifiCaps()
+            every { connectivityManager.getActiveNetwork() } returns activeNetwork
+            every { connectivityManager.getNetworkCapabilities(activeNetwork) } returns caps
+            every { connectivityManager.registerDefaultNetworkCallback(capture(callbackSlot)) } just Runs
+
+            observer.start(testScope.backgroundScope)
+
+            verify(exactly = 1) { connectivityManager.registerDefaultNetworkCallback(any()) }
+            assertEquals(CurrentTransport.WIFI_LIKE, observer.currentTransport.value)
+            assertEquals(CurrentTransport.WIFI_LIKE, observer.snapshotTransport())
+        }
+
+    @Test
+    fun `first default capabilities trigger filtering and reload`() =
+        runTest {
+            val defaultNetwork = mockk<Network>()
+            val caps = wifiCaps()
+            every { connectivityManager.getActiveNetwork() } returns defaultNetwork
+            every { connectivityManager.getNetworkCapabilities(defaultNetwork) } returns caps
+            every { connectivityManager.registerDefaultNetworkCallback(capture(callbackSlot)) } just Runs
+            every { interfaceRepository.enabledInterfaces } returns flowOf(sampleConfigs())
+
+            observer.start(testScope.backgroundScope)
+            callbackSlot.captured.onAvailable(defaultNetwork)
+            callbackSlot.captured.onCapabilitiesChanged(defaultNetwork, caps)
+            advanceUntilIdle()
+
+            assertEquals(CurrentTransport.WIFI_LIKE, observer.currentTransport.value)
+            coVerify(timeout = 5_000, exactly = 1) {
+                transportAdmin.reloadInterfaces(
+                    match { configs ->
+                        configs == listOf(sampleConfigs()[0], sampleConfigs()[1])
+                    },
+                )
+            }
+        }
+
+    @Test
+    fun `wifi to cellular handoff updates state and reloads once per meaningful transition`() =
+        runTest {
+            val wifiNetwork = mockk<Network>()
+            val cellularNetwork = mockk<Network>()
+            val wifiCaps = wifiCaps()
+            val cellularCaps = cellularCaps()
+            every { connectivityManager.getActiveNetwork() } returns wifiNetwork
+            every { connectivityManager.getNetworkCapabilities(wifiNetwork) } returns wifiCaps
+            every { connectivityManager.registerDefaultNetworkCallback(capture(callbackSlot)) } just Runs
+            every { interfaceRepository.enabledInterfaces } returns flowOf(sampleConfigs())
+
+            observer.start(testScope.backgroundScope)
+            callbackSlot.captured.onAvailable(wifiNetwork)
+            callbackSlot.captured.onCapabilitiesChanged(wifiNetwork, wifiCaps)
+            coVerify(timeout = 5_000, exactly = 1) {
+                transportAdmin.reloadInterfaces(any())
+            }
+
+            callbackSlot.captured.onAvailable(cellularNetwork)
+            callbackSlot.captured.onCapabilitiesChanged(cellularNetwork, cellularCaps)
+            coVerify(timeout = 5_000, exactly = 2) {
+                transportAdmin.reloadInterfaces(any())
+            }
+
+            assertEquals(CurrentTransport.CELLULAR, observer.currentTransport.value)
+        }
+
+    @Test
+    fun `stale wifi onLost after cellular promotion does not emit none or reload`() =
+        runTest {
+            val wifiNetwork = mockk<Network>()
+            val cellularNetwork = mockk<Network>()
+            val wifiCaps = wifiCaps()
+            val cellularCaps = cellularCaps()
+            every { connectivityManager.getActiveNetwork() } returns wifiNetwork
+            every { connectivityManager.getNetworkCapabilities(wifiNetwork) } returns wifiCaps
+            every { connectivityManager.registerDefaultNetworkCallback(capture(callbackSlot)) } just Runs
+            every { interfaceRepository.enabledInterfaces } returns flowOf(sampleConfigs())
+
+            observer.start(testScope.backgroundScope)
+            callbackSlot.captured.onAvailable(wifiNetwork)
+            callbackSlot.captured.onCapabilitiesChanged(wifiNetwork, wifiCaps)
+            coVerify(timeout = 5_000, exactly = 1) {
+                transportAdmin.reloadInterfaces(any())
+            }
+            callbackSlot.captured.onAvailable(cellularNetwork)
+            callbackSlot.captured.onCapabilitiesChanged(cellularNetwork, cellularCaps)
+            coVerify(timeout = 5_000, exactly = 2) {
+                transportAdmin.reloadInterfaces(any())
+            }
+
+            callbackSlot.captured.onLost(wifiNetwork)
+            advanceUntilIdle()
+
+            assertEquals(CurrentTransport.CELLULAR, observer.currentTransport.value)
+            coVerify(timeout = 5_000, exactly = 2) {
+                transportAdmin.reloadInterfaces(any())
+            }
+        }
+
+    @Test
+    fun `final default loss emits none and reloads`() =
+        runTest {
+            val wifiNetwork = mockk<Network>()
+            val wifiCaps = wifiCaps()
+            every { connectivityManager.getActiveNetwork() } returns wifiNetwork
+            every { connectivityManager.getNetworkCapabilities(wifiNetwork) } returns wifiCaps
+            every { connectivityManager.registerDefaultNetworkCallback(capture(callbackSlot)) } just Runs
+            every { interfaceRepository.enabledInterfaces } returns flowOf(sampleConfigs())
+
+            observer.start(testScope.backgroundScope)
+            callbackSlot.captured.onAvailable(wifiNetwork)
+            callbackSlot.captured.onCapabilitiesChanged(wifiNetwork, wifiCaps)
+            advanceUntilIdle()
+
+            callbackSlot.captured.onLost(wifiNetwork)
+            advanceUntilIdle()
+
+            assertEquals(CurrentTransport.NONE, observer.currentTransport.value)
+            coVerify(timeout = 5_000, exactly = 2) {
+                transportAdmin.reloadInterfaces(any())
+            }
+        }
+
+    @Test
+    fun `vpn and unsupported capabilities emit unknown`() =
+        runTest {
+            val defaultNetwork = mockk<Network>()
+            val caps = mockk<NetworkCapabilities>()
+            every { caps.hasTransport(NetworkCapabilities.TRANSPORT_WIFI) } returns false
+            every { caps.hasTransport(NetworkCapabilities.TRANSPORT_ETHERNET) } returns false
+            every { caps.hasTransport(NetworkCapabilities.TRANSPORT_CELLULAR) } returns false
+            every { connectivityManager.getActiveNetwork() } returns defaultNetwork
+            every { connectivityManager.getNetworkCapabilities(defaultNetwork) } returns caps
+            every { connectivityManager.registerDefaultNetworkCallback(capture(callbackSlot)) } just Runs
+            every { interfaceRepository.enabledInterfaces } returns flowOf(sampleConfigs())
+
+            observer.start(testScope.backgroundScope)
+            callbackSlot.captured.onAvailable(defaultNetwork)
+            callbackSlot.captured.onCapabilitiesChanged(defaultNetwork, caps)
+            advanceUntilIdle()
+
+            assertEquals(CurrentTransport.UNKNOWN, observer.currentTransport.value)
+            coVerify(timeout = 5_000, exactly = 1) {
+                transportAdmin.reloadInterfaces(
+                    match { configs -> configs == listOf(sampleConfigs()[1]) },
+                )
+            }
+        }
+
+    @Test
+    fun `duplicate same bucket capability updates are deduplicated`() =
+        runTest {
+            val defaultNetwork = mockk<Network>()
+            val wifiCaps = wifiCaps()
+            every { connectivityManager.getActiveNetwork() } returns defaultNetwork
+            every { connectivityManager.getNetworkCapabilities(defaultNetwork) } returns wifiCaps
+            every { connectivityManager.registerDefaultNetworkCallback(capture(callbackSlot)) } just Runs
+            every { interfaceRepository.enabledInterfaces } returns flowOf(sampleConfigs())
+
+            observer.start(testScope.backgroundScope)
+            callbackSlot.captured.onAvailable(defaultNetwork)
+            callbackSlot.captured.onCapabilitiesChanged(defaultNetwork, wifiCaps)
+            callbackSlot.captured.onCapabilitiesChanged(defaultNetwork, wifiCaps)
+            advanceUntilIdle()
+
+            assertEquals(CurrentTransport.WIFI_LIKE, observer.currentTransport.value)
+            coVerify(timeout = 5_000, exactly = 1) {
+                transportAdmin.reloadInterfaces(any())
+            }
+        }
+
+    @Test
+    fun `stop and restart clears callback identity and duplicate state`() =
+        runTest {
+            val firstNetwork = mockk<Network>()
+            val secondNetwork = mockk<Network>()
+            val wifiCaps = wifiCaps()
+            every { connectivityManager.getActiveNetwork() } returns firstNetwork
+            every { connectivityManager.getNetworkCapabilities(firstNetwork) } returns wifiCaps
+            every { connectivityManager.registerDefaultNetworkCallback(capture(callbackSlot)) } just Runs
+            every { interfaceRepository.enabledInterfaces } returns flowOf(sampleConfigs())
+
+            observer.start(testScope.backgroundScope)
+            val firstCallback = callbackSlot.captured
+            firstCallback.onAvailable(firstNetwork)
+            firstCallback.onCapabilitiesChanged(firstNetwork, wifiCaps)
+            advanceUntilIdle()
+
+            observer.stop()
+            verify(exactly = 1) { connectivityManager.unregisterNetworkCallback(firstCallback) }
+
+            every { connectivityManager.getActiveNetwork() } returns secondNetwork
+            every { connectivityManager.getNetworkCapabilities(secondNetwork) } returns wifiCaps
+            observer.start(testScope.backgroundScope)
+            val secondCallback = callbackSlot.captured
+            assertTrue(firstCallback !== secondCallback)
+
+            secondCallback.onAvailable(secondNetwork)
+            secondCallback.onCapabilitiesChanged(secondNetwork, wifiCaps)
+            advanceUntilIdle()
+
+            coVerify(timeout = 5_000, atLeast = 1) {
+                transportAdmin.reloadInterfaces(any())
+            }
+        }
+
+    private fun wifiCaps(): NetworkCapabilities =
+        mockk<NetworkCapabilities>().also {
+            every { it.hasTransport(NetworkCapabilities.TRANSPORT_WIFI) } returns true
+            every { it.hasTransport(NetworkCapabilities.TRANSPORT_ETHERNET) } returns false
+            every { it.hasTransport(NetworkCapabilities.TRANSPORT_CELLULAR) } returns false
+        }
+
+    private fun cellularCaps(): NetworkCapabilities =
+        mockk<NetworkCapabilities>().also {
+            every { it.hasTransport(NetworkCapabilities.TRANSPORT_WIFI) } returns false
+            every { it.hasTransport(NetworkCapabilities.TRANSPORT_ETHERNET) } returns false
+            every { it.hasTransport(NetworkCapabilities.TRANSPORT_CELLULAR) } returns true
+        }
+
+    private fun sampleConfigs(): List<InterfaceConfig> =
+        listOf(
+            InterfaceConfig.AutoInterface(name = "wifi", networkRestriction = NetworkRestriction.WIFI_ONLY),
+            InterfaceConfig.TCPClient(name = "any", targetHost = "10.0.0.1", targetPort = 4242),
+            InterfaceConfig.TCPClient(
+                name = "cell",
+                targetHost = "10.0.0.2",
+                targetPort = 4242,
+                networkRestriction = NetworkRestriction.CELLULAR_ONLY,
+            ),
+        )
+}

--- a/app/src/test/java/network/columba/app/ui/screens/InterfaceManagementUtilsTest.kt
+++ b/app/src/test/java/network/columba/app/ui/screens/InterfaceManagementUtilsTest.kt
@@ -57,6 +57,17 @@ class InterfaceManagementUtilsTest {
             InterfaceRestrictionView.NotApplicable,
             entity.restrictionView(CurrentTransport.NONE),
         )
+        assertEquals(
+            InterfaceRestrictionView.NotApplicable,
+            entity.restrictionView(CurrentTransport.UNKNOWN),
+        )
+    }
+
+    @Test
+    fun restrictionView_restrictedIpInterface_onUnknown_returnsBlockedNotNoNetwork() {
+        val entity = autoInterface(restrictionJsonValue = "wifi_only")
+        val result = entity.restrictionView(CurrentTransport.UNKNOWN)
+        assertEquals(InterfaceRestrictionView.Blocked(NetworkRestriction.WIFI_ONLY), result)
     }
 
     // region restrictionView — Non-IP bypass

--- a/port-deviations.md
+++ b/port-deviations.md
@@ -19,8 +19,8 @@ and not user-controllable, and no other interface type exposes a transport filte
 
 The field is enforced by `InterfaceTransportFilter.filterByTransport` against the
 device's current `NetworkCapabilities` (Wi-Fi/Ethernet → `WIFI_LIKE`, cellular →
-`CELLULAR`, none → `NONE`). On transport transitions, `InterfaceTransportObserver`
-re-applies the filter and feeds the resulting subset into
+`CELLULAR`, unsupported live default route → `UNKNOWN`, none → `NONE`). On transport
+transitions, `InterfaceTransportObserver` re-applies the filter and feeds the resulting subset into
 `ReticulumProtocol.reloadInterfaces`. The filter ignores the field for non-IP
 transports (`AndroidBLE` and `RNode` with `connectionMode != "tcp"`) — those don't
 ride on the IP carrier so the restriction is meaningless for them.

--- a/port-deviations.md
+++ b/port-deviations.md
@@ -37,7 +37,8 @@ not a port gap.
 **ETHERNET bucketing.** `TRANSPORT_ETHERNET` is treated as `WIFI_LIKE` so USB tethering
 to a PC and dock setups behave like the user expects (a wired LAN-only TCP transport
 should reach a LAN node over Ethernet, not get filtered out as "not Wi-Fi"). A
-VPN-only default network is classified as `UNKNOWN` so unrestricted IP interfaces stay
-up while Wi-Fi-only and cellular-only interfaces remain safely filtered out. If Android
-also exposes a deterministic underlying transport on the same default-network
-capabilities, that underlying transport wins.
+VPN-only or otherwise unsupported live default network is classified as `UNKNOWN` so
+unrestricted IP interfaces stay up while Wi-Fi-only and cellular-only interfaces remain
+safely filtered out. If Android exposes a deterministic underlying transport on the same
+default-network capabilities, that underlying transport wins. `NONE` is reserved for the
+absence of a live default route.

--- a/port-deviations.md
+++ b/port-deviations.md
@@ -36,6 +36,8 @@ not a port gap.
 
 **ETHERNET bucketing.** `TRANSPORT_ETHERNET` is treated as `WIFI_LIKE` so USB tethering
 to a PC and dock setups behave like the user expects (a wired LAN-only TCP transport
-should reach a LAN node over Ethernet, not get filtered out as "not Wi-Fi"). VPN-over-X
-is treated as the underlying X — Android typically reports both transport flags on the
-same `NetworkCapabilities`, and the underlying transport check wins.
+should reach a LAN node over Ethernet, not get filtered out as "not Wi-Fi"). A
+VPN-only default network is classified as `UNKNOWN` so unrestricted IP interfaces stay
+up while Wi-Fi-only and cellular-only interfaces remain safely filtered out. If Android
+also exposes a deterministic underlying transport on the same default-network
+capabilities, that underlying transport wins.

--- a/rns-host/src/main/kotlin/network/columba/app/rns/host/manager/InterfaceTransportFilter.kt
+++ b/rns-host/src/main/kotlin/network/columba/app/rns/host/manager/InterfaceTransportFilter.kt
@@ -89,17 +89,16 @@ fun currentTransportOf(connectivityManager: ConnectivityManager): CurrentTranspo
 /**
  * Map a `NetworkCapabilities` instance to the closest matching `CurrentTransport`.
  * Wi-Fi and Ethernet collapse to `WIFI_LIKE`; cellular maps to `CELLULAR`. If Android
- * exposes only a VPN transport on the default network, classify that as `UNKNOWN` so
- * unrestricted IP interfaces stay alive without falsely enabling Wi-Fi-only or
- * cellular-only ones.
+ * exposes only VPN or another unsupported transport on the live default network,
+ * classify that as `UNKNOWN` so unrestricted IP interfaces stay alive without falsely
+ * enabling Wi-Fi-only or cellular-only ones. `NONE` is reserved for no live default.
  */
 fun currentTransportOf(capabilities: NetworkCapabilities): CurrentTransport =
     when {
         capabilities.hasTransport(NetworkCapabilities.TRANSPORT_WIFI) -> CurrentTransport.WIFI_LIKE
         capabilities.hasTransport(NetworkCapabilities.TRANSPORT_ETHERNET) -> CurrentTransport.WIFI_LIKE
         capabilities.hasTransport(NetworkCapabilities.TRANSPORT_CELLULAR) -> CurrentTransport.CELLULAR
-        capabilities.hasTransport(NetworkCapabilities.TRANSPORT_VPN) -> CurrentTransport.UNKNOWN
-        else -> CurrentTransport.NONE
+        else -> CurrentTransport.UNKNOWN
     }
 
 /**

--- a/rns-host/src/main/kotlin/network/columba/app/rns/host/manager/InterfaceTransportFilter.kt
+++ b/rns-host/src/main/kotlin/network/columba/app/rns/host/manager/InterfaceTransportFilter.kt
@@ -77,13 +77,13 @@ fun InterfaceConfig.ridesOnIpCarrier(): Boolean =
     }
 
 /**
- * Snapshot the device's current transport from the system `ConnectivityManager`. Returns
- * `NONE` if no default network is active or capabilities are unavailable.
+ * Snapshot the currently active default network. A missing default route maps to `NONE`;
+ * a live default whose capabilities are not yet published maps to `UNKNOWN`.
  */
 fun currentTransportOf(connectivityManager: ConnectivityManager): CurrentTransport {
-    val active = connectivityManager.activeNetwork ?: return CurrentTransport.NONE
-    val caps = connectivityManager.getNetworkCapabilities(active) ?: return CurrentTransport.NONE
-    return currentTransportOf(caps)
+    val activeNetwork = connectivityManager.activeNetwork ?: return CurrentTransport.NONE
+    val capabilities = connectivityManager.getNetworkCapabilities(activeNetwork) ?: return CurrentTransport.UNKNOWN
+    return currentTransportOf(capabilities)
 }
 
 /**

--- a/rns-host/src/main/kotlin/network/columba/app/rns/host/manager/InterfaceTransportFilter.kt
+++ b/rns-host/src/main/kotlin/network/columba/app/rns/host/manager/InterfaceTransportFilter.kt
@@ -20,6 +20,12 @@ enum class CurrentTransport {
     /** Cellular (mobile data). */
     CELLULAR,
 
+    /**
+     * A live default network exists, but Android's callback-visible capabilities do not
+     * identify a Wi-Fi / Ethernet / cellular underlay. VPN-only defaults land here.
+     */
+    UNKNOWN,
+
     /** No active default network. */
     NONE,
 }
@@ -81,20 +87,18 @@ fun currentTransportOf(connectivityManager: ConnectivityManager): CurrentTranspo
 }
 
 /**
- * Map a `NetworkCapabilities` instance to the closest matching `CurrentTransport`. Wi-Fi
- * and Ethernet collapse to `WIFI_LIKE`; cellular maps to `CELLULAR`; anything else (e.g.
- * `TRANSPORT_VPN` alone, `TRANSPORT_BLUETOOTH` tether) falls through to `NONE`.
- *
- * For VPN over an underlying transport (the common case), Android typically reports both
- * `TRANSPORT_VPN` and the underlying transport on the same `NetworkCapabilities` — so the
- * underlying-transport check still wins, which is the intended VPN behaviour (classify by
- * the underlying transport, not the VPN itself).
+ * Map a `NetworkCapabilities` instance to the closest matching `CurrentTransport`.
+ * Wi-Fi and Ethernet collapse to `WIFI_LIKE`; cellular maps to `CELLULAR`. If Android
+ * exposes only a VPN transport on the default network, classify that as `UNKNOWN` so
+ * unrestricted IP interfaces stay alive without falsely enabling Wi-Fi-only or
+ * cellular-only ones.
  */
 fun currentTransportOf(capabilities: NetworkCapabilities): CurrentTransport =
     when {
         capabilities.hasTransport(NetworkCapabilities.TRANSPORT_WIFI) -> CurrentTransport.WIFI_LIKE
         capabilities.hasTransport(NetworkCapabilities.TRANSPORT_ETHERNET) -> CurrentTransport.WIFI_LIKE
         capabilities.hasTransport(NetworkCapabilities.TRANSPORT_CELLULAR) -> CurrentTransport.CELLULAR
+        capabilities.hasTransport(NetworkCapabilities.TRANSPORT_VPN) -> CurrentTransport.UNKNOWN
         else -> CurrentTransport.NONE
     }
 

--- a/rns-host/src/main/kotlin/network/columba/app/rns/host/manager/NetworkChangeManager.kt
+++ b/rns-host/src/main/kotlin/network/columba/app/rns/host/manager/NetworkChangeManager.kt
@@ -4,7 +4,6 @@ import android.content.Context
 import android.net.ConnectivityManager
 import android.net.Network
 import android.net.NetworkCapabilities
-import android.net.NetworkRequest
 import android.util.Log
 
 /**
@@ -42,7 +41,7 @@ class NetworkChangeManager(
 
     private var networkCallback: ConnectivityManager.NetworkCallback? = null
     private var isMonitoring = false
-    private var lastNetworkId: String? = null
+    private var currentDefaultNetwork: Network? = null
 
     // Last-emitted transport, used to suppress duplicate `onTransportChanged` callbacks
     // when capabilities update without actually changing the transport class. Initialised
@@ -61,29 +60,29 @@ class NetworkChangeManager(
         networkCallback =
             object : ConnectivityManager.NetworkCallback() {
                 override fun onAvailable(network: Network) {
-                    val networkId = network.toString()
-                    Log.d(TAG, "Network available: $networkId (previous: $lastNetworkId)")
+                    val previous = currentDefaultNetwork
+                    currentDefaultNetwork = network
+                    Log.d(TAG, "Default network available: $network (previous: $previous)")
 
-                    // Trigger on first connection OR network switch.
-                    // First-connection case (lastNetworkId == null) handles the scenario where
+                    // Trigger on first connection OR default-network switch.
+                    // First-connection case (previous == null) handles the scenario where
                     // the app starts without WiFi and later connects — AutoInterface needs to
                     // scan for the new network interface. The caller guards against premature
                     // invocation before Reticulum is initialized.
-                    if (lastNetworkId == null || lastNetworkId != networkId) {
+                    if (previous == null || previous != network) {
                         Log.i(TAG, "Network changed - reacquiring locks and triggering announce")
                         handleNetworkChange()
                     }
-                    lastNetworkId = networkId
                 }
 
                 override fun onLost(network: Network) {
                     Log.d(TAG, "Network lost: $network")
-                    // The lost network may have been the default while an already-available
-                    // backup became active. Its capabilities need not change during that
-                    // handoff, so classify the current default here as well as in
-                    // onCapabilitiesChanged. This also emits NONE when no default remains.
-                    emitTransportIfChanged(currentTransportOf(connectivityManager))
-                    // Don't clear lastNetworkId here - we want to detect when a new network connects
+                    // Only the current default route can drive transport loss. If another
+                    // callback already promoted a replacement default, ignore this stale loss.
+                    if (currentDefaultNetwork == network) {
+                        currentDefaultNetwork = null
+                        emitTransportIfChanged(CurrentTransport.NONE)
+                    }
                 }
 
                 override fun onCapabilitiesChanged(
@@ -95,21 +94,15 @@ class NetworkChangeManager(
                     val isValidated = networkCapabilities.hasCapability(NetworkCapabilities.NET_CAPABILITY_VALIDATED)
                     Log.v(TAG, "Network capabilities changed: internet=$hasInternet, validated=$isValidated")
 
-                    // This callback fires for every network matching NET_CAPABILITY_INTERNET,
-                    // not only the active route. Classify the system's current active network
-                    // so capability updates from a backup network cannot emit a false switch.
-                    emitTransportIfChanged(currentTransportOf(connectivityManager))
+                    // Only the current default route can drive transport classification.
+                    if (network == currentDefaultNetwork) {
+                        emitTransportIfChanged(currentTransportOf(networkCapabilities))
+                    }
                 }
             }
 
-        val request =
-            NetworkRequest
-                .Builder()
-                .addCapability(NetworkCapabilities.NET_CAPABILITY_INTERNET)
-                .build()
-
         try {
-            connectivityManager.registerNetworkCallback(request, networkCallback!!)
+            connectivityManager.registerDefaultNetworkCallback(networkCallback!!)
             isMonitoring = true
             Log.d(TAG, "Network monitoring started")
         } catch (e: Exception) {
@@ -132,7 +125,7 @@ class NetworkChangeManager(
         }
         networkCallback = null
         isMonitoring = false
-        lastNetworkId = null
+        currentDefaultNetwork = null
         lastTransport = null
     }
 

--- a/rns-host/src/main/kotlin/network/columba/app/rns/host/manager/NetworkChangeManager.kt
+++ b/rns-host/src/main/kotlin/network/columba/app/rns/host/manager/NetworkChangeManager.kt
@@ -78,12 +78,11 @@ class NetworkChangeManager(
 
                 override fun onLost(network: Network) {
                     Log.d(TAG, "Network lost: $network")
-                    // If no default network remains, emit NONE so transport-restricted
-                    // interfaces detach. ConnectivityManager.activeNetwork goes null only
-                    // after the OS finishes the disconnection, so check it here.
-                    if (connectivityManager.activeNetwork == null) {
-                        emitTransportIfChanged(CurrentTransport.NONE)
-                    }
+                    // The lost network may have been the default while an already-available
+                    // backup became active. Its capabilities need not change during that
+                    // handoff, so classify the current default here as well as in
+                    // onCapabilitiesChanged. This also emits NONE when no default remains.
+                    emitTransportIfChanged(currentTransportOf(connectivityManager))
                     // Don't clear lastNetworkId here - we want to detect when a new network connects
                 }
 
@@ -96,12 +95,10 @@ class NetworkChangeManager(
                     val isValidated = networkCapabilities.hasCapability(NetworkCapabilities.NET_CAPABILITY_VALIDATED)
                     Log.v(TAG, "Network capabilities changed: internet=$hasInternet, validated=$isValidated")
 
-                    // Compute transport class and emit if it changed since last emission.
-                    // `onCapabilitiesChanged` fires after `onAvailable` and again whenever a
-                    // capability flips (validation, metered, etc.) — the last-value cache
-                    // collapses those into a single `onTransportChanged` per actual transport
-                    // transition.
-                    emitTransportIfChanged(currentTransportOf(networkCapabilities))
+                    // This callback fires for every network matching NET_CAPABILITY_INTERNET,
+                    // not only the active route. Classify the system's current active network
+                    // so capability updates from a backup network cannot emit a false switch.
+                    emitTransportIfChanged(currentTransportOf(connectivityManager))
                 }
             }
 

--- a/rns-host/src/test/kotlin/network/columba/app/rns/host/manager/InterfaceTransportFilterTest.kt
+++ b/rns-host/src/test/kotlin/network/columba/app/rns/host/manager/InterfaceTransportFilterTest.kt
@@ -1,5 +1,9 @@
 package network.columba.app.rns.host.manager
 
+import android.net.ConnectivityManager
+import android.net.Network
+import io.mockk.every
+import io.mockk.mockk
 import network.columba.app.rns.api.model.InterfaceConfig
 import network.columba.app.rns.api.model.NetworkRestriction
 import org.junit.Assert.assertEquals
@@ -10,6 +14,24 @@ import org.junit.Test
  * identity (by name) of the filtered set so behaviour change is caught precisely.
  */
 class InterfaceTransportFilterTest {
+    @Test
+    fun `snapshot with live default but unpublished capabilities is unknown`() {
+        val connectivityManager = mockk<ConnectivityManager>()
+        val activeNetwork = mockk<Network>()
+        every { connectivityManager.activeNetwork } returns activeNetwork
+        every { connectivityManager.getNetworkCapabilities(activeNetwork) } returns null
+
+        assertEquals(CurrentTransport.UNKNOWN, currentTransportOf(connectivityManager))
+    }
+
+    @Test
+    fun `snapshot without a default route is none`() {
+        val connectivityManager = mockk<ConnectivityManager>()
+        every { connectivityManager.activeNetwork } returns null
+
+        assertEquals(CurrentTransport.NONE, currentTransportOf(connectivityManager))
+    }
+
     @Test
     fun `filter anyRestriction passes on all transports`() {
         val cfg = tcp("x", NetworkRestriction.ANY)

--- a/rns-host/src/test/kotlin/network/columba/app/rns/host/manager/InterfaceTransportFilterTest.kt
+++ b/rns-host/src/test/kotlin/network/columba/app/rns/host/manager/InterfaceTransportFilterTest.kt
@@ -15,6 +15,7 @@ class InterfaceTransportFilterTest {
         val cfg = tcp("x", NetworkRestriction.ANY)
         assertEquals(listOf("x"), filterByTransport(listOf(cfg), CurrentTransport.WIFI_LIKE).map { it.name })
         assertEquals(listOf("x"), filterByTransport(listOf(cfg), CurrentTransport.CELLULAR).map { it.name })
+        assertEquals(listOf("x"), filterByTransport(listOf(cfg), CurrentTransport.UNKNOWN).map { it.name })
         // NONE drops IP interfaces regardless of restriction — no route, nothing to attach.
         assertEquals(emptyList<String>(), filterByTransport(listOf(cfg), CurrentTransport.NONE).map { it.name })
     }
@@ -34,9 +35,11 @@ class InterfaceTransportFilterTest {
         val cfg = tcp("x", NetworkRestriction.CELLULAR_ONLY)
         val onWifi = filterByTransport(listOf(cfg), CurrentTransport.WIFI_LIKE)
         val onCell = filterByTransport(listOf(cfg), CurrentTransport.CELLULAR)
+        val onUnknown = filterByTransport(listOf(cfg), CurrentTransport.UNKNOWN)
         assertEquals(0, onWifi.size)
         assertEquals(1, onCell.size)
         assertEquals("x", onCell.single().name)
+        assertEquals(0, onUnknown.size)
     }
 
     @Test
@@ -49,9 +52,12 @@ class InterfaceTransportFilterTest {
                 networkRestriction = NetworkRestriction.WIFI_ONLY,
             )
         val onCell = filterByTransport(listOf(cfg), CurrentTransport.CELLULAR)
+        val onUnknown = filterByTransport(listOf(cfg), CurrentTransport.UNKNOWN)
         val onNone = filterByTransport(listOf(cfg), CurrentTransport.NONE)
         assertEquals(1, onCell.size)
         assertEquals("ble", onCell.single().name)
+        assertEquals(1, onUnknown.size)
+        assertEquals("ble", onUnknown.single().name)
         // BLE survives even NONE — Bluetooth doesn't depend on Android's IP carrier.
         assertEquals(1, onNone.size)
         assertEquals("ble", onNone.single().name)
@@ -83,8 +89,11 @@ class InterfaceTransportFilterTest {
             )
         // connectionMode != "tcp" → not riding IP → restriction ignored.
         val onCell = filterByTransport(listOf(cfg), CurrentTransport.CELLULAR)
+        val onUnknown = filterByTransport(listOf(cfg), CurrentTransport.UNKNOWN)
         assertEquals(1, onCell.size)
         assertEquals("rnode-ble", onCell.single().name)
+        assertEquals(1, onUnknown.size)
+        assertEquals("rnode-ble", onUnknown.single().name)
     }
 
     @Test
@@ -98,8 +107,11 @@ class InterfaceTransportFilterTest {
                 networkRestriction = NetworkRestriction.CELLULAR_ONLY,
             )
         val onWifi = filterByTransport(listOf(cfg), CurrentTransport.WIFI_LIKE)
+        val onUnknown = filterByTransport(listOf(cfg), CurrentTransport.UNKNOWN)
         assertEquals(1, onWifi.size)
         assertEquals("rnode-usb", onWifi.single().name)
+        assertEquals(1, onUnknown.size)
+        assertEquals("rnode-usb", onUnknown.single().name)
     }
 
     @Test
@@ -123,6 +135,9 @@ class InterfaceTransportFilterTest {
 
         val onWifi = filterByTransport(configs, CurrentTransport.WIFI_LIKE)
         assertEquals(listOf("home-lan", "ble", "rnode-bt"), onWifi.map { it.name })
+
+        val onUnknown = filterByTransport(configs, CurrentTransport.UNKNOWN)
+        assertEquals(listOf("ble", "rnode-bt"), onUnknown.map { it.name })
     }
 
     private fun tcp(

--- a/rns-host/src/test/kotlin/network/columba/app/rns/host/manager/NetworkChangeManagerTest.kt
+++ b/rns-host/src/test/kotlin/network/columba/app/rns/host/manager/NetworkChangeManagerTest.kt
@@ -342,6 +342,21 @@ class NetworkChangeManagerTest {
 
     @Suppress("NoRelaxedMocks")
     @Test
+    fun `unsupported live default transport emits UNKNOWN rather than NONE`() {
+        val transports = mutableListOf<CurrentTransport>()
+        val mgr = transportManager(transports)
+        val network = mockk<android.net.Network>(relaxed = true)
+
+        mgr.start()
+        callbackSlot.captured.onAvailable(network)
+        callbackSlot.captured.onCapabilitiesChanged(network, mockNetworkCapabilities())
+
+        assertEquals(listOf(CurrentTransport.UNKNOWN), transports)
+        mgr.stop()
+    }
+
+    @Suppress("NoRelaxedMocks")
+    @Test
     fun `vpn with deterministic wifi underlay classifies as wifi like`() {
         val transports = mutableListOf<CurrentTransport>()
         val mgr = transportManager(transports)

--- a/rns-host/src/test/kotlin/network/columba/app/rns/host/manager/NetworkChangeManagerTest.kt
+++ b/rns-host/src/test/kotlin/network/columba/app/rns/host/manager/NetworkChangeManagerTest.kt
@@ -271,23 +271,89 @@ class NetworkChangeManagerTest {
 
     // ========== onTransportChanged callback tests ==========
 
-    @Suppress("NoRelaxedMocks") // android.net.Network/NetworkCapabilities are system classes; relaxed mock is the standard pattern
+    @Suppress("NoRelaxedMocks")
     @Test
-    fun `onCapabilitiesChanged wifi to cellular fires onTransportChanged once`() {
+    fun `cellular backup capability change keeps wifi active transport`() {
         val transports = mutableListOf<CurrentTransport>()
-        val mgr =
-            NetworkChangeManager(
-                context = context,
-                lockManager = lockManager,
-                onTransportChanged = { transports.add(it) },
-            )
-        mgr.start()
-        val network = mockk<android.net.Network>(relaxed = true)
+        val mgr = transportManager(transports)
+        val wifiNetwork = mockk<android.net.Network>(relaxed = true)
+        val cellularNetwork = mockk<android.net.Network>(relaxed = true)
         val wifiCaps = mockNetworkCapabilities(wifi = true)
-        val cellCaps = mockNetworkCapabilities(cellular = true)
+        val cellularCaps = mockNetworkCapabilities(cellular = true)
+        every { connectivityManager.activeNetwork } returns wifiNetwork
+        every { connectivityManager.getNetworkCapabilities(wifiNetwork) } returns wifiCaps
 
-        callbackSlot.captured.onCapabilitiesChanged(network, wifiCaps)
-        callbackSlot.captured.onCapabilitiesChanged(network, cellCaps)
+        mgr.start()
+        callbackSlot.captured.onCapabilitiesChanged(wifiNetwork, wifiCaps)
+        callbackSlot.captured.onCapabilitiesChanged(cellularNetwork, cellularCaps)
+
+        assertEquals(listOf(CurrentTransport.WIFI_LIKE), transports)
+        mgr.stop()
+    }
+
+    @Suppress("NoRelaxedMocks")
+    @Test
+    fun `wifi backup capability change keeps cellular active transport`() {
+        val transports = mutableListOf<CurrentTransport>()
+        val mgr = transportManager(transports)
+        val wifiNetwork = mockk<android.net.Network>(relaxed = true)
+        val cellularNetwork = mockk<android.net.Network>(relaxed = true)
+        val wifiCaps = mockNetworkCapabilities(wifi = true)
+        val cellularCaps = mockNetworkCapabilities(cellular = true)
+        every { connectivityManager.activeNetwork } returns cellularNetwork
+        every { connectivityManager.getNetworkCapabilities(cellularNetwork) } returns cellularCaps
+
+        mgr.start()
+        callbackSlot.captured.onCapabilitiesChanged(cellularNetwork, cellularCaps)
+        callbackSlot.captured.onCapabilitiesChanged(wifiNetwork, wifiCaps)
+
+        assertEquals(listOf(CurrentTransport.CELLULAR), transports)
+        mgr.stop()
+    }
+
+    @Suppress("NoRelaxedMocks")
+    @Test
+    fun `non-default network capability changes do not emit transport switch`() {
+        val transports = mutableListOf<CurrentTransport>()
+        val mgr = transportManager(transports)
+        val wifiNetwork = mockk<android.net.Network>(relaxed = true)
+        val cellularNetwork = mockk<android.net.Network>(relaxed = true)
+        val wifiCaps = mockNetworkCapabilities(wifi = true)
+        every { connectivityManager.activeNetwork } returns wifiNetwork
+        every { connectivityManager.getNetworkCapabilities(wifiNetwork) } returns wifiCaps
+
+        mgr.start()
+        callbackSlot.captured.onCapabilitiesChanged(wifiNetwork, wifiCaps)
+        callbackSlot.captured.onCapabilitiesChanged(
+            cellularNetwork,
+            mockNetworkCapabilities(cellular = true),
+        )
+        callbackSlot.captured.onCapabilitiesChanged(
+            cellularNetwork,
+            mockNetworkCapabilities(cellular = true, metered = true),
+        )
+
+        assertEquals(listOf(CurrentTransport.WIFI_LIKE), transports)
+        mgr.stop()
+    }
+
+    @Suppress("NoRelaxedMocks")
+    @Test
+    fun `losing default emits transport of already available backup`() {
+        val transports = mutableListOf<CurrentTransport>()
+        val mgr = transportManager(transports)
+        val wifiNetwork = mockk<android.net.Network>(relaxed = true)
+        val cellularNetwork = mockk<android.net.Network>(relaxed = true)
+        val wifiCaps = mockNetworkCapabilities(wifi = true)
+        val cellularCaps = mockNetworkCapabilities(cellular = true)
+        every { connectivityManager.activeNetwork } returns wifiNetwork
+        every { connectivityManager.getNetworkCapabilities(wifiNetwork) } returns wifiCaps
+
+        mgr.start()
+        callbackSlot.captured.onCapabilitiesChanged(wifiNetwork, wifiCaps)
+        every { connectivityManager.activeNetwork } returns cellularNetwork
+        every { connectivityManager.getNetworkCapabilities(cellularNetwork) } returns cellularCaps
+        callbackSlot.captured.onLost(wifiNetwork)
 
         assertEquals(
             listOf(CurrentTransport.WIFI_LIKE, CurrentTransport.CELLULAR),
@@ -298,28 +364,21 @@ class NetworkChangeManagerTest {
 
     @Suppress("NoRelaxedMocks")
     @Test
-    fun `onCapabilitiesChanged cellular twice does not refire`() {
+    fun `active network with unavailable capabilities emits NONE`() {
         val transports = mutableListOf<CurrentTransport>()
-        val mgr =
-            NetworkChangeManager(
-                context = context,
-                lockManager = lockManager,
-                onTransportChanged = { transports.add(it) },
-            )
+        val mgr = transportManager(transports)
+        val activeNetwork = mockk<android.net.Network>(relaxed = true)
+        val callbackNetwork = mockk<android.net.Network>(relaxed = true)
+        every { connectivityManager.activeNetwork } returns activeNetwork
+        every { connectivityManager.getNetworkCapabilities(activeNetwork) } returns null
+
         mgr.start()
-        val network = mockk<android.net.Network>(relaxed = true)
-        val wifiCaps = mockNetworkCapabilities(wifi = true)
-        val cellCaps = mockNetworkCapabilities(cellular = true)
-
-        callbackSlot.captured.onCapabilitiesChanged(network, wifiCaps)
-        callbackSlot.captured.onCapabilitiesChanged(network, cellCaps)
-        // Same transport class fired again — should be suppressed by the last-value cache.
-        callbackSlot.captured.onCapabilitiesChanged(network, cellCaps)
-
-        assertEquals(
-            listOf(CurrentTransport.WIFI_LIKE, CurrentTransport.CELLULAR),
-            transports,
+        callbackSlot.captured.onCapabilitiesChanged(
+            callbackNetwork,
+            mockNetworkCapabilities(cellular = true),
         )
+
+        assertEquals(listOf(CurrentTransport.NONE), transports)
         mgr.stop()
     }
 
@@ -327,19 +386,14 @@ class NetworkChangeManagerTest {
     @Test
     fun `onLost when no default network remains fires NONE`() {
         val transports = mutableListOf<CurrentTransport>()
-        val mgr =
-            NetworkChangeManager(
-                context = context,
-                lockManager = lockManager,
-                onTransportChanged = { transports.add(it) },
-            )
-        mgr.start()
+        val mgr = transportManager(transports)
         val network = mockk<android.net.Network>(relaxed = true)
-        callbackSlot.captured.onCapabilitiesChanged(
-            network,
-            mockNetworkCapabilities(wifi = true),
-        )
-        // Active network goes null — simulates last network gone.
+        val wifiCaps = mockNetworkCapabilities(wifi = true)
+        every { connectivityManager.activeNetwork } returns network
+        every { connectivityManager.getNetworkCapabilities(network) } returns wifiCaps
+
+        mgr.start()
+        callbackSlot.captured.onCapabilitiesChanged(network, wifiCaps)
         every { connectivityManager.activeNetwork } returns null
         callbackSlot.captured.onLost(network)
 
@@ -352,29 +406,73 @@ class NetworkChangeManagerTest {
 
     @Suppress("NoRelaxedMocks")
     @Test
-    fun `ethernet capability buckets as wifi like`() {
+    fun `repeated callbacks and metered VPN changes are deduplicated by underlying active transport`() {
         val transports = mutableListOf<CurrentTransport>()
-        val mgr =
-            NetworkChangeManager(
-                context = context,
-                lockManager = lockManager,
-                onTransportChanged = { transports.add(it) },
-            )
+        val mgr = transportManager(transports)
+        val vpnNetwork = mockk<android.net.Network>(relaxed = true)
+        val unmeteredVpnCaps = mockNetworkCapabilities(wifi = true, vpn = true)
+        val meteredVpnCaps = mockNetworkCapabilities(wifi = true, vpn = true, metered = true)
+        every { connectivityManager.activeNetwork } returns vpnNetwork
+        every { connectivityManager.getNetworkCapabilities(vpnNetwork) } returns unmeteredVpnCaps
+
         mgr.start()
-        val network = mockk<android.net.Network>(relaxed = true)
-        callbackSlot.captured.onCapabilitiesChanged(
-            network,
-            mockNetworkCapabilities(ethernet = true),
-        )
+        callbackSlot.captured.onCapabilitiesChanged(vpnNetwork, unmeteredVpnCaps)
+        every { connectivityManager.getNetworkCapabilities(vpnNetwork) } returns meteredVpnCaps
+        callbackSlot.captured.onCapabilitiesChanged(vpnNetwork, meteredVpnCaps)
+        callbackSlot.captured.onCapabilitiesChanged(vpnNetwork, meteredVpnCaps)
+
         assertEquals(listOf(CurrentTransport.WIFI_LIKE), transports)
         mgr.stop()
     }
 
-    @Suppress("NoRelaxedMocks") // android.net.NetworkCapabilities is a system class; explicit hasTransport stubs follow
+    @Suppress("NoRelaxedMocks")
+    @Test
+    fun `active VPN without underlying supported transport emits NONE`() {
+        val transports = mutableListOf<CurrentTransport>()
+        val mgr = transportManager(transports)
+        val vpnNetwork = mockk<android.net.Network>(relaxed = true)
+        val vpnCaps = mockNetworkCapabilities(vpn = true)
+        every { connectivityManager.activeNetwork } returns vpnNetwork
+        every { connectivityManager.getNetworkCapabilities(vpnNetwork) } returns vpnCaps
+
+        mgr.start()
+        callbackSlot.captured.onCapabilitiesChanged(vpnNetwork, vpnCaps)
+
+        assertEquals(listOf(CurrentTransport.NONE), transports)
+        mgr.stop()
+    }
+
+    @Suppress("NoRelaxedMocks")
+    @Test
+    fun `ethernet active network buckets as wifi like`() {
+        val transports = mutableListOf<CurrentTransport>()
+        val mgr = transportManager(transports)
+        val network = mockk<android.net.Network>(relaxed = true)
+        val ethernetCaps = mockNetworkCapabilities(ethernet = true)
+        every { connectivityManager.activeNetwork } returns network
+        every { connectivityManager.getNetworkCapabilities(network) } returns ethernetCaps
+
+        mgr.start()
+        callbackSlot.captured.onCapabilitiesChanged(network, ethernetCaps)
+
+        assertEquals(listOf(CurrentTransport.WIFI_LIKE), transports)
+        mgr.stop()
+    }
+
+    private fun transportManager(transports: MutableList<CurrentTransport>) =
+        NetworkChangeManager(
+            context = context,
+            lockManager = lockManager,
+            onTransportChanged = { transports.add(it) },
+        )
+
+    @Suppress("NoRelaxedMocks")
     private fun mockNetworkCapabilities(
         wifi: Boolean = false,
         ethernet: Boolean = false,
         cellular: Boolean = false,
+        vpn: Boolean = false,
+        metered: Boolean = false,
     ): android.net.NetworkCapabilities {
         val caps = mockk<android.net.NetworkCapabilities>(relaxed = true)
         every { caps.hasTransport(android.net.NetworkCapabilities.TRANSPORT_WIFI) } returns wifi
@@ -384,6 +482,10 @@ class NetworkChangeManagerTest {
         every {
             caps.hasTransport(android.net.NetworkCapabilities.TRANSPORT_CELLULAR)
         } returns cellular
+        every { caps.hasTransport(android.net.NetworkCapabilities.TRANSPORT_VPN) } returns vpn
+        every {
+            caps.hasCapability(android.net.NetworkCapabilities.NET_CAPABILITY_NOT_METERED)
+        } returns !metered
         return caps
     }
 }

--- a/rns-host/src/test/kotlin/network/columba/app/rns/host/manager/NetworkChangeManagerTest.kt
+++ b/rns-host/src/test/kotlin/network/columba/app/rns/host/manager/NetworkChangeManagerTest.kt
@@ -2,15 +2,12 @@ package network.columba.app.rns.host.manager
 
 import android.content.Context
 import android.net.ConnectivityManager
-import android.net.NetworkRequest
 import io.mockk.clearAllMocks
 import io.mockk.every
 import io.mockk.just
 import io.mockk.mockk
-import io.mockk.mockkConstructor
-import io.mockk.runs
 import io.mockk.slot
-import io.mockk.unmockkConstructor
+import io.mockk.runs
 import io.mockk.verify
 import org.junit.After
 import org.junit.Assert.assertEquals
@@ -41,22 +38,13 @@ class NetworkChangeManagerTest {
         lockManager = mockk()
         networkChangedCallCount = 0
 
-        // Explicit stubs for LockManager
         every { lockManager.acquireAll() } returns Unit
         every { lockManager.releaseAll() } returns Unit
 
-        // Mock Android framework classes
-        mockkConstructor(NetworkRequest.Builder::class)
-        every { anyConstructed<NetworkRequest.Builder>().addCapability(any()) } answers {
-            self as NetworkRequest.Builder
-        }
-        @Suppress("NoRelaxedMocks") // Android NetworkRequest.Builder
-        val networkRequest = mockk<NetworkRequest>(relaxed = true)
-        every { anyConstructed<NetworkRequest.Builder>().build() } returns networkRequest
-
         every { context.getSystemService(any<String>()) } returns connectivityManager
+        every { connectivityManager.registerDefaultNetworkCallback(capture(callbackSlot)) } just runs
         every {
-            connectivityManager.registerNetworkCallback(any(), capture(callbackSlot))
+            connectivityManager.unregisterNetworkCallback(any<ConnectivityManager.NetworkCallback>())
         } just runs
 
         networkChangeManager =
@@ -70,18 +58,16 @@ class NetworkChangeManagerTest {
     @After
     fun tearDown() {
         networkChangeManager.stop()
-        unmockkConstructor(NetworkRequest.Builder::class)
         clearAllMocks()
     }
 
     @Test
-    fun `start registers network callback`() {
+    fun `start registers default network callback`() {
         networkChangeManager.start()
 
-        val isMonitoring = networkChangeManager.isMonitoring()
-        assertTrue("Should be monitoring after start", isMonitoring)
+        assertTrue("Should be monitoring after start", networkChangeManager.isMonitoring())
         verify(exactly = 1) {
-            connectivityManager.registerNetworkCallback(any(), any<ConnectivityManager.NetworkCallback>())
+            connectivityManager.registerDefaultNetworkCallback(any<ConnectivityManager.NetworkCallback>())
         }
     }
 
@@ -90,8 +76,7 @@ class NetworkChangeManagerTest {
         networkChangeManager.start()
         networkChangeManager.stop()
 
-        val isMonitoring = networkChangeManager.isMonitoring()
-        assertFalse("Should not be monitoring after stop", isMonitoring)
+        assertFalse("Should not be monitoring after stop", networkChangeManager.isMonitoring())
         verify(exactly = 1) {
             connectivityManager.unregisterNetworkCallback(any<ConnectivityManager.NetworkCallback>())
         }
@@ -106,7 +91,6 @@ class NetworkChangeManagerTest {
     fun `stop is safe to call when not monitoring`() {
         assertFalse(networkChangeManager.isMonitoring())
 
-        // Should not throw
         networkChangeManager.stop()
 
         assertFalse(networkChangeManager.isMonitoring())
@@ -128,95 +112,74 @@ class NetworkChangeManagerTest {
         networkChangeManager.start()
         assertTrue(networkChangeManager.isMonitoring())
 
-        // Start again should work without error
         networkChangeManager.start()
 
-        val isMonitoring = networkChangeManager.isMonitoring()
-        assertTrue("Should still be monitoring after restart", isMonitoring)
-        // Should have unregistered previous callback
+        assertTrue("Should still be monitoring after restart", networkChangeManager.isMonitoring())
         verify(exactly = 1) {
             connectivityManager.unregisterNetworkCallback(any<ConnectivityManager.NetworkCallback>())
         }
     }
 
-    @Suppress("NoRelaxedMocks") // Android Network framework class
+    @Suppress("NoRelaxedMocks")
     @Test
-    fun `first network available triggers callback for hot-add`() {
+    fun `first default network available reacquires locks`() {
         networkChangeManager.start()
 
-        // Simulate first network connection (e.g., WiFi connects after starting without it)
         val network = mockk<android.net.Network>(relaxed = true)
-        every { network.toString() } returns "network1"
-
         callbackSlot.captured.onAvailable(network)
 
-        // First network SHOULD trigger callback so AutoInterface can hot-add the new interface
-        assertTrue("Callback should trigger on first network", networkChangedCallCount == 1)
+        assertEquals(1, networkChangedCallCount)
         verify(exactly = 1) { lockManager.acquireAll() }
     }
 
-    @Suppress("NoRelaxedMocks") // Android Network framework class
+    @Suppress("NoRelaxedMocks")
     @Test
     fun `network change triggers callback and reacquires locks`() {
         networkChangeManager.start()
 
-        // Simulate first network (triggers once for initial connection)
         val network1 = mockk<android.net.Network>(relaxed = true)
-        every { network1.toString() } returns "network1"
-        callbackSlot.captured.onAvailable(network1)
-
-        // Simulate network change (triggers again for the switch)
         val network2 = mockk<android.net.Network>(relaxed = true)
-        every { network2.toString() } returns "network2"
+
+        callbackSlot.captured.onAvailable(network1)
         callbackSlot.captured.onAvailable(network2)
 
-        // Should trigger callback for both first connection and network switch
-        assertTrue("Callback should trigger on both connections", networkChangedCallCount == 2)
+        assertEquals(2, networkChangedCallCount)
         verify(exactly = 2) { lockManager.acquireAll() }
     }
 
-    @Suppress("NoRelaxedMocks") // Android Network framework class
+    @Suppress("NoRelaxedMocks")
     @Test
     fun `same network reconnecting does not trigger callback again`() {
         networkChangeManager.start()
 
-        // Simulate network
         val network = mockk<android.net.Network>(relaxed = true)
-        every { network.toString() } returns "network1"
 
-        // Connect twice with same network
         callbackSlot.captured.onAvailable(network)
         callbackSlot.captured.onAvailable(network)
 
-        // Should trigger once for first connection, but not for same-network reconnect
-        assertTrue("Callback should only trigger once for same network", networkChangedCallCount == 1)
+        assertEquals(1, networkChangedCallCount)
         verify(exactly = 1) { lockManager.acquireAll() }
     }
 
-    @Suppress("NoRelaxedMocks") // Android Network framework class
+    @Suppress("NoRelaxedMocks")
     @Test
     fun `exception in lock acquisition does not crash`() {
         every { lockManager.acquireAll() } throws RuntimeException("Test error")
 
         networkChangeManager.start()
 
-        // First connection triggers callback despite lock error
         val network1 = mockk<android.net.Network>(relaxed = true)
-        every { network1.toString() } returns "network1"
-        callbackSlot.captured.onAvailable(network1)
-
-        // Network switch also triggers callback despite lock error
         val network2 = mockk<android.net.Network>(relaxed = true)
-        every { network2.toString() } returns "network2"
 
-        // Should not throw despite lock acquisition failure
-        callbackSlot.captured.onAvailable(network2)
+        val result1 = runCatching { callbackSlot.captured.onAvailable(network1) }
+        val result2 = runCatching { callbackSlot.captured.onAvailable(network2) }
 
-        // Callback should be invoked for both connections
-        assertTrue("Callback should be invoked for both connections after lock error", networkChangedCallCount == 2)
+        assertTrue(result1.isSuccess)
+        assertTrue(result2.isSuccess)
+        assertEquals(2, networkChangedCallCount)
     }
 
-    @Suppress("NoRelaxedMocks") // Android Network framework class
+    @Suppress("NoRelaxedMocks")
     @Test
     fun `exception in callback does not crash`() {
         val crashingManager =
@@ -229,13 +192,10 @@ class NetworkChangeManagerTest {
         crashingManager.start()
 
         val network1 = mockk<android.net.Network>(relaxed = true)
-        every { network1.toString() } returns "network1"
+        val network2 = mockk<android.net.Network>(relaxed = true)
+
         callbackSlot.captured.onAvailable(network1)
 
-        val network2 = mockk<android.net.Network>(relaxed = true)
-        every { network2.toString() } returns "network2"
-
-        // Should not throw despite callback failure
         val result = runCatching { callbackSlot.captured.onAvailable(network2) }
 
         assertTrue("Exception in callback should not crash", result.isSuccess)
@@ -245,13 +205,11 @@ class NetworkChangeManagerTest {
     @Test
     fun `registration failure is handled gracefully`() {
         every {
-            connectivityManager.registerNetworkCallback(any(), any<ConnectivityManager.NetworkCallback>())
+            connectivityManager.registerDefaultNetworkCallback(any<ConnectivityManager.NetworkCallback>())
         } throws RuntimeException("Registration failed")
 
-        // Should not throw
         networkChangeManager.start()
 
-        // Should not be monitoring since registration failed
         assertFalse(networkChangeManager.isMonitoring())
     }
 
@@ -263,7 +221,6 @@ class NetworkChangeManagerTest {
             connectivityManager.unregisterNetworkCallback(any<ConnectivityManager.NetworkCallback>())
         } throws RuntimeException("Unregistration failed")
 
-        // Should not throw
         networkChangeManager.stop()
 
         assertFalse(networkChangeManager.isMonitoring())
@@ -273,19 +230,18 @@ class NetworkChangeManagerTest {
 
     @Suppress("NoRelaxedMocks")
     @Test
-    fun `cellular backup capability change keeps wifi active transport`() {
+    fun `broad backup capabilities do not drive transport when not default`() {
         val transports = mutableListOf<CurrentTransport>()
         val mgr = transportManager(transports)
-        val wifiNetwork = mockk<android.net.Network>(relaxed = true)
-        val cellularNetwork = mockk<android.net.Network>(relaxed = true)
+        val defaultNetwork = mockk<android.net.Network>(relaxed = true)
+        val backupNetwork = mockk<android.net.Network>(relaxed = true)
         val wifiCaps = mockNetworkCapabilities(wifi = true)
         val cellularCaps = mockNetworkCapabilities(cellular = true)
-        every { connectivityManager.activeNetwork } returns wifiNetwork
-        every { connectivityManager.getNetworkCapabilities(wifiNetwork) } returns wifiCaps
 
         mgr.start()
-        callbackSlot.captured.onCapabilitiesChanged(wifiNetwork, wifiCaps)
-        callbackSlot.captured.onCapabilitiesChanged(cellularNetwork, cellularCaps)
+        callbackSlot.captured.onAvailable(defaultNetwork)
+        callbackSlot.captured.onCapabilitiesChanged(defaultNetwork, wifiCaps)
+        callbackSlot.captured.onCapabilitiesChanged(backupNetwork, cellularCaps)
 
         assertEquals(listOf(CurrentTransport.WIFI_LIKE), transports)
         mgr.stop()
@@ -293,152 +249,131 @@ class NetworkChangeManagerTest {
 
     @Suppress("NoRelaxedMocks")
     @Test
-    fun `wifi backup capability change keeps cellular active transport`() {
+    fun `wifi to cellular handoff emits both transports in order`() {
         val transports = mutableListOf<CurrentTransport>()
         val mgr = transportManager(transports)
         val wifiNetwork = mockk<android.net.Network>(relaxed = true)
         val cellularNetwork = mockk<android.net.Network>(relaxed = true)
-        val wifiCaps = mockNetworkCapabilities(wifi = true)
-        val cellularCaps = mockNetworkCapabilities(cellular = true)
-        every { connectivityManager.activeNetwork } returns cellularNetwork
-        every { connectivityManager.getNetworkCapabilities(cellularNetwork) } returns cellularCaps
 
         mgr.start()
-        callbackSlot.captured.onCapabilitiesChanged(cellularNetwork, cellularCaps)
-        callbackSlot.captured.onCapabilitiesChanged(wifiNetwork, wifiCaps)
-
-        assertEquals(listOf(CurrentTransport.CELLULAR), transports)
-        mgr.stop()
-    }
-
-    @Suppress("NoRelaxedMocks")
-    @Test
-    fun `non-default network capability changes do not emit transport switch`() {
-        val transports = mutableListOf<CurrentTransport>()
-        val mgr = transportManager(transports)
-        val wifiNetwork = mockk<android.net.Network>(relaxed = true)
-        val cellularNetwork = mockk<android.net.Network>(relaxed = true)
-        val wifiCaps = mockNetworkCapabilities(wifi = true)
-        every { connectivityManager.activeNetwork } returns wifiNetwork
-        every { connectivityManager.getNetworkCapabilities(wifiNetwork) } returns wifiCaps
-
-        mgr.start()
-        callbackSlot.captured.onCapabilitiesChanged(wifiNetwork, wifiCaps)
+        callbackSlot.captured.onAvailable(wifiNetwork)
+        callbackSlot.captured.onCapabilitiesChanged(wifiNetwork, mockNetworkCapabilities(wifi = true))
+        callbackSlot.captured.onAvailable(cellularNetwork)
         callbackSlot.captured.onCapabilitiesChanged(
             cellularNetwork,
             mockNetworkCapabilities(cellular = true),
         )
-        callbackSlot.captured.onCapabilitiesChanged(
-            cellularNetwork,
-            mockNetworkCapabilities(cellular = true, metered = true),
-        )
 
-        assertEquals(listOf(CurrentTransport.WIFI_LIKE), transports)
+        assertEquals(listOf(CurrentTransport.WIFI_LIKE, CurrentTransport.CELLULAR), transports)
         mgr.stop()
     }
 
     @Suppress("NoRelaxedMocks")
     @Test
-    fun `losing default emits transport of already available backup`() {
+    fun `old default onLost after replacement does not emit NONE`() {
         val transports = mutableListOf<CurrentTransport>()
         val mgr = transportManager(transports)
         val wifiNetwork = mockk<android.net.Network>(relaxed = true)
         val cellularNetwork = mockk<android.net.Network>(relaxed = true)
-        val wifiCaps = mockNetworkCapabilities(wifi = true)
-        val cellularCaps = mockNetworkCapabilities(cellular = true)
-        every { connectivityManager.activeNetwork } returns wifiNetwork
-        every { connectivityManager.getNetworkCapabilities(wifiNetwork) } returns wifiCaps
 
         mgr.start()
-        callbackSlot.captured.onCapabilitiesChanged(wifiNetwork, wifiCaps)
-        every { connectivityManager.activeNetwork } returns cellularNetwork
-        every { connectivityManager.getNetworkCapabilities(cellularNetwork) } returns cellularCaps
+        callbackSlot.captured.onAvailable(wifiNetwork)
+        callbackSlot.captured.onCapabilitiesChanged(wifiNetwork, mockNetworkCapabilities(wifi = true))
+        callbackSlot.captured.onAvailable(cellularNetwork)
+        callbackSlot.captured.onCapabilitiesChanged(
+            cellularNetwork,
+            mockNetworkCapabilities(cellular = true),
+        )
         callbackSlot.captured.onLost(wifiNetwork)
 
-        assertEquals(
-            listOf(CurrentTransport.WIFI_LIKE, CurrentTransport.CELLULAR),
-            transports,
-        )
+        assertEquals(listOf(CurrentTransport.WIFI_LIKE, CurrentTransport.CELLULAR), transports)
         mgr.stop()
     }
 
     @Suppress("NoRelaxedMocks")
     @Test
-    fun `active network with unavailable capabilities emits NONE`() {
+    fun `true final default loss emits NONE`() {
         val transports = mutableListOf<CurrentTransport>()
         val mgr = transportManager(transports)
-        val activeNetwork = mockk<android.net.Network>(relaxed = true)
-        val callbackNetwork = mockk<android.net.Network>(relaxed = true)
-        every { connectivityManager.activeNetwork } returns activeNetwork
-        every { connectivityManager.getNetworkCapabilities(activeNetwork) } returns null
+        val network = mockk<android.net.Network>(relaxed = true)
 
         mgr.start()
-        callbackSlot.captured.onCapabilitiesChanged(
-            callbackNetwork,
-            mockNetworkCapabilities(cellular = true),
-        )
+        callbackSlot.captured.onAvailable(network)
+        callbackSlot.captured.onCapabilitiesChanged(network, mockNetworkCapabilities(wifi = true))
+        callbackSlot.captured.onLost(network)
 
-        assertEquals(listOf(CurrentTransport.NONE), transports)
+        assertEquals(listOf(CurrentTransport.WIFI_LIKE, CurrentTransport.NONE), transports)
         mgr.stop()
     }
 
     @Suppress("NoRelaxedMocks")
     @Test
-    fun `onLost when no default network remains fires NONE`() {
+    fun `vpn only keeps any active but does not satisfy wifi or cellular restrictions`() {
+        val transports = mutableListOf<CurrentTransport>()
+        val mgr = transportManager(transports)
+        val vpnNetwork = mockk<android.net.Network>(relaxed = true)
+
+        mgr.start()
+        callbackSlot.captured.onAvailable(vpnNetwork)
+        callbackSlot.captured.onCapabilitiesChanged(vpnNetwork, mockNetworkCapabilities(vpn = true))
+
+        assertEquals(listOf(CurrentTransport.UNKNOWN), transports)
+        assertEquals(
+            listOf("any"),
+            filterByTransport(listOf(tcp("any", network.columba.app.rns.api.model.NetworkRestriction.ANY)), CurrentTransport.UNKNOWN)
+                .map { it.name },
+        )
+        assertEquals(
+            emptyList<String>(),
+            filterByTransport(
+                listOf(tcp("wifi", network.columba.app.rns.api.model.NetworkRestriction.WIFI_ONLY)),
+                CurrentTransport.UNKNOWN,
+            ).map { it.name },
+        )
+        assertEquals(
+            emptyList<String>(),
+            filterByTransport(
+                listOf(tcp("cell", network.columba.app.rns.api.model.NetworkRestriction.CELLULAR_ONLY)),
+                CurrentTransport.UNKNOWN,
+            ).map { it.name },
+        )
+        mgr.stop()
+    }
+
+    @Suppress("NoRelaxedMocks")
+    @Test
+    fun `vpn with deterministic wifi underlay classifies as wifi like`() {
+        val transports = mutableListOf<CurrentTransport>()
+        val mgr = transportManager(transports)
+        val vpnNetwork = mockk<android.net.Network>(relaxed = true)
+
+        mgr.start()
+        callbackSlot.captured.onAvailable(vpnNetwork)
+        callbackSlot.captured.onCapabilitiesChanged(
+            vpnNetwork,
+            mockNetworkCapabilities(vpn = true, wifi = true),
+        )
+
+        assertEquals(listOf(CurrentTransport.WIFI_LIKE), transports)
+        mgr.stop()
+    }
+
+    @Suppress("NoRelaxedMocks")
+    @Test
+    fun `duplicate capability updates remain deduplicated`() {
         val transports = mutableListOf<CurrentTransport>()
         val mgr = transportManager(transports)
         val network = mockk<android.net.Network>(relaxed = true)
         val wifiCaps = mockNetworkCapabilities(wifi = true)
-        every { connectivityManager.activeNetwork } returns network
-        every { connectivityManager.getNetworkCapabilities(network) } returns wifiCaps
+        val wifiCapsMetered = mockNetworkCapabilities(wifi = true, metered = true)
 
         mgr.start()
+        callbackSlot.captured.onAvailable(network)
         callbackSlot.captured.onCapabilitiesChanged(network, wifiCaps)
-        every { connectivityManager.activeNetwork } returns null
-        callbackSlot.captured.onLost(network)
-
-        assertEquals(
-            listOf(CurrentTransport.WIFI_LIKE, CurrentTransport.NONE),
-            transports,
-        )
-        mgr.stop()
-    }
-
-    @Suppress("NoRelaxedMocks")
-    @Test
-    fun `repeated callbacks and metered VPN changes are deduplicated by underlying active transport`() {
-        val transports = mutableListOf<CurrentTransport>()
-        val mgr = transportManager(transports)
-        val vpnNetwork = mockk<android.net.Network>(relaxed = true)
-        val unmeteredVpnCaps = mockNetworkCapabilities(wifi = true, vpn = true)
-        val meteredVpnCaps = mockNetworkCapabilities(wifi = true, vpn = true, metered = true)
-        every { connectivityManager.activeNetwork } returns vpnNetwork
-        every { connectivityManager.getNetworkCapabilities(vpnNetwork) } returns unmeteredVpnCaps
-
-        mgr.start()
-        callbackSlot.captured.onCapabilitiesChanged(vpnNetwork, unmeteredVpnCaps)
-        every { connectivityManager.getNetworkCapabilities(vpnNetwork) } returns meteredVpnCaps
-        callbackSlot.captured.onCapabilitiesChanged(vpnNetwork, meteredVpnCaps)
-        callbackSlot.captured.onCapabilitiesChanged(vpnNetwork, meteredVpnCaps)
+        callbackSlot.captured.onCapabilitiesChanged(network, wifiCapsMetered)
+        callbackSlot.captured.onCapabilitiesChanged(network, wifiCapsMetered)
 
         assertEquals(listOf(CurrentTransport.WIFI_LIKE), transports)
-        mgr.stop()
-    }
-
-    @Suppress("NoRelaxedMocks")
-    @Test
-    fun `active VPN without underlying supported transport emits NONE`() {
-        val transports = mutableListOf<CurrentTransport>()
-        val mgr = transportManager(transports)
-        val vpnNetwork = mockk<android.net.Network>(relaxed = true)
-        val vpnCaps = mockNetworkCapabilities(vpn = true)
-        every { connectivityManager.activeNetwork } returns vpnNetwork
-        every { connectivityManager.getNetworkCapabilities(vpnNetwork) } returns vpnCaps
-
-        mgr.start()
-        callbackSlot.captured.onCapabilitiesChanged(vpnNetwork, vpnCaps)
-
-        assertEquals(listOf(CurrentTransport.NONE), transports)
         mgr.stop()
     }
 
@@ -449,10 +384,9 @@ class NetworkChangeManagerTest {
         val mgr = transportManager(transports)
         val network = mockk<android.net.Network>(relaxed = true)
         val ethernetCaps = mockNetworkCapabilities(ethernet = true)
-        every { connectivityManager.activeNetwork } returns network
-        every { connectivityManager.getNetworkCapabilities(network) } returns ethernetCaps
 
         mgr.start()
+        callbackSlot.captured.onAvailable(network)
         callbackSlot.captured.onCapabilitiesChanged(network, ethernetCaps)
 
         assertEquals(listOf(CurrentTransport.WIFI_LIKE), transports)
@@ -488,4 +422,15 @@ class NetworkChangeManagerTest {
         } returns !metered
         return caps
     }
+
+    private fun tcp(
+        name: String,
+        restriction: network.columba.app.rns.api.model.NetworkRestriction,
+    ): network.columba.app.rns.api.model.InterfaceConfig.TCPClient =
+        network.columba.app.rns.api.model.InterfaceConfig.TCPClient(
+            name = name,
+            targetHost = "10.0.0.1",
+            targetPort = 4242,
+            networkRestriction = restriction,
+        )
 }


### PR DESCRIPTION
## Summary

- classify transport from Android's active default-network callback rather than broad matching-network callbacks plus a separate `activeNetwork` snapshot
- reapply interface restrictions coherently across Wi-Fi/cellular handoffs while ignoring stale `onLost` callbacks
- reserve `NONE` for the absence of a default route and represent VPN-only, unsupported, or temporarily unpublished capabilities as `UNKNOWN`
- keep unrestricted IP interfaces available on `UNKNOWN` while conservatively filtering Wi-Fi-only and cellular-only interfaces
- align the production `InterfaceTransportObserver`, host manager, and interface-management UI with the same transport truth table
- seed observer state before callback registration so a stale startup snapshot cannot overwrite a newer default-network callback
- document the Android-only network-restriction behavior in `port-deviations.md`

This is a current-main replacement for stale draft PR #903. The old draft is intentionally left open pending explicit closure authorization.

## Verification

Exact rebased head: `253b11d322520efe17143c172dd4c9e70b13c7b5`

- `NetworkChangeManagerTest` and `InterfaceTransportFilterTest`
  - Kotlin backend: passed
  - Python backend: passed
- `InterfaceTransportObserverTest` and `InterfaceManagementUtilsTest`
  - no-Sentry Kotlin backend: passed
  - no-Sentry Python backend: passed
- `:rns-host:ktlintCheck :rns-host:detekt`: passed
- `:app:ktlintCheck :app:detekt`: passed
- `:app:assembleNoSentryPythonBackendDebug`: passed
- `git diff --check origin/main...HEAD`: passed
- ARM64 Python debug APK:
  - APK Signature Scheme v2 verified
  - installed successfully on the test phone
  - interface configuration completed successfully
  - Wi-Fi/cellular physical handoff matrix remains pending until a Wi-Fi network is available

## Behavior

- Wi-Fi and Ethernet map to `WIFI_LIKE`.
- Cellular maps to `CELLULAR`.
- A live but opaque route maps to `UNKNOWN`; `ANY` remains active while transport-specific interfaces pause.
- No live default route maps to `NONE`; IP interfaces pause.
- BLE and non-TCP RNode interfaces bypass the IP-carrier restriction.
