### PR TITLE
fix(android): enforce predictable navigation back stacks

### DIFF
--- a/app/src/main/java/network/columba/app/MainActivity.kt
+++ b/app/src/main/java/network/columba/app/MainActivity.kt
@@ -63,7 +63,6 @@ import androidx.lifecycle.lifecycleScope
 import androidx.lifecycle.viewmodel.compose.viewModel
 import androidx.navigation.NavType
 import androidx.navigation.compose.NavHost
-import androidx.navigation.compose.composable
 import androidx.navigation.compose.currentBackStackEntryAsState
 import androidx.navigation.compose.rememberNavController
 import androidx.navigation.navArgument
@@ -79,7 +78,13 @@ import kotlinx.coroutines.flow.receiveAsFlow
 import kotlinx.coroutines.launch
 import network.columba.app.data.database.entity.InterfaceEntity
 import network.columba.app.di.RnsTelephonyEntryPoint
+import network.columba.app.navigation.AppDestination
 import network.columba.app.navigation.ConversationNavigation
+import network.columba.app.navigation.appComposable
+import network.columba.app.navigation.completeCurrentFlow
+import network.columba.app.navigation.navigateToAnsweredCall
+import network.columba.app.navigation.navigateToEntity
+import network.columba.app.navigation.navigateToIncomingCall
 import network.columba.app.notifications.CallNotificationHelper
 import network.columba.app.repository.InterfaceRepository
 import network.columba.app.repository.SettingsRepository
@@ -676,21 +681,21 @@ sealed class Screen(
     val title: String,
     val icon: androidx.compose.ui.graphics.vector.ImageVector,
 ) {
-    object Welcome : Screen("welcome", "Welcome", Icons.Default.Sensors)
+    object Welcome : Screen(AppDestination.WELCOME.routePattern, "Welcome", Icons.Default.Sensors)
 
-    object IdentityUnlock : Screen("identity_unlock", "Restore Identity", Icons.Default.Sensors)
+    object IdentityUnlock : Screen(AppDestination.IDENTITY_UNLOCK.routePattern, "Restore Identity", Icons.Default.Sensors)
 
-    object Chats : Screen("chats", "Chats", Icons.Default.Chat)
+    object Chats : Screen(AppDestination.CHATS.routePattern, "Chats", Icons.Default.Chat)
 
     object Announces : Screen("announce_stream", "Announces", Icons.Default.Sensors)
 
-    object Contacts : Screen("contacts", "Contacts", Icons.Default.People)
+    object Contacts : Screen(AppDestination.CONTACTS.routePattern, "Contacts", Icons.Default.People)
 
-    object Map : Screen("map", "Map", Icons.Default.Map)
+    object Map : Screen(AppDestination.MAP.routePattern, "Map", Icons.Default.Map)
 
-    object Identity : Screen("identity", "Network Status", Icons.Default.Info)
+    object Identity : Screen(AppDestination.IDENTITY.routePattern, "Network Status", Icons.Default.Info)
 
-    object Settings : Screen("settings", "Settings", Icons.Default.Settings)
+    object Settings : Screen(AppDestination.SETTINGS.routePattern, "Settings", Icons.Default.Settings)
 }
 
 @OptIn(ExperimentalMaterial3Api::class)
@@ -834,7 +839,11 @@ fun ColumbaNavigation(
                 when (navigation) {
                     is PendingNavigation.AnnounceDetail -> {
                         val encodedHash = Uri.encode(navigation.destinationHash)
-                        navController.navigate("announce_detail/$encodedHash")
+                        navController.navigateToEntity(
+                            destination = AppDestination.ANNOUNCE_DETAIL,
+                            route = "announce_detail/$encodedHash",
+                            identityArguments = mapOf("destinationHash" to navigation.destinationHash),
+                        )
                         Log.d("ColumbaNavigation", "Navigated to announce detail: ${navigation.destinationHash}")
                     }
                     is PendingNavigation.Conversation -> {
@@ -899,7 +908,11 @@ fun ColumbaNavigation(
                     is PendingNavigation.ImportIdentityFromText -> {
                         // Navigate to Identity Manager with pre-filled Base32 key
                         val encodedKey = Uri.encode(navigation.base32Text)
-                        navController.navigate("identity_manager?base32Key=$encodedKey")
+                        navController.navigateToEntity(
+                            destination = AppDestination.IDENTITY_MANAGER,
+                            route = "identity_manager?base32Key=$encodedKey",
+                            identityArguments = mapOf("base32Key" to navigation.base32Text),
+                        )
                         Log.d("ColumbaNavigation", "Navigated to identity import from shared text")
                     }
                     is PendingNavigation.SharedText -> {
@@ -937,7 +950,7 @@ fun ColumbaNavigation(
                     is PendingNavigation.IncomingCall -> {
                         // Navigate to incoming call screen
                         val encodedHash = Uri.encode(navigation.identityHash)
-                        navController.navigate("incoming_call/$encodedHash")
+                        navController.navigateToIncomingCall("incoming_call/$encodedHash")
                         Log.d("ColumbaNavigation", "Navigated to incoming call: ${navigation.identityHash.take(16)}...")
                     }
                     is PendingNavigation.AnswerCall -> {
@@ -948,9 +961,7 @@ fun ColumbaNavigation(
                         val route = "voice_call/$encodedHash?autoAnswer=true"
                         Log.w("ColumbaNavigation", "📞 AnswerCall handler - navigating to $route")
                         Log.w("ColumbaNavigation", "📞 Current backstack: ${navController.currentBackStackEntry?.destination?.route}")
-                        navController.navigate(route) {
-                            launchSingleTop = true
-                        }
+                        navController.navigateToAnsweredCall(route)
                         Log.w("ColumbaNavigation", "📞 After navigation, current: ${navController.currentBackStackEntry?.destination?.route}")
                     }
                     is PendingNavigation.InterfaceStats -> {
@@ -986,7 +997,11 @@ fun ColumbaNavigation(
                                     "&usbProductId=${navigation.productId}" +
                                     "&usbDeviceName=${Uri.encode(navigation.deviceName)}" +
                                     "&pyxisVersion=${Uri.encode(navigation.pyxisVersion ?: "")}"
-                            navController.navigate(route)
+                            navController.navigateToEntity(
+                                destination = AppDestination.USB_DEVICE_ACTION,
+                                route = route,
+                                identityArguments = mapOf("usbDeviceId" to navigation.usbDeviceId),
+                            )
                             Log.d("ColumbaNavigation", "Navigated to USB device action: ${navigation.usbDeviceId}")
                         } else {
                             Log.d("ColumbaNavigation", "Skipped detached USB device: ${navigation.usbDeviceId}")
@@ -1000,7 +1015,11 @@ fun ColumbaNavigation(
                                 "&usbVendorId=${navigation.vendorId}" +
                                 "&usbProductId=${navigation.productId}" +
                                 "&usbDeviceName=${Uri.encode(navigation.deviceName)}"
-                        navController.navigate(route)
+                        navController.navigateToEntity(
+                            destination = AppDestination.RNODE_WIZARD,
+                            route = route,
+                            identityArguments = mapOf("usbDeviceId" to navigation.usbDeviceId),
+                        )
                         Log.d("ColumbaNavigation", "Navigated to RNode wizard with USB: ${navigation.usbDeviceId}")
                     }
                     is PendingNavigation.DirectFlash -> {
@@ -1011,12 +1030,24 @@ fun ColumbaNavigation(
                                 "&usbVendorId=${navigation.vendorId}" +
                                 "&usbProductId=${navigation.productId}" +
                                 "&usbDeviceName=${Uri.encode(navigation.deviceName)}"
-                        navController.navigate(route)
+                        navController.navigateToEntity(
+                            destination = AppDestination.RNODE_FLASHER,
+                            route = route,
+                            identityArguments = mapOf("usbDeviceId" to navigation.usbDeviceId),
+                        )
                         Log.d("ColumbaNavigation", "Navigated to flasher (direct): ${navigation.usbDeviceId}")
                     }
                     is PendingNavigation.NomadNetBrowser -> {
                         val encoded = Uri.encode(navigation.path)
-                        navController.navigate("nomadnet_browser/${navigation.nodeHash}?path=$encoded")
+                        navController.navigateToEntity(
+                            destination = AppDestination.NOMADNET_BROWSER,
+                            route = "nomadnet_browser/${navigation.nodeHash}?path=$encoded",
+                            identityArguments =
+                                mapOf(
+                                    "destinationHash" to navigation.nodeHash,
+                                    "path" to navigation.path,
+                                ),
+                        )
                         Log.d("ColumbaNavigation", "Navigated to NomadNet browser: ${navigation.nodeHash}")
                     }
                 }
@@ -1146,7 +1177,7 @@ fun ColumbaNavigation(
                     Log.i("MainActivity", "📞 Navigating to IncomingCallScreen: $identityHash")
                     // Dismiss the notification — the user is now looking at the call screen
                     CallNotificationHelper(context).cancelIncomingCallNotification()
-                    navController.navigate("incoming_call/$encodedHash")
+                    navController.navigateToIncomingCall("incoming_call/$encodedHash")
                 } else {
                     Log.i("MainActivity", "📞 Skipping navigation (onCallScreen=$isOnCallScreen, isAnsweringCall=$isAnsweringCall)")
                 }
@@ -1201,7 +1232,7 @@ fun ColumbaNavigation(
 
     // Double-back-to-exit state: first back press on a root tab shows a toast,
     // second press within 2 seconds finishes the activity.
-    // The BackHandler is placed inside each root tab's composable() so it takes
+    // The BackHandler is placed inside each root tab's appComposable() so it takes
     // priority over NavHost's internal back-stack popping between tabs.
     var backPressedOnce by remember(currentRoute) { mutableStateOf(false) }
 
@@ -1293,7 +1324,7 @@ fun ColumbaNavigation(
                             popEnterTransition = { fadeIn(tween(150)) },
                             popExitTransition = { fadeOut(tween(75)) },
                         ) {
-                            composable(Screen.Welcome.route) {
+                            appComposable(AppDestination.WELCOME) {
                                 OnboardingPagerScreen(
                                     onOnboardingComplete = { navigateToRNodeWizard ->
                                         navController.navigate(Screen.Chats.route) {
@@ -1310,7 +1341,7 @@ fun ColumbaNavigation(
                                 )
                             }
 
-                            composable(Screen.IdentityUnlock.route) {
+                            appComposable(AppDestination.IDENTITY_UNLOCK) {
                                 network.columba.app.ui.screens.IdentityUnlockScreen(
                                     onResolved = {
                                         // ColumbaApplication bailed out of Reticulum init when
@@ -1327,7 +1358,7 @@ fun ColumbaNavigation(
                                 )
                             }
 
-                            composable(Screen.Chats.route) {
+                            appComposable(AppDestination.CHATS) {
                                 DoubleBackToExitHandler(Screen.Chats.route)
                                 ChatsScreen(
                                     onChatClick = { destinationHash, peerName ->
@@ -1356,8 +1387,8 @@ fun ColumbaNavigation(
                                 )
                             }
 
-                            composable(
-                                route = "${Screen.Announces.route}?filterType={filterType}",
+                            appComposable(
+                                AppDestination.ANNOUNCES,
                                 arguments =
                                     listOf(
                                         navArgument("filterType") {
@@ -1382,7 +1413,7 @@ fun ColumbaNavigation(
                                 )
                             }
 
-                            composable(Screen.Contacts.route) {
+                            appComposable(AppDestination.CONTACTS) {
                                 DoubleBackToExitHandler(Screen.Contacts.route)
                                 val contactsViewModel: ContactsViewModel = hiltViewModel()
                                 ContactsScreen(
@@ -1427,7 +1458,7 @@ fun ColumbaNavigation(
                                 )
                             }
 
-                            composable(Screen.Map.route) {
+                            appComposable(AppDestination.MAP) {
                                 DoubleBackToExitHandler(Screen.Map.route)
                                 MapScreen(
                                     viewModel = mapViewModel,
@@ -1456,11 +1487,8 @@ fun ColumbaNavigation(
                             }
 
                             // Map with focus location (for discovered interfaces)
-                            composable(
-                                route =
-                                    "map_focus?lat={lat}&lon={lon}&label={label}&type={type}&height={height}" +
-                                        "&reachableOn={reachableOn}&port={port}&frequency={frequency}&bandwidth={bandwidth}" +
-                                        "&sf={sf}&cr={cr}&modulation={modulation}&status={status}&lastHeard={lastHeard}&hops={hops}",
+                            appComposable(
+                                AppDestination.MAP_FOCUS,
                                 arguments =
                                     listOf(
                                         navArgument("lat") {
@@ -1589,7 +1617,7 @@ fun ColumbaNavigation(
                                 )
                             }
 
-                            composable(Screen.Identity.route) {
+                            appComposable(AppDestination.IDENTITY) {
                                 IdentityScreen(
                                     onBackClick = { navController.popBackStack() },
                                     settingsViewModel = settingsViewModel,
@@ -1605,7 +1633,7 @@ fun ColumbaNavigation(
                                 )
                             }
 
-                            composable(Screen.Settings.route) {
+                            appComposable(AppDestination.SETTINGS) {
                                 DoubleBackToExitHandler(Screen.Settings.route)
                                 SettingsScreen(
                                     viewModel = settingsViewModel,
@@ -1665,14 +1693,8 @@ fun ColumbaNavigation(
                                 )
                             }
 
-                            composable(
-                                route =
-                                    "usb_device_action" +
-                                        "?usbDeviceId={usbDeviceId}" +
-                                        "&usbVendorId={usbVendorId}" +
-                                        "&usbProductId={usbProductId}" +
-                                        "&usbDeviceName={usbDeviceName}" +
-                                        "&pyxisVersion={pyxisVersion}",
+                            appComposable(
+                                AppDestination.USB_DEVICE_ACTION,
                                 arguments =
                                     listOf(
                                         navArgument("usbDeviceId") {
@@ -1780,8 +1802,8 @@ fun ColumbaNavigation(
                                 )
                             }
 
-                            composable(
-                                route = "pyxis_updater?packageUri={packageUri}&usbDeviceId={usbDeviceId}",
+                            appComposable(
+                                AppDestination.PYXIS_UPDATER,
                                 arguments =
                                     listOf(
                                         navArgument("packageUri") {
@@ -1803,11 +1825,8 @@ fun ColumbaNavigation(
                                 )
                             }
 
-                            composable(
-                                route =
-                                    "rnode_flasher?skipDetection={skipDetection}&tncConfigOnly={tncConfigOnly}" +
-                                        "&usbDeviceId={usbDeviceId}" +
-                                        "&usbVendorId={usbVendorId}&usbProductId={usbProductId}&usbDeviceName={usbDeviceName}",
+                            appComposable(
+                                AppDestination.RNODE_FLASHER,
                                 arguments =
                                     listOf(
                                         navArgument("skipDetection") {
@@ -1852,7 +1871,7 @@ fun ColumbaNavigation(
                                 )
                             }
 
-                            composable("interface_management") {
+                            appComposable(AppDestination.INTERFACE_MANAGEMENT) {
                                 InterfaceManagementScreen(
                                     onNavigateBack = { navController.popBackStack() },
                                     onNavigateToRNodeWizard = { interfaceId ->
@@ -1878,7 +1897,7 @@ fun ColumbaNavigation(
                                 )
                             }
 
-                            composable("discovered_interfaces") {
+                            appComposable(AppDestination.DISCOVERED_INTERFACES) {
                                 DiscoveredInterfacesScreen(
                                     onNavigateBack = { navController.popBackStack() },
                                     onNavigateToTcpClientWizard = { host, port, name, ifacNet, ifacKey ->
@@ -1921,10 +1940,8 @@ fun ColumbaNavigation(
                                 )
                             }
 
-                            composable(
-                                route =
-                                    "tcp_client_wizard?interfaceId={interfaceId}&host={host}&port={port}&name={name}" +
-                                        "&ifacNetname={ifacNetname}&ifacNetkey={ifacNetkey}",
+                            appComposable(
+                                AppDestination.TCP_CLIENT_WIZARD,
                                 arguments =
                                     listOf(
                                         navArgument("interfaceId") {
@@ -1962,9 +1979,7 @@ fun ColumbaNavigation(
                                 TcpClientWizardScreen(
                                     onNavigateBack = { navController.popBackStack() },
                                     onComplete = {
-                                        navController.navigate("interface_management") {
-                                            popUpTo("interface_management") { inclusive = true }
-                                        }
+                                        navController.completeCurrentFlow(AppDestination.TCP_CLIENT_WIZARD)
                                     },
                                     interfaceId = if (interfaceId > 0) interfaceId else null,
                                     initialHost = host.ifEmpty { null },
@@ -1975,19 +1990,8 @@ fun ColumbaNavigation(
                                 )
                             }
 
-                            composable(
-                                route =
-                                    "rnode_wizard?interfaceId={interfaceId}" +
-                                        "&connectionType={connectionType}" +
-                                        "&transportMode={transportMode}" +
-                                        "&usbDeviceId={usbDeviceId}" +
-                                        "&usbVendorId={usbVendorId}" +
-                                        "&usbProductId={usbProductId}" +
-                                        "&usbDeviceName={usbDeviceName}" +
-                                        "&loraFrequency={loraFrequency}" +
-                                        "&loraBandwidth={loraBandwidth}" +
-                                        "&loraSf={loraSf}" +
-                                        "&loraCr={loraCr}",
+                            appComposable(
+                                AppDestination.RNODE_WIZARD,
                                 arguments =
                                     listOf(
                                         navArgument("interfaceId") {
@@ -2066,16 +2070,14 @@ fun ColumbaNavigation(
                                         if (transportMode) {
                                             navController.popBackStack()
                                         } else {
-                                            navController.navigate("interface_management") {
-                                                popUpTo("interface_management") { inclusive = true }
-                                            }
+                                            navController.completeCurrentFlow(AppDestination.RNODE_WIZARD)
                                         }
                                     },
                                 )
                             }
 
-                            composable(
-                                route = "interface_stats/{interfaceId}",
+                            appComposable(
+                                AppDestination.INTERFACE_STATS,
                                 arguments =
                                     listOf(
                                         navArgument("interfaceId") {
@@ -2098,19 +2100,19 @@ fun ColumbaNavigation(
                                 )
                             }
 
-                            composable("notification_settings") {
+                            appComposable(AppDestination.NOTIFICATION_SETTINGS) {
                                 NotificationSettingsScreen(
                                     onNavigateBack = { navController.popBackStack() },
                                 )
                             }
 
-                            composable("blocked_users") {
+                            appComposable(AppDestination.BLOCKED_USERS) {
                                 BlockedUsersScreen(
                                     onBackClick = { navController.popBackStack() },
                                 )
                             }
 
-                            composable("theme_management") {
+                            appComposable(AppDestination.THEME_MANAGEMENT) {
                                 ThemeManagementScreen(
                                     onBackClick = { navController.popBackStack() },
                                     onCreateTheme = {
@@ -2125,7 +2127,7 @@ fun ColumbaNavigation(
                                 )
                             }
 
-                            composable("theme_editor") {
+                            appComposable(AppDestination.THEME_EDITOR_NEW) {
                                 ThemeEditorScreen(
                                     themeId = null,
                                     onBackClick = { navController.popBackStack() },
@@ -2133,8 +2135,8 @@ fun ColumbaNavigation(
                                 )
                             }
 
-                            composable(
-                                route = "theme_editor/{themeId}",
+                            appComposable(
+                                AppDestination.THEME_EDITOR_EXISTING,
                                 arguments =
                                     listOf(
                                         navArgument("themeId") { type = NavType.LongType },
@@ -2149,14 +2151,14 @@ fun ColumbaNavigation(
                                 )
                             }
 
-                            composable("ble_connection_status") {
+                            appComposable(AppDestination.BLE_CONNECTION_STATUS) {
                                 BleConnectionStatusScreen(
                                     onBackClick = { navController.popBackStack() },
                                 )
                             }
 
-                            composable(
-                                "identity_manager?base32Key={base32Key}",
+                            appComposable(
+                                AppDestination.IDENTITY_MANAGER,
                                 arguments =
                                     listOf(
                                         navArgument("base32Key") {
@@ -2173,7 +2175,7 @@ fun ColumbaNavigation(
                                 )
                             }
 
-                            composable("migration") {
+                            appComposable(AppDestination.MIGRATION) {
                                 MigrationScreen(
                                     onNavigateBack = { navController.popBackStack() },
                                     onImportComplete = {
@@ -2186,13 +2188,13 @@ fun ColumbaNavigation(
                                 )
                             }
 
-                            composable("apk_sharing") {
+                            appComposable(AppDestination.APK_SHARING) {
                                 ApkSharingScreen(
                                     onNavigateBack = { navController.popBackStack() },
                                 )
                             }
 
-                            composable("my_identity") {
+                            appComposable(AppDestination.MY_IDENTITY) {
                                 MyIdentityScreen(
                                     onNavigateBack = { navController.popBackStack() },
                                     settingsViewModel = settingsViewModel,
@@ -2202,7 +2204,7 @@ fun ColumbaNavigation(
                                 )
                             }
 
-                            composable("network_status") {
+                            appComposable(AppDestination.NETWORK_STATUS) {
                                 IdentityScreen(
                                     onBackClick = { navController.popBackStack() },
                                     settingsViewModel = settingsViewModel,
@@ -2218,7 +2220,7 @@ fun ColumbaNavigation(
                                 )
                             }
 
-                            composable("qr_scanner") {
+                            appComposable(AppDestination.QR_SCANNER) {
                                 val contactsViewModel: ContactsViewModel = hiltViewModel()
                                 QrScannerScreen(
                                     onBackClick = { navController.popBackStack() },
@@ -2238,10 +2240,8 @@ fun ColumbaNavigation(
                                 )
                             }
 
-                            composable(
-                                route = "messaging/{destinationHash}/{peerName}" +
-                                    "?fromNotification={fromNotification}" +
-                                    "&notificationEventId={notificationEventId}",
+                            appComposable(
+                                AppDestination.MESSAGING,
                                 arguments =
                                     listOf(
                                         navArgument("destinationHash") { type = NavType.StringType },
@@ -2298,8 +2298,8 @@ fun ColumbaNavigation(
                                 )
                             }
 
-                            composable(
-                                route = "message_detail/{messageId}",
+                            appComposable(
+                                AppDestination.MESSAGE_DETAIL,
                                 arguments =
                                     listOf(
                                         navArgument("messageId") { type = NavType.StringType },
@@ -2313,8 +2313,8 @@ fun ColumbaNavigation(
                                 )
                             }
 
-                            composable(
-                                route = "announce_detail/{destinationHash}",
+                            appComposable(
+                                AppDestination.ANNOUNCE_DETAIL,
                                 arguments =
                                     listOf(
                                         navArgument("destinationHash") { type = NavType.StringType },
@@ -2326,7 +2326,11 @@ fun ColumbaNavigation(
                                     destinationHash = destinationHash,
                                     onBackClick = { navController.popBackStack() },
                                     onViewAnnounce = { hash ->
-                                        navController.navigate("announce_detail/${Uri.encode(hash)}")
+                                        navController.navigateToEntity(
+                                            destination = AppDestination.ANNOUNCE_DETAIL,
+                                            route = "announce_detail/${Uri.encode(hash)}",
+                                            identityArguments = mapOf("destinationHash" to hash),
+                                        )
                                     },
                                     onStartChat = { destHash, peerName ->
                                         // Navigate back to chats tab
@@ -2344,14 +2348,22 @@ fun ColumbaNavigation(
                                         navController.navigate("messaging/$encodedHash/$encodedName")
                                     },
                                     onBrowseNode = { destHash ->
-                                        navController.navigate("nomadnet_browser/$destHash")
+                                        navController.navigateToEntity(
+                                            destination = AppDestination.NOMADNET_BROWSER,
+                                            route = "nomadnet_browser/$destHash",
+                                            identityArguments =
+                                                mapOf(
+                                                    "destinationHash" to destHash,
+                                                    "path" to "/page/index.mu",
+                                                ),
+                                        )
                                     },
                                 )
                             }
 
                             // NomadNet Browser screen
-                            composable(
-                                route = "nomadnet_browser/{destinationHash}?path={path}",
+                            appComposable(
+                                AppDestination.NOMADNET_BROWSER,
                                 arguments =
                                     listOf(
                                         navArgument("destinationHash") { type = NavType.StringType },
@@ -2376,7 +2388,7 @@ fun ColumbaNavigation(
                             }
 
                             // Offline Maps management screen
-                            composable("offline_maps") {
+                            appComposable(AppDestination.OFFLINE_MAPS) {
                                 OfflineMapsScreen(
                                     onNavigateBack = { navController.popBackStack() },
                                     onNavigateToDownload = { navController.navigate("offline_map_download") },
@@ -2387,8 +2399,8 @@ fun ColumbaNavigation(
                             }
 
                             // Offline Map download wizard (with optional update parameter)
-                            composable(
-                                route = "offline_map_download?updateRegionId={updateRegionId}",
+                            appComposable(
+                                AppDestination.OFFLINE_MAP_DOWNLOAD,
                                 arguments =
                                     listOf(
                                         navArgument("updateRegionId") {
@@ -2400,14 +2412,16 @@ fun ColumbaNavigation(
                                 val updateRegionId = backStackEntry.arguments?.getLong("updateRegionId") ?: -1L
                                 OfflineMapDownloadScreen(
                                     onNavigateBack = { navController.popBackStack() },
-                                    onDownloadComplete = { navController.popBackStack() },
+                                    onDownloadComplete = {
+                                        navController.completeCurrentFlow(AppDestination.OFFLINE_MAP_DOWNLOAD)
+                                    },
                                     updateRegionId = if (updateRegionId > 0) updateRegionId else null,
                                 )
                             }
 
                             // Voice Call Screen (outgoing/active call)
-                            composable(
-                                route = "voice_call/{destinationHash}?autoAnswer={autoAnswer}&profileCode={profileCode}",
+                            appComposable(
+                                AppDestination.VOICE_CALL,
                                 arguments =
                                     listOf(
                                         navArgument("destinationHash") { type = NavType.StringType },
@@ -2435,8 +2449,8 @@ fun ColumbaNavigation(
                             }
 
                             // Incoming Call Screen
-                            composable(
-                                route = "incoming_call/{identityHash}",
+                            appComposable(
+                                AppDestination.INCOMING_CALL,
                                 arguments =
                                     listOf(
                                         navArgument("identityHash") { type = NavType.StringType },
@@ -2449,9 +2463,7 @@ fun ColumbaNavigation(
                                     onCallAnswered = {
                                         // Navigate to voice call screen when answered
                                         val encodedHash = Uri.encode(identityHash)
-                                        navController.navigate("voice_call/$encodedHash") {
-                                            popUpTo("incoming_call/$identityHash") { inclusive = true }
-                                        }
+                                        navController.navigateToAnsweredCall("voice_call/$encodedHash")
                                     },
                                     onCallDeclined = exitCallFlow,
                                 )

--- a/app/src/main/java/network/columba/app/navigation/AppDestination.kt
+++ b/app/src/main/java/network/columba/app/navigation/AppDestination.kt
@@ -1,0 +1,159 @@
+package network.columba.app.navigation
+
+/**
+ * Canonical registry for every destination in Columba's application NavHost.
+ *
+ * [sampleRoute] is a concrete, navigable route used by the global Back contract
+ * tests. New destinations must be registered here and through `appComposable`
+ * so they automatically participate in those tests. New completion flows must
+ * also declare [completionContract] and finish through `completeCurrentFlow`.
+ * Event-driven entity destinations declare [externalIdentityArguments] and use
+ * `navigateToEntity`, which enrolls them in repeated-delivery tests.
+ */
+enum class AppDestination(
+    val routePattern: String,
+    val sampleRoute: String = routePattern,
+    val backContract: BackContract = BackContract.POP_TO_CALLER,
+    val completionContract: CompletionContract = CompletionContract.NONE,
+    val completionTargetRoute: String? = null,
+    val externalIdentityArguments: Map<String, Any> = emptyMap(),
+    val externalNavigationPolicy: ExternalNavigationPolicy = ExternalNavigationPolicy.NONE,
+) {
+    WELCOME("welcome", backContract = BackContract.ENTRY_GATE),
+    IDENTITY_UNLOCK("identity_unlock", backContract = BackContract.ENTRY_GATE),
+    CHATS("chats", backContract = BackContract.TOP_LEVEL),
+    ANNOUNCES("announce_stream?filterType={filterType}", "announce_stream?filterType=all"),
+    CONTACTS("contacts", backContract = BackContract.TOP_LEVEL),
+    MAP("map", backContract = BackContract.TOP_LEVEL),
+    IDENTITY("identity"),
+    SETTINGS("settings", backContract = BackContract.TOP_LEVEL),
+    MAP_FOCUS(
+        routePattern = "map_focus?lat={lat}&lon={lon}&label={label}&type={type}&height={height}" +
+            "&reachableOn={reachableOn}&port={port}&frequency={frequency}&bandwidth={bandwidth}" +
+            "&sf={sf}&cr={cr}&modulation={modulation}&status={status}&lastHeard={lastHeard}&hops={hops}",
+        sampleRoute = "map_focus?lat=45.5&lon=-122.6&label=Test&type=RNode&height=10.0" +
+            "&reachableOn=&port=-1&frequency=915000000&bandwidth=125000" +
+            "&sf=10&cr=5&modulation=LoRa&status=online&lastHeard=1&hops=1",
+    ),
+    USB_DEVICE_ACTION(
+        routePattern = "usb_device_action?usbDeviceId={usbDeviceId}&usbVendorId={usbVendorId}" +
+            "&usbProductId={usbProductId}&usbDeviceName={usbDeviceName}&pyxisVersion={pyxisVersion}",
+        sampleRoute = "usb_device_action?usbDeviceId=1&usbVendorId=2&usbProductId=3" +
+            "&usbDeviceName=Test&pyxisVersion=1.0",
+        externalIdentityArguments = mapOf("usbDeviceId" to 1),
+        externalNavigationPolicy = ExternalNavigationPolicy.REUSE_SAME_ENTITY,
+    ),
+    PYXIS_UPDATER(
+        "pyxis_updater?packageUri={packageUri}&usbDeviceId={usbDeviceId}",
+        "pyxis_updater?packageUri=&usbDeviceId=-1",
+    ),
+    RNODE_FLASHER(
+        routePattern = "rnode_flasher?skipDetection={skipDetection}&tncConfigOnly={tncConfigOnly}" +
+            "&usbDeviceId={usbDeviceId}&usbVendorId={usbVendorId}" +
+            "&usbProductId={usbProductId}&usbDeviceName={usbDeviceName}",
+        sampleRoute = "rnode_flasher?skipDetection=false&tncConfigOnly=false&usbDeviceId=-1" +
+            "&usbVendorId=-1&usbProductId=-1&usbDeviceName=",
+        externalIdentityArguments = mapOf("usbDeviceId" to -1),
+        externalNavigationPolicy = ExternalNavigationPolicy.REUSE_SAME_ENTITY,
+    ),
+    INTERFACE_MANAGEMENT("interface_management"),
+    DISCOVERED_INTERFACES("discovered_interfaces"),
+    TCP_CLIENT_WIZARD(
+        routePattern = "tcp_client_wizard?interfaceId={interfaceId}&host={host}&port={port}&name={name}" +
+            "&ifacNetname={ifacNetname}&ifacNetkey={ifacNetkey}",
+        sampleRoute = "tcp_client_wizard?interfaceId=-1&host=&port=0&name=&ifacNetname=&ifacNetkey=",
+        completionContract = CompletionContract.SHOW_RESULT,
+        completionTargetRoute = "interface_management",
+    ),
+    RNODE_WIZARD(
+        routePattern = "rnode_wizard?interfaceId={interfaceId}&connectionType={connectionType}" +
+            "&transportMode={transportMode}&usbDeviceId={usbDeviceId}&usbVendorId={usbVendorId}" +
+            "&usbProductId={usbProductId}&usbDeviceName={usbDeviceName}&loraFrequency={loraFrequency}" +
+            "&loraBandwidth={loraBandwidth}&loraSf={loraSf}&loraCr={loraCr}",
+        sampleRoute = "rnode_wizard?interfaceId=-1&connectionType=&transportMode=false&usbDeviceId=-1" +
+            "&usbVendorId=-1&usbProductId=-1&usbDeviceName=&loraFrequency=-1" +
+            "&loraBandwidth=-1&loraSf=-1&loraCr=-1",
+        completionContract = CompletionContract.SHOW_RESULT,
+        completionTargetRoute = "interface_management",
+        externalIdentityArguments = mapOf("usbDeviceId" to -1),
+        externalNavigationPolicy = ExternalNavigationPolicy.REUSE_SAME_ENTITY,
+    ),
+    INTERFACE_STATS("interface_stats/{interfaceId}", "interface_stats/1"),
+    NOTIFICATION_SETTINGS("notification_settings"),
+    BLOCKED_USERS("blocked_users"),
+    THEME_MANAGEMENT("theme_management"),
+    THEME_EDITOR_NEW("theme_editor"),
+    THEME_EDITOR_EXISTING("theme_editor/{themeId}", "theme_editor/1"),
+    BLE_CONNECTION_STATUS("ble_connection_status"),
+    IDENTITY_MANAGER(
+        "identity_manager?base32Key={base32Key}",
+        "identity_manager?base32Key=test",
+        externalIdentityArguments = mapOf("base32Key" to "test"),
+        externalNavigationPolicy = ExternalNavigationPolicy.REPLACE_DESTINATION,
+    ),
+    MIGRATION("migration"),
+    APK_SHARING("apk_sharing"),
+    MY_IDENTITY("my_identity"),
+    NETWORK_STATUS("network_status"),
+    QR_SCANNER("qr_scanner"),
+    MESSAGING(
+        routePattern = "messaging/{destinationHash}/{peerName}" +
+            "?fromNotification={fromNotification}&notificationEventId={notificationEventId}",
+        sampleRoute = "messaging/0123456789abcdef/Test?fromNotification=false&notificationEventId=0",
+    ),
+    MESSAGE_DETAIL("message_detail/{messageId}", "message_detail/1"),
+    ANNOUNCE_DETAIL(
+        "announce_detail/{destinationHash}",
+        "announce_detail/0123456789abcdef",
+        externalIdentityArguments = mapOf("destinationHash" to "0123456789abcdef"),
+        externalNavigationPolicy = ExternalNavigationPolicy.REUSE_SAME_ENTITY,
+    ),
+    NOMADNET_BROWSER(
+        "nomadnet_browser/{destinationHash}?path={path}",
+        "nomadnet_browser/0123456789abcdef?path=%2Fpage%2Findex.mu",
+        externalIdentityArguments =
+            mapOf(
+                "destinationHash" to "0123456789abcdef",
+                "path" to "/page/index.mu",
+            ),
+        externalNavigationPolicy = ExternalNavigationPolicy.REUSE_SAME_ENTITY,
+    ),
+    OFFLINE_MAPS("offline_maps"),
+    OFFLINE_MAP_DOWNLOAD(
+        "offline_map_download?updateRegionId={updateRegionId}",
+        "offline_map_download?updateRegionId=-1",
+        completionContract = CompletionContract.RETURN_TO_CALLER,
+    ),
+    VOICE_CALL(
+        "voice_call/{destinationHash}?autoAnswer={autoAnswer}&profileCode={profileCode}",
+        "voice_call/0123456789abcdef?autoAnswer=false&profileCode=-1",
+    ),
+    INCOMING_CALL("incoming_call/{identityHash}", "incoming_call/0123456789abcdef"),
+}
+
+enum class BackContract {
+    /** Root destinations own app-exit behavior rather than popping another app destination. */
+    TOP_LEVEL,
+
+    /** Entry gates are selected as start destinations and are removed when completed. */
+    ENTRY_GATE,
+
+    /** One Android Back press at the destination root returns to its caller. */
+    POP_TO_CALLER,
+}
+
+enum class CompletionContract {
+    NONE,
+
+    /** Successful completion removes the flow and reveals its caller. */
+    RETURN_TO_CALLER,
+
+    /** Successful completion removes the flow and presents [AppDestination.completionTargetRoute]. */
+    SHOW_RESULT,
+}
+
+enum class ExternalNavigationPolicy {
+    NONE,
+    REUSE_SAME_ENTITY,
+    REPLACE_DESTINATION,
+}

--- a/app/src/main/java/network/columba/app/navigation/AppNavigationGraph.kt
+++ b/app/src/main/java/network/columba/app/navigation/AppNavigationGraph.kt
@@ -1,0 +1,21 @@
+package network.columba.app.navigation
+
+import androidx.compose.animation.AnimatedContentScope
+import androidx.compose.runtime.Composable
+import androidx.navigation.NamedNavArgument
+import androidx.navigation.NavBackStackEntry
+import androidx.navigation.NavGraphBuilder
+import androidx.navigation.compose.composable
+
+/** Registers a production destination through the canonical [AppDestination] registry. */
+fun NavGraphBuilder.appComposable(
+    destination: AppDestination,
+    arguments: List<NamedNavArgument> = emptyList(),
+    content: @Composable AnimatedContentScope.(NavBackStackEntry) -> Unit,
+) {
+    composable(
+        route = destination.routePattern,
+        arguments = arguments,
+        content = content,
+    )
+}

--- a/app/src/main/java/network/columba/app/navigation/ExternalNavigationActions.kt
+++ b/app/src/main/java/network/columba/app/navigation/ExternalNavigationActions.kt
@@ -1,0 +1,77 @@
+package network.columba.app.navigation
+
+import androidx.navigation.NavController
+
+/**
+ * Navigates to an externally requested entity without stacking the same logical
+ * entity repeatedly. A different entity remains a normal push so its history is
+ * preserved.
+ */
+fun NavController.navigateToEntity(
+    destination: AppDestination,
+    route: String,
+    identityArguments: Map<String, Any>,
+) {
+    require(destination.externalIdentityArguments.isNotEmpty()) {
+        "${destination.name} must declare external identity arguments"
+    }
+    require(destination.externalNavigationPolicy != ExternalNavigationPolicy.NONE) {
+        "${destination.name} must declare an external navigation policy"
+    }
+    require(identityArguments.keys == destination.externalIdentityArguments.keys) {
+        "Identity arguments for ${destination.name} must be ${destination.externalIdentityArguments.keys}"
+    }
+
+    val currentEntry = currentBackStackEntry
+    val isSameEntity =
+        currentEntry?.destination?.route == destination.routePattern &&
+            identityArguments.all { (name, expectedValue) ->
+                val arguments = currentEntry.arguments ?: return@all false
+                when (expectedValue) {
+                    is String -> arguments.getString(name) == expectedValue
+                    is Int -> arguments.getInt(name, Int.MIN_VALUE) == expectedValue
+                    is Long -> arguments.getLong(name, Long.MIN_VALUE) == expectedValue
+                    is Boolean -> arguments.containsKey(name) && arguments.getBoolean(name) == expectedValue
+                    else -> error("Unsupported navigation identity type: ${expectedValue::class.simpleName}")
+                }
+            }
+
+    val shouldReuseCurrentDestination =
+        currentEntry?.destination?.route == destination.routePattern &&
+            when (destination.externalNavigationPolicy) {
+                ExternalNavigationPolicy.REUSE_SAME_ENTITY -> isSameEntity
+                ExternalNavigationPolicy.REPLACE_DESTINATION -> true
+                ExternalNavigationPolicy.NONE -> false
+            }
+
+    navigate(route) {
+        launchSingleTop = shouldReuseCurrentDestination
+    }
+}
+
+/**
+ * Presents the one active incoming-call destination. Competing notification and
+ * call-state producers replace the current incoming-call entry rather than
+ * leaving stale call screens in history.
+ */
+fun NavController.navigateToIncomingCall(route: String) {
+    if (currentDestination?.route == AppDestination.VOICE_CALL.routePattern) {
+        return
+    }
+    navigate(route) {
+        launchSingleTop = currentDestination?.route == AppDestination.INCOMING_CALL.routePattern
+    }
+}
+
+/**
+ * Replaces the incoming-call flow with the active voice call.
+ *
+ * If an incoming-call entry exists, it and everything above it are removed. If
+ * the voice call is already visible, launchSingleTop updates/reuses that entry.
+ */
+fun NavController.navigateToAnsweredCall(route: String) {
+    popBackStack(AppDestination.INCOMING_CALL.routePattern, inclusive = true)
+    navigate(route) {
+        launchSingleTop = true
+    }
+}

--- a/app/src/main/java/network/columba/app/navigation/NavigationStackActions.kt
+++ b/app/src/main/java/network/columba/app/navigation/NavigationStackActions.kt
@@ -1,0 +1,40 @@
+package network.columba.app.navigation
+
+import androidx.navigation.NavController
+
+/**
+ * Completes the currently visible flow according to its declared contract.
+ *
+ * The flow entry is always removed regardless of which origin launched it. A
+ * result flow then presents its result destination; a return flow reveals its
+ * caller. Android Back can therefore never expose a completed flow.
+ */
+fun NavController.completeCurrentFlow(flow: AppDestination) {
+    require(currentDestination?.route == flow.routePattern) {
+        "Cannot complete ${flow.name} while ${currentDestination?.route} is visible"
+    }
+    when (flow.completionContract) {
+        CompletionContract.NONE -> error("${flow.name} does not declare a completion contract")
+        CompletionContract.RETURN_TO_CALLER -> popBackStack()
+        CompletionContract.SHOW_RESULT -> {
+            val resultRoute = requireNotNull(flow.completionTargetRoute) {
+                "${flow.name} does not declare a completion target"
+            }
+            completeCurrentFlowTo(resultRoute)
+        }
+    }
+}
+
+internal fun NavController.completeCurrentFlowTo(resultRoute: String) {
+    if (popBackStack(resultRoute, inclusive = false)) {
+        return
+    }
+
+    val completedDestinationId = currentDestination?.id
+    navigate(resultRoute) {
+        if (completedDestinationId != null) {
+            popUpTo(completedDestinationId) { inclusive = true }
+        }
+        launchSingleTop = true
+    }
+}

--- a/app/src/main/java/network/columba/app/ui/screens/offlinemaps/OfflineMapDownloadScreen.kt
+++ b/app/src/main/java/network/columba/app/ui/screens/offlinemaps/OfflineMapDownloadScreen.kt
@@ -3,6 +3,7 @@ package network.columba.app.ui.screens.offlinemaps
 import android.Manifest
 import android.location.Location
 import android.util.Log
+import androidx.activity.compose.BackHandler
 import androidx.activity.compose.rememberLauncherForActivityResult
 import androidx.activity.result.contract.ActivityResultContracts
 import androidx.compose.foundation.layout.Arrangement
@@ -94,6 +95,17 @@ fun OfflineMapDownloadScreen(
     val snackbarHostState = remember { SnackbarHostState() }
     var showCancelDialog by remember { mutableStateOf(false) }
     val context = LocalContext.current
+    val handleBack = {
+        when (state.step) {
+            DownloadWizardStep.DOWNLOADING -> showCancelDialog = true
+            DownloadWizardStep.LOCATION -> onNavigateBack()
+            DownloadWizardStep.RADIUS,
+            DownloadWizardStep.CONFIRM,
+            -> viewModel.previousStep()
+        }
+    }
+
+    BackHandler(onBack = handleBack)
 
     // Pre-fill wizard when updating an existing region
     LaunchedEffect(updateRegionId) {
@@ -147,15 +159,7 @@ fun OfflineMapDownloadScreen(
                 },
                 navigationIcon = {
                     IconButton(
-                        onClick = {
-                            if (state.step == DownloadWizardStep.DOWNLOADING) {
-                                showCancelDialog = true
-                            } else if (state.step == DownloadWizardStep.LOCATION) {
-                                onNavigateBack()
-                            } else {
-                                viewModel.previousStep()
-                            }
-                        },
+                        onClick = handleBack,
                     ) {
                         Icon(
                             imageVector =

--- a/app/src/main/java/network/columba/app/ui/screens/rnode/RNodeWizardScreen.kt
+++ b/app/src/main/java/network/columba/app/ui/screens/rnode/RNodeWizardScreen.kt
@@ -111,6 +111,7 @@ fun RNodeWizardScreen(
     // Handle save success
     LaunchedEffect(state.saveSuccess) {
         if (state.saveSuccess) {
+            viewModel.consumeSaveSuccess()
             onComplete()
         }
     }

--- a/app/src/main/java/network/columba/app/ui/screens/tcpclient/TcpClientWizardScreen.kt
+++ b/app/src/main/java/network/columba/app/ui/screens/tcpclient/TcpClientWizardScreen.kt
@@ -74,6 +74,7 @@ fun TcpClientWizardScreen(
     // Handle save success
     LaunchedEffect(state.saveSuccess) {
         if (state.saveSuccess) {
+            viewModel.consumeSaveSuccess()
             onComplete()
         }
     }

--- a/app/src/main/java/network/columba/app/viewmodel/RNodeWizardViewModel.kt
+++ b/app/src/main/java/network/columba/app/viewmodel/RNodeWizardViewModel.kt
@@ -645,6 +645,11 @@ class RNodeWizardViewModel
             }
         }
 
+        /** Consumes the one-shot save completion before navigation removes this screen. */
+        fun consumeSaveSuccess() {
+            _state.update { it.copy(saveSuccess = false) }
+        }
+
         fun canProceed(): Boolean {
             val state = _state.value
             return when (state.currentStep) {

--- a/app/src/main/java/network/columba/app/viewmodel/TcpClientWizardViewModel.kt
+++ b/app/src/main/java/network/columba/app/viewmodel/TcpClientWizardViewModel.kt
@@ -340,6 +340,11 @@ class TcpClientWizardViewModel
             _state.update { it.copy(currentStep = previousStep) }
         }
 
+        /** Consumes the one-shot save completion before navigation removes this screen. */
+        fun consumeSaveSuccess() {
+            _state.update { it.copy(saveSuccess = false) }
+        }
+
         /**
          * Save the TCP Client interface configuration.
          */

--- a/app/src/test/java/network/columba/app/navigation/NavigationBackStackContractTest.kt
+++ b/app/src/test/java/network/columba/app/navigation/NavigationBackStackContractTest.kt
@@ -1,0 +1,361 @@
+package network.columba.app.navigation
+
+import android.app.Application
+import android.os.Looper
+import androidx.activity.ComponentActivity
+import androidx.compose.animation.EnterTransition
+import androidx.compose.animation.ExitTransition
+import androidx.compose.ui.test.junit4.createAndroidComposeRule
+import androidx.navigation.NavHostController
+import androidx.navigation.NavType
+import androidx.navigation.compose.NavHost
+import androidx.navigation.compose.rememberNavController
+import androidx.navigation.navArgument
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.Shadows.shadowOf
+import org.robolectric.annotation.Config
+
+/**
+ * NavController-level contracts using placeholder destination content.
+ *
+ * These tests exercise the real Android Back dispatcher and navigation stack,
+ * but screen-specific BackHandlers require separate UI/instrumented coverage.
+ */
+@RunWith(RobolectricTestRunner::class)
+@Config(sdk = [34], application = Application::class)
+@Suppress("DEPRECATION")
+class NavigationBackStackContractTest {
+    @get:Rule
+    val composeRule = createAndroidComposeRule<ComponentActivity>()
+
+    private lateinit var navController: NavHostController
+
+    @Before
+    fun setUp() {
+        composeRule.setContent {
+            navController = rememberNavController()
+            NavHost(
+                navController = navController,
+                startDestination = AppDestination.CHATS.routePattern,
+                enterTransition = { EnterTransition.None },
+                exitTransition = { ExitTransition.None },
+                popEnterTransition = { EnterTransition.None },
+                popExitTransition = { ExitTransition.None },
+            ) {
+                AppDestination.entries.forEach { destination ->
+                    appComposable(
+                        destination = destination,
+                        arguments = testArguments(destination),
+                    ) { }
+                }
+            }
+        }
+        composeRule.waitForIdle()
+        idleMainLooper()
+        assertCurrentDestination(AppDestination.CHATS)
+    }
+
+    @Test
+    fun `Android Back returns every child destination to every top-level caller`() {
+        val callers = AppDestination.entries.filter { it.backContract == BackContract.TOP_LEVEL }
+        val children = AppDestination.entries.filter { it.backContract == BackContract.POP_TO_CALLER }
+
+        callers.forEach { caller ->
+            if (caller != AppDestination.CHATS) {
+                navigateTo(caller.sampleRoute)
+            }
+            children.forEach { destination ->
+                navigateTo(destination.sampleRoute)
+                assertCurrentDestination(destination)
+
+                pressAndroidBack()
+
+                assertCurrentDestination(
+                    caller,
+                    "Android Back from ${destination.name} must return to ${caller.name}",
+                )
+            }
+            if (caller != AppDestination.CHATS) {
+                pressAndroidBack()
+                assertCurrentDestination(AppDestination.CHATS)
+            }
+        }
+    }
+
+    @Test
+    fun `completing every registered flow removes it from the back stack`() {
+        val flows = AppDestination.entries.filter { it.completionContract != CompletionContract.NONE }
+        assertTrue("At least one completion flow must be registered", flows.isNotEmpty())
+
+        flows.forEach { flow ->
+            navigateTo(flow.sampleRoute)
+            assertCurrentDestination(flow)
+
+            runOnMainThread {
+                navController.completeCurrentFlow(flow)
+            }
+            idleMainLooper()
+
+            when (flow.completionContract) {
+                CompletionContract.NONE -> error("Filtered above")
+                CompletionContract.RETURN_TO_CALLER -> {
+                    assertCurrentDestination(
+                        AppDestination.CHATS,
+                        "Completing ${flow.name} must return directly to its caller",
+                    )
+                }
+                CompletionContract.SHOW_RESULT -> {
+                    assertEquals(
+                        "Completion target for ${flow.name}",
+                        flow.completionTargetRoute,
+                        navController.currentDestination?.route,
+                    )
+                    pressAndroidBack()
+                    assertCurrentDestination(
+                        AppDestination.CHATS,
+                        "Android Back after completing ${flow.name} must not reveal the completed flow",
+                    )
+                }
+            }
+        }
+    }
+
+    @Test
+    fun `flow completion reuses an existing result destination without duplication`() {
+        AppDestination.entries
+            .filter { it.completionTargetRoute != null }
+            .forEach { flow ->
+                val result = AppDestination.entries.single {
+                    it.routePattern == flow.completionTargetRoute
+                }
+                navigateTo(result.sampleRoute)
+                navigateTo(flow.sampleRoute)
+
+                runOnMainThread {
+                    navController.completeCurrentFlow(flow)
+                }
+                idleMainLooper()
+                assertCurrentDestination(result)
+
+                pressAndroidBack()
+
+                assertCurrentDestination(
+                    AppDestination.CHATS,
+                    "Completing ${flow.name} must not duplicate ${result.name}",
+                )
+            }
+    }
+
+    @Test
+    fun `flow completion removes intermediate destinations above an existing result`() {
+        AppDestination.entries
+            .filter { it.completionContract == CompletionContract.SHOW_RESULT }
+            .forEach { flow ->
+                val result = AppDestination.entries.single {
+                    it.routePattern == flow.completionTargetRoute
+                }
+                navigateTo(result.sampleRoute)
+                navigateTo(AppDestination.DISCOVERED_INTERFACES.sampleRoute)
+                navigateTo(flow.sampleRoute)
+
+                runOnMainThread {
+                    navController.completeCurrentFlow(flow)
+                }
+                idleMainLooper()
+                assertCurrentDestination(result)
+
+                pressAndroidBack()
+
+                assertCurrentDestination(
+                    AppDestination.CHATS,
+                    "Completing ${flow.name} must remove intermediate destinations above ${result.name}",
+                )
+            }
+    }
+
+    @Test
+    fun `repeated external navigation to the same entity creates one Back destination`() {
+        val destinations = AppDestination.entries.filter { it.externalIdentityArguments.isNotEmpty() }
+        assertTrue("At least one external entity destination must be registered", destinations.isNotEmpty())
+
+        destinations.forEach { destination ->
+            runOnMainThread {
+                navController.navigateToEntity(
+                    destination = destination,
+                    route = destination.sampleRoute,
+                    identityArguments = destination.externalIdentityArguments,
+                )
+                navController.navigateToEntity(
+                    destination = destination,
+                    route = destination.sampleRoute,
+                    identityArguments = destination.externalIdentityArguments,
+                )
+            }
+            assertCurrentDestination(destination)
+
+            pressAndroidBack()
+
+            assertCurrentDestination(
+                AppDestination.CHATS,
+                "Repeated delivery of ${destination.name} must not require an ineffective extra Back press",
+            )
+        }
+    }
+
+    @Test
+    fun `external navigation to a different entity preserves legitimate history`() {
+        runOnMainThread {
+            navController.navigateToEntity(
+                destination = AppDestination.ANNOUNCE_DETAIL,
+                route = "announce_detail/announce-a",
+                identityArguments = mapOf("destinationHash" to "announce-a"),
+            )
+            navController.navigateToEntity(
+                destination = AppDestination.ANNOUNCE_DETAIL,
+                route = "announce_detail/announce-b",
+                identityArguments = mapOf("destinationHash" to "announce-b"),
+            )
+        }
+        assertBackStackArgument("destinationHash", "announce-b")
+
+        pressAndroidBack()
+
+        assertCurrentDestination(AppDestination.ANNOUNCE_DETAIL)
+        assertBackStackArgument("destinationHash", "announce-a")
+    }
+
+    @Test
+    fun `singleton external destination replaces a different entity payload`() {
+        runOnMainThread {
+            navController.navigateToEntity(
+                destination = AppDestination.IDENTITY_MANAGER,
+                route = "identity_manager?base32Key=key-a",
+                identityArguments = mapOf("base32Key" to "key-a"),
+            )
+            navController.navigateToEntity(
+                destination = AppDestination.IDENTITY_MANAGER,
+                route = "identity_manager?base32Key=key-b",
+                identityArguments = mapOf("base32Key" to "key-b"),
+            )
+        }
+        assertCurrentDestination(AppDestination.IDENTITY_MANAGER)
+        assertBackStackArgument("base32Key", "key-b")
+
+        pressAndroidBack()
+
+        assertCurrentDestination(AppDestination.CHATS)
+    }
+
+    @Test
+    fun `repeated incoming call ingress replaces the current call destination`() {
+        runOnMainThread {
+            navController.navigateToIncomingCall("incoming_call/caller-a")
+            navController.navigateToIncomingCall("incoming_call/caller-a")
+            navController.navigateToIncomingCall("incoming_call/caller-b")
+        }
+        assertCurrentDestination(AppDestination.INCOMING_CALL)
+        assertBackStackArgument("identityHash", "caller-b")
+
+        pressAndroidBack()
+
+        assertCurrentDestination(
+            AppDestination.CHATS,
+            "Repeated incoming-call producers must not leave stale call screens in history",
+        )
+    }
+
+    @Test
+    fun `answering a call removes incoming call and intermediate destinations`() {
+        navigateTo("incoming_call/caller-a")
+        navigateTo(AppDestination.ANNOUNCE_DETAIL.sampleRoute)
+
+        runOnMainThread {
+            navController.navigateToAnsweredCall("voice_call/caller-a?autoAnswer=true")
+        }
+        assertCurrentDestination(AppDestination.VOICE_CALL)
+
+        pressAndroidBack()
+
+        assertCurrentDestination(
+            AppDestination.CHATS,
+            "Back after answering must not expose an active incoming-call destination",
+        )
+    }
+
+    @Test
+    fun `answering an already visible voice call does not duplicate it`() {
+        navigateTo("voice_call/caller-a?autoAnswer=false")
+
+        runOnMainThread {
+            navController.navigateToAnsweredCall("voice_call/caller-a?autoAnswer=true")
+        }
+        assertCurrentDestination(AppDestination.VOICE_CALL)
+
+        pressAndroidBack()
+
+        assertCurrentDestination(AppDestination.CHATS)
+    }
+
+    @Test
+    fun `late incoming call ingress cannot cover an active voice call`() {
+        navigateTo("voice_call/caller-a?autoAnswer=true")
+
+        runOnMainThread {
+            navController.navigateToIncomingCall("incoming_call/caller-a")
+        }
+        assertCurrentDestination(AppDestination.VOICE_CALL)
+
+        pressAndroidBack()
+
+        assertCurrentDestination(AppDestination.CHATS)
+    }
+
+    private fun testArguments(destination: AppDestination) =
+        when (destination) {
+            AppDestination.USB_DEVICE_ACTION,
+            AppDestination.RNODE_WIZARD,
+            AppDestination.RNODE_FLASHER,
+            -> listOf(navArgument("usbDeviceId") { type = NavType.IntType })
+            else -> emptyList()
+        }
+
+    private fun navigateTo(route: String) {
+        runOnMainThread { navController.navigate(route) }
+        idleMainLooper()
+    }
+
+    private fun pressAndroidBack() {
+        runOnMainThread { composeRule.activity.onBackPressedDispatcher.onBackPressed() }
+        idleMainLooper()
+    }
+
+    private fun runOnMainThread(block: () -> Unit) {
+        composeRule.runOnUiThread(block)
+        composeRule.waitForIdle()
+        idleMainLooper()
+    }
+
+    private fun idleMainLooper() {
+        shadowOf(Looper.getMainLooper()).idle()
+    }
+
+    private fun assertCurrentDestination(
+        expected: AppDestination,
+        message: String = "Expected ${expected.name}",
+    ) {
+        assertEquals(message, expected.routePattern, navController.currentDestination?.route)
+    }
+
+    private fun assertBackStackArgument(
+        name: String,
+        expected: String,
+    ) {
+        assertEquals(expected, navController.currentBackStackEntry?.arguments?.getString(name))
+    }
+}

--- a/app/src/test/java/network/columba/app/navigation/NavigationDestinationRegistryTest.kt
+++ b/app/src/test/java/network/columba/app/navigation/NavigationDestinationRegistryTest.kt
@@ -1,0 +1,120 @@
+package network.columba.app.navigation
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import java.io.File
+
+class NavigationDestinationRegistryTest {
+    @Test
+    fun `destination and completion contracts are internally consistent`() {
+        val routes = AppDestination.entries.map { it.routePattern }
+        assertEquals("Destination route patterns must be unique", routes.size, routes.toSet().size)
+
+        AppDestination.entries.forEach { destination ->
+            destination.externalIdentityArguments.forEach { (argument, sampleValue) ->
+                assertTrue(
+                    "${destination.name} external identity argument $argument must exist in its route",
+                    "{$argument}" in destination.routePattern,
+                )
+                assertTrue(
+                    "${destination.name} has unsupported external identity value ${sampleValue::class.simpleName}",
+                    sampleValue is String || sampleValue is Int || sampleValue is Long || sampleValue is Boolean,
+                )
+            }
+            assertEquals(
+                "${destination.name} external policy and identity metadata must be declared together",
+                destination.externalIdentityArguments.isEmpty(),
+                destination.externalNavigationPolicy == ExternalNavigationPolicy.NONE,
+            )
+            when (destination.completionContract) {
+                CompletionContract.NONE,
+                CompletionContract.RETURN_TO_CALLER -> assertEquals(
+                    "${destination.name} must not declare an unused result route",
+                    null,
+                    destination.completionTargetRoute,
+                )
+                CompletionContract.SHOW_RESULT -> {
+                    val resultRoute = requireNotNull(destination.completionTargetRoute)
+                    assertTrue(
+                        "${destination.name} result route must be a registered destination",
+                        AppDestination.entries.any { it.routePattern == resultRoute },
+                    )
+                }
+            }
+        }
+    }
+
+    @Test
+    fun `production graph registers every destination through the contract registry`() {
+        val sources = mainKotlinSources()
+        val combinedSource = sources.joinToString("\n") { it.readText() }
+        val registeredNames =
+            Regex("""appComposable\(\s*AppDestination\.([A-Z_]+)""")
+                .findAll(combinedSource)
+                .map { it.groupValues[1] }
+                .toList()
+        val registered = registeredNames.toSet()
+        val expected = AppDestination.entries.map { it.name }.toSet()
+        val entityNavigationNames =
+            Regex("""navigateToEntity\(\s*destination\s*=\s*AppDestination\.([A-Z_]+)""")
+                .findAll(combinedSource)
+                .map { it.groupValues[1] }
+                .toSet()
+        val expectedEntityNavigationNames =
+            AppDestination.entries
+                .filter { it.externalIdentityArguments.isNotEmpty() }
+                .map { it.name }
+                .toSet()
+        val incomingCallIngressCount =
+            Regex("""navController\.navigateToIncomingCall\(""").findAll(combinedSource).count()
+        val answerCallIngressCount =
+            Regex("""navController\.navigateToAnsweredCall\(""").findAll(combinedSource).count()
+        val directIncomingCallNavigation =
+            Regex("""navController\.navigate\(\s*"incoming_call/""").containsMatchIn(combinedSource)
+        val rawRegistrations =
+            sources
+                .filterNot { it.name == "AppNavigationGraph.kt" }
+                .flatMap { source ->
+                    source.readLines().mapIndexedNotNull { index, line ->
+                        if (Regex("""^\s*composable\(""").containsMatchIn(line)) {
+                            "${source.relativeTo(mainKotlinSourceRoot())}:${index + 1}"
+                        } else {
+                            null
+                        }
+                    }
+                }
+
+        assertEquals(
+            "Every destination must be registered exactly once",
+            expected.size,
+            registeredNames.size,
+        )
+        assertEquals("Production graph and destination registry must stay in lockstep", expected, registered)
+        assertEquals(
+            "Every declared external entity destination must use navigateToEntity",
+            expectedEntityNavigationNames,
+            entityNavigationNames,
+        )
+        assertTrue("Intent and call-state incoming producers must use the call policy", incomingCallIngressCount >= 2)
+        assertTrue("Notification and in-screen answer paths must use the call policy", answerCallIngressCount >= 2)
+        assertTrue("Direct incoming-call navigation bypasses rebound protection", !directIncomingCallNavigation)
+        assertTrue(
+            "Raw composable registrations bypass global navigation contracts: $rawRegistrations",
+            rawRegistrations.isEmpty(),
+        )
+    }
+
+    private fun mainKotlinSources(): List<File> =
+        mainKotlinSourceRoot()
+            .walkTopDown()
+            .filter { it.isFile && it.extension == "kt" }
+            .sortedBy { it.path }
+            .toList()
+
+    private fun mainKotlinSourceRoot(): File {
+        val fromModule = File("src/main/java")
+        if (fromModule.exists()) return fromModule
+        return File("app/src/main/java")
+    }
+}

--- a/app/src/test/java/network/columba/app/ui/MainActivityTcpClientNavigationTest.kt
+++ b/app/src/test/java/network/columba/app/ui/MainActivityTcpClientNavigationTest.kt
@@ -14,7 +14,6 @@ import network.columba.app.viewmodel.TcpClientWizardViewModel
 import io.mockk.every
 import io.mockk.mockk
 import kotlinx.coroutines.flow.MutableStateFlow
-import org.junit.Assert.assertTrue
 import org.junit.Rule
 import org.junit.Test
 import org.junit.rules.RuleChain
@@ -23,8 +22,10 @@ import org.robolectric.RobolectricTestRunner
 import org.robolectric.annotation.Config
 
 /**
- * Navigation tests for TCP Client Wizard integration with main navigation.
- * Tests that the wizard integrates correctly with the app's navigation graph.
+ * Rendering smoke tests for the TCP Client Wizard in a NavHost.
+ *
+ * Back-stack completion behavior is covered by NavigationBackStackContractTest;
+ * this class intentionally does not substitute callbacks for production navigation.
  */
 @RunWith(RobolectricTestRunner::class)
 @Config(sdk = [34], application = Application::class)
@@ -66,107 +67,6 @@ class MainActivityTcpClientNavigationTest {
         }
 
         // Then - Wizard content is displayed (appears in TopAppBar and step header)
-        composeTestRule.onAllNodesWithText("Choose Server").assertCountEquals(2)
-    }
-
-    @Test
-    fun tcpClientWizard_onComplete_navigatesToDestination() {
-        // Given
-        var navigationCompleted = false
-        val mockViewModel = mockk<TcpClientWizardViewModel>()
-        every { mockViewModel.state } returns
-            MutableStateFlow(
-                TcpClientWizardTestFixtures.successState(),
-            )
-        every { mockViewModel.canProceed() } returns true
-
-        // When
-        composeTestRule.setContent {
-            val navController = rememberNavController()
-            NavHost(
-                navController = navController,
-                startDestination = "tcp_client_wizard",
-            ) {
-                composable("tcp_client_wizard") {
-                    TcpClientWizardScreen(
-                        onNavigateBack = {},
-                        onComplete = {
-                            navigationCompleted = true
-                            // In real app: navController.navigate("interface_management")
-                        },
-                        viewModel = mockViewModel,
-                    )
-                }
-            }
-        }
-
-        // Then - onComplete callback was triggered (saveSuccess causes navigation)
-        assertTrue(navigationCompleted)
-    }
-
-    @Test
-    fun tcpClientWizard_onNavigateBack_popBackStack() {
-        // Given
-        val mockViewModel = mockk<TcpClientWizardViewModel>()
-        every { mockViewModel.state } returns
-            MutableStateFlow(
-                TcpClientWizardTestFixtures.serverSelectionState(),
-            )
-        every { mockViewModel.canProceed() } returns false
-        every { mockViewModel.getCommunityServers() } returns TcpClientWizardTestFixtures.testServers
-
-        // When
-        composeTestRule.setContent {
-            NavHost(
-                navController = rememberNavController(),
-                startDestination = "tcp_client_wizard",
-            ) {
-                composable("tcp_client_wizard") {
-                    TcpClientWizardScreen(
-                        onNavigateBack = {},
-                        onComplete = {},
-                        viewModel = mockViewModel,
-                    )
-                }
-            }
-        }
-
-        // Then - Back navigation callback is available
-        // The actual back button click is tested in TcpClientWizardScreenTest
-        composeTestRule.onAllNodesWithText("Choose Server").assertCountEquals(2)
-    }
-
-    @Test
-    fun tcpClientWizard_navigationRoute_matchesMainActivity() {
-        // This test verifies the route name matches what MainActivity uses
-        // The route "tcp_client_wizard" is the same as in MainActivity.kt line 576
-        val expectedRoute = "tcp_client_wizard"
-        val mockViewModel = mockk<TcpClientWizardViewModel>()
-        every { mockViewModel.state } returns
-            MutableStateFlow(
-                TcpClientWizardTestFixtures.serverSelectionState(),
-            )
-        every { mockViewModel.canProceed() } returns false
-        every { mockViewModel.getCommunityServers() } returns TcpClientWizardTestFixtures.testServers
-
-        // When
-        composeTestRule.setContent {
-            val navController = rememberNavController()
-            NavHost(
-                navController = navController,
-                startDestination = expectedRoute,
-            ) {
-                composable(expectedRoute) {
-                    TcpClientWizardScreen(
-                        onNavigateBack = {},
-                        onComplete = {},
-                        viewModel = mockViewModel,
-                    )
-                }
-            }
-        }
-
-        // Then - Content renders successfully with the expected route
         composeTestRule.onAllNodesWithText("Choose Server").assertCountEquals(2)
     }
 }

--- a/app/src/test/java/network/columba/app/ui/screens/offlinemaps/OfflineMapDownloadBackTest.kt
+++ b/app/src/test/java/network/columba/app/ui/screens/offlinemaps/OfflineMapDownloadBackTest.kt
@@ -1,0 +1,119 @@
+package network.columba.app.ui.screens.offlinemaps
+
+import android.app.Application
+import androidx.activity.OnBackPressedDispatcher
+import androidx.activity.compose.LocalOnBackPressedDispatcherOwner
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.junit4.v2.createComposeRule
+import androidx.compose.ui.test.onNodeWithContentDescription
+import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.performClick
+import network.columba.app.test.RegisterComponentActivityRule
+import network.columba.app.viewmodel.DownloadProgress
+import network.columba.app.viewmodel.DownloadWizardStep
+import network.columba.app.viewmodel.OfflineMapDownloadState
+import network.columba.app.viewmodel.OfflineMapDownloadViewModel
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import kotlinx.coroutines.flow.MutableStateFlow
+import org.junit.Assert.assertEquals
+import org.junit.Rule
+import org.junit.Test
+import org.junit.rules.RuleChain
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+
+@RunWith(RobolectricTestRunner::class)
+@Config(sdk = [34], application = Application::class)
+class OfflineMapDownloadBackTest {
+    private val registerActivityRule = RegisterComponentActivityRule()
+    private val composeRule = createComposeRule()
+
+    @get:Rule
+    val ruleChain: RuleChain = RuleChain.outerRule(registerActivityRule).around(composeRule)
+
+    @Test
+    fun toolbarAndSystemBack_onLocation_bothExitWizard() {
+        lateinit var backDispatcher: OnBackPressedDispatcher
+        val viewModel = mockk<OfflineMapDownloadViewModel>()
+        every { viewModel.state } returns MutableStateFlow(OfflineMapDownloadState())
+        var exitCount = 0
+
+        composeRule.setContent {
+            backDispatcher = LocalOnBackPressedDispatcherOwner.current!!.onBackPressedDispatcher
+            OfflineMapDownloadScreen(
+                onNavigateBack = { exitCount++ },
+                viewModel = viewModel,
+            )
+        }
+
+        composeRule.onNodeWithContentDescription("Back").performClick()
+        composeRule.runOnUiThread { backDispatcher.onBackPressed() }
+        composeRule.waitForIdle()
+
+        assertEquals(2, exitCount)
+    }
+
+    @Test
+    fun toolbarAndSystemBack_onSetupStep_bothMoveToPreviousStep() {
+        lateinit var backDispatcher: OnBackPressedDispatcher
+        val viewModel = mockk<OfflineMapDownloadViewModel>()
+        val radiusState =
+            OfflineMapDownloadState(
+                step = DownloadWizardStep.RADIUS,
+                centerLatitude = 45.5,
+                centerLongitude = -122.6,
+            )
+        val state = MutableStateFlow(radiusState)
+        every { viewModel.state } returns state
+        every { viewModel.previousStep() } answers {
+            state.value = state.value.copy(step = DownloadWizardStep.LOCATION)
+        }
+
+        composeRule.setContent {
+            backDispatcher = LocalOnBackPressedDispatcherOwner.current!!.onBackPressedDispatcher
+            OfflineMapDownloadScreen(viewModel = viewModel)
+        }
+
+        composeRule.onNodeWithContentDescription("Back").performClick()
+        composeRule.waitForIdle()
+        assertEquals(DownloadWizardStep.LOCATION, state.value.step)
+
+        state.value = radiusState
+        composeRule.waitForIdle()
+        composeRule.runOnUiThread { backDispatcher.onBackPressed() }
+        composeRule.waitForIdle()
+
+        assertEquals(DownloadWizardStep.LOCATION, state.value.step)
+        verify(exactly = 2) { viewModel.previousStep() }
+    }
+
+    @Test
+    fun toolbarAndSystemBack_duringDownload_bothRequireCancellationConfirmation() {
+        lateinit var backDispatcher: OnBackPressedDispatcher
+        val viewModel = mockk<OfflineMapDownloadViewModel>()
+        every { viewModel.state } returns
+            MutableStateFlow(
+                OfflineMapDownloadState(
+                    step = DownloadWizardStep.DOWNLOADING,
+                    downloadProgress = DownloadProgress(progress = 0.5f),
+                ),
+            )
+
+        composeRule.setContent {
+            backDispatcher = LocalOnBackPressedDispatcherOwner.current!!.onBackPressedDispatcher
+            OfflineMapDownloadScreen(viewModel = viewModel)
+        }
+
+        composeRule.onNodeWithContentDescription("Cancel").performClick()
+        composeRule.onNodeWithText("Cancel Download?").assertIsDisplayed()
+        composeRule.onNodeWithText("Continue").performClick()
+
+        composeRule.runOnUiThread { backDispatcher.onBackPressed() }
+        composeRule.waitForIdle()
+
+        composeRule.onNodeWithText("Cancel Download?").assertIsDisplayed()
+    }
+}

--- a/app/src/test/java/network/columba/app/ui/screens/rnode/RNodeWizardCompletionTest.kt
+++ b/app/src/test/java/network/columba/app/ui/screens/rnode/RNodeWizardCompletionTest.kt
@@ -1,0 +1,113 @@
+package network.columba.app.ui.screens.rnode
+
+import android.app.Application
+import androidx.activity.OnBackPressedDispatcher
+import androidx.activity.compose.LocalOnBackPressedDispatcherOwner
+import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.onNodeWithContentDescription
+import androidx.compose.ui.test.performClick
+import network.columba.app.test.RegisterComponentActivityRule
+import network.columba.app.viewmodel.RNodeWizardState
+import network.columba.app.viewmodel.RNodeWizardViewModel
+import network.columba.app.viewmodel.WizardStep
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import kotlinx.coroutines.flow.MutableStateFlow
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Rule
+import org.junit.Test
+import org.junit.rules.RuleChain
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+
+@RunWith(RobolectricTestRunner::class)
+@Config(sdk = [34], application = Application::class)
+@Suppress("NoRelaxedMocks") // Screen orchestration tests isolate navigation callbacks from unrelated wizard UI methods.
+class RNodeWizardCompletionTest {
+    private val registerActivityRule = RegisterComponentActivityRule()
+    private val composeRule = createComposeRule()
+
+    @get:Rule
+    val ruleChain: RuleChain = RuleChain.outerRule(registerActivityRule).around(composeRule)
+
+    @Test
+    fun saveSuccess_isConsumedBeforeCompletionNavigation() {
+        val state = MutableStateFlow(RNodeWizardState(saveSuccess = true))
+        val viewModel = mockk<RNodeWizardViewModel>(relaxed = true)
+        var completionCount = 0
+        var completionWasConsumed = false
+        every { viewModel.state } returns state
+        every { viewModel.consumeSaveSuccess() } answers {
+            completionWasConsumed = true
+            state.value = state.value.copy(saveSuccess = false)
+        }
+
+        composeRule.setContent {
+            RNodeWizardScreen(
+                onNavigateBack = {},
+                onComplete = {
+                    assertTrue(completionWasConsumed)
+                    completionCount++
+                },
+                viewModel = viewModel,
+            )
+        }
+        composeRule.waitForIdle()
+
+        assertEquals(1, completionCount)
+        verify(exactly = 1) { viewModel.consumeSaveSuccess() }
+    }
+
+    @Test
+    fun toolbarAndSystemBack_onFirstStep_bothExitWizard() {
+        lateinit var backDispatcher: OnBackPressedDispatcher
+        var backCount = 0
+        val viewModel = mockk<RNodeWizardViewModel>(relaxed = true)
+        every { viewModel.state } returns MutableStateFlow(RNodeWizardState())
+
+        composeRule.setContent {
+            backDispatcher = LocalOnBackPressedDispatcherOwner.current!!.onBackPressedDispatcher
+            RNodeWizardScreen(
+                onNavigateBack = { backCount++ },
+                onComplete = {},
+                viewModel = viewModel,
+            )
+        }
+
+        composeRule.onNodeWithContentDescription("Back").performClick()
+        composeRule.runOnUiThread { backDispatcher.onBackPressed() }
+        composeRule.waitForIdle()
+
+        assertEquals(2, backCount)
+    }
+
+    @Test
+    fun toolbarAndSystemBack_onLaterStep_bothMoveToPreviousStep() {
+        lateinit var backDispatcher: OnBackPressedDispatcher
+        val viewModel = mockk<RNodeWizardViewModel>(relaxed = true)
+        val state = MutableStateFlow(RNodeWizardState(currentStep = WizardStep.REVIEW_CONFIGURE))
+        every { viewModel.state } returns state
+        every { viewModel.goToPreviousStep() } answers {
+            state.value = state.value.copy(currentStep = WizardStep.FREQUENCY_SLOT)
+        }
+
+        composeRule.setContent {
+            backDispatcher = LocalOnBackPressedDispatcherOwner.current!!.onBackPressedDispatcher
+            RNodeWizardScreen(
+                onNavigateBack = {},
+                onComplete = {},
+                viewModel = viewModel,
+            )
+        }
+
+        composeRule.onNodeWithContentDescription("Back").performClick()
+        composeRule.runOnUiThread { backDispatcher.onBackPressed() }
+        composeRule.waitForIdle()
+
+        assertEquals(WizardStep.FREQUENCY_SLOT, state.value.currentStep)
+        verify(exactly = 2) { viewModel.goToPreviousStep() }
+    }
+}

--- a/app/src/test/java/network/columba/app/ui/screens/tcpclient/TcpClientWizardScreenTest.kt
+++ b/app/src/test/java/network/columba/app/ui/screens/tcpclient/TcpClientWizardScreenTest.kt
@@ -1,6 +1,8 @@
 package network.columba.app.ui.screens.tcpclient
 
 import android.app.Application
+import androidx.activity.OnBackPressedDispatcher
+import androidx.activity.compose.LocalOnBackPressedDispatcherOwner
 import androidx.compose.ui.test.assertCountEquals
 import androidx.compose.ui.test.assertIsDisplayed
 import androidx.compose.ui.test.assertIsNotEnabled
@@ -11,6 +13,7 @@ import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.performClick
 import network.columba.app.test.RegisterComponentActivityRule
 import network.columba.app.test.TcpClientWizardTestFixtures
+import network.columba.app.viewmodel.TcpClientWizardStep
 import network.columba.app.viewmodel.TcpClientWizardViewModel
 import io.mockk.Runs
 import io.mockk.every
@@ -18,6 +21,7 @@ import io.mockk.just
 import io.mockk.mockk
 import io.mockk.verify
 import kotlinx.coroutines.flow.MutableStateFlow
+import org.junit.Assert.assertEquals
 import org.junit.Assert.assertTrue
 import org.junit.Rule
 import org.junit.Test
@@ -40,6 +44,38 @@ class TcpClientWizardScreenTest {
     val ruleChain: RuleChain = RuleChain.outerRule(registerActivityRule).around(composeRule)
 
     val composeTestRule get() = composeRule
+
+    @Test
+    fun saveSuccess_isConsumedBeforeCompletionNavigation() {
+        val state =
+            MutableStateFlow(
+                TcpClientWizardTestFixtures.reviewConfigureState().copy(saveSuccess = true),
+            )
+        val mockViewModel = mockk<TcpClientWizardViewModel>()
+        var completionCount = 0
+        var completionWasConsumed = false
+        every { mockViewModel.state } returns state
+        every { mockViewModel.canProceed() } returns true
+        every { mockViewModel.consumeSaveSuccess() } answers {
+            completionWasConsumed = true
+            state.value = state.value.copy(saveSuccess = false)
+        }
+
+        composeTestRule.setContent {
+            TcpClientWizardScreen(
+                onNavigateBack = {},
+                onComplete = {
+                    assertTrue(completionWasConsumed)
+                    completionCount++
+                },
+                viewModel = mockViewModel,
+            )
+        }
+        composeTestRule.waitForIdle()
+
+        assertEquals(1, completionCount)
+        verify(exactly = 1) { mockViewModel.consumeSaveSuccess() }
+    }
 
     // ========== TopAppBar Title Tests ==========
 
@@ -147,6 +183,59 @@ class TcpClientWizardScreenTest {
         // Then
         assertTrue("Back button click should succeed", result.isSuccess)
         verify { mockViewModel.goToPreviousStep() }
+    }
+
+    @Test
+    fun systemBack_onFirstStep_matchesToolbarBack() {
+        var backClicked = false
+        lateinit var backDispatcher: OnBackPressedDispatcher
+        val mockViewModel = mockk<TcpClientWizardViewModel>()
+        every { mockViewModel.state } returns
+            MutableStateFlow(TcpClientWizardTestFixtures.serverSelectionState())
+        every { mockViewModel.canProceed() } returns false
+        every { mockViewModel.getCommunityServers() } returns TcpClientWizardTestFixtures.testServers
+
+        composeTestRule.setContent {
+            backDispatcher = LocalOnBackPressedDispatcherOwner.current!!.onBackPressedDispatcher
+            TcpClientWizardScreen(
+                onNavigateBack = { backClicked = true },
+                onComplete = {},
+                viewModel = mockViewModel,
+            )
+        }
+
+        composeTestRule.runOnUiThread { backDispatcher.onBackPressed() }
+        composeTestRule.waitForIdle()
+
+        assertTrue(backClicked)
+    }
+
+    @Test
+    fun systemBack_onSecondStep_matchesToolbarBack() {
+        lateinit var backDispatcher: OnBackPressedDispatcher
+        val mockViewModel = mockk<TcpClientWizardViewModel>()
+        val state = MutableStateFlow(TcpClientWizardTestFixtures.reviewConfigureState())
+        every { mockViewModel.state } returns state
+        every { mockViewModel.canProceed() } returns true
+        every { mockViewModel.getCommunityServers() } returns TcpClientWizardTestFixtures.testServers
+        every { mockViewModel.goToPreviousStep() } answers {
+            state.value = state.value.copy(currentStep = TcpClientWizardStep.SERVER_SELECTION)
+        }
+
+        composeTestRule.setContent {
+            backDispatcher = LocalOnBackPressedDispatcherOwner.current!!.onBackPressedDispatcher
+            TcpClientWizardScreen(
+                onNavigateBack = {},
+                onComplete = {},
+                viewModel = mockViewModel,
+            )
+        }
+
+        composeTestRule.runOnUiThread { backDispatcher.onBackPressed() }
+        composeTestRule.waitForIdle()
+
+        assertEquals(TcpClientWizardStep.SERVER_SELECTION, state.value.currentStep)
+        verify(exactly = 1) { mockViewModel.goToPreviousStep() }
     }
 
     // ========== BottomBar Button Tests ==========
@@ -342,32 +431,6 @@ class TcpClientWizardScreenTest {
         // Then
         assertTrue("OK button click should succeed", result.isSuccess)
         verify { mockViewModel.clearSaveError() }
-    }
-
-    // ========== Save Success Tests ==========
-
-    @Test
-    fun saveSuccess_callsOnComplete() {
-        // Given
-        var completeCalled = false
-        val mockViewModel = mockk<TcpClientWizardViewModel>()
-        every { mockViewModel.state } returns
-            MutableStateFlow(
-                TcpClientWizardTestFixtures.successState(),
-            )
-        every { mockViewModel.canProceed() } returns true
-
-        // When
-        composeTestRule.setContent {
-            TcpClientWizardScreen(
-                onNavigateBack = {},
-                onComplete = { completeCalled = true },
-                viewModel = mockViewModel,
-            )
-        }
-
-        // Then - LaunchedEffect triggers onComplete when saveSuccess is true
-        assertTrue(completeCalled)
     }
 
     // ========== Saving State Tests ==========


### PR DESCRIPTION
## Summary

- add a canonical registry and registration seam for all 37 production navigation destinations
- centralize completed-flow, incoming-call, and external-entity stack policies
- fix RNode/TCP/offline-map completion history and consume sticky completion state
- prevent duplicate/rebounding call, announce, NomadNet, identity-import, and USB/RNode/flasher ingress
- align toolbar and Android system Back behavior in RNode, TCP, and offline-map wizards
- add real `NavHostController`/`OnBackPressedDispatcher` contracts plus production registration guards

Fixes #1042

## Verification

- `NavigationBackStackContractTest`: 11 passed
- `NavigationDestinationRegistryTest`: 2 passed
- `OfflineMapDownloadBackTest`: 3 passed
- focused RNode/TCP wizard, conversation-navigation, and MainActivity navigation tests passed
- `./gradlew :app:detekt`
- `git diff --check`
- `./gradlew :app:assembleNoSentryKotlinBackendDebug`

## Risk and rollback

The main risk is changed Back-stack behavior for completion and externally delivered navigation. The new contracts exercise same-entity deduplication, different-entity history, call phase replacement, deeper result reuse, and toolbar/system Back parity. Rollback is limited to the two commits in this PR.