### PR TITLE
Fix jumpy contacts across interface path changes

### DIFF
--- a/app/src/main/java/network/columba/app/ui/components/PeerCard.kt
+++ b/app/src/main/java/network/columba/app/ui/components/PeerCard.kt
@@ -40,6 +40,8 @@ import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.hapticfeedback.HapticFeedbackType
 import androidx.compose.ui.platform.LocalHapticFeedback
 import androidx.compose.ui.res.vectorResource
+import androidx.compose.ui.semantics.clearAndSetSemantics
+import androidx.compose.ui.semantics.contentDescription
 import androidx.compose.ui.text.font.FontFamily
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
@@ -92,7 +94,7 @@ fun PeerCard(
                     Modifier
                         .fillMaxWidth()
                         .padding(16.dp)
-                        .padding(end = 32.dp),
+                        .padding(end = 48.dp),
                 horizontalArrangement = Arrangement.spacedBy(16.dp),
             ) {
                 // Profile icon (with identicon fallback)
@@ -208,15 +210,51 @@ fun PeerCard(
                         isStarred = announce.isFavorite || !showFavoriteToggle,
                         onClick = onFavoriteClick,
                     )
-                    // Read the RAW `receivingInterface` here (not the cached
-                    // `receivingInterfaceType` column) so any classifier
-                    // improvement applies retroactively to existing rows
-                    // — the cache is set ONCE at announce-save time, so a
-                    // bug fix to `InterfaceType.fromName` would otherwise
-                    // only land for new announces. The icon has been the
-                    // recurring casualty of classifier-cache drift.
-                    InterfaceTypeIcon(interfaceType = announce.receivingInterface)
+                    // Prefer the raw receiving interface so classifier fixes apply
+                    // retroactively; fall back to the canonical cached type when
+                    // a backend does not provide a raw interface name.
+                    InterfaceHistoryIndicator(announce = announce)
                 }
+            }
+        }
+    }
+}
+
+/** Current Reticulum path icon plus a compact count of other recent path types. */
+@Composable
+private fun InterfaceHistoryIndicator(announce: Announce) {
+    val rawCurrentType = InterfaceType.fromName(announce.receivingInterface)
+    val currentType =
+        rawCurrentType.takeUnless { it == InterfaceType.UNKNOWN }
+            ?: InterfaceType.fromName(announce.receivingInterfaceType)
+    val recentTypes = announce.recentInterfaceTypes + currentType
+    val additionalCount = (recentTypes.size - 1).coerceAtLeast(0)
+    val accessibilityDescription =
+        if (additionalCount == 0) {
+            "Current path ${currentType.displayLabel}"
+        } else {
+            "Current path ${currentType.displayLabel}; also seen via $additionalCount other " +
+                "interface ${if (additionalCount == 1) "type" else "types"} in the past 30 days"
+        }
+
+    Row(
+        modifier = Modifier.clearAndSetSemantics { contentDescription = accessibilityDescription },
+        horizontalArrangement = Arrangement.spacedBy(3.dp),
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
+        InterfaceTypeIcon(interfaceType = currentType.storageName)
+        if (additionalCount > 0) {
+            Surface(
+                shape = RoundedCornerShape(8.dp),
+                color = MaterialTheme.colorScheme.secondaryContainer,
+            ) {
+                Text(
+                    text = "+$additionalCount",
+                    style = MaterialTheme.typography.labelSmall,
+                    color = MaterialTheme.colorScheme.onSecondaryContainer,
+                    maxLines = 1,
+                    modifier = Modifier.padding(horizontal = 4.dp, vertical = 1.dp),
+                )
             }
         }
     }

--- a/app/src/main/java/network/columba/app/ui/screens/AnnounceDetailScreen.kt
+++ b/app/src/main/java/network/columba/app/ui/screens/AnnounceDetailScreen.kt
@@ -84,6 +84,11 @@ fun AnnounceDetailScreen(
 
     // Observe specific announce reactively (not search in list)
     val announce by viewModel.getAnnounceFlow(destinationHash).collectAsState(initial = null)
+    val interfaceSightingsFlow =
+        remember(destinationHash, viewModel) {
+            viewModel.getRecentInterfaceSightings(destinationHash)
+        }
+    val interfaceSightings by interfaceSightingsFlow.collectAsState(initial = emptyList())
 
     // Separately observe contact status for star button
     val isContact by viewModel.isContactFlow(destinationHash).collectAsState(initial = false)
@@ -446,18 +451,47 @@ fun AnnounceDetailScreen(
                     )
                 }
 
-                // Show interface information if available
+                // Show the current Reticulum-selected path separately from
+                // the stable 30-day interface history used by list filters.
                 // The Python layer now provides the full interface name including user-configured names
                 // (e.g., "TCPInterface[Sideband Server/192.168.1.100:4965]")
                 // getInterfaceInfo() extracts the friendly name from this string
-                announceNonNull.receivingInterface?.let { interfaceName ->
+                val currentInterfaceName =
+                    announceNonNull.receivingInterface ?: announceNonNull.receivingInterfaceType
+                currentInterfaceName?.let { interfaceName ->
                     val interfaceInfo = getInterfaceInfo(interfaceName)
                     InfoCard(
                         icon = interfaceInfo.icon,
-                        title = "Received Via",
+                        title = "Current Path",
                         content = interfaceInfo.text,
-                        subtitle = interfaceInfo.subtitle,
+                        subtitle = "${interfaceInfo.subtitle} — latest Reticulum-selected route",
                     )
+                }
+
+                if (interfaceSightings.isNotEmpty()) {
+                    Text(
+                        text = "Seen Via — Last 30 Days",
+                        style = MaterialTheme.typography.titleMedium,
+                        fontWeight = FontWeight.SemiBold,
+                        modifier = Modifier.padding(top = 8.dp),
+                    )
+                    Text(
+                        text = "Interfaces Reticulum selected for this destination",
+                        style = MaterialTheme.typography.bodySmall,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    )
+                    interfaceSightings.forEach { sighting ->
+                        val rawInterface = sighting.receivingInterface ?: sighting.interfaceType.storageName
+                        val interfaceInfo = getInterfaceInfo(rawInterface)
+                        InfoCard(
+                            icon = interfaceInfo.icon,
+                            title = sighting.interfaceType.displayLabel,
+                            content = interfaceInfo.text,
+                            subtitle =
+                                "${formatTimeSince(sighting.lastSeenTimestamp)} — " +
+                                    "${sighting.hops} ${if (sighting.hops == 1) "hop" else "hops"}",
+                        )
+                    }
                 }
 
                 // Show aspect information

--- a/app/src/main/java/network/columba/app/viewmodel/AnnounceStreamViewModel.kt
+++ b/app/src/main/java/network/columba/app/viewmodel/AnnounceStreamViewModel.kt
@@ -82,6 +82,7 @@ class AnnounceStreamViewModel
             val selectedTypes: Set<NodeType>,
             val showAudio: Boolean,
             val selectedInterfaces: Set<InterfaceType>,
+            val interfaceWindowGeneration: Long,
         )
 
         // Search query state
@@ -98,6 +99,7 @@ class AnnounceStreamViewModel
         // Interface type filter state - empty set means show all (no interface filter)
         private val _selectedInterfaceTypes = MutableStateFlow<Set<InterfaceType>>(emptySet())
         val selectedInterfaceTypes: StateFlow<Set<InterfaceType>> = _selectedInterfaceTypes.asStateFlow()
+        private val interfaceWindowGeneration = MutableStateFlow(0L)
 
         // Total announce count for tab label
         val announceCount: StateFlow<Int> =
@@ -117,8 +119,9 @@ class AnnounceStreamViewModel
                 _selectedNodeTypes,
                 _showAudioAnnounces,
                 _selectedInterfaceTypes,
-            ) { query, selectedTypes, showAudio, selectedInterfaces ->
-                FilterParams(query, selectedTypes, showAudio, selectedInterfaces)
+                interfaceWindowGeneration,
+            ) { query, selectedTypes, showAudio, selectedInterfaces, generation ->
+                FilterParams(query, selectedTypes, showAudio, selectedInterfaces, generation)
             }.flatMapLatest { params ->
                 val query = params.query
                 val selectedTypes = params.selectedTypes
@@ -204,6 +207,12 @@ class AnnounceStreamViewModel
                     while (true) {
                         if (reachableCountDirty.getAndSet(false)) {
                             updateReachableCount()
+                        }
+                        // Wall-clock advancement does not invalidate Room PagingSources.
+                        // Recreate active interface-filtered pagers so 30-day expirations
+                        // become visible without waiting for another database write.
+                        if (_selectedInterfaceTypes.value.isNotEmpty()) {
+                            interfaceWindowGeneration.value += 1
                         }
                         kotlinx.coroutines.delay(updateIntervalMs)
                     }

--- a/app/src/main/java/network/columba/app/viewmodel/AnnounceStreamViewModel.kt
+++ b/app/src/main/java/network/columba/app/viewmodel/AnnounceStreamViewModel.kt
@@ -36,6 +36,18 @@ import kotlinx.coroutines.withContext
 import kotlinx.coroutines.withTimeoutOrNull
 import javax.inject.Inject
 
+internal fun matchesRecentInterfaceFilter(
+    announce: Announce,
+    selectedInterfaces: Set<InterfaceType>,
+): Boolean {
+    if (selectedInterfaces.isEmpty()) return true
+    val recentInterfaces =
+        announce.recentInterfaceTypes.ifEmpty {
+            setOf(InterfaceType.fromName(announce.receivingInterface))
+        }
+    return recentInterfaces.any(selectedInterfaces::contains)
+}
+
 @Suppress("TooManyFunctions") // ViewModels naturally have many public functions for UI interactions
 @HiltViewModel
 class AnnounceStreamViewModel
@@ -131,8 +143,10 @@ class AnnounceStreamViewModel
                         .getAnnouncesPaged(
                             nodeTypes = typeStrings,
                             searchQuery = query.trim(),
+                            interfaceTypes = selectedInterfaces.map { it.storageName },
                         ).map { pagingData ->
-                            // Apply in-memory filters for nodeType, audio aspect, and interface type
+                            // Interface filtering is handled in SQL so Paging can fill pages correctly.
+                            // Keep only the audio/node-type compatibility filter in memory.
                             pagingData.filter { announce ->
                                 // Filter by nodeType
                                 // (exclude PEER if user didn't select it and we only added it for audio)
@@ -143,14 +157,7 @@ class AnnounceStreamViewModel
                                 val matchesTypeOrAudio =
                                     (matchesNodeType && (showAudio || !isAudioAnnounce)) || (isAudioAnnounce && showAudio)
 
-                                // Filter by interface type (empty set = show all)
-                                val matchesInterface =
-                                    selectedInterfaces.isEmpty() ||
-                                        selectedInterfaces.contains(
-                                            InterfaceType.fromName(announce.receivingInterface),
-                                        )
-
-                                matchesTypeOrAudio && matchesInterface
+                                matchesTypeOrAudio
                             }
                         }
                 }
@@ -412,6 +419,9 @@ class AnnounceStreamViewModel
          * Observe a specific announce reactively
          */
         fun getAnnounceFlow(destinationHash: String): Flow<Announce?> = announceRepository.getAnnounceFlow(destinationHash)
+
+        fun getRecentInterfaceSightings(destinationHash: String) =
+            announceRepository.getRecentInterfaceSightings(destinationHash)
 
         /**
          * Observe contact status reactively

--- a/app/src/test/java/network/columba/app/test/TestFactories.kt
+++ b/app/src/test/java/network/columba/app/test/TestFactories.kt
@@ -4,6 +4,7 @@ import network.columba.app.data.db.entity.ContactEntity
 import network.columba.app.data.db.entity.ContactStatus
 import network.columba.app.data.db.entity.LocalIdentityEntity
 import network.columba.app.data.model.EnrichedContact
+import network.columba.app.data.model.InterfaceType
 import network.columba.app.data.repository.Announce
 import network.columba.app.data.repository.Conversation
 import network.columba.app.service.RelayInfo
@@ -150,6 +151,7 @@ object TestFactories {
         isFavorite: Boolean = false,
         receivingInterface: String? = null,
         receivingInterfaceType: String? = null,
+        recentInterfaceTypes: Set<InterfaceType> = emptySet(),
     ) = Announce(
         destinationHash = destinationHash,
         peerName = peerName,
@@ -160,6 +162,7 @@ object TestFactories {
         nodeType = nodeType,
         receivingInterface = receivingInterface,
         receivingInterfaceType = receivingInterfaceType,
+        recentInterfaceTypes = recentInterfaceTypes,
         isFavorite = isFavorite,
     )
 

--- a/app/src/test/java/network/columba/app/ui/components/PeerCardTest.kt
+++ b/app/src/test/java/network/columba/app/ui/components/PeerCardTest.kt
@@ -10,6 +10,7 @@ import androidx.compose.ui.test.performClick
 import androidx.compose.ui.test.performTouchInput
 import network.columba.app.test.RegisterComponentActivityRule
 import network.columba.app.test.TestFactories
+import network.columba.app.data.model.InterfaceType
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertTrue
 import org.junit.Rule
@@ -246,7 +247,7 @@ class PeerCardTest {
             )
         }
 
-        composeTestRule.onNodeWithContentDescription("WiFi").assertIsDisplayed()
+        composeTestRule.onNodeWithContentDescription("Current path Local").assertIsDisplayed()
     }
 
     @Test
@@ -267,7 +268,7 @@ class PeerCardTest {
             )
         }
 
-        composeTestRule.onNodeWithContentDescription("WiFi").assertIsDisplayed()
+        composeTestRule.onNodeWithContentDescription("Current path Local").assertIsDisplayed()
     }
 
     @Test
@@ -285,7 +286,7 @@ class PeerCardTest {
             )
         }
 
-        composeTestRule.onNodeWithContentDescription("Internet").assertIsDisplayed()
+        composeTestRule.onNodeWithContentDescription("Current path TCP").assertIsDisplayed()
     }
 
     @Test
@@ -303,7 +304,7 @@ class PeerCardTest {
             )
         }
 
-        composeTestRule.onNodeWithContentDescription("Bluetooth").assertIsDisplayed()
+        composeTestRule.onNodeWithContentDescription("Current path BLE").assertIsDisplayed()
     }
 
     @Test
@@ -321,7 +322,7 @@ class PeerCardTest {
             )
         }
 
-        composeTestRule.onNodeWithContentDescription("LoRa/RNode").assertIsDisplayed()
+        composeTestRule.onNodeWithContentDescription("Current path RNode").assertIsDisplayed()
     }
 
     @Test
@@ -342,7 +343,7 @@ class PeerCardTest {
             )
         }
 
-        composeTestRule.onNodeWithContentDescription("LoRa/RNode").assertIsDisplayed()
+        composeTestRule.onNodeWithContentDescription("Current path RNode").assertIsDisplayed()
     }
 
     @Test
@@ -366,7 +367,7 @@ class PeerCardTest {
             )
         }
 
-        composeTestRule.onNodeWithContentDescription("Internet").assertIsDisplayed()
+        composeTestRule.onNodeWithContentDescription("Current path TCP").assertIsDisplayed()
     }
 
     @Test
@@ -460,6 +461,30 @@ class PeerCardTest {
     }
 
     // ========== Signal Strength Indicator Tests ==========
+
+    @Test
+    fun peerCard_displaysAdditionalInterfaceCount() {
+        val announce =
+            TestFactories.createAnnounce(
+                receivingInterface = "RNodeInterface[Radio]",
+                recentInterfaceTypes =
+                    setOf(
+                        InterfaceType.RNODE,
+                        InterfaceType.TCP_CLIENT,
+                        InterfaceType.BLE,
+                    ),
+            )
+
+        composeTestRule.setContent {
+            PeerCard(announce = announce)
+        }
+
+        composeTestRule.onNodeWithText("+2", useUnmergedTree = true).assertIsDisplayed()
+        composeTestRule
+            .onNodeWithContentDescription(
+                "Current path RNode; also seen via 2 other interface types in the past 30 days",
+            ).assertIsDisplayed()
+    }
 
     @Test
     fun peerCard_displaysWeakSignal_forHighHops() {

--- a/app/src/test/java/network/columba/app/ui/screens/AnnounceDetailScreenTest.kt
+++ b/app/src/test/java/network/columba/app/ui/screens/AnnounceDetailScreenTest.kt
@@ -6,7 +6,9 @@ import androidx.compose.ui.test.assertIsDisplayed
 import androidx.compose.ui.test.junit4.createComposeRule
 import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.performScrollTo
+import network.columba.app.data.model.InterfaceType
 import network.columba.app.data.repository.Announce
+import network.columba.app.data.repository.AnnounceInterfaceSighting
 import network.columba.app.test.RegisterComponentActivityRule
 import network.columba.app.viewmodel.AnnounceStreamViewModel
 import io.mockk.every
@@ -46,6 +48,7 @@ class AnnounceDetailScreenTest {
         every { mockViewModel.isMyRelayFlow(any()) } returns MutableStateFlow(false)
         every { mockViewModel.isTransportEnabled } returns MutableStateFlow(false)
         every { mockViewModel.getLinkedAnnouncesFlow(any()) } returns MutableStateFlow(emptyList())
+        every { mockViewModel.getRecentInterfaceSightings(any()) } returns MutableStateFlow(emptyList())
 
         composeTestRule.setContent {
             MaterialTheme {
@@ -77,6 +80,7 @@ class AnnounceDetailScreenTest {
         every { mockViewModel.isMyRelayFlow(any()) } returns MutableStateFlow(false)
         every { mockViewModel.isTransportEnabled } returns MutableStateFlow(false)
         every { mockViewModel.getLinkedAnnouncesFlow(any()) } returns MutableStateFlow(emptyList())
+        every { mockViewModel.getRecentInterfaceSightings(any()) } returns MutableStateFlow(emptyList())
 
         composeTestRule.setContent {
             MaterialTheme {
@@ -104,6 +108,7 @@ class AnnounceDetailScreenTest {
         every { mockViewModel.isMyRelayFlow(any()) } returns MutableStateFlow(false)
         every { mockViewModel.isTransportEnabled } returns MutableStateFlow(false)
         every { mockViewModel.getLinkedAnnouncesFlow(any()) } returns MutableStateFlow(emptyList())
+        every { mockViewModel.getRecentInterfaceSightings(any()) } returns MutableStateFlow(emptyList())
 
         composeTestRule.setContent {
             MaterialTheme {
@@ -131,6 +136,7 @@ class AnnounceDetailScreenTest {
         every { mockViewModel.isMyRelayFlow(any()) } returns MutableStateFlow(false)
         every { mockViewModel.isTransportEnabled } returns MutableStateFlow(false)
         every { mockViewModel.getLinkedAnnouncesFlow(any()) } returns MutableStateFlow(emptyList())
+        every { mockViewModel.getRecentInterfaceSightings(any()) } returns MutableStateFlow(emptyList())
 
         composeTestRule.setContent {
             MaterialTheme {
@@ -157,6 +163,7 @@ class AnnounceDetailScreenTest {
         every { mockViewModel.isMyRelayFlow(any()) } returns MutableStateFlow(false)
         every { mockViewModel.isTransportEnabled } returns MutableStateFlow(false)
         every { mockViewModel.getLinkedAnnouncesFlow(any()) } returns MutableStateFlow(emptyList())
+        every { mockViewModel.getRecentInterfaceSightings(any()) } returns MutableStateFlow(emptyList())
 
         composeTestRule.setContent {
             MaterialTheme {
@@ -171,6 +178,53 @@ class AnnounceDetailScreenTest {
         }
 
         composeTestRule.onNodeWithText("Transfer Size Limit").assertDoesNotExist()
+    }
+
+    @Test
+    fun `node details distinguishes current path from recent interfaces`() {
+        val mockViewModel = mockk<AnnounceStreamViewModel>()
+        val announce = createLxmfPeerAnnounce().copy(
+            receivingInterface = "TCPClientInterface[Backbone]",
+            receivingInterfaceType = "TCP_CLIENT",
+        )
+        val sightings =
+            listOf(
+                AnnounceInterfaceSighting(
+                    interfaceType = InterfaceType.TCP_CLIENT,
+                    receivingInterface = "TCPClientInterface[Backbone]",
+                    lastSeenTimestamp = System.currentTimeMillis(),
+                    hops = 1,
+                ),
+                AnnounceInterfaceSighting(
+                    interfaceType = InterfaceType.RNODE,
+                    receivingInterface = "RNodeInterface[Radio]",
+                    lastSeenTimestamp = System.currentTimeMillis() - 60_000,
+                    hops = 2,
+                ),
+            )
+
+        every { mockViewModel.getAnnounceFlow(any()) } returns MutableStateFlow(announce)
+        every { mockViewModel.isContactFlow(any()) } returns MutableStateFlow(false)
+        every { mockViewModel.isMyRelayFlow(any()) } returns MutableStateFlow(false)
+        every { mockViewModel.isTransportEnabled } returns MutableStateFlow(false)
+        every { mockViewModel.getLinkedAnnouncesFlow(any()) } returns MutableStateFlow(emptyList())
+        every { mockViewModel.getRecentInterfaceSightings(any()) } returns MutableStateFlow(sightings)
+
+        composeTestRule.setContent {
+            MaterialTheme {
+                AnnounceDetailScreen(
+                    destinationHash = "test_hash",
+                    onBackClick = {},
+                    onStartChat = { _, _ -> },
+                    onViewAnnounce = {},
+                    viewModel = mockViewModel,
+                )
+            }
+        }
+
+        composeTestRule.onNodeWithText("Current Path").performScrollTo().assertIsDisplayed()
+        composeTestRule.onNodeWithText("Seen Via — Last 30 Days").performScrollTo().assertIsDisplayed()
+        composeTestRule.onNodeWithText("RNode").performScrollTo().assertIsDisplayed()
     }
 
     // ========== Helper Functions ==========

--- a/app/src/test/java/network/columba/app/viewmodel/AnnounceStreamViewModelTest.kt
+++ b/app/src/test/java/network/columba/app/viewmodel/AnnounceStreamViewModelTest.kt
@@ -7,6 +7,8 @@ import androidx.lifecycle.viewModelScope
 import androidx.paging.PagingData
 import app.cash.turbine.test
 import network.columba.app.data.db.entity.LocalIdentityEntity
+import network.columba.app.data.model.InterfaceType
+import network.columba.app.data.repository.Announce
 import network.columba.app.data.repository.AnnounceRepository
 import network.columba.app.data.repository.ContactRepository
 import network.columba.app.data.repository.IdentityRepository
@@ -120,7 +122,7 @@ class AnnounceStreamViewModelTest {
         // Mock repository methods
         every { announceRepository.getAnnounces() } returns flowOf(emptyList())
         every { announceRepository.getAnnouncesByTypes(any()) } returns flowOf(emptyList())
-        every { announceRepository.getAnnouncesPaged(any(), any()) } returns flowOf(PagingData.empty())
+        every { announceRepository.getAnnouncesPaged(any(), any(), any()) } returns flowOf(PagingData.empty())
         every { announceRepository.getAnnounceCountFlow() } returns flowOf(0)
         coEvery { announceRepository.saveAnnounce(any(), any(), any(), any(), any(), any(), any(), any(), any(), any(), any(), any(), any()) } just Runs
         coEvery { announceRepository.getAnnounceCount() } returns 0
@@ -156,6 +158,26 @@ class AnnounceStreamViewModelTest {
         clearAllMocks()
         // Reset update interval to default
         AnnounceStreamViewModel.updateIntervalMs = 30_000L
+    }
+
+    @Test
+    fun interfaceFilter_matchesRecentHistoryAfterCurrentPathChanges() {
+        val announce =
+            Announce(
+                destinationHash = "destination",
+                peerName = "Peer",
+                publicKey = ByteArray(32),
+                appData = null,
+                hops = 1,
+                lastSeenTimestamp = 1L,
+                nodeType = "PEER",
+                receivingInterface = "TCPClientInterface[Backbone]",
+                recentInterfaceTypes = setOf(InterfaceType.RNODE, InterfaceType.TCP_CLIENT),
+            )
+
+        assertTrue(matchesRecentInterfaceFilter(announce, setOf(InterfaceType.RNODE)))
+        assertTrue(matchesRecentInterfaceFilter(announce, setOf(InterfaceType.TCP_CLIENT)))
+        assertFalse(matchesRecentInterfaceFilter(announce, setOf(InterfaceType.BLE)))
     }
 
     @Test
@@ -396,7 +418,7 @@ class AnnounceStreamViewModelTest {
             advanceUntilIdle()
 
             // Verify repository was called with correct parameters (default PEER filter)
-            verify { announceRepository.getAnnouncesPaged(listOf("PEER"), "") }
+            verify { announceRepository.getAnnouncesPaged(listOf("PEER"), "", emptyList()) }
         }
 
     @Test
@@ -508,7 +530,7 @@ class AnnounceStreamViewModelTest {
             networkStatusFlow.value = NetworkStatus.READY
 
             // Mock both PEER (default) and the types we'll filter by
-            every { announceRepository.getAnnouncesPaged(any(), any()) } returns flowOf(PagingData.empty())
+            every { announceRepository.getAnnouncesPaged(any(), any(), any()) } returns flowOf(PagingData.empty())
 
             viewModel =
                 AnnounceStreamViewModel(
@@ -539,7 +561,43 @@ class AnnounceStreamViewModelTest {
             advanceUntilIdle()
 
             // Verify repository was called with new filter types
-            verify { announceRepository.getAnnouncesPaged(match { it.containsAll(listOf("NODE", "PROPAGATION_NODE")) }, "") }
+            verify {
+                announceRepository.getAnnouncesPaged(
+                    match { it.containsAll(listOf("NODE", "PROPAGATION_NODE")) },
+                    "",
+                    emptyList(),
+                )
+            }
+        }
+
+    @Test
+    fun interfaceFilter_isPassedToPagingQuery() =
+        runTest {
+            networkStatusFlow.value = NetworkStatus.READY
+            viewModel =
+                AnnounceStreamViewModel(
+                    reticulumProtocol,
+                    announceRepository,
+                    contactRepository,
+                    propagationNodeManager,
+                    identityRepository,
+                    mockk(),
+                    identityResolutionManager,
+                )
+            advanceUntilIdle()
+
+            viewModel.updateSelectedInterfaceTypes(setOf(InterfaceType.RNODE))
+            viewModel.announces.first()
+            advanceUntilIdle()
+
+            assertEquals(setOf(InterfaceType.RNODE), viewModel.selectedInterfaceTypes.value)
+            verify {
+                announceRepository.getAnnouncesPaged(
+                    listOf("PEER"),
+                    "",
+                    listOf(InterfaceType.RNODE.storageName),
+                )
+            }
         }
 
     @Test
@@ -575,7 +633,7 @@ class AnnounceStreamViewModelTest {
 
             // With empty filter, repository should NOT be called (empty flow returned directly)
             // Verify that with empty types, we don't call the repository
-            verify(exactly = 0) { announceRepository.getAnnouncesPaged(emptyList(), any()) }
+            verify(exactly = 0) { announceRepository.getAnnouncesPaged(emptyList(), any(), any()) }
         }
 
     @Test
@@ -607,7 +665,7 @@ class AnnounceStreamViewModelTest {
             advanceUntilIdle()
 
             // Verify repository was called with search query
-            verify { announceRepository.getAnnouncesPaged(listOf("PEER"), "Alice") }
+            verify { announceRepository.getAnnouncesPaged(listOf("PEER"), "Alice", emptyList()) }
         }
 
     // ========== Manual Announce Tests ==========

--- a/app/src/test/java/network/columba/app/viewmodel/AnnounceStreamViewModelTest.kt
+++ b/app/src/test/java/network/columba/app/viewmodel/AnnounceStreamViewModelTest.kt
@@ -23,10 +23,12 @@ import io.mockk.*
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.cancel
+import kotlinx.coroutines.flow.collect
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.launch
 import kotlinx.coroutines.test.StandardTestDispatcher
 import kotlinx.coroutines.test.advanceTimeBy
 import kotlinx.coroutines.test.advanceUntilIdle
@@ -598,6 +600,48 @@ class AnnounceStreamViewModelTest {
                     listOf(InterfaceType.RNODE.storageName),
                 )
             }
+        }
+
+    @Test
+    fun interfaceFilterPager_isRecreatedWhenRetentionWindowAdvances() =
+        runTest {
+            AnnounceStreamViewModel.updateIntervalMs = 1_000L
+            networkStatusFlow.value = NetworkStatus.READY
+            viewModel =
+                AnnounceStreamViewModel(
+                    reticulumProtocol,
+                    announceRepository,
+                    contactRepository,
+                    propagationNodeManager,
+                    identityRepository,
+                    mockk(),
+                    identityResolutionManager,
+                )
+            runCurrent()
+
+            viewModel.updateSelectedInterfaceTypes(setOf(InterfaceType.RNODE))
+            val collection = launch { viewModel.announces.collect {} }
+            runCurrent()
+            verify(exactly = 1) {
+                announceRepository.getAnnouncesPaged(
+                    listOf("PEER"),
+                    "",
+                    listOf(InterfaceType.RNODE.storageName),
+                )
+            }
+
+            advanceTimeBy(1_000L)
+            runCurrent()
+            assertEquals(setOf(InterfaceType.RNODE), viewModel.selectedInterfaceTypes.value)
+            verify(atLeast = 2) {
+                announceRepository.getAnnouncesPaged(
+                    listOf("PEER"),
+                    "",
+                    listOf(InterfaceType.RNODE.storageName),
+                )
+            }
+            collection.cancel()
+            viewModel.viewModelScope.cancel()
         }
 
     @Test

--- a/data/schemas/network.columba.app.data.db.ColumbaDatabase/4.json
+++ b/data/schemas/network.columba.app.data.db.ColumbaDatabase/4.json
@@ -1,0 +1,1778 @@
+{
+  "formatVersion": 1,
+  "database": {
+    "version": 4,
+    "identityHash": "e7fcde4b41565a3b13777e818675c260",
+    "entities": [
+      {
+        "tableName": "conversations",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`peerHash` TEXT NOT NULL, `identityHash` TEXT NOT NULL, `peerName` TEXT NOT NULL, `peerPublicKey` BLOB, `lastMessage` TEXT NOT NULL, `lastMessageTimestamp` INTEGER NOT NULL, `unreadCount` INTEGER NOT NULL, `lastSeenTimestamp` INTEGER NOT NULL, PRIMARY KEY(`peerHash`, `identityHash`), FOREIGN KEY(`identityHash`) REFERENCES `local_identities`(`identityHash`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "peerHash",
+            "columnName": "peerHash",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "identityHash",
+            "columnName": "identityHash",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "peerName",
+            "columnName": "peerName",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "peerPublicKey",
+            "columnName": "peerPublicKey",
+            "affinity": "BLOB"
+          },
+          {
+            "fieldPath": "lastMessage",
+            "columnName": "lastMessage",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastMessageTimestamp",
+            "columnName": "lastMessageTimestamp",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "unreadCount",
+            "columnName": "unreadCount",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastSeenTimestamp",
+            "columnName": "lastSeenTimestamp",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "peerHash",
+            "identityHash"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_conversations_identityHash",
+            "unique": false,
+            "columnNames": [
+              "identityHash"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_conversations_identityHash` ON `${TABLE_NAME}` (`identityHash`)"
+          },
+          {
+            "name": "index_conversations_identityHash_lastMessageTimestamp",
+            "unique": false,
+            "columnNames": [
+              "identityHash",
+              "lastMessageTimestamp"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_conversations_identityHash_lastMessageTimestamp` ON `${TABLE_NAME}` (`identityHash`, `lastMessageTimestamp`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "local_identities",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "identityHash"
+            ],
+            "referencedColumns": [
+              "identityHash"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "messages",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `conversationHash` TEXT NOT NULL, `identityHash` TEXT NOT NULL, `content` TEXT NOT NULL, `timestamp` INTEGER NOT NULL, `isFromMe` INTEGER NOT NULL, `status` TEXT NOT NULL, `isRead` INTEGER NOT NULL, `fieldsJson` TEXT, `reactionsJson` TEXT, `deliveryMethod` TEXT, `errorMessage` TEXT, `replyToMessageId` TEXT, `receivedHopCount` INTEGER, `receivedInterface` TEXT, `receivedRssi` INTEGER, `receivedSnr` REAL, `receivedAt` INTEGER, `sentInterface` TEXT, PRIMARY KEY(`id`, `identityHash`), FOREIGN KEY(`conversationHash`, `identityHash`) REFERENCES `conversations`(`peerHash`, `identityHash`) ON UPDATE NO ACTION ON DELETE CASCADE , FOREIGN KEY(`identityHash`) REFERENCES `local_identities`(`identityHash`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "conversationHash",
+            "columnName": "conversationHash",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "identityHash",
+            "columnName": "identityHash",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "content",
+            "columnName": "content",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "timestamp",
+            "columnName": "timestamp",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "isFromMe",
+            "columnName": "isFromMe",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "status",
+            "columnName": "status",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "isRead",
+            "columnName": "isRead",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "fieldsJson",
+            "columnName": "fieldsJson",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "reactionsJson",
+            "columnName": "reactionsJson",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "deliveryMethod",
+            "columnName": "deliveryMethod",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "errorMessage",
+            "columnName": "errorMessage",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "replyToMessageId",
+            "columnName": "replyToMessageId",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "receivedHopCount",
+            "columnName": "receivedHopCount",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "receivedInterface",
+            "columnName": "receivedInterface",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "receivedRssi",
+            "columnName": "receivedRssi",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "receivedSnr",
+            "columnName": "receivedSnr",
+            "affinity": "REAL"
+          },
+          {
+            "fieldPath": "receivedAt",
+            "columnName": "receivedAt",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "sentInterface",
+            "columnName": "sentInterface",
+            "affinity": "TEXT"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id",
+            "identityHash"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_messages_conversationHash_identityHash",
+            "unique": false,
+            "columnNames": [
+              "conversationHash",
+              "identityHash"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_messages_conversationHash_identityHash` ON `${TABLE_NAME}` (`conversationHash`, `identityHash`)"
+          },
+          {
+            "name": "index_messages_identityHash",
+            "unique": false,
+            "columnNames": [
+              "identityHash"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_messages_identityHash` ON `${TABLE_NAME}` (`identityHash`)"
+          },
+          {
+            "name": "index_messages_timestamp",
+            "unique": false,
+            "columnNames": [
+              "timestamp"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_messages_timestamp` ON `${TABLE_NAME}` (`timestamp`)"
+          },
+          {
+            "name": "index_messages_conversationHash_identityHash_timestamp",
+            "unique": false,
+            "columnNames": [
+              "conversationHash",
+              "identityHash",
+              "timestamp"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_messages_conversationHash_identityHash_timestamp` ON `${TABLE_NAME}` (`conversationHash`, `identityHash`, `timestamp`)"
+          },
+          {
+            "name": "index_messages_conversationHash_identityHash_isFromMe_isRead",
+            "unique": false,
+            "columnNames": [
+              "conversationHash",
+              "identityHash",
+              "isFromMe",
+              "isRead"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_messages_conversationHash_identityHash_isFromMe_isRead` ON `${TABLE_NAME}` (`conversationHash`, `identityHash`, `isFromMe`, `isRead`)"
+          },
+          {
+            "name": "index_messages_replyToMessageId",
+            "unique": false,
+            "columnNames": [
+              "replyToMessageId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_messages_replyToMessageId` ON `${TABLE_NAME}` (`replyToMessageId`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "conversations",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "conversationHash",
+              "identityHash"
+            ],
+            "referencedColumns": [
+              "peerHash",
+              "identityHash"
+            ]
+          },
+          {
+            "table": "local_identities",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "identityHash"
+            ],
+            "referencedColumns": [
+              "identityHash"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "announces",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`destinationHash` TEXT NOT NULL, `peerName` TEXT NOT NULL, `publicKey` BLOB NOT NULL, `appData` BLOB, `hops` INTEGER NOT NULL, `lastSeenTimestamp` INTEGER NOT NULL, `nodeType` TEXT NOT NULL, `receivingInterface` TEXT, `receivingInterfaceType` TEXT, `aspect` TEXT, `isFavorite` INTEGER NOT NULL, `favoritedTimestamp` INTEGER, `stampCost` INTEGER, `stampCostFlexibility` INTEGER, `peeringCost` INTEGER, `propagationTransferLimitKb` INTEGER, `computedIdentityHash` TEXT, PRIMARY KEY(`destinationHash`))",
+        "fields": [
+          {
+            "fieldPath": "destinationHash",
+            "columnName": "destinationHash",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "peerName",
+            "columnName": "peerName",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "publicKey",
+            "columnName": "publicKey",
+            "affinity": "BLOB",
+            "notNull": true
+          },
+          {
+            "fieldPath": "appData",
+            "columnName": "appData",
+            "affinity": "BLOB"
+          },
+          {
+            "fieldPath": "hops",
+            "columnName": "hops",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastSeenTimestamp",
+            "columnName": "lastSeenTimestamp",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "nodeType",
+            "columnName": "nodeType",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "receivingInterface",
+            "columnName": "receivingInterface",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "receivingInterfaceType",
+            "columnName": "receivingInterfaceType",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "aspect",
+            "columnName": "aspect",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "isFavorite",
+            "columnName": "isFavorite",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "favoritedTimestamp",
+            "columnName": "favoritedTimestamp",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "stampCost",
+            "columnName": "stampCost",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "stampCostFlexibility",
+            "columnName": "stampCostFlexibility",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "peeringCost",
+            "columnName": "peeringCost",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "propagationTransferLimitKb",
+            "columnName": "propagationTransferLimitKb",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "computedIdentityHash",
+            "columnName": "computedIdentityHash",
+            "affinity": "TEXT"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "destinationHash"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_announces_lastSeenTimestamp",
+            "unique": false,
+            "columnNames": [
+              "lastSeenTimestamp"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_announces_lastSeenTimestamp` ON `${TABLE_NAME}` (`lastSeenTimestamp`)"
+          },
+          {
+            "name": "index_announces_isFavorite_favoritedTimestamp",
+            "unique": false,
+            "columnNames": [
+              "isFavorite",
+              "favoritedTimestamp"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_announces_isFavorite_favoritedTimestamp` ON `${TABLE_NAME}` (`isFavorite`, `favoritedTimestamp`)"
+          },
+          {
+            "name": "index_announces_nodeType_lastSeenTimestamp",
+            "unique": false,
+            "columnNames": [
+              "nodeType",
+              "lastSeenTimestamp"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_announces_nodeType_lastSeenTimestamp` ON `${TABLE_NAME}` (`nodeType`, `lastSeenTimestamp`)"
+          },
+          {
+            "name": "index_announces_computedIdentityHash",
+            "unique": false,
+            "columnNames": [
+              "computedIdentityHash"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_announces_computedIdentityHash` ON `${TABLE_NAME}` (`computedIdentityHash`)"
+          }
+        ]
+      },
+      {
+        "tableName": "announce_interface_sightings",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`destinationHash` TEXT NOT NULL, `interfaceType` TEXT NOT NULL, `receivingInterface` TEXT, `lastSeenTimestamp` INTEGER NOT NULL, `hops` INTEGER NOT NULL, PRIMARY KEY(`destinationHash`, `interfaceType`), FOREIGN KEY(`destinationHash`) REFERENCES `announces`(`destinationHash`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "destinationHash",
+            "columnName": "destinationHash",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "interfaceType",
+            "columnName": "interfaceType",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "receivingInterface",
+            "columnName": "receivingInterface",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "lastSeenTimestamp",
+            "columnName": "lastSeenTimestamp",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "hops",
+            "columnName": "hops",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "destinationHash",
+            "interfaceType"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_announce_interface_sightings_destinationHash",
+            "unique": false,
+            "columnNames": [
+              "destinationHash"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_announce_interface_sightings_destinationHash` ON `${TABLE_NAME}` (`destinationHash`)"
+          },
+          {
+            "name": "index_announce_interface_sightings_interfaceType_lastSeenTimestamp",
+            "unique": false,
+            "columnNames": [
+              "interfaceType",
+              "lastSeenTimestamp"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_announce_interface_sightings_interfaceType_lastSeenTimestamp` ON `${TABLE_NAME}` (`interfaceType`, `lastSeenTimestamp`)"
+          },
+          {
+            "name": "index_announce_interface_sightings_lastSeenTimestamp",
+            "unique": false,
+            "columnNames": [
+              "lastSeenTimestamp"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_announce_interface_sightings_lastSeenTimestamp` ON `${TABLE_NAME}` (`lastSeenTimestamp`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "announces",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "destinationHash"
+            ],
+            "referencedColumns": [
+              "destinationHash"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "peer_identities",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`peerHash` TEXT NOT NULL, `publicKey` BLOB NOT NULL, `lastSeenTimestamp` INTEGER NOT NULL, PRIMARY KEY(`peerHash`))",
+        "fields": [
+          {
+            "fieldPath": "peerHash",
+            "columnName": "peerHash",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "publicKey",
+            "columnName": "publicKey",
+            "affinity": "BLOB",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastSeenTimestamp",
+            "columnName": "lastSeenTimestamp",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "peerHash"
+          ]
+        }
+      },
+      {
+        "tableName": "peer_icons",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`destinationHash` TEXT NOT NULL, `iconName` TEXT NOT NULL, `foregroundColor` TEXT NOT NULL, `backgroundColor` TEXT NOT NULL, `updatedTimestamp` INTEGER NOT NULL, PRIMARY KEY(`destinationHash`))",
+        "fields": [
+          {
+            "fieldPath": "destinationHash",
+            "columnName": "destinationHash",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "iconName",
+            "columnName": "iconName",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "foregroundColor",
+            "columnName": "foregroundColor",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "backgroundColor",
+            "columnName": "backgroundColor",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "updatedTimestamp",
+            "columnName": "updatedTimestamp",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "destinationHash"
+          ]
+        }
+      },
+      {
+        "tableName": "contacts",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`destinationHash` TEXT NOT NULL, `identityHash` TEXT NOT NULL, `publicKey` BLOB, `customNickname` TEXT, `notes` TEXT, `tags` TEXT, `addedTimestamp` INTEGER NOT NULL, `addedVia` TEXT NOT NULL, `lastInteractionTimestamp` INTEGER NOT NULL, `isPinned` INTEGER NOT NULL, `status` TEXT NOT NULL, `isMyRelay` INTEGER NOT NULL, PRIMARY KEY(`destinationHash`, `identityHash`), FOREIGN KEY(`identityHash`) REFERENCES `local_identities`(`identityHash`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "destinationHash",
+            "columnName": "destinationHash",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "identityHash",
+            "columnName": "identityHash",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "publicKey",
+            "columnName": "publicKey",
+            "affinity": "BLOB"
+          },
+          {
+            "fieldPath": "customNickname",
+            "columnName": "customNickname",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "notes",
+            "columnName": "notes",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "tags",
+            "columnName": "tags",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "addedTimestamp",
+            "columnName": "addedTimestamp",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "addedVia",
+            "columnName": "addedVia",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastInteractionTimestamp",
+            "columnName": "lastInteractionTimestamp",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "isPinned",
+            "columnName": "isPinned",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "status",
+            "columnName": "status",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "isMyRelay",
+            "columnName": "isMyRelay",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "destinationHash",
+            "identityHash"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_contacts_identityHash",
+            "unique": false,
+            "columnNames": [
+              "identityHash"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_contacts_identityHash` ON `${TABLE_NAME}` (`identityHash`)"
+          },
+          {
+            "name": "index_contacts_identityHash_isPinned",
+            "unique": false,
+            "columnNames": [
+              "identityHash",
+              "isPinned"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_contacts_identityHash_isPinned` ON `${TABLE_NAME}` (`identityHash`, `isPinned`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "local_identities",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "identityHash"
+            ],
+            "referencedColumns": [
+              "identityHash"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "custom_themes",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `name` TEXT NOT NULL, `description` TEXT NOT NULL, `createdTimestamp` INTEGER NOT NULL, `modifiedTimestamp` INTEGER NOT NULL, `baseTheme` TEXT, `seedPrimary` INTEGER NOT NULL, `seedSecondary` INTEGER NOT NULL, `seedTertiary` INTEGER NOT NULL, `lightPrimary` INTEGER NOT NULL, `lightOnPrimary` INTEGER NOT NULL, `lightPrimaryContainer` INTEGER NOT NULL, `lightOnPrimaryContainer` INTEGER NOT NULL, `lightSecondary` INTEGER NOT NULL, `lightOnSecondary` INTEGER NOT NULL, `lightSecondaryContainer` INTEGER NOT NULL, `lightOnSecondaryContainer` INTEGER NOT NULL, `lightTertiary` INTEGER NOT NULL, `lightOnTertiary` INTEGER NOT NULL, `lightTertiaryContainer` INTEGER NOT NULL, `lightOnTertiaryContainer` INTEGER NOT NULL, `lightError` INTEGER NOT NULL, `lightOnError` INTEGER NOT NULL, `lightErrorContainer` INTEGER NOT NULL, `lightOnErrorContainer` INTEGER NOT NULL, `lightBackground` INTEGER NOT NULL, `lightOnBackground` INTEGER NOT NULL, `lightSurface` INTEGER NOT NULL, `lightOnSurface` INTEGER NOT NULL, `lightSurfaceVariant` INTEGER NOT NULL, `lightOnSurfaceVariant` INTEGER NOT NULL, `lightOutline` INTEGER NOT NULL, `lightOutlineVariant` INTEGER NOT NULL, `darkPrimary` INTEGER NOT NULL, `darkOnPrimary` INTEGER NOT NULL, `darkPrimaryContainer` INTEGER NOT NULL, `darkOnPrimaryContainer` INTEGER NOT NULL, `darkSecondary` INTEGER NOT NULL, `darkOnSecondary` INTEGER NOT NULL, `darkSecondaryContainer` INTEGER NOT NULL, `darkOnSecondaryContainer` INTEGER NOT NULL, `darkTertiary` INTEGER NOT NULL, `darkOnTertiary` INTEGER NOT NULL, `darkTertiaryContainer` INTEGER NOT NULL, `darkOnTertiaryContainer` INTEGER NOT NULL, `darkError` INTEGER NOT NULL, `darkOnError` INTEGER NOT NULL, `darkErrorContainer` INTEGER NOT NULL, `darkOnErrorContainer` INTEGER NOT NULL, `darkBackground` INTEGER NOT NULL, `darkOnBackground` INTEGER NOT NULL, `darkSurface` INTEGER NOT NULL, `darkOnSurface` INTEGER NOT NULL, `darkSurfaceVariant` INTEGER NOT NULL, `darkOnSurfaceVariant` INTEGER NOT NULL, `darkOutline` INTEGER NOT NULL, `darkOutlineVariant` INTEGER NOT NULL)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "description",
+            "columnName": "description",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "createdTimestamp",
+            "columnName": "createdTimestamp",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "modifiedTimestamp",
+            "columnName": "modifiedTimestamp",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "baseTheme",
+            "columnName": "baseTheme",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "seedPrimary",
+            "columnName": "seedPrimary",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "seedSecondary",
+            "columnName": "seedSecondary",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "seedTertiary",
+            "columnName": "seedTertiary",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lightPrimary",
+            "columnName": "lightPrimary",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lightOnPrimary",
+            "columnName": "lightOnPrimary",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lightPrimaryContainer",
+            "columnName": "lightPrimaryContainer",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lightOnPrimaryContainer",
+            "columnName": "lightOnPrimaryContainer",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lightSecondary",
+            "columnName": "lightSecondary",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lightOnSecondary",
+            "columnName": "lightOnSecondary",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lightSecondaryContainer",
+            "columnName": "lightSecondaryContainer",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lightOnSecondaryContainer",
+            "columnName": "lightOnSecondaryContainer",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lightTertiary",
+            "columnName": "lightTertiary",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lightOnTertiary",
+            "columnName": "lightOnTertiary",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lightTertiaryContainer",
+            "columnName": "lightTertiaryContainer",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lightOnTertiaryContainer",
+            "columnName": "lightOnTertiaryContainer",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lightError",
+            "columnName": "lightError",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lightOnError",
+            "columnName": "lightOnError",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lightErrorContainer",
+            "columnName": "lightErrorContainer",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lightOnErrorContainer",
+            "columnName": "lightOnErrorContainer",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lightBackground",
+            "columnName": "lightBackground",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lightOnBackground",
+            "columnName": "lightOnBackground",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lightSurface",
+            "columnName": "lightSurface",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lightOnSurface",
+            "columnName": "lightOnSurface",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lightSurfaceVariant",
+            "columnName": "lightSurfaceVariant",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lightOnSurfaceVariant",
+            "columnName": "lightOnSurfaceVariant",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lightOutline",
+            "columnName": "lightOutline",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lightOutlineVariant",
+            "columnName": "lightOutlineVariant",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "darkPrimary",
+            "columnName": "darkPrimary",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "darkOnPrimary",
+            "columnName": "darkOnPrimary",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "darkPrimaryContainer",
+            "columnName": "darkPrimaryContainer",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "darkOnPrimaryContainer",
+            "columnName": "darkOnPrimaryContainer",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "darkSecondary",
+            "columnName": "darkSecondary",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "darkOnSecondary",
+            "columnName": "darkOnSecondary",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "darkSecondaryContainer",
+            "columnName": "darkSecondaryContainer",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "darkOnSecondaryContainer",
+            "columnName": "darkOnSecondaryContainer",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "darkTertiary",
+            "columnName": "darkTertiary",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "darkOnTertiary",
+            "columnName": "darkOnTertiary",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "darkTertiaryContainer",
+            "columnName": "darkTertiaryContainer",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "darkOnTertiaryContainer",
+            "columnName": "darkOnTertiaryContainer",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "darkError",
+            "columnName": "darkError",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "darkOnError",
+            "columnName": "darkOnError",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "darkErrorContainer",
+            "columnName": "darkErrorContainer",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "darkOnErrorContainer",
+            "columnName": "darkOnErrorContainer",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "darkBackground",
+            "columnName": "darkBackground",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "darkOnBackground",
+            "columnName": "darkOnBackground",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "darkSurface",
+            "columnName": "darkSurface",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "darkOnSurface",
+            "columnName": "darkOnSurface",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "darkSurfaceVariant",
+            "columnName": "darkSurfaceVariant",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "darkOnSurfaceVariant",
+            "columnName": "darkOnSurfaceVariant",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "darkOutline",
+            "columnName": "darkOutline",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "darkOutlineVariant",
+            "columnName": "darkOutlineVariant",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_custom_themes_createdTimestamp",
+            "unique": false,
+            "columnNames": [
+              "createdTimestamp"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_custom_themes_createdTimestamp` ON `${TABLE_NAME}` (`createdTimestamp`)"
+          }
+        ]
+      },
+      {
+        "tableName": "local_identities",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`identityHash` TEXT NOT NULL, `displayName` TEXT NOT NULL, `destinationHash` TEXT NOT NULL, `filePath` TEXT NOT NULL, `keyData` BLOB, `encryptedKeyData` BLOB, `keyEncryptionVersion` INTEGER NOT NULL, `passwordSalt` BLOB, `passwordVerificationHash` BLOB, `createdTimestamp` INTEGER NOT NULL, `lastUsedTimestamp` INTEGER NOT NULL, `isActive` INTEGER NOT NULL, `iconName` TEXT, `iconForegroundColor` TEXT, `iconBackgroundColor` TEXT, PRIMARY KEY(`identityHash`))",
+        "fields": [
+          {
+            "fieldPath": "identityHash",
+            "columnName": "identityHash",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "displayName",
+            "columnName": "displayName",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "destinationHash",
+            "columnName": "destinationHash",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "filePath",
+            "columnName": "filePath",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "keyData",
+            "columnName": "keyData",
+            "affinity": "BLOB"
+          },
+          {
+            "fieldPath": "encryptedKeyData",
+            "columnName": "encryptedKeyData",
+            "affinity": "BLOB"
+          },
+          {
+            "fieldPath": "keyEncryptionVersion",
+            "columnName": "keyEncryptionVersion",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "passwordSalt",
+            "columnName": "passwordSalt",
+            "affinity": "BLOB"
+          },
+          {
+            "fieldPath": "passwordVerificationHash",
+            "columnName": "passwordVerificationHash",
+            "affinity": "BLOB"
+          },
+          {
+            "fieldPath": "createdTimestamp",
+            "columnName": "createdTimestamp",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastUsedTimestamp",
+            "columnName": "lastUsedTimestamp",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "isActive",
+            "columnName": "isActive",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "iconName",
+            "columnName": "iconName",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "iconForegroundColor",
+            "columnName": "iconForegroundColor",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "iconBackgroundColor",
+            "columnName": "iconBackgroundColor",
+            "affinity": "TEXT"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "identityHash"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_local_identities_lastUsedTimestamp",
+            "unique": false,
+            "columnNames": [
+              "lastUsedTimestamp"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_local_identities_lastUsedTimestamp` ON `${TABLE_NAME}` (`lastUsedTimestamp`)"
+          },
+          {
+            "name": "index_local_identities_isActive",
+            "unique": false,
+            "columnNames": [
+              "isActive"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_local_identities_isActive` ON `${TABLE_NAME}` (`isActive`)"
+          }
+        ]
+      },
+      {
+        "tableName": "received_locations",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `senderHash` TEXT NOT NULL, `latitude` REAL NOT NULL, `longitude` REAL NOT NULL, `accuracy` REAL NOT NULL, `timestamp` INTEGER NOT NULL, `expiresAt` INTEGER, `receivedAt` INTEGER NOT NULL, `approximateRadius` INTEGER NOT NULL, `appearanceJson` TEXT, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "senderHash",
+            "columnName": "senderHash",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "latitude",
+            "columnName": "latitude",
+            "affinity": "REAL",
+            "notNull": true
+          },
+          {
+            "fieldPath": "longitude",
+            "columnName": "longitude",
+            "affinity": "REAL",
+            "notNull": true
+          },
+          {
+            "fieldPath": "accuracy",
+            "columnName": "accuracy",
+            "affinity": "REAL",
+            "notNull": true
+          },
+          {
+            "fieldPath": "timestamp",
+            "columnName": "timestamp",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "expiresAt",
+            "columnName": "expiresAt",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "receivedAt",
+            "columnName": "receivedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "approximateRadius",
+            "columnName": "approximateRadius",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "appearanceJson",
+            "columnName": "appearanceJson",
+            "affinity": "TEXT"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_received_locations_senderHash",
+            "unique": false,
+            "columnNames": [
+              "senderHash"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_received_locations_senderHash` ON `${TABLE_NAME}` (`senderHash`)"
+          },
+          {
+            "name": "index_received_locations_senderHash_timestamp",
+            "unique": false,
+            "columnNames": [
+              "senderHash",
+              "timestamp"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_received_locations_senderHash_timestamp` ON `${TABLE_NAME}` (`senderHash`, `timestamp`)"
+          },
+          {
+            "name": "index_received_locations_expiresAt",
+            "unique": false,
+            "columnNames": [
+              "expiresAt"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_received_locations_expiresAt` ON `${TABLE_NAME}` (`expiresAt`)"
+          }
+        ]
+      },
+      {
+        "tableName": "offline_map_regions",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `name` TEXT NOT NULL, `centerLatitude` REAL NOT NULL, `centerLongitude` REAL NOT NULL, `radiusKm` INTEGER NOT NULL, `minZoom` INTEGER NOT NULL, `maxZoom` INTEGER NOT NULL, `status` TEXT NOT NULL, `mbtilesPath` TEXT, `tileCount` INTEGER NOT NULL, `sizeBytes` INTEGER NOT NULL, `downloadProgress` REAL NOT NULL, `errorMessage` TEXT, `createdAt` INTEGER NOT NULL, `completedAt` INTEGER, `source` TEXT NOT NULL, `tileVersion` TEXT, `maplibreRegionId` INTEGER, `localStylePath` TEXT, `isDefault` INTEGER NOT NULL)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "centerLatitude",
+            "columnName": "centerLatitude",
+            "affinity": "REAL",
+            "notNull": true
+          },
+          {
+            "fieldPath": "centerLongitude",
+            "columnName": "centerLongitude",
+            "affinity": "REAL",
+            "notNull": true
+          },
+          {
+            "fieldPath": "radiusKm",
+            "columnName": "radiusKm",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "minZoom",
+            "columnName": "minZoom",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "maxZoom",
+            "columnName": "maxZoom",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "status",
+            "columnName": "status",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "mbtilesPath",
+            "columnName": "mbtilesPath",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "tileCount",
+            "columnName": "tileCount",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "sizeBytes",
+            "columnName": "sizeBytes",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "downloadProgress",
+            "columnName": "downloadProgress",
+            "affinity": "REAL",
+            "notNull": true
+          },
+          {
+            "fieldPath": "errorMessage",
+            "columnName": "errorMessage",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "createdAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "completedAt",
+            "columnName": "completedAt",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "source",
+            "columnName": "source",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "tileVersion",
+            "columnName": "tileVersion",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "maplibreRegionId",
+            "columnName": "maplibreRegionId",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "localStylePath",
+            "columnName": "localStylePath",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "isDefault",
+            "columnName": "isDefault",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_offline_map_regions_createdAt",
+            "unique": false,
+            "columnNames": [
+              "createdAt"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_offline_map_regions_createdAt` ON `${TABLE_NAME}` (`createdAt`)"
+          },
+          {
+            "name": "index_offline_map_regions_status",
+            "unique": false,
+            "columnNames": [
+              "status"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_offline_map_regions_status` ON `${TABLE_NAME}` (`status`)"
+          }
+        ]
+      },
+      {
+        "tableName": "rmsp_servers",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`destinationHash` TEXT NOT NULL, `serverName` TEXT NOT NULL, `publicKey` BLOB NOT NULL, `coverageGeohashes` TEXT NOT NULL, `minZoom` INTEGER NOT NULL, `maxZoom` INTEGER NOT NULL, `formats` TEXT NOT NULL, `layers` TEXT NOT NULL, `dataUpdatedTimestamp` INTEGER NOT NULL, `dataSize` INTEGER, `version` TEXT NOT NULL, `lastSeenTimestamp` INTEGER NOT NULL, `hops` INTEGER NOT NULL, PRIMARY KEY(`destinationHash`))",
+        "fields": [
+          {
+            "fieldPath": "destinationHash",
+            "columnName": "destinationHash",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "serverName",
+            "columnName": "serverName",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "publicKey",
+            "columnName": "publicKey",
+            "affinity": "BLOB",
+            "notNull": true
+          },
+          {
+            "fieldPath": "coverageGeohashes",
+            "columnName": "coverageGeohashes",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "minZoom",
+            "columnName": "minZoom",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "maxZoom",
+            "columnName": "maxZoom",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "formats",
+            "columnName": "formats",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "layers",
+            "columnName": "layers",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "dataUpdatedTimestamp",
+            "columnName": "dataUpdatedTimestamp",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "dataSize",
+            "columnName": "dataSize",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "version",
+            "columnName": "version",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastSeenTimestamp",
+            "columnName": "lastSeenTimestamp",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "hops",
+            "columnName": "hops",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "destinationHash"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_rmsp_servers_lastSeenTimestamp",
+            "unique": false,
+            "columnNames": [
+              "lastSeenTimestamp"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_rmsp_servers_lastSeenTimestamp` ON `${TABLE_NAME}` (`lastSeenTimestamp`)"
+          },
+          {
+            "name": "index_rmsp_servers_hops",
+            "unique": false,
+            "columnNames": [
+              "hops"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_rmsp_servers_hops` ON `${TABLE_NAME}` (`hops`)"
+          }
+        ]
+      },
+      {
+        "tableName": "drafts",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`conversationHash` TEXT NOT NULL, `identityHash` TEXT NOT NULL, `content` TEXT NOT NULL, `updatedTimestamp` INTEGER NOT NULL, PRIMARY KEY(`conversationHash`, `identityHash`), FOREIGN KEY(`conversationHash`, `identityHash`) REFERENCES `conversations`(`peerHash`, `identityHash`) ON UPDATE NO ACTION ON DELETE CASCADE , FOREIGN KEY(`identityHash`) REFERENCES `local_identities`(`identityHash`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "conversationHash",
+            "columnName": "conversationHash",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "identityHash",
+            "columnName": "identityHash",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "content",
+            "columnName": "content",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "updatedTimestamp",
+            "columnName": "updatedTimestamp",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "conversationHash",
+            "identityHash"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_drafts_identityHash",
+            "unique": false,
+            "columnNames": [
+              "identityHash"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_drafts_identityHash` ON `${TABLE_NAME}` (`identityHash`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "conversations",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "conversationHash",
+              "identityHash"
+            ],
+            "referencedColumns": [
+              "peerHash",
+              "identityHash"
+            ]
+          },
+          {
+            "table": "local_identities",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "identityHash"
+            ],
+            "referencedColumns": [
+              "identityHash"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "blocked_peers",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`peerHash` TEXT NOT NULL, `identityHash` TEXT NOT NULL, `peerIdentityHash` TEXT, `displayName` TEXT, `blockedTimestamp` INTEGER NOT NULL, `isBlackholeEnabled` INTEGER NOT NULL, PRIMARY KEY(`peerHash`, `identityHash`), FOREIGN KEY(`identityHash`) REFERENCES `local_identities`(`identityHash`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "peerHash",
+            "columnName": "peerHash",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "identityHash",
+            "columnName": "identityHash",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "peerIdentityHash",
+            "columnName": "peerIdentityHash",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "displayName",
+            "columnName": "displayName",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "blockedTimestamp",
+            "columnName": "blockedTimestamp",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "isBlackholeEnabled",
+            "columnName": "isBlackholeEnabled",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "peerHash",
+            "identityHash"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_blocked_peers_identityHash",
+            "unique": false,
+            "columnNames": [
+              "identityHash"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_blocked_peers_identityHash` ON `${TABLE_NAME}` (`identityHash`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "local_identities",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "identityHash"
+            ],
+            "referencedColumns": [
+              "identityHash"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "interface_first_seen",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`interfaceId` TEXT NOT NULL, `firstSeenTimestamp` INTEGER NOT NULL, PRIMARY KEY(`interfaceId`))",
+        "fields": [
+          {
+            "fieldPath": "interfaceId",
+            "columnName": "interfaceId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "firstSeenTimestamp",
+            "columnName": "firstSeenTimestamp",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "interfaceId"
+          ]
+        }
+      },
+      {
+        "tableName": "peer_activity",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`destinationHash` TEXT NOT NULL, `lastReceivedAt` INTEGER NOT NULL, `activityType` TEXT NOT NULL, PRIMARY KEY(`destinationHash`))",
+        "fields": [
+          {
+            "fieldPath": "destinationHash",
+            "columnName": "destinationHash",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastReceivedAt",
+            "columnName": "lastReceivedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "activityType",
+            "columnName": "activityType",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "destinationHash"
+          ]
+        }
+      },
+      {
+        "tableName": "peer_activity_events",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`eventId` TEXT NOT NULL, PRIMARY KEY(`eventId`))",
+        "fields": [
+          {
+            "fieldPath": "eventId",
+            "columnName": "eventId",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "eventId"
+          ]
+        }
+      }
+    ],
+    "setupQueries": [
+      "CREATE TABLE IF NOT EXISTS room_master_table (id INTEGER PRIMARY KEY,identity_hash TEXT)",
+      "INSERT OR REPLACE INTO room_master_table (id,identity_hash) VALUES(42, 'e7fcde4b41565a3b13777e818675c260')"
+    ]
+  }
+}

--- a/data/src/main/java/network/columba/app/data/db/ColumbaDatabase.kt
+++ b/data/src/main/java/network/columba/app/data/db/ColumbaDatabase.kt
@@ -21,6 +21,7 @@ import network.columba.app.data.db.dao.PeerIdentityDao
 import network.columba.app.data.db.dao.ReceivedLocationDao
 import network.columba.app.data.db.dao.RmspServerDao
 import network.columba.app.data.db.entity.AnnounceEntity
+import network.columba.app.data.db.entity.AnnounceInterfaceSightingEntity
 import network.columba.app.data.db.entity.BlockedPeerEntity
 import network.columba.app.data.db.entity.ContactEntity
 import network.columba.app.data.db.entity.ConversationEntity
@@ -42,6 +43,7 @@ import network.columba.app.data.db.entity.RmspServerEntity
         ConversationEntity::class,
         MessageEntity::class,
         AnnounceEntity::class,
+        AnnounceInterfaceSightingEntity::class,
         PeerIdentityEntity::class,
         PeerIconEntity::class,
         ContactEntity::class,
@@ -56,7 +58,7 @@ import network.columba.app.data.db.entity.RmspServerEntity
         PeerActivityEntity::class,
         PeerActivityEventEntity::class,
     ],
-    version = 3,
+    version = 4,
     exportSchema = true,
 )
 abstract class ColumbaDatabase : RoomDatabase() {
@@ -158,6 +160,85 @@ abstract class ColumbaDatabase : RoomDatabase() {
                             "AND receivedAt > 0 AND receivedAt <= $maxTrustedReceivedAt " +
                             "GROUP BY LOWER(conversationHash)",
                         "MESSAGE",
+                    )
+                }
+            }
+
+        /**
+         * v3 → v4: retain recent accepted-path history by interface type.
+         * Existing announces are backfilled with their current interface so
+         * stable filtering works immediately after upgrade.
+         */
+        val MIGRATION_3_4: Migration =
+            object : Migration(3, 4) {
+                override fun migrate(db: SupportSQLiteDatabase) {
+                    db.execSQL(
+                        """
+                        CREATE TABLE IF NOT EXISTS `announce_interface_sightings` (
+                            `destinationHash` TEXT NOT NULL,
+                            `interfaceType` TEXT NOT NULL,
+                            `receivingInterface` TEXT,
+                            `lastSeenTimestamp` INTEGER NOT NULL,
+                            `hops` INTEGER NOT NULL,
+                            PRIMARY KEY(`destinationHash`, `interfaceType`),
+                            FOREIGN KEY(`destinationHash`) REFERENCES `announces`(`destinationHash`)
+                                ON UPDATE NO ACTION ON DELETE CASCADE
+                        )
+                        """.trimIndent(),
+                    )
+                    db.execSQL(
+                        "CREATE INDEX IF NOT EXISTS `index_announce_interface_sightings_destinationHash` " +
+                            "ON `announce_interface_sightings` (`destinationHash`)",
+                    )
+                    db.execSQL(
+                        "CREATE INDEX IF NOT EXISTS `index_announce_interface_sightings_interfaceType_lastSeenTimestamp` " +
+                            "ON `announce_interface_sightings` (`interfaceType`, `lastSeenTimestamp`)",
+                    )
+                    db.execSQL(
+                        "CREATE INDEX IF NOT EXISTS `index_announce_interface_sightings_lastSeenTimestamp` " +
+                            "ON `announce_interface_sightings` (`lastSeenTimestamp`)",
+                    )
+                    db.execSQL(
+                        """
+                        INSERT OR REPLACE INTO announce_interface_sightings
+                            (destinationHash, interfaceType, receivingInterface, lastSeenTimestamp, hops)
+                        SELECT
+                            destinationHash,
+                            CASE
+                                WHEN receivingInterfaceType IN ('AUTO', 'AUTO_INTERFACE') THEN 'AUTO'
+                                WHEN receivingInterfaceType = 'TCP_CLIENT' THEN 'TCP_CLIENT'
+                                WHEN receivingInterfaceType = 'TCP_SERVER' THEN 'TCP_SERVER'
+                                WHEN receivingInterfaceType IN ('BLE', 'ANDROID_BLE') THEN 'BLE'
+                                WHEN receivingInterfaceType = 'RNODE' THEN 'RNODE'
+                                WHEN receivingInterfaceType = 'SHARED_INSTANCE' THEN 'SHARED_INSTANCE'
+                                WHEN lower(receivingInterface) LIKE '%autointerface%' OR
+                                     lower(receivingInterface) LIKE '%auto discovery%' THEN 'AUTO'
+                                WHEN lower(receivingInterface) LIKE '%rnode%' OR
+                                     lower(receivingInterface) LIKE '%kiss%' OR
+                                     lower(receivingInterface) LIKE '%lora%' OR
+                                     lower(receivingInterface) LIKE '%weave%' THEN 'RNODE'
+                                WHEN lower(receivingInterface) LIKE '%tcpserver%' THEN 'TCP_SERVER'
+                                WHEN lower(receivingInterface) LIKE '%tcpclient%' OR
+                                     lower(receivingInterface) LIKE '%tcpinterface%' OR
+                                     lower(receivingInterface) LIKE '%backbone%' THEN 'TCP_CLIENT'
+                                WHEN lower(receivingInterface) LIKE '%androidble%' OR
+                                     lower(receivingInterface) LIKE '%ble%' OR
+                                     lower(receivingInterface) LIKE '%bluetooth%' THEN 'BLE'
+                                WHEN lower(receivingInterface) LIKE '%shared instance%' THEN 'SHARED_INSTANCE'
+                                ELSE 'UNKNOWN'
+                            END,
+                            receivingInterface,
+                            lastSeenTimestamp,
+                            hops
+                        FROM announces
+                        """.trimIndent(),
+                    )
+                    // Persist the same canonical value on the parent so current-path
+                    // fallback remains filterable after the 30-day sighting expires.
+                    db.execSQL(
+                        "UPDATE announces SET receivingInterfaceType = (" +
+                            "SELECT interfaceType FROM announce_interface_sightings sighting " +
+                            "WHERE sighting.destinationHash = announces.destinationHash)",
                     )
                 }
             }

--- a/data/src/main/java/network/columba/app/data/db/dao/AnnounceDao.kt
+++ b/data/src/main/java/network/columba/app/data/db/dao/AnnounceDao.kt
@@ -5,8 +5,12 @@ import androidx.room.Dao
 import androidx.room.Insert
 import androidx.room.OnConflictStrategy
 import androidx.room.Query
+import androidx.room.Transaction
+import androidx.room.Upsert
 import network.columba.app.data.db.entity.AnnounceEntity
+import network.columba.app.data.db.entity.AnnounceInterfaceSightingEntity
 import network.columba.app.data.model.EnrichedAnnounce
+import network.columba.app.data.model.InterfaceType
 import network.columba.app.data.model.MapAnnounceLookup
 import kotlinx.coroutines.flow.Flow
 
@@ -15,11 +19,82 @@ import kotlinx.coroutines.flow.Flow
 interface AnnounceDao {
     /**
      * Insert or update an announce. If the destinationHash already exists,
-     * the entire row is replaced (updating the timestamp and other fields).
+     * the row is updated in place (updating the timestamp and other fields).
      * This implements the "move to top" behavior when a peer re-announces.
      */
-    @Insert(onConflict = OnConflictStrategy.REPLACE)
+    @Upsert
     suspend fun upsertAnnounce(announce: AnnounceEntity)
+
+    @Insert(onConflict = OnConflictStrategy.IGNORE)
+    suspend fun insertInterfaceSighting(sighting: AnnounceInterfaceSightingEntity): Long
+
+    @Query(
+        """
+        UPDATE announce_interface_sightings
+        SET receivingInterface = :receivingInterface,
+            lastSeenTimestamp = :lastSeenTimestamp,
+            hops = :hops
+        WHERE destinationHash = :destinationHash
+          AND interfaceType = :interfaceType
+          AND lastSeenTimestamp < :lastSeenTimestamp
+        """,
+    )
+    suspend fun updateInterfaceSightingIfNewer(
+        destinationHash: String,
+        interfaceType: String,
+        receivingInterface: String?,
+        lastSeenTimestamp: Long,
+        hops: Int,
+    ): Int
+
+    /** Equal or older observations retain the existing newest metadata. */
+    @Transaction
+    suspend fun upsertInterfaceSighting(sighting: AnnounceInterfaceSightingEntity) {
+        val inserted = insertInterfaceSighting(sighting)
+        if (inserted == -1L) {
+            updateInterfaceSightingIfNewer(
+                destinationHash = sighting.destinationHash,
+                interfaceType = sighting.interfaceType,
+                receivingInterface = sighting.receivingInterface,
+                lastSeenTimestamp = sighting.lastSeenTimestamp,
+                hops = sighting.hops,
+            )
+        }
+    }
+
+    /** Atomically update the current announce and its accepted-path history. */
+    @Transaction
+    suspend fun upsertAnnounceWithSighting(
+        announce: AnnounceEntity,
+        sighting: AnnounceInterfaceSightingEntity,
+    ) {
+        val existing = getAnnounce(announce.destinationHash)
+        if (existing == null || announce.lastSeenTimestamp > existing.lastSeenTimestamp) {
+            upsertAnnounce(
+                announce.copy(
+                    isFavorite = existing?.isFavorite ?: announce.isFavorite,
+                    favoritedTimestamp = existing?.favoritedTimestamp ?: announce.favoritedTimestamp,
+                ),
+            )
+        }
+        upsertInterfaceSighting(sighting)
+    }
+
+    @Query(
+        """
+        SELECT * FROM announce_interface_sightings
+        WHERE destinationHash = :destinationHash
+        AND lastSeenTimestamp >= :cutoffTime
+        ORDER BY lastSeenTimestamp DESC
+        """,
+    )
+    fun getRecentInterfaceSightings(
+        destinationHash: String,
+        cutoffTime: Long,
+    ): Flow<List<AnnounceInterfaceSightingEntity>>
+
+    @Query("DELETE FROM announce_interface_sightings WHERE lastSeenTimestamp < :cutoffTime")
+    suspend fun deleteStaleInterfaceSightings(cutoffTime: Long): Int
 
     /**
      * Get all announces, sorted by most recently seen (descending).
@@ -48,11 +123,36 @@ interface AnnounceDao {
         offset: Int,
     ): List<AnnounceEntity>
 
+    @Upsert
+    suspend fun upsertAnnounceRows(announces: List<AnnounceEntity>)
+
     /**
-     * Insert multiple announces at once (for import).
+     * Insert multiple announces for import and seed their current interfaces
+     * as sightings. Updating in place avoids REPLACE cascading away history.
      */
-    @Insert(onConflict = OnConflictStrategy.REPLACE)
-    suspend fun insertAnnounces(announces: List<AnnounceEntity>)
+    @Transaction
+    suspend fun insertAnnounces(announces: List<AnnounceEntity>) {
+        val canonicalizedAnnounces =
+            announces.map { announce ->
+                val declaredInterfaceType = InterfaceType.fromName(announce.receivingInterfaceType)
+                val interfaceType =
+                    declaredInterfaceType.takeUnless { it == InterfaceType.UNKNOWN }
+                        ?: InterfaceType.fromName(announce.receivingInterface)
+                announce.copy(receivingInterfaceType = interfaceType.storageName)
+            }
+        upsertAnnounceRows(canonicalizedAnnounces)
+        canonicalizedAnnounces.forEach { announce ->
+            upsertInterfaceSighting(
+                AnnounceInterfaceSightingEntity(
+                    destinationHash = announce.destinationHash,
+                    interfaceType = requireNotNull(announce.receivingInterfaceType),
+                    receivingInterface = announce.receivingInterface,
+                    lastSeenTimestamp = announce.lastSeenTimestamp,
+                    hops = announce.hops,
+                ),
+            )
+        }
+    }
 
     /**
      * Search announces by peer name or destination hash.
@@ -291,6 +391,12 @@ interface AnnounceDao {
             a.stampCostFlexibility,
             a.peeringCost,
             a.propagationTransferLimitKb,
+            (
+                SELECT GROUP_CONCAT(DISTINCT s.interfaceType)
+                FROM announce_interface_sightings s
+                WHERE s.destinationHash = a.destinationHash
+                AND s.lastSeenTimestamp >= (CAST(strftime('%s', 'now') AS INTEGER) * 1000 - 2592000000)
+            ) AS recentInterfaceTypes,
             pi.iconName as iconName,
             pi.foregroundColor as iconForegroundColor,
             pi.backgroundColor as iconBackgroundColor
@@ -346,6 +452,12 @@ interface AnnounceDao {
             a.stampCostFlexibility,
             a.peeringCost,
             a.propagationTransferLimitKb,
+            (
+                SELECT GROUP_CONCAT(DISTINCT s.interfaceType)
+                FROM announce_interface_sightings s
+                WHERE s.destinationHash = a.destinationHash
+                AND s.lastSeenTimestamp >= (CAST(strftime('%s', 'now') AS INTEGER) * 1000 - 2592000000)
+            ) AS recentInterfaceTypes,
             pi.iconName as iconName,
             pi.foregroundColor as iconForegroundColor,
             pi.backgroundColor as iconBackgroundColor
@@ -379,6 +491,12 @@ interface AnnounceDao {
             a.stampCostFlexibility,
             a.peeringCost,
             a.propagationTransferLimitKb,
+            (
+                SELECT GROUP_CONCAT(DISTINCT s.interfaceType)
+                FROM announce_interface_sightings s
+                WHERE s.destinationHash = a.destinationHash
+                AND s.lastSeenTimestamp >= (CAST(strftime('%s', 'now') AS INTEGER) * 1000 - 2592000000)
+            ) AS recentInterfaceTypes,
             pi.iconName as iconName,
             pi.foregroundColor as iconForegroundColor,
             pi.backgroundColor as iconBackgroundColor
@@ -413,6 +531,12 @@ interface AnnounceDao {
             a.stampCostFlexibility,
             a.peeringCost,
             a.propagationTransferLimitKb,
+            (
+                SELECT GROUP_CONCAT(DISTINCT s.interfaceType)
+                FROM announce_interface_sightings s
+                WHERE s.destinationHash = a.destinationHash
+                AND s.lastSeenTimestamp >= (CAST(strftime('%s', 'now') AS INTEGER) * 1000 - 2592000000)
+            ) AS recentInterfaceTypes,
             pi.iconName as iconName,
             pi.foregroundColor as iconForegroundColor,
             pi.backgroundColor as iconBackgroundColor
@@ -446,6 +570,12 @@ interface AnnounceDao {
             a.stampCostFlexibility,
             a.peeringCost,
             a.propagationTransferLimitKb,
+            (
+                SELECT GROUP_CONCAT(DISTINCT s.interfaceType)
+                FROM announce_interface_sightings s
+                WHERE s.destinationHash = a.destinationHash
+                AND s.lastSeenTimestamp >= (CAST(strftime('%s', 'now') AS INTEGER) * 1000 - 2592000000)
+            ) AS recentInterfaceTypes,
             pi.iconName as iconName,
             pi.foregroundColor as iconForegroundColor,
             pi.backgroundColor as iconBackgroundColor
@@ -480,6 +610,12 @@ interface AnnounceDao {
             a.stampCostFlexibility,
             a.peeringCost,
             a.propagationTransferLimitKb,
+            (
+                SELECT GROUP_CONCAT(DISTINCT s.interfaceType)
+                FROM announce_interface_sightings s
+                WHERE s.destinationHash = a.destinationHash
+                AND s.lastSeenTimestamp >= (CAST(strftime('%s', 'now') AS INTEGER) * 1000 - 2592000000)
+            ) AS recentInterfaceTypes,
             pi.iconName as iconName,
             pi.foregroundColor as iconForegroundColor,
             pi.backgroundColor as iconBackgroundColor
@@ -512,6 +648,12 @@ interface AnnounceDao {
             a.stampCostFlexibility,
             a.peeringCost,
             a.propagationTransferLimitKb,
+            (
+                SELECT GROUP_CONCAT(DISTINCT s.interfaceType)
+                FROM announce_interface_sightings s
+                WHERE s.destinationHash = a.destinationHash
+                AND s.lastSeenTimestamp >= (CAST(strftime('%s', 'now') AS INTEGER) * 1000 - 2592000000)
+            ) AS recentInterfaceTypes,
             pi.iconName as iconName,
             pi.foregroundColor as iconForegroundColor,
             pi.backgroundColor as iconBackgroundColor
@@ -553,16 +695,35 @@ interface AnnounceDao {
             a.stampCostFlexibility,
             a.peeringCost,
             a.propagationTransferLimitKb,
+            (
+                SELECT GROUP_CONCAT(DISTINCT s.interfaceType)
+                FROM announce_interface_sightings s
+                WHERE s.destinationHash = a.destinationHash
+                AND s.lastSeenTimestamp >= (CAST(strftime('%s', 'now') AS INTEGER) * 1000 - 2592000000)
+            ) AS recentInterfaceTypes,
             pi.iconName as iconName,
             pi.foregroundColor as iconForegroundColor,
             pi.backgroundColor as iconBackgroundColor
         FROM announces a
         LEFT JOIN peer_icons pi ON a.destinationHash = pi.destinationHash
         WHERE (a.nodeType != 'PROPAGATION_NODE' OR a.stampCostFlexibility IS NOT NULL)
-        ORDER BY a.lastSeenTimestamp DESC
+        AND (
+            :interfaceTypeCount = 0 OR
+            a.receivingInterfaceType IN (:interfaceTypes) OR EXISTS (
+                SELECT 1 FROM announce_interface_sightings filter_sighting
+                WHERE filter_sighting.destinationHash = a.destinationHash
+                AND filter_sighting.interfaceType IN (:interfaceTypes)
+                AND filter_sighting.lastSeenTimestamp >= :interfaceCutoff
+            )
+        )
+        ORDER BY a.lastSeenTimestamp DESC, a.destinationHash ASC
         """,
     )
-    fun getEnrichedAnnouncesPaged(): PagingSource<Int, EnrichedAnnounce>
+    fun getEnrichedAnnouncesPaged(
+        interfaceTypes: List<String>,
+        interfaceTypeCount: Int,
+        interfaceCutoff: Long,
+    ): PagingSource<Int, EnrichedAnnounce>
 
     /**
      * Get announces filtered by node types with icon data and pagination support.
@@ -586,6 +747,12 @@ interface AnnounceDao {
             a.stampCostFlexibility,
             a.peeringCost,
             a.propagationTransferLimitKb,
+            (
+                SELECT GROUP_CONCAT(DISTINCT s.interfaceType)
+                FROM announce_interface_sightings s
+                WHERE s.destinationHash = a.destinationHash
+                AND s.lastSeenTimestamp >= (CAST(strftime('%s', 'now') AS INTEGER) * 1000 - 2592000000)
+            ) AS recentInterfaceTypes,
             pi.iconName as iconName,
             pi.foregroundColor as iconForegroundColor,
             pi.backgroundColor as iconBackgroundColor
@@ -593,10 +760,24 @@ interface AnnounceDao {
         LEFT JOIN peer_icons pi ON a.destinationHash = pi.destinationHash
         WHERE a.nodeType IN (:nodeTypes)
         AND (a.nodeType != 'PROPAGATION_NODE' OR a.stampCostFlexibility IS NOT NULL)
-        ORDER BY a.lastSeenTimestamp DESC
+        AND (
+            :interfaceTypeCount = 0 OR
+            a.receivingInterfaceType IN (:interfaceTypes) OR EXISTS (
+                SELECT 1 FROM announce_interface_sightings filter_sighting
+                WHERE filter_sighting.destinationHash = a.destinationHash
+                AND filter_sighting.interfaceType IN (:interfaceTypes)
+                AND filter_sighting.lastSeenTimestamp >= :interfaceCutoff
+            )
+        )
+        ORDER BY a.lastSeenTimestamp DESC, a.destinationHash ASC
         """,
     )
-    fun getEnrichedAnnouncesByTypesPaged(nodeTypes: List<String>): PagingSource<Int, EnrichedAnnounce>
+    fun getEnrichedAnnouncesByTypesPaged(
+        nodeTypes: List<String>,
+        interfaceTypes: List<String>,
+        interfaceTypeCount: Int,
+        interfaceCutoff: Long,
+    ): PagingSource<Int, EnrichedAnnounce>
 
     /**
      * Search announces with icon data and pagination support.
@@ -620,6 +801,12 @@ interface AnnounceDao {
             a.stampCostFlexibility,
             a.peeringCost,
             a.propagationTransferLimitKb,
+            (
+                SELECT GROUP_CONCAT(DISTINCT s.interfaceType)
+                FROM announce_interface_sightings s
+                WHERE s.destinationHash = a.destinationHash
+                AND s.lastSeenTimestamp >= (CAST(strftime('%s', 'now') AS INTEGER) * 1000 - 2592000000)
+            ) AS recentInterfaceTypes,
             pi.iconName as iconName,
             pi.foregroundColor as iconForegroundColor,
             pi.backgroundColor as iconBackgroundColor
@@ -627,10 +814,24 @@ interface AnnounceDao {
         LEFT JOIN peer_icons pi ON a.destinationHash = pi.destinationHash
         WHERE (a.peerName LIKE '%' || :query || '%' OR a.destinationHash LIKE '%' || :query || '%')
         AND (a.nodeType != 'PROPAGATION_NODE' OR a.stampCostFlexibility IS NOT NULL)
-        ORDER BY a.lastSeenTimestamp DESC
+        AND (
+            :interfaceTypeCount = 0 OR
+            a.receivingInterfaceType IN (:interfaceTypes) OR EXISTS (
+                SELECT 1 FROM announce_interface_sightings filter_sighting
+                WHERE filter_sighting.destinationHash = a.destinationHash
+                AND filter_sighting.interfaceType IN (:interfaceTypes)
+                AND filter_sighting.lastSeenTimestamp >= :interfaceCutoff
+            )
+        )
+        ORDER BY a.lastSeenTimestamp DESC, a.destinationHash ASC
         """,
     )
-    fun searchEnrichedAnnouncesPaged(query: String): PagingSource<Int, EnrichedAnnounce>
+    fun searchEnrichedAnnouncesPaged(
+        query: String,
+        interfaceTypes: List<String>,
+        interfaceTypeCount: Int,
+        interfaceCutoff: Long,
+    ): PagingSource<Int, EnrichedAnnounce>
 
     /**
      * Get announces filtered by node types AND search query with icon data and pagination.
@@ -654,6 +855,12 @@ interface AnnounceDao {
             a.stampCostFlexibility,
             a.peeringCost,
             a.propagationTransferLimitKb,
+            (
+                SELECT GROUP_CONCAT(DISTINCT s.interfaceType)
+                FROM announce_interface_sightings s
+                WHERE s.destinationHash = a.destinationHash
+                AND s.lastSeenTimestamp >= (CAST(strftime('%s', 'now') AS INTEGER) * 1000 - 2592000000)
+            ) AS recentInterfaceTypes,
             pi.iconName as iconName,
             pi.foregroundColor as iconForegroundColor,
             pi.backgroundColor as iconBackgroundColor
@@ -662,12 +869,24 @@ interface AnnounceDao {
         WHERE a.nodeType IN (:nodeTypes)
         AND (a.peerName LIKE '%' || :query || '%' OR a.destinationHash LIKE '%' || :query || '%')
         AND (a.nodeType != 'PROPAGATION_NODE' OR a.stampCostFlexibility IS NOT NULL)
-        ORDER BY a.lastSeenTimestamp DESC
+        AND (
+            :interfaceTypeCount = 0 OR
+            a.receivingInterfaceType IN (:interfaceTypes) OR EXISTS (
+                SELECT 1 FROM announce_interface_sightings filter_sighting
+                WHERE filter_sighting.destinationHash = a.destinationHash
+                AND filter_sighting.interfaceType IN (:interfaceTypes)
+                AND filter_sighting.lastSeenTimestamp >= :interfaceCutoff
+            )
+        )
+        ORDER BY a.lastSeenTimestamp DESC, a.destinationHash ASC
         """,
     )
     fun getEnrichedAnnouncesByTypesAndSearchPaged(
         nodeTypes: List<String>,
         query: String,
+        interfaceTypes: List<String>,
+        interfaceTypeCount: Int,
+        interfaceCutoff: Long,
     ): PagingSource<Int, EnrichedAnnounce>
 
     // Paging3 methods for infinite scroll

--- a/data/src/main/java/network/columba/app/data/db/dao/AnnounceDao.kt
+++ b/data/src/main/java/network/columba/app/data/db/dao/AnnounceDao.kt
@@ -713,7 +713,7 @@ interface AnnounceDao {
                 SELECT 1 FROM announce_interface_sightings filter_sighting
                 WHERE filter_sighting.destinationHash = a.destinationHash
                 AND filter_sighting.interfaceType IN (:interfaceTypes)
-                AND filter_sighting.lastSeenTimestamp >= :interfaceCutoff
+                AND filter_sighting.lastSeenTimestamp >= (strftime('%s', 'now') * 1000) - 2592000000
             )
         )
         ORDER BY a.lastSeenTimestamp DESC, a.destinationHash ASC
@@ -722,7 +722,6 @@ interface AnnounceDao {
     fun getEnrichedAnnouncesPaged(
         interfaceTypes: List<String>,
         interfaceTypeCount: Int,
-        interfaceCutoff: Long,
     ): PagingSource<Int, EnrichedAnnounce>
 
     /**
@@ -766,7 +765,7 @@ interface AnnounceDao {
                 SELECT 1 FROM announce_interface_sightings filter_sighting
                 WHERE filter_sighting.destinationHash = a.destinationHash
                 AND filter_sighting.interfaceType IN (:interfaceTypes)
-                AND filter_sighting.lastSeenTimestamp >= :interfaceCutoff
+                AND filter_sighting.lastSeenTimestamp >= (strftime('%s', 'now') * 1000) - 2592000000
             )
         )
         ORDER BY a.lastSeenTimestamp DESC, a.destinationHash ASC
@@ -776,7 +775,6 @@ interface AnnounceDao {
         nodeTypes: List<String>,
         interfaceTypes: List<String>,
         interfaceTypeCount: Int,
-        interfaceCutoff: Long,
     ): PagingSource<Int, EnrichedAnnounce>
 
     /**
@@ -820,7 +818,7 @@ interface AnnounceDao {
                 SELECT 1 FROM announce_interface_sightings filter_sighting
                 WHERE filter_sighting.destinationHash = a.destinationHash
                 AND filter_sighting.interfaceType IN (:interfaceTypes)
-                AND filter_sighting.lastSeenTimestamp >= :interfaceCutoff
+                AND filter_sighting.lastSeenTimestamp >= (strftime('%s', 'now') * 1000) - 2592000000
             )
         )
         ORDER BY a.lastSeenTimestamp DESC, a.destinationHash ASC
@@ -830,7 +828,6 @@ interface AnnounceDao {
         query: String,
         interfaceTypes: List<String>,
         interfaceTypeCount: Int,
-        interfaceCutoff: Long,
     ): PagingSource<Int, EnrichedAnnounce>
 
     /**
@@ -875,7 +872,7 @@ interface AnnounceDao {
                 SELECT 1 FROM announce_interface_sightings filter_sighting
                 WHERE filter_sighting.destinationHash = a.destinationHash
                 AND filter_sighting.interfaceType IN (:interfaceTypes)
-                AND filter_sighting.lastSeenTimestamp >= :interfaceCutoff
+                AND filter_sighting.lastSeenTimestamp >= (strftime('%s', 'now') * 1000) - 2592000000
             )
         )
         ORDER BY a.lastSeenTimestamp DESC, a.destinationHash ASC
@@ -886,7 +883,6 @@ interface AnnounceDao {
         query: String,
         interfaceTypes: List<String>,
         interfaceTypeCount: Int,
-        interfaceCutoff: Long,
     ): PagingSource<Int, EnrichedAnnounce>
 
     // Paging3 methods for infinite scroll

--- a/data/src/main/java/network/columba/app/data/db/entity/AnnounceInterfaceSightingEntity.kt
+++ b/data/src/main/java/network/columba/app/data/db/entity/AnnounceInterfaceSightingEntity.kt
@@ -1,0 +1,38 @@
+package network.columba.app.data.db.entity
+
+import androidx.room.Entity
+import androidx.room.ForeignKey
+import androidx.room.Index
+
+/**
+ * Most recent accepted Reticulum path observation for one destination and
+ * canonical interface type.
+ *
+ * Reticulum keeps one active path per destination. This table preserves the
+ * recent history of interfaces which have won that path selection so the
+ * user-facing interface filter does not flicker when the active path moves.
+ */
+@Entity(
+    tableName = "announce_interface_sightings",
+    primaryKeys = ["destinationHash", "interfaceType"],
+    foreignKeys = [
+        ForeignKey(
+            entity = AnnounceEntity::class,
+            parentColumns = ["destinationHash"],
+            childColumns = ["destinationHash"],
+            onDelete = ForeignKey.CASCADE,
+        ),
+    ],
+    indices = [
+        Index("destinationHash"),
+        Index("interfaceType", "lastSeenTimestamp"),
+        Index("lastSeenTimestamp"),
+    ],
+)
+data class AnnounceInterfaceSightingEntity(
+    val destinationHash: String,
+    val interfaceType: String,
+    val receivingInterface: String?,
+    val lastSeenTimestamp: Long,
+    val hops: Int,
+)

--- a/data/src/main/java/network/columba/app/data/di/DatabaseModule.kt
+++ b/data/src/main/java/network/columba/app/data/di/DatabaseModule.kt
@@ -110,7 +110,11 @@ object DatabaseModule {
                 context,
                 ColumbaDatabase::class.java,
                 DATABASE_NAME,
-            ).addMigrations(ColumbaDatabase.MIGRATION_1_2, ColumbaDatabase.MIGRATION_2_3)
+            ).addMigrations(
+                ColumbaDatabase.MIGRATION_1_2,
+                ColumbaDatabase.MIGRATION_2_3,
+                ColumbaDatabase.MIGRATION_3_4,
+            )
             .fallbackToDestructiveMigration()
             .fallbackToDestructiveMigrationOnDowngrade()
             .enableMultiInstanceInvalidation()

--- a/data/src/main/java/network/columba/app/data/model/EnrichedAnnounce.kt
+++ b/data/src/main/java/network/columba/app/data/model/EnrichedAnnounce.kt
@@ -27,6 +27,8 @@ data class EnrichedAnnounce(
     val stampCostFlexibility: Int?,
     val peeringCost: Int?,
     val propagationTransferLimitKb: Int?,
+    /** Comma-separated canonical interface storage names seen in the last 30 days. */
+    val recentInterfaceTypes: String? = null,
     // Profile icon (from peer_icons table)
     val iconName: String? = null,
     val iconForegroundColor: String? = null,
@@ -60,6 +62,7 @@ data class EnrichedAnnounce(
         if (stampCostFlexibility != other.stampCostFlexibility) return false
         if (peeringCost != other.peeringCost) return false
         if (propagationTransferLimitKb != other.propagationTransferLimitKb) return false
+        if (recentInterfaceTypes != other.recentInterfaceTypes) return false
         if (iconName != other.iconName) return false
         if (iconForegroundColor != other.iconForegroundColor) return false
         if (iconBackgroundColor != other.iconBackgroundColor) return false
@@ -84,6 +87,7 @@ data class EnrichedAnnounce(
         result = 31 * result + (stampCostFlexibility?.hashCode() ?: 0)
         result = 31 * result + (peeringCost?.hashCode() ?: 0)
         result = 31 * result + (propagationTransferLimitKb?.hashCode() ?: 0)
+        result = 31 * result + (recentInterfaceTypes?.hashCode() ?: 0)
         result = 31 * result + (iconName?.hashCode() ?: 0)
         result = 31 * result + (iconForegroundColor?.hashCode() ?: 0)
         result = 31 * result + (iconBackgroundColor?.hashCode() ?: 0)

--- a/data/src/main/java/network/columba/app/data/repository/AnnounceRepository.kt
+++ b/data/src/main/java/network/columba/app/data/repository/AnnounceRepository.kt
@@ -6,7 +6,9 @@ import androidx.paging.PagingData
 import androidx.paging.map
 import network.columba.app.data.db.dao.AnnounceDao
 import network.columba.app.data.db.entity.AnnounceEntity
+import network.columba.app.data.db.entity.AnnounceInterfaceSightingEntity
 import network.columba.app.data.model.EnrichedAnnounce
+import network.columba.app.data.model.InterfaceType
 import network.columba.app.data.util.HashUtils
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.map
@@ -37,6 +39,7 @@ data class Announce(
     val iconForegroundColor: String? = null, // Hex RGB e.g., "FFFFFF"
     val iconBackgroundColor: String? = null, // Hex RGB e.g., "1E88E5"
     val propagationTransferLimitKb: Int? = null, // Per-message size limit for propagation nodes (in KB)
+    val recentInterfaceTypes: Set<InterfaceType> = emptySet(),
 ) {
     @Suppress("CyclomaticComplexMethod")
     override fun equals(other: Any?): Boolean {
@@ -68,6 +71,7 @@ data class Announce(
         if (iconForegroundColor != other.iconForegroundColor) return false
         if (iconBackgroundColor != other.iconBackgroundColor) return false
         if (propagationTransferLimitKb != other.propagationTransferLimitKb) return false
+        if (recentInterfaceTypes != other.recentInterfaceTypes) return false
 
         return true
     }
@@ -91,9 +95,18 @@ data class Announce(
         result = 31 * result + (iconForegroundColor?.hashCode() ?: 0)
         result = 31 * result + (iconBackgroundColor?.hashCode() ?: 0)
         result = 31 * result + (propagationTransferLimitKb?.hashCode() ?: 0)
+        result = 31 * result + recentInterfaceTypes.hashCode()
         return result
     }
 }
+
+/** A recent Reticulum-selected path for a destination and interface type. */
+data class AnnounceInterfaceSighting(
+    val interfaceType: InterfaceType,
+    val receivingInterface: String?,
+    val lastSeenTimestamp: Long,
+    val hops: Int,
+)
 
 /**
  * Repository for managing network announces.
@@ -106,6 +119,9 @@ class AnnounceRepository
     constructor(
         private val announceDao: AnnounceDao,
     ) {
+        companion object {
+            const val RECENT_INTERFACE_WINDOW_MS = 30L * 24 * 60 * 60 * 1000
+        }
         /**
          * Get all announces as a Flow, sorted by most recently seen.
          * Automatically updates UI when announces are added or updated.
@@ -162,8 +178,11 @@ class AnnounceRepository
         fun getAnnouncesPaged(
             nodeTypes: List<String>,
             searchQuery: String,
-        ): Flow<PagingData<Announce>> =
-            Pager(
+            interfaceTypes: List<String> = emptyList(),
+        ): Flow<PagingData<Announce>> {
+            val interfaceCutoff = System.currentTimeMillis() - RECENT_INTERFACE_WINDOW_MS
+            val interfaceTypeCount = interfaceTypes.size
+            return Pager(
                 config =
                     PagingConfig(
                         pageSize = 30,
@@ -175,21 +194,42 @@ class AnnounceRepository
                     when {
                         // Filter by node types AND search query
                         nodeTypes.isNotEmpty() && searchQuery.isNotEmpty() ->
-                            announceDao.getEnrichedAnnouncesByTypesAndSearchPaged(nodeTypes, searchQuery)
+                            announceDao.getEnrichedAnnouncesByTypesAndSearchPaged(
+                                nodeTypes,
+                                searchQuery,
+                                interfaceTypes,
+                                interfaceTypeCount,
+                                interfaceCutoff,
+                            )
                         // Filter by node types only
                         nodeTypes.isNotEmpty() ->
-                            announceDao.getEnrichedAnnouncesByTypesPaged(nodeTypes)
+                            announceDao.getEnrichedAnnouncesByTypesPaged(
+                                nodeTypes,
+                                interfaceTypes,
+                                interfaceTypeCount,
+                                interfaceCutoff,
+                            )
                         // Filter by search query only
                         searchQuery.isNotEmpty() ->
-                            announceDao.searchEnrichedAnnouncesPaged(searchQuery)
+                            announceDao.searchEnrichedAnnouncesPaged(
+                                searchQuery,
+                                interfaceTypes,
+                                interfaceTypeCount,
+                                interfaceCutoff,
+                            )
                         // No filters
                         else ->
-                            announceDao.getEnrichedAnnouncesPaged()
+                            announceDao.getEnrichedAnnouncesPaged(
+                                interfaceTypes,
+                                interfaceTypeCount,
+                                interfaceCutoff,
+                            )
                     }
                 },
             ).flow.map { pagingData ->
                 pagingData.map { enriched -> enriched.toAnnounce() }
             }
+        }
 
         /**
          * Get a specific announce by destination hash
@@ -239,6 +279,10 @@ class AnnounceRepository
             // Note: Icons are stored separately in peer_icons table (from LXMF messages)
             val existing = announceDao.getAnnounce(normalizedHash)
 
+            val declaredInterfaceType = InterfaceType.fromName(receivingInterfaceType)
+            val canonicalInterfaceType =
+                declaredInterfaceType.takeUnless { it == InterfaceType.UNKNOWN }
+                    ?: InterfaceType.fromName(receivingInterface)
             val entity =
                 AnnounceEntity(
                     destinationHash = normalizedHash,
@@ -249,7 +293,7 @@ class AnnounceRepository
                     lastSeenTimestamp = timestamp,
                     nodeType = nodeType,
                     receivingInterface = receivingInterface,
-                    receivingInterfaceType = receivingInterfaceType,
+                    receivingInterfaceType = canonicalInterfaceType.storageName,
                     aspect = aspect,
                     isFavorite = existing?.isFavorite ?: false,
                     favoritedTimestamp = existing?.favoritedTimestamp,
@@ -259,8 +303,25 @@ class AnnounceRepository
                     propagationTransferLimitKb = propagationTransferLimitKb,
                     computedIdentityHash = HashUtils.computeIdentityHash(publicKey),
                 )
-            announceDao.upsertAnnounce(entity)
+            val sighting =
+                AnnounceInterfaceSightingEntity(
+                    destinationHash = normalizedHash,
+                    interfaceType = canonicalInterfaceType.storageName,
+                    receivingInterface = receivingInterface,
+                    lastSeenTimestamp = timestamp,
+                    hops = hops,
+                )
+            announceDao.upsertAnnounceWithSighting(entity, sighting)
         }
+
+        fun getRecentInterfaceSightings(destinationHash: String): Flow<List<AnnounceInterfaceSighting>> =
+            announceDao
+                .getRecentInterfaceSightings(
+                    destinationHash = destinationHash.lowercase(),
+                    cutoffTime = System.currentTimeMillis() - RECENT_INTERFACE_WINDOW_MS,
+                ).map { sightings ->
+                    sightings.map { it.toInterfaceSighting() }
+                }
 
         /**
          * Find all announces for the same identity, excluding a given destination hash.
@@ -430,6 +491,7 @@ class AnnounceRepository
                 iconForegroundColor = null,
                 iconBackgroundColor = null,
                 propagationTransferLimitKb = propagationTransferLimitKb,
+                recentInterfaceTypes = setOf(InterfaceType.fromName(receivingInterfaceType ?: receivingInterface)),
             )
 
         private fun EnrichedAnnounce.toAnnounce() =
@@ -453,5 +515,19 @@ class AnnounceRepository
                 iconForegroundColor = iconForegroundColor,
                 iconBackgroundColor = iconBackgroundColor,
                 propagationTransferLimitKb = propagationTransferLimitKb,
+                recentInterfaceTypes =
+                    recentInterfaceTypes
+                        ?.split(',')
+                        ?.filter(String::isNotBlank)
+                        ?.mapTo(linkedSetOf(), InterfaceType::fromName)
+                        .orEmpty(),
+            )
+
+        private fun AnnounceInterfaceSightingEntity.toInterfaceSighting() =
+            AnnounceInterfaceSighting(
+                interfaceType = InterfaceType.fromName(interfaceType),
+                receivingInterface = receivingInterface,
+                lastSeenTimestamp = lastSeenTimestamp,
+                hops = hops,
             )
     }

--- a/data/src/main/java/network/columba/app/data/repository/AnnounceRepository.kt
+++ b/data/src/main/java/network/columba/app/data/repository/AnnounceRepository.kt
@@ -180,7 +180,6 @@ class AnnounceRepository
             searchQuery: String,
             interfaceTypes: List<String> = emptyList(),
         ): Flow<PagingData<Announce>> {
-            val interfaceCutoff = System.currentTimeMillis() - RECENT_INTERFACE_WINDOW_MS
             val interfaceTypeCount = interfaceTypes.size
             return Pager(
                 config =
@@ -199,7 +198,6 @@ class AnnounceRepository
                                 searchQuery,
                                 interfaceTypes,
                                 interfaceTypeCount,
-                                interfaceCutoff,
                             )
                         // Filter by node types only
                         nodeTypes.isNotEmpty() ->
@@ -207,7 +205,6 @@ class AnnounceRepository
                                 nodeTypes,
                                 interfaceTypes,
                                 interfaceTypeCount,
-                                interfaceCutoff,
                             )
                         // Filter by search query only
                         searchQuery.isNotEmpty() ->
@@ -215,14 +212,12 @@ class AnnounceRepository
                                 searchQuery,
                                 interfaceTypes,
                                 interfaceTypeCount,
-                                interfaceCutoff,
                             )
                         // No filters
                         else ->
                             announceDao.getEnrichedAnnouncesPaged(
                                 interfaceTypes,
                                 interfaceTypeCount,
-                                interfaceCutoff,
                             )
                     }
                 },

--- a/data/src/test/java/network/columba/app/data/db/Migration3To4SchemaTest.kt
+++ b/data/src/test/java/network/columba/app/data/db/Migration3To4SchemaTest.kt
@@ -1,0 +1,36 @@
+package network.columba.app.data.db
+
+import android.app.Application
+import androidx.room.testing.MigrationTestHelper
+import androidx.test.platform.app.InstrumentationRegistry
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+
+@RunWith(RobolectricTestRunner::class)
+@Config(sdk = [34], application = Application::class)
+class Migration3To4SchemaTest {
+    @get:Rule
+    val helper =
+        MigrationTestHelper(
+            InstrumentationRegistry.getInstrumentation(),
+            ColumbaDatabase::class.java,
+        )
+
+    @Test
+    fun `migration output matches exported Room version 4 schema`() {
+        helper.createDatabase(DATABASE_NAME, 3).close()
+        helper.runMigrationsAndValidate(
+            DATABASE_NAME,
+            4,
+            true,
+            ColumbaDatabase.MIGRATION_3_4,
+        ).close()
+    }
+
+    private companion object {
+        const val DATABASE_NAME = "announce-interface-room-schema-migration"
+    }
+}

--- a/data/src/test/java/network/columba/app/data/db/Migration3To4Test.kt
+++ b/data/src/test/java/network/columba/app/data/db/Migration3To4Test.kt
@@ -1,0 +1,114 @@
+package network.columba.app.data.db
+
+import android.app.Application
+import android.content.Context
+import androidx.sqlite.db.SupportSQLiteDatabase
+import androidx.sqlite.db.SupportSQLiteOpenHelper
+import androidx.sqlite.db.framework.FrameworkSQLiteOpenHelperFactory
+import androidx.test.core.app.ApplicationProvider
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+
+@RunWith(RobolectricTestRunner::class)
+@Config(sdk = [34], application = Application::class)
+class Migration3To4Test {
+    private lateinit var context: Context
+    private val databaseName = "migration-3-4-test.db"
+
+    @Before
+    fun setup() {
+        context = ApplicationProvider.getApplicationContext()
+        context.deleteDatabase(databaseName)
+    }
+
+    @After
+    fun teardown() {
+        context.deleteDatabase(databaseName)
+    }
+
+    @Test
+    fun migration_backfillsCurrentInterfaceAsFirstSighting() {
+        openAtVersion3().close()
+        val migrated = openAtVersion4()
+
+        migrated.query(
+            "SELECT destinationHash, interfaceType, receivingInterface, lastSeenTimestamp, hops " +
+                "FROM announce_interface_sightings",
+        ).use { cursor ->
+            assertEquals(1, cursor.count)
+            cursor.moveToFirst()
+            assertEquals("destination", cursor.getString(0))
+            assertEquals("RNODE", cursor.getString(1))
+            assertEquals("RNodeInterface[Radio]", cursor.getString(2))
+            assertEquals(1234L, cursor.getLong(3))
+            assertEquals(2, cursor.getInt(4))
+        }
+        migrated.query(
+            "SELECT receivingInterfaceType FROM announces WHERE destinationHash = 'destination'",
+        ).use { cursor ->
+            cursor.moveToFirst()
+            assertEquals("RNODE", cursor.getString(0))
+        }
+        migrated.close()
+    }
+
+    private fun openAtVersion3(): SupportSQLiteDatabase {
+        val callback =
+            object : SupportSQLiteOpenHelper.Callback(3) {
+                override fun onCreate(db: SupportSQLiteDatabase) {
+                    db.execSQL(
+                        """
+                        CREATE TABLE announces (
+                            destinationHash TEXT NOT NULL PRIMARY KEY,
+                            receivingInterface TEXT,
+                            receivingInterfaceType TEXT,
+                            lastSeenTimestamp INTEGER NOT NULL,
+                            hops INTEGER NOT NULL
+                        )
+                        """.trimIndent(),
+                    )
+                    db.execSQL(
+                        "INSERT INTO announces VALUES (?, ?, ?, ?, ?)",
+                        arrayOf<Any?>("destination", "RNodeInterface[Radio]", "UNKNOWN", 1234L, 2),
+                    )
+                }
+
+                override fun onUpgrade(
+                    db: SupportSQLiteDatabase,
+                    oldVersion: Int,
+                    newVersion: Int,
+                ) = Unit
+            }
+        return createHelper(callback).writableDatabase
+    }
+
+    private fun openAtVersion4(): SupportSQLiteDatabase {
+        val callback =
+            object : SupportSQLiteOpenHelper.Callback(4) {
+                override fun onCreate(db: SupportSQLiteDatabase) = Unit
+
+                override fun onUpgrade(
+                    db: SupportSQLiteDatabase,
+                    oldVersion: Int,
+                    newVersion: Int,
+                ) {
+                    ColumbaDatabase.MIGRATION_3_4.migrate(db)
+                }
+            }
+        return createHelper(callback).writableDatabase
+    }
+
+    private fun createHelper(callback: SupportSQLiteOpenHelper.Callback): SupportSQLiteOpenHelper =
+        FrameworkSQLiteOpenHelperFactory().create(
+            SupportSQLiteOpenHelper.Configuration
+                .builder(context)
+                .name(databaseName)
+                .callback(callback)
+                .build(),
+        )
+}

--- a/data/src/test/java/network/columba/app/data/repository/AnnounceRepositoryTest.kt
+++ b/data/src/test/java/network/columba/app/data/repository/AnnounceRepositoryTest.kt
@@ -88,7 +88,6 @@ class AnnounceRepositoryTest {
                     .getEnrichedAnnouncesPaged(
                         interfaceTypes = listOf(InterfaceType.RNODE.storageName),
                         interfaceTypeCount = 1,
-                        interfaceCutoff = now - AnnounceRepository.RECENT_INTERFACE_WINDOW_MS,
                     ).load(PagingSource.LoadParams.Refresh(key = null, loadSize = 1, placeholdersEnabled = false))
             val filteredRows =
                 (filteredPage as PagingSource.LoadResult.Page<Int, EnrichedAnnounce>).data
@@ -138,7 +137,6 @@ class AnnounceRepositoryTest {
                 dao.getEnrichedAnnouncesPaged(
                     interfaceTypes = listOf(InterfaceType.RNODE.storageName),
                     interfaceTypeCount = 1,
-                    interfaceCutoff = System.currentTimeMillis() - AnnounceRepository.RECENT_INTERFACE_WINDOW_MS,
                 ).load(PagingSource.LoadParams.Refresh(key = null, loadSize = 1, placeholdersEnabled = false))
             val filteredRows =
                 (filteredPage as PagingSource.LoadResult.Page<Int, EnrichedAnnounce>).data
@@ -177,11 +175,34 @@ class AnnounceRepositoryTest {
                 dao.getEnrichedAnnouncesPaged(
                     interfaceTypes = listOf(InterfaceType.BLE.storageName),
                     interfaceTypeCount = 1,
-                    interfaceCutoff = System.currentTimeMillis() - AnnounceRepository.RECENT_INTERFACE_WINDOW_MS,
                 ).load(PagingSource.LoadParams.Refresh(key = null, loadSize = 1, placeholdersEnabled = false))
             val filteredRows =
                 (filteredPage as PagingSource.LoadResult.Page<Int, EnrichedAnnounce>).data
             assertEquals(listOf(destinationHash), filteredRows.map { it.destinationHash })
+        }
+
+    @Test
+    fun expiredHistoricalInterface_doesNotMatchCurrentPagingWindow() =
+        runTest {
+            val destinationHash = "cdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcd"
+            val now = System.currentTimeMillis()
+            saveTestAnnounce(
+                destinationHash,
+                "RNodeInterface[Expired radio]",
+                now - AnnounceRepository.RECENT_INTERFACE_WINDOW_MS - 1_000,
+                hops = 3,
+            )
+            saveTestAnnounce(destinationHash, "TCPClientInterface[Current path]", now, hops = 1)
+
+            val page =
+                database
+                    .announceDao()
+                    .getEnrichedAnnouncesPaged(
+                        interfaceTypes = listOf(InterfaceType.RNODE.storageName),
+                        interfaceTypeCount = 1,
+                    ).load(PagingSource.LoadParams.Refresh(key = null, loadSize = 1, placeholdersEnabled = false))
+            val rows = (page as PagingSource.LoadResult.Page<Int, EnrichedAnnounce>).data
+            assertTrue(rows.isEmpty())
         }
 
     private suspend fun saveTestAnnounce(

--- a/data/src/test/java/network/columba/app/data/repository/AnnounceRepositoryTest.kt
+++ b/data/src/test/java/network/columba/app/data/repository/AnnounceRepositoryTest.kt
@@ -1,0 +1,206 @@
+package network.columba.app.data.repository
+
+import android.app.Application
+import android.content.Context
+import androidx.paging.PagingSource
+import androidx.room.Room
+import androidx.test.core.app.ApplicationProvider
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.test.runTest
+import network.columba.app.data.db.ColumbaDatabase
+import network.columba.app.data.db.entity.AnnounceEntity
+import network.columba.app.data.model.EnrichedAnnounce
+import network.columba.app.data.model.InterfaceType
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+
+@RunWith(RobolectricTestRunner::class)
+@Config(sdk = [34], application = Application::class)
+class AnnounceRepositoryTest {
+    private lateinit var database: ColumbaDatabase
+    private lateinit var repository: AnnounceRepository
+
+    @Before
+    fun setup() {
+        val context = ApplicationProvider.getApplicationContext<Context>()
+        database =
+            Room
+                .inMemoryDatabaseBuilder(context, ColumbaDatabase::class.java)
+                .allowMainThreadQueries()
+                .build()
+        repository = AnnounceRepository(database.announceDao())
+    }
+
+    @After
+    fun teardown() {
+        database.close()
+    }
+
+    @Test
+    fun saveAnnounce_preservesRecentInterfaceTypesWhenCurrentPathChanges() =
+        runTest {
+            val destinationHash = "0123456789abcdef0123456789abcdef"
+            val now = System.currentTimeMillis()
+
+            saveTestAnnounce(
+                destinationHash = destinationHash,
+                receivingInterface = "RNodeInterface[Radio]",
+                timestamp = now,
+                hops = 2,
+            )
+            saveTestAnnounce(
+                destinationHash = destinationHash,
+                receivingInterface = "TCPClientInterface[Backbone]",
+                timestamp = now + 1,
+                hops = 1,
+            )
+
+            val updated = requireNotNull(repository.getAnnounceFlow(destinationHash).first())
+            assertEquals(1, database.announceDao().getAnnounceCount())
+            assertEquals("TCPClientInterface[Backbone]", updated.receivingInterface)
+            assertEquals(
+                setOf(InterfaceType.RNODE, InterfaceType.TCP_CLIENT),
+                updated.recentInterfaceTypes,
+            )
+
+            val sightings = repository.getRecentInterfaceSightings(destinationHash).first()
+            assertEquals(2, sightings.size)
+            assertTrue(sightings.any { it.interfaceType == InterfaceType.RNODE && it.hops == 2 })
+            assertTrue(sightings.any { it.interfaceType == InterfaceType.TCP_CLIENT && it.hops == 1 })
+
+            // A newer non-matching row must not consume the first Paging slot and
+            // produce a false-empty RNode page.
+            saveTestAnnounce(
+                destinationHash = "ffffffffffffffffffffffffffffffff",
+                receivingInterface = "AndroidBLE[Nearby phone]",
+                timestamp = now + 2_000,
+                hops = 1,
+            )
+            val filteredPage =
+                database
+                    .announceDao()
+                    .getEnrichedAnnouncesPaged(
+                        interfaceTypes = listOf(InterfaceType.RNODE.storageName),
+                        interfaceTypeCount = 1,
+                        interfaceCutoff = now - AnnounceRepository.RECENT_INTERFACE_WINDOW_MS,
+                    ).load(PagingSource.LoadParams.Refresh(key = null, loadSize = 1, placeholdersEnabled = false))
+            val filteredRows =
+                (filteredPage as PagingSource.LoadResult.Page<Int, EnrichedAnnounce>).data
+            assertEquals(listOf(destinationHash), filteredRows.map { it.destinationHash })
+        }
+
+    @Test
+    fun olderOrEqualObservation_cannotRegressCurrentPathOrSightingMetadata() =
+        runTest {
+            val destinationHash = "00112233445566778899aabbccddeeff"
+            val newest = System.currentTimeMillis()
+            saveTestAnnounce(destinationHash, "RNodeInterface[Newest]", newest, hops = 1)
+            saveTestAnnounce(destinationHash, "RNodeInterface[Older]", newest - 1, hops = 5)
+            saveTestAnnounce(destinationHash, "RNodeInterface[Equal]", newest, hops = 4)
+
+            val current = requireNotNull(repository.getAnnounceFlow(destinationHash).first())
+            assertEquals("RNodeInterface[Newest]", current.receivingInterface)
+            assertEquals(1, current.hops)
+
+            val sighting = repository.getRecentInterfaceSightings(destinationHash).first().single()
+            assertEquals("RNodeInterface[Newest]", sighting.receivingInterface)
+            assertEquals(newest, sighting.lastSeenTimestamp)
+            assertEquals(1, sighting.hops)
+        }
+
+    @Test
+    fun staleSighting_isExcludedFromHistoryButFavoriteMatchesItsCurrentInterface() =
+        runTest {
+            val destinationHash = "fedcba9876543210fedcba9876543210"
+            val staleTimestamp =
+                System.currentTimeMillis() - AnnounceRepository.RECENT_INTERFACE_WINDOW_MS - 1
+
+            saveTestAnnounce(
+                destinationHash = destinationHash,
+                receivingInterface = "RNodeInterface[Old Radio]",
+                timestamp = staleTimestamp,
+                hops = 3,
+            )
+
+            assertTrue(repository.getRecentInterfaceSightings(destinationHash).first().isEmpty())
+
+            val dao = database.announceDao()
+            dao.updateFavoriteStatus(destinationHash, isFavorite = true, timestamp = System.currentTimeMillis())
+            dao.deleteStaleInterfaceSightings(System.currentTimeMillis() - AnnounceRepository.RECENT_INTERFACE_WINDOW_MS)
+
+            val filteredPage =
+                dao.getEnrichedAnnouncesPaged(
+                    interfaceTypes = listOf(InterfaceType.RNODE.storageName),
+                    interfaceTypeCount = 1,
+                    interfaceCutoff = System.currentTimeMillis() - AnnounceRepository.RECENT_INTERFACE_WINDOW_MS,
+                ).load(PagingSource.LoadParams.Refresh(key = null, loadSize = 1, placeholdersEnabled = false))
+            val filteredRows =
+                (filteredPage as PagingSource.LoadResult.Page<Int, EnrichedAnnounce>).data
+            assertEquals(listOf(destinationHash), filteredRows.map { it.destinationHash })
+        }
+
+    @Test
+    fun importedFavorite_canonicalizesParentBeforeSightingExpires() =
+        runTest {
+            val destinationHash = "abababababababababababababababab"
+            val staleTimestamp =
+                System.currentTimeMillis() - AnnounceRepository.RECENT_INTERFACE_WINDOW_MS - 1
+            val dao = database.announceDao()
+            dao.insertAnnounces(
+                listOf(
+                    AnnounceEntity(
+                        destinationHash = destinationHash,
+                        peerName = "Imported peer",
+                        publicKey = ByteArray(32) { it.toByte() },
+                        appData = null,
+                        hops = 2,
+                        lastSeenTimestamp = staleTimestamp,
+                        nodeType = "PEER",
+                        receivingInterface = "AndroidBLE[Imported phone]",
+                        receivingInterfaceType = "ANDROID_BLE",
+                        isFavorite = true,
+                        favoritedTimestamp = System.currentTimeMillis(),
+                    ),
+                ),
+            )
+
+            assertEquals(InterfaceType.BLE.storageName, dao.getAnnounce(destinationHash)?.receivingInterfaceType)
+            dao.deleteStaleInterfaceSightings(System.currentTimeMillis() - AnnounceRepository.RECENT_INTERFACE_WINDOW_MS)
+
+            val filteredPage =
+                dao.getEnrichedAnnouncesPaged(
+                    interfaceTypes = listOf(InterfaceType.BLE.storageName),
+                    interfaceTypeCount = 1,
+                    interfaceCutoff = System.currentTimeMillis() - AnnounceRepository.RECENT_INTERFACE_WINDOW_MS,
+                ).load(PagingSource.LoadParams.Refresh(key = null, loadSize = 1, placeholdersEnabled = false))
+            val filteredRows =
+                (filteredPage as PagingSource.LoadResult.Page<Int, EnrichedAnnounce>).data
+            assertEquals(listOf(destinationHash), filteredRows.map { it.destinationHash })
+        }
+
+    private suspend fun saveTestAnnounce(
+        destinationHash: String,
+        receivingInterface: String,
+        timestamp: Long,
+        hops: Int,
+    ) {
+        repository.saveAnnounce(
+            destinationHash = destinationHash,
+            peerName = "Test peer",
+            publicKey = ByteArray(32) { it.toByte() },
+            appData = null,
+            hops = hops,
+            timestamp = timestamp,
+            nodeType = "PEER",
+            receivingInterface = receivingInterface,
+            receivingInterfaceType = InterfaceType.fromName(receivingInterface).storageName,
+            aspect = "lxmf.delivery",
+        )
+    }
+}

--- a/rns-host/src/main/kotlin/network/columba/app/rns/host/di/ServiceDatabaseProvider.kt
+++ b/rns-host/src/main/kotlin/network/columba/app/rns/host/di/ServiceDatabaseProvider.kt
@@ -29,7 +29,11 @@ object ServiceDatabaseProvider {
                 context.applicationContext,
                 ColumbaDatabase::class.java,
                 DatabaseModule.DATABASE_NAME,
-            ).addMigrations(ColumbaDatabase.MIGRATION_1_2, ColumbaDatabase.MIGRATION_2_3)
+            ).addMigrations(
+                ColumbaDatabase.MIGRATION_1_2,
+                ColumbaDatabase.MIGRATION_2_3,
+                ColumbaDatabase.MIGRATION_3_4,
+            )
             .fallbackToDestructiveMigration()
             .fallbackToDestructiveMigrationOnDowngrade()
             .enableMultiInstanceInvalidation()

--- a/rns-host/src/main/kotlin/network/columba/app/rns/host/persistence/ServicePersistenceManager.kt
+++ b/rns-host/src/main/kotlin/network/columba/app/rns/host/persistence/ServicePersistenceManager.kt
@@ -4,12 +4,14 @@ import android.content.Context
 import android.util.Log
 import network.columba.app.data.db.ColumbaDatabase
 import network.columba.app.data.db.entity.AnnounceEntity
+import network.columba.app.data.db.entity.AnnounceInterfaceSightingEntity
 import network.columba.app.data.db.entity.ConversationEntity
 import network.columba.app.data.db.entity.MessageEntity
 import network.columba.app.data.db.entity.PeerActivityType
 import network.columba.app.data.db.entity.PeerIdentityEntity
 import network.columba.app.data.util.HashUtils
 import network.columba.app.data.util.TextSanitizer
+import network.columba.app.data.model.InterfaceType
 import network.columba.app.rns.host.di.ServiceDatabaseProvider
 import network.columba.app.rns.host.util.PeerNameResolver
 import kotlinx.coroutines.CoroutineScope
@@ -120,11 +122,16 @@ class ServicePersistenceManager(
             try {
                 // Preserve favorite status if announce already exists
                 // Note: Icons are stored separately in peer_icons table (from LXMF messages)
-                val existing = announceDao.getAnnounce(destinationHash)
+                val normalizedHash = destinationHash.lowercase()
+                val existing = announceDao.getAnnounce(normalizedHash)
+                val declaredInterfaceType = InterfaceType.fromName(receivingInterfaceType)
+                val canonicalInterfaceType =
+                    declaredInterfaceType.takeUnless { it == InterfaceType.UNKNOWN }
+                        ?: InterfaceType.fromName(receivingInterface)
 
                 val entity =
                     AnnounceEntity(
-                        destinationHash = destinationHash,
+                        destinationHash = normalizedHash,
                         peerName = peerName,
                         publicKey = publicKey,
                         appData = appData,
@@ -132,7 +139,7 @@ class ServicePersistenceManager(
                         lastSeenTimestamp = timestamp,
                         nodeType = nodeType,
                         receivingInterface = receivingInterface,
-                        receivingInterfaceType = receivingInterfaceType,
+                        receivingInterfaceType = canonicalInterfaceType.storageName,
                         aspect = aspect,
                         isFavorite = existing?.isFavorite ?: false,
                         favoritedTimestamp = existing?.favoritedTimestamp,
@@ -142,10 +149,18 @@ class ServicePersistenceManager(
                         propagationTransferLimitKb = propagationTransferLimitKb,
                         computedIdentityHash = HashUtils.computeIdentityHash(publicKey),
                     )
+                val sighting =
+                    AnnounceInterfaceSightingEntity(
+                        destinationHash = normalizedHash,
+                        interfaceType = canonicalInterfaceType.storageName,
+                        receivingInterface = receivingInterface,
+                        lastSeenTimestamp = timestamp,
+                        hops = hops,
+                    )
 
-                announceDao.upsertAnnounce(entity)
+                announceDao.upsertAnnounceWithSighting(entity, sighting)
                 peerActivityDao.recordActivity(
-                    destinationHash = destinationHash,
+                    destinationHash = normalizedHash,
                     receivedAt = timestamp,
                     activityType = PeerActivityType.ANNOUNCE,
                 )
@@ -625,7 +640,11 @@ class ServicePersistenceManager(
         scope.launch {
             try {
                 val cutoffTime = System.currentTimeMillis() - ANNOUNCE_TTL_MS
+                val deletedSightings = announceDao.deleteStaleInterfaceSightings(cutoffTime)
                 val deleted = announceDao.deleteStaleAnnounces(cutoffTime)
+                if (deletedSightings > 0) {
+                    Log.d(TAG, "Cleaned up $deletedSightings stale interface sightings (>30 days old)")
+                }
                 if (deleted > 0) {
                     Log.d(TAG, "Cleaned up $deleted stale announces (>30 days old)")
                 }

--- a/rns-host/src/test/kotlin/network/columba/app/rns/host/persistence/ServicePersistenceManagerTest.kt
+++ b/rns-host/src/test/kotlin/network/columba/app/rns/host/persistence/ServicePersistenceManagerTest.kt
@@ -111,7 +111,7 @@ class ServicePersistenceManagerTest {
     fun `persistAnnounce saves new announce to database`() =
         runTest {
             coEvery { announceDao.getAnnounce(testDestinationHash) } returns null
-            coEvery { announceDao.upsertAnnounce(any()) } just Runs
+            coEvery { announceDao.upsertAnnounceWithSighting(any(), any()) } just Runs
 
             val result =
                 runCatching {
@@ -136,7 +136,7 @@ class ServicePersistenceManagerTest {
             testScope.advanceUntilIdle()
 
             assertTrue("persistAnnounce should complete without throwing", result.isSuccess)
-            coVerify { announceDao.upsertAnnounce(any()) }
+            coVerify { announceDao.upsertAnnounceWithSighting(any(), any()) }
         }
 
     @Test
@@ -157,7 +157,7 @@ class ServicePersistenceManagerTest {
                 )
 
             coEvery { announceDao.getAnnounce(testDestinationHash) } returns existingAnnounce
-            coEvery { announceDao.upsertAnnounce(any()) } just Runs
+            coEvery { announceDao.upsertAnnounceWithSighting(any(), any()) } just Runs
 
             val result =
                 runCatching {
@@ -183,10 +183,11 @@ class ServicePersistenceManagerTest {
 
             assertTrue("persistAnnounce should complete without throwing", result.isSuccess)
             coVerify {
-                announceDao.upsertAnnounce(
+                announceDao.upsertAnnounceWithSighting(
                     match { entity ->
                         entity.isFavorite && entity.peerName == "New Name"
                     },
+                    any(),
                 )
             }
         }
@@ -195,7 +196,7 @@ class ServicePersistenceManagerTest {
     fun `persistAnnounce sets computedIdentityHash from publicKey`() =
         runTest {
             coEvery { announceDao.getAnnounce(testDestinationHash) } returns null
-            coEvery { announceDao.upsertAnnounce(any()) } just Runs
+            coEvery { announceDao.upsertAnnounceWithSighting(any(), any()) } just Runs
 
             val result =
                 runCatching {
@@ -221,12 +222,13 @@ class ServicePersistenceManagerTest {
 
             assertTrue("persistAnnounce should complete without throwing", result.isSuccess)
             coVerify {
-                announceDao.upsertAnnounce(
+                announceDao.upsertAnnounceWithSighting(
                     match { entity ->
                         entity.computedIdentityHash != null &&
                             entity.computedIdentityHash!!.length == 32 &&
                             entity.computedIdentityHash == entity.computedIdentityHash!!.lowercase()
                     },
+                    any(),
                 )
             }
         }


### PR DESCRIPTION
## Summary
- retain one contact card per destination while tracking accepted path history by interface type
- keep 30-day interface filters stable when Reticulum changes the current accepted path
- show the current path plus a compact additional-interface count and detailed recent path history
- add Room v3→v4 migration, multi-process persistence, cleanup, canonical import handling, and deterministic Paging queries

## Verification
- full `:data:testDebugUnitTest`
- focused service persistence tests
- targeted ViewModel, PeerCard, and Node Details tests
- real Room v3→v4 exported-schema migration validation
- `detekt`
- Kotlin and Python backend compilation
- `:app:assembleNoSentryKotlinBackendDebug`

## Semantics
History represents accepted Reticulum path updates, not every rejected duplicate reception. The parent announce remains the current path; retained history is used for filtering and diagnostics.

Fixes #1045