### PR TITLE
fix(settings): handle unavailable external links (COLUMBA-AV)

### DIFF
--- a/app/src/main/java/network/columba/app/ui/screens/settings/cards/AboutCard.kt
+++ b/app/src/main/java/network/columba/app/ui/screens/settings/cards/AboutCard.kt
@@ -1,8 +1,7 @@
 package network.columba.app.ui.screens.settings.cards
 
 import android.content.Context
-import android.content.Intent
-import android.net.Uri
+import android.widget.Toast
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
@@ -36,8 +35,8 @@ import network.columba.app.R
 import network.columba.app.service.AppUpdateResult
 import network.columba.app.ui.components.CollapsibleSettingsCard
 import network.columba.app.util.SystemInfo
+import network.columba.app.util.safeOpenUrl
 import java.util.Locale
-import androidx.core.net.toUri
 
 @Composable
 fun AboutCard(
@@ -159,8 +158,7 @@ fun AboutCard(
                 )
                 TextButton(
                     onClick = {
-                        val intent = Intent(Intent.ACTION_VIEW, "https://github.com/torlando-tech/columba/blob/main/LICENSE.md".toUri())
-                        context.startActivity(intent)
+                        openExternalUrl(context, "https://github.com/torlando-tech/columba/blob/main/LICENSE.md")
                     },
                 ) {
                     Text("View License", style = MaterialTheme.typography.bodySmall)
@@ -238,8 +236,7 @@ fun AboutCard(
                             )
                             TextButton(
                                 onClick = {
-                                    val intent = Intent(Intent.ACTION_VIEW, result.htmlUrl.toUri())
-                                    context.startActivity(intent)
+                                    openExternalUrl(context, result.htmlUrl)
                                 },
                             ) {
                                 Text("View Release")
@@ -344,11 +341,19 @@ private fun LinkButton(
 ) {
     TextButton(
         onClick = {
-            val intent = Intent(Intent.ACTION_VIEW, url.toUri())
-            context.startActivity(intent)
+            openExternalUrl(context, url)
         },
         modifier = Modifier.fillMaxWidth(),
     ) {
         Text(label)
+    }
+}
+
+private fun openExternalUrl(
+    context: Context,
+    url: String,
+) {
+    if (!safeOpenUrl(context, url)) {
+        Toast.makeText(context, R.string.error_no_app_for_link, Toast.LENGTH_SHORT).show()
     }
 }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -11,6 +11,7 @@
     <string name="call_answer_content_description">Answer call</string>
     <string name="call_decline_content_description">Decline call</string>
     <string name="error_no_file_manager">No file manager app found on this device</string>
+    <string name="error_no_app_for_link">No app found to open link</string>
 
     <!-- Locate on Map -->
     <string name="locate_on_map">Locate on Map</string>

--- a/app/src/test/java/network/columba/app/ui/screens/settings/cards/AboutCardTest.kt
+++ b/app/src/test/java/network/columba/app/ui/screens/settings/cards/AboutCardTest.kt
@@ -1,18 +1,35 @@
 package network.columba.app.ui.screens.settings.cards
 
 import android.app.Application
+import android.content.ActivityNotFoundException
+import android.content.Context
+import android.content.ContextWrapper
+import android.content.Intent
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.test.junit4.createComposeRule
 import androidx.compose.ui.test.onNodeWithContentDescription
 import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.performClick
+import androidx.compose.ui.test.performScrollTo
+import androidx.test.core.app.ApplicationProvider
+import network.columba.app.R
+import network.columba.app.service.AppUpdateResult
 import network.columba.app.test.RegisterComponentActivityRule
 import network.columba.app.ui.theme.ColumbaTheme
 import network.columba.app.util.SystemInfo
+import org.junit.Assert.assertEquals
 import org.junit.Rule
 import org.junit.Test
 import org.junit.rules.RuleChain
 import org.junit.runner.RunWith
 import org.robolectric.RobolectricTestRunner
 import org.robolectric.annotation.Config
+import org.robolectric.shadows.ShadowToast
 
 @RunWith(RobolectricTestRunner::class)
 @Config(sdk = [34], application = Application::class)
@@ -163,8 +180,81 @@ class AboutCardTest {
         composeTestRule.onNodeWithText("Report Bug").assertExists()
     }
 
-    // Note: Button click tests are skipped in Robolectric due to framework limitations
-    // with Compose UI interactions. These should be tested with instrumented tests.
+    @Test
+    fun `view license handles missing external activity without crashing`() {
+        assertMissingExternalActivityHandled("View License")
+    }
+
+    @Test
+    fun `resource link handles missing external activity without crashing`() {
+        assertMissingExternalActivityHandled("GitHub Repository")
+    }
+
+    @Test
+    fun `view release handles missing external activity without crashing`() {
+        assertMissingExternalActivityHandled(
+            buttonText = "View Release",
+            updateCheckResult =
+                AppUpdateResult.UpdateAvailable(
+                    currentVersion = "3.0.7",
+                    tagName = "v3.0.8",
+                    htmlUrl = "https://example.invalid/release",
+                    isPrerelease = false,
+                ),
+        )
+    }
+
+    @Test
+    fun `external links handle security exception without crashing`() {
+        assertMissingExternalActivityHandled(
+            buttonText = "View License",
+            launchFailure = SecurityException("External activities blocked"),
+        )
+    }
+
+    private fun assertMissingExternalActivityHandled(
+        buttonText: String,
+        updateCheckResult: AppUpdateResult = AppUpdateResult.Idle,
+        launchFailure: RuntimeException = ActivityNotFoundException("No browser installed"),
+    ) {
+        val baseContext = ApplicationProvider.getApplicationContext<Context>()
+        var launchAttempts = 0
+        val noExternalActivityContext =
+            object : ContextWrapper(baseContext) {
+                override fun startActivity(intent: Intent) {
+                    launchAttempts += 1
+                    throw launchFailure
+                }
+            }
+
+        composeTestRule.setContent {
+            CompositionLocalProvider(LocalContext provides noExternalActivityContext) {
+                Column(modifier = Modifier.verticalScroll(rememberScrollState())) {
+                    ColumbaTheme {
+                        AboutCard(
+                            isExpanded = true,
+                            onExpandedChange = {},
+                            systemInfo = fullSystemInfo,
+                            onCopySystemInfo = {},
+                            onReportBug = {},
+                            updateCheckResult = updateCheckResult,
+                        )
+                    }
+                }
+            }
+        }
+
+        composeTestRule
+            .onNodeWithText(buttonText)
+            .performScrollTo()
+            .performClick()
+
+        assertEquals(1, launchAttempts)
+        assertEquals(
+            baseContext.getString(R.string.error_no_app_for_link),
+            ShadowToast.getTextOfLatestToast(),
+        )
+    }
 
     @Test
     fun `renders without crashing with full system info`() {


### PR DESCRIPTION
## Summary

- route all three external-link actions in `AboutCard` through the existing exception-safe `safeOpenUrl()` utility
- show a localized fallback toast when Android has no permitted activity that can open the link
- add Compose/Robolectric regression coverage for the license, release, and generic resource-link paths
- verify graceful handling of both `ActivityNotFoundException` and `SecurityException`

## Replacement context

This PR supersedes outdated PR #1013 by porting its external-link crash fix onto the latest `main`.

The replacement also addresses gaps in #1013:

- adds focused regression tests that exercise the actual Compose click handlers
- replaces the triplicated hardcoded fallback text identified in the unresolved Greptile P2 finding with one Android string resource and one shared helper

PR #1013 is intentionally not closed by this PR.

## Reproduction

On unmodified `main`, the focused `View License` test clicks the real Compose button with a context whose `startActivity()` throws because no browser is installed. It fails through the production click handler with:

```text
android.content.ActivityNotFoundException: No browser installed
    at AboutCardTest...startActivity
    at AboutCardKt...AboutCard
    at ClickableNode.handleUpEvent
```

The same unchanged test passes after applying this fix, records exactly one launch attempt, and verifies the fallback toast.

## Verification

- `AboutCardTest`: 20/20 passed
- `./gradlew ktlintCheck detekt cpdCheck lint :app:lintNoSentryKotlinBackendDebug :rns-host:lintPythonBackendDebug`: passed (456 tasks)
- final `ktlintCheck` plus complete `AboutCardTest`: passed
- `git diff --check`: clean
- base verified against current `origin/main`

## Scope

Changed files are limited to:

- `app/src/main/java/network/columba/app/ui/screens/settings/cards/AboutCard.kt`
- `app/src/main/res/values/strings.xml`
- `app/src/test/java/network/columba/app/ui/screens/settings/cards/AboutCardTest.kt`
