### PR TITLE
fix(android): persist LXMF peer names below IPC

### DIFF
--- a/rns-host/src/main/kotlin/network/columba/app/rns/host/persistence/PeerActivityCollector.kt
+++ b/rns-host/src/main/kotlin/network/columba/app/rns/host/persistence/PeerActivityCollector.kt
@@ -6,8 +6,12 @@ import kotlinx.coroutines.Job
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.supervisorScope
 import network.columba.app.data.db.entity.PeerActivityType
+import network.columba.app.data.model.InterfaceType
 import network.columba.app.rns.api.RnsBackend
+import network.columba.app.rns.api.model.AnnounceEvent
 import network.columba.app.rns.api.model.LinkEvent
+import network.columba.app.rns.api.util.AppDataParser
+import network.columba.app.rns.host.util.PeerNameResolver
 import org.json.JSONObject
 
 /**
@@ -39,13 +43,7 @@ internal class PeerActivityCollector(
                     }
                 }
                 launch(start = CoroutineStart.UNDISPATCHED) {
-                    backend.core.observeAnnounces().collect { announce ->
-                        persistence.recordPeerActivity(
-                            destinationHash = announce.destinationHash.toHex(),
-                            activityType = PeerActivityType.ANNOUNCE,
-                            receivedAt = now(),
-                        )
-                    }
+                    backend.core.observeAnnounces().collect(::persistAnnounceEvent)
                 }
                 launch(start = CoroutineStart.UNDISPATCHED) {
                     backend.lxmf.observeDeliveryStatus().collect { update ->
@@ -98,6 +96,55 @@ internal class PeerActivityCollector(
                 }
             }
         }.also { collectionJob = it }
+    }
+
+    private suspend fun persistAnnounceEvent(announce: AnnounceEvent) {
+        val destinationHash = announce.destinationHash.toHex()
+        val publicKey = announce.identity.publicKey
+        val parsedName =
+            announce.displayName
+                ?: announce.appData?.let {
+                    AppDataParser.parseDisplayName(it, announce.aspect.orEmpty())
+                }
+        val peerName =
+            parsedName?.takeIf(PeerNameResolver::isValidPeerName)
+                ?: PeerNameResolver.formatHashAsFallback(destinationHash)
+        val receivedAt = now()
+
+        if (publicKey.isEmpty()) {
+            // A malformed/incomplete announce cannot populate the announce
+            // identity row, but it still proves receiver-side activity.
+            persistence.recordPeerActivity(
+                destinationHash = destinationHash,
+                activityType = PeerActivityType.ANNOUNCE,
+                receivedAt = receivedAt,
+            )
+            return
+        }
+
+        // Persist below the IPC boundary. Announce events are non-replaying;
+        // relying on the UI-process MessageCollector loses the display name
+        // whenever the UI is absent or attaches after this event.
+        persistence.persistAnnounce(
+            destinationHash = destinationHash,
+            peerName = peerName,
+            publicKey = publicKey,
+            appData = announce.appData,
+            hops = announce.hops,
+            timestamp = receivedAt,
+            nodeType = announce.nodeType.name,
+            receivingInterface = announce.receivingInterface,
+            receivingInterfaceType = InterfaceType.fromName(announce.receivingInterface).storageName,
+            aspect = announce.aspect,
+            stampCost = announce.stampCost,
+            stampCostFlexibility = announce.stampCostFlexibility,
+            peeringCost = announce.peeringCost,
+            propagationTransferLimitKb = null,
+        )
+        val identityHash = announce.identity.hash.toHex()
+        if (identityHash.isNotEmpty()) {
+            persistence.persistPeerIdentity(identityHash, publicKey)
+        }
     }
 
     private fun ByteArray.toHex(): String = joinToString("") { "%02x".format(it) }

--- a/rns-host/src/main/kotlin/network/columba/app/rns/host/persistence/PeerActivityCollector.kt
+++ b/rns-host/src/main/kotlin/network/columba/app/rns/host/persistence/PeerActivityCollector.kt
@@ -141,10 +141,6 @@ internal class PeerActivityCollector(
             peeringCost = announce.peeringCost,
             propagationTransferLimitKb = null,
         )
-        val identityHash = announce.identity.hash.toHex()
-        if (identityHash.isNotEmpty()) {
-            persistence.persistPeerIdentity(identityHash, publicKey)
-        }
     }
 
     private fun ByteArray.toHex(): String = joinToString("") { "%02x".format(it) }

--- a/rns-host/src/main/kotlin/network/columba/app/rns/host/persistence/PeerActivityCollector.kt
+++ b/rns-host/src/main/kotlin/network/columba/app/rns/host/persistence/PeerActivityCollector.kt
@@ -112,13 +112,8 @@ internal class PeerActivityCollector(
         val receivedAt = now()
 
         if (publicKey.isEmpty()) {
-            // A malformed/incomplete announce cannot populate the announce
-            // identity row, but it still proves receiver-side activity.
-            persistence.recordPeerActivity(
-                destinationHash = destinationHash,
-                activityType = PeerActivityType.ANNOUNCE,
-                receivedAt = receivedAt,
-            )
+            // Without a validated identity key, do not let malformed or
+            // blackholed announces repopulate durable activity.
             return
         }
 

--- a/rns-host/src/main/kotlin/network/columba/app/rns/host/persistence/ServicePersistenceManager.kt
+++ b/rns-host/src/main/kotlin/network/columba/app/rns/host/persistence/ServicePersistenceManager.kt
@@ -2,6 +2,7 @@ package network.columba.app.rns.host.persistence
 
 import android.content.Context
 import android.util.Log
+import androidx.room.withTransaction
 import network.columba.app.data.db.ColumbaDatabase
 import network.columba.app.data.db.entity.AnnounceEntity
 import network.columba.app.data.db.entity.AnnounceInterfaceSightingEntity
@@ -126,62 +127,64 @@ class ServicePersistenceManager(
                 Log.d(TAG, "Ignoring announce from blocked peer: ${normalizedHash.take(16)}")
                 false
             } else {
-                // Preserve favorite status and richer metadata if a later announce
-                // omits fields which were previously learned.
-                val existing = announceDao.getAnnounce(normalizedHash)
-                val persistedName =
-                    peerName.takeIf(PeerNameResolver::isValidPeerName)
-                        ?: existing?.peerName?.takeIf(PeerNameResolver::isValidPeerName)
-                        ?: PeerNameResolver.formatHashAsFallback(normalizedHash)
-                val declaredInterfaceType = InterfaceType.fromName(receivingInterfaceType)
-                val canonicalInterfaceType =
-                    declaredInterfaceType.takeUnless { it == InterfaceType.UNKNOWN }
-                        ?: InterfaceType.fromName(receivingInterface)
-                val identityHash = HashUtils.computeIdentityHash(publicKey)
+                database.withTransaction {
+                    // Preserve favorite status and richer metadata if a later announce
+                    // omits fields which were previously learned.
+                    val existing = announceDao.getAnnounce(normalizedHash)
+                    val persistedName =
+                        peerName.takeIf(PeerNameResolver::isValidPeerName)
+                            ?: existing?.peerName?.takeIf(PeerNameResolver::isValidPeerName)
+                            ?: PeerNameResolver.formatHashAsFallback(normalizedHash)
+                    val declaredInterfaceType = InterfaceType.fromName(receivingInterfaceType)
+                    val canonicalInterfaceType =
+                        declaredInterfaceType.takeUnless { it == InterfaceType.UNKNOWN }
+                            ?: InterfaceType.fromName(receivingInterface)
+                    val identityHash = HashUtils.computeIdentityHash(publicKey)
 
-                val entity =
-                    AnnounceEntity(
-                        destinationHash = normalizedHash,
-                        peerName = persistedName,
-                        publicKey = publicKey,
-                        appData = appData,
-                        hops = hops,
-                        lastSeenTimestamp = timestamp,
-                        nodeType = nodeType,
-                        receivingInterface = receivingInterface,
-                        receivingInterfaceType = canonicalInterfaceType.storageName,
-                        aspect = aspect,
-                        isFavorite = existing?.isFavorite ?: false,
-                        favoritedTimestamp = existing?.favoritedTimestamp,
-                        stampCost = stampCost,
-                        stampCostFlexibility = stampCostFlexibility,
-                        peeringCost = peeringCost,
-                        propagationTransferLimitKb =
-                            propagationTransferLimitKb ?: existing?.propagationTransferLimitKb,
-                        computedIdentityHash = identityHash,
-                    )
-                val sighting =
-                    AnnounceInterfaceSightingEntity(
-                        destinationHash = normalizedHash,
-                        interfaceType = canonicalInterfaceType.storageName,
-                        receivingInterface = receivingInterface,
-                        lastSeenTimestamp = timestamp,
-                        hops = hops,
-                    )
+                    val entity =
+                        AnnounceEntity(
+                            destinationHash = normalizedHash,
+                            peerName = persistedName,
+                            publicKey = publicKey,
+                            appData = appData,
+                            hops = hops,
+                            lastSeenTimestamp = timestamp,
+                            nodeType = nodeType,
+                            receivingInterface = receivingInterface,
+                            receivingInterfaceType = canonicalInterfaceType.storageName,
+                            aspect = aspect,
+                            isFavorite = existing?.isFavorite ?: false,
+                            favoritedTimestamp = existing?.favoritedTimestamp,
+                            stampCost = stampCost,
+                            stampCostFlexibility = stampCostFlexibility,
+                            peeringCost = peeringCost,
+                            propagationTransferLimitKb =
+                                propagationTransferLimitKb ?: existing?.propagationTransferLimitKb,
+                            computedIdentityHash = identityHash,
+                        )
+                    val sighting =
+                        AnnounceInterfaceSightingEntity(
+                            destinationHash = normalizedHash,
+                            interfaceType = canonicalInterfaceType.storageName,
+                            receivingInterface = receivingInterface,
+                            lastSeenTimestamp = timestamp,
+                            hops = hops,
+                        )
 
-                announceDao.upsertAnnounceWithSighting(entity, sighting)
-                peerActivityDao.recordActivity(
-                    destinationHash = normalizedHash,
-                    receivedAt = timestamp,
-                    activityType = PeerActivityType.ANNOUNCE,
-                )
-                peerIdentityDao.insertPeerIdentity(
-                    PeerIdentityEntity(
-                        peerHash = identityHash,
-                        publicKey = publicKey,
-                        lastSeenTimestamp = timestamp,
-                    ),
-                )
+                    announceDao.upsertAnnounceWithSighting(entity, sighting)
+                    peerActivityDao.recordActivity(
+                        destinationHash = normalizedHash,
+                        receivedAt = timestamp,
+                        activityType = PeerActivityType.ANNOUNCE,
+                    )
+                    peerIdentityDao.insertPeerIdentity(
+                        PeerIdentityEntity(
+                            peerHash = identityHash,
+                            publicKey = publicKey,
+                            lastSeenTimestamp = timestamp,
+                        ),
+                    )
+                }
                 Log.d(TAG, "Service persisted announce: ${normalizedHash.take(16)}")
                 true
             }

--- a/rns-host/src/main/kotlin/network/columba/app/rns/host/persistence/ServicePersistenceManager.kt
+++ b/rns-host/src/main/kotlin/network/columba/app/rns/host/persistence/ServicePersistenceManager.kt
@@ -97,12 +97,13 @@ class ServicePersistenceManager(
 
     /**
      * Persist an announce to the database.
-     * Called from EventHandler.handleAnnounceEvent() in the service process.
+     * Called from PeerActivityCollector in the service process. This suspends
+     * until the announce, activity, and derived peer identity are persisted.
      *
      * This preserves existing favorite status and icon appearance.
      */
     @Suppress("LongParameterList") // Parameters mirror AnnounceEntity fields for direct persistence
-    fun persistAnnounce(
+    suspend fun persistAnnounce(
         destinationHash: String,
         peerName: String,
         publicKey: ByteArray,
@@ -117,22 +118,31 @@ class ServicePersistenceManager(
         stampCostFlexibility: Int?,
         peeringCost: Int?,
         propagationTransferLimitKb: Int?,
-    ) {
-        scope.launch {
-            try {
-                // Preserve favorite status if announce already exists
-                // Note: Icons are stored separately in peer_icons table (from LXMF messages)
-                val normalizedHash = destinationHash.lowercase()
+    ): Boolean =
+        try {
+            val normalizedHash = destinationHash.lowercase()
+            val activeIdentity = localIdentityDao.getActiveIdentitySync()
+            if (activeIdentity != null && isBlockedPeer(normalizedHash, activeIdentity.identityHash)) {
+                Log.d(TAG, "Ignoring announce from blocked peer: ${normalizedHash.take(16)}")
+                false
+            } else {
+                // Preserve favorite status and richer metadata if a later announce
+                // omits fields which were previously learned.
                 val existing = announceDao.getAnnounce(normalizedHash)
+                val persistedName =
+                    peerName.takeIf(PeerNameResolver::isValidPeerName)
+                        ?: existing?.peerName?.takeIf(PeerNameResolver::isValidPeerName)
+                        ?: PeerNameResolver.formatHashAsFallback(normalizedHash)
                 val declaredInterfaceType = InterfaceType.fromName(receivingInterfaceType)
                 val canonicalInterfaceType =
                     declaredInterfaceType.takeUnless { it == InterfaceType.UNKNOWN }
                         ?: InterfaceType.fromName(receivingInterface)
+                val identityHash = HashUtils.computeIdentityHash(publicKey)
 
                 val entity =
                     AnnounceEntity(
                         destinationHash = normalizedHash,
-                        peerName = peerName,
+                        peerName = persistedName,
                         publicKey = publicKey,
                         appData = appData,
                         hops = hops,
@@ -146,8 +156,9 @@ class ServicePersistenceManager(
                         stampCost = stampCost,
                         stampCostFlexibility = stampCostFlexibility,
                         peeringCost = peeringCost,
-                        propagationTransferLimitKb = propagationTransferLimitKb,
-                        computedIdentityHash = HashUtils.computeIdentityHash(publicKey),
+                        propagationTransferLimitKb =
+                            propagationTransferLimitKb ?: existing?.propagationTransferLimitKb,
+                        computedIdentityHash = identityHash,
                     )
                 val sighting =
                     AnnounceInterfaceSightingEntity(
@@ -164,12 +175,20 @@ class ServicePersistenceManager(
                     receivedAt = timestamp,
                     activityType = PeerActivityType.ANNOUNCE,
                 )
-                Log.d(TAG, "Service persisted announce: ${destinationHash.take(16)}")
-            } catch (e: Exception) {
-                Log.e(TAG, "Error persisting announce in service: $destinationHash", e)
+                peerIdentityDao.insertPeerIdentity(
+                    PeerIdentityEntity(
+                        peerHash = identityHash,
+                        publicKey = publicKey,
+                        lastSeenTimestamp = timestamp,
+                    ),
+                )
+                Log.d(TAG, "Service persisted announce: ${normalizedHash.take(16)}")
+                true
             }
+        } catch (e: Exception) {
+            Log.e(TAG, "Error persisting announce in service: $destinationHash", e)
+            false
         }
-    }
 
     /**
      * Persist a peer's public key to the database.

--- a/rns-host/src/test/kotlin/network/columba/app/rns/host/persistence/PeerActivityCollectorTest.kt
+++ b/rns-host/src/test/kotlin/network/columba/app/rns/host/persistence/PeerActivityCollectorTest.kt
@@ -1,12 +1,9 @@
 package network.columba.app.rns.host.persistence
 
-import io.mockk.Runs
 import io.mockk.coEvery
 import io.mockk.coVerify
 import io.mockk.every
-import io.mockk.just
 import io.mockk.mockk
-import io.mockk.verify
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.test.advanceUntilIdle
@@ -62,12 +59,11 @@ class PeerActivityCollectorTest {
         coEvery { persistence.persistReactionActivity(any(), any(), any()) } returns true
         coEvery { persistence.persistDeliveryProof(any(), any()) } returns true
         coEvery { persistence.persistTelemetryActivity(any(), any(), any(), any()) } returns true
-        every {
+        coEvery {
             persistence.persistAnnounce(
                 any(), any(), any(), any(), any(), any(), any(), any(), any(), any(), any(), any(), any(), any(),
             )
-        } just Runs
-        every { persistence.persistPeerIdentity(any(), any()) } just Runs
+        } returns true
 
         val collector = PeerActivityCollector(backend, persistence) { 500L }
         val firstJob = collector.start(this)
@@ -79,7 +75,7 @@ class PeerActivityCollectorTest {
         messages.emit(ReceivedMessage("message", "hello", source, ByteArray(16), Long.MAX_VALUE))
         val announcePublicKey = ByteArray(32) { (it + 1).toByte() }
         val announceIdentityHash = ByteArray(16) { (it + 32).toByte() }
-        announces.emit(iosDeliveryAnnounce(source, announceIdentityHash, announcePublicKey))
+        announces.emit(lxmfDeliveryAnnounce(source, announceIdentityHash, announcePublicKey))
         statuses.emit(DeliveryStatusUpdate("delivered", "delivered", Long.MAX_VALUE))
         statuses.emit(DeliveryStatusUpdate("failed", "failed", Long.MAX_VALUE))
         statuses.emit(DeliveryStatusUpdate("propagated", "propagated", Long.MAX_VALUE))
@@ -95,7 +91,7 @@ class PeerActivityCollectorTest {
         links.emit(LinkEvent.Closed(link, "closed"))
         runCurrent()
 
-        verifyInboundPersistence(persistence, source, announceIdentityHash, announcePublicKey)
+        verifyInboundPersistence(persistence, source, announcePublicKey)
 
         firstJob.cancel()
         runCurrent()
@@ -105,7 +101,7 @@ class PeerActivityCollectorTest {
         advanceUntilIdle()
     }
 
-    private fun iosDeliveryAnnounce(
+    private fun lxmfDeliveryAnnounce(
         destinationHash: ByteArray,
         identityHash: ByteArray,
         publicKey: ByteArray,
@@ -119,7 +115,7 @@ class PeerActivityCollectorTest {
         appData =
             byteArrayOf(0x93.toByte(), 0xc4.toByte(), 0x08.toByte()) +
                 "iOS Name".encodeToByteArray() +
-                byteArrayOf(0xc0.toByte(), 0x91.toByte(), 0x01.toByte()),
+                byteArrayOf(0xc0.toByte(), 0x91.toByte(), 0x00.toByte()),
         hops = 1,
         timestamp = Long.MAX_VALUE,
         nodeType = NodeType.PEER,
@@ -131,15 +127,13 @@ class PeerActivityCollectorTest {
     private fun verifyInboundPersistence(
         persistence: ServicePersistenceManager,
         source: ByteArray,
-        announceIdentityHash: ByteArray,
         announcePublicKey: ByteArray,
     ) {
         val sourceHex = source.joinToString("") { "%02x".format(it) }
-        val identityHex = announceIdentityHash.joinToString("") { "%02x".format(it) }
         coVerify(exactly = 1) {
             persistence.persistIncomingMessageActivity("message", sourceHex, null, 500L)
         }
-        verify(exactly = 1) {
+        coVerify(exactly = 1) {
             persistence.persistAnnounce(
                 destinationHash = sourceHex,
                 peerName = "iOS Name",
@@ -157,7 +151,6 @@ class PeerActivityCollectorTest {
                 propagationTransferLimitKb = null,
             )
         }
-        verify(exactly = 1) { persistence.persistPeerIdentity(identityHex, announcePublicKey) }
         coVerify(exactly = 1) { persistence.persistDeliveryProof("delivered", 500L) }
         coVerify(exactly = 0) { persistence.persistDeliveryProof("failed", any()) }
         coVerify(exactly = 0) { persistence.persistDeliveryProof("propagated", any()) }

--- a/rns-host/src/test/kotlin/network/columba/app/rns/host/persistence/PeerActivityCollectorTest.kt
+++ b/rns-host/src/test/kotlin/network/columba/app/rns/host/persistence/PeerActivityCollectorTest.kt
@@ -76,6 +76,7 @@ class PeerActivityCollectorTest {
         val announcePublicKey = ByteArray(32) { (it + 1).toByte() }
         val announceIdentityHash = ByteArray(16) { (it + 32).toByte() }
         announces.emit(lxmfDeliveryAnnounce(source, announceIdentityHash, announcePublicKey))
+        announces.emit(lxmfDeliveryAnnounce(source, announceIdentityHash, byteArrayOf()))
         statuses.emit(DeliveryStatusUpdate("delivered", "delivered", Long.MAX_VALUE))
         statuses.emit(DeliveryStatusUpdate("failed", "failed", Long.MAX_VALUE))
         statuses.emit(DeliveryStatusUpdate("propagated", "propagated", Long.MAX_VALUE))
@@ -150,6 +151,9 @@ class PeerActivityCollectorTest {
                 peeringCost = null,
                 propagationTransferLimitKb = null,
             )
+        }
+        coVerify(exactly = 0) {
+            persistence.recordPeerActivity(sourceHex, PeerActivityType.ANNOUNCE, any())
         }
         coVerify(exactly = 1) { persistence.persistDeliveryProof("delivered", 500L) }
         coVerify(exactly = 0) { persistence.persistDeliveryProof("failed", any()) }

--- a/rns-host/src/test/kotlin/network/columba/app/rns/host/persistence/PeerActivityCollectorTest.kt
+++ b/rns-host/src/test/kotlin/network/columba/app/rns/host/persistence/PeerActivityCollectorTest.kt
@@ -1,9 +1,12 @@
 package network.columba.app.rns.host.persistence
 
+import io.mockk.Runs
 import io.mockk.coEvery
 import io.mockk.coVerify
 import io.mockk.every
+import io.mockk.just
 import io.mockk.mockk
+import io.mockk.verify
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.test.advanceUntilIdle
@@ -21,6 +24,7 @@ import network.columba.app.rns.api.model.Identity
 import network.columba.app.rns.api.model.Link
 import network.columba.app.rns.api.model.LinkEvent
 import network.columba.app.rns.api.model.LocationTelemetry
+import network.columba.app.rns.api.model.NodeType
 import network.columba.app.rns.api.model.ReceivedMessage
 import org.junit.Assert.assertNotSame
 import org.junit.Assert.assertSame
@@ -58,6 +62,12 @@ class PeerActivityCollectorTest {
         coEvery { persistence.persistReactionActivity(any(), any(), any()) } returns true
         coEvery { persistence.persistDeliveryProof(any(), any()) } returns true
         coEvery { persistence.persistTelemetryActivity(any(), any(), any(), any()) } returns true
+        every {
+            persistence.persistAnnounce(
+                any(), any(), any(), any(), any(), any(), any(), any(), any(), any(), any(), any(), any(), any(),
+            )
+        } just Runs
+        every { persistence.persistPeerIdentity(any(), any()) } just Runs
 
         val collector = PeerActivityCollector(backend, persistence) { 500L }
         val firstJob = collector.start(this)
@@ -67,15 +77,9 @@ class PeerActivityCollectorTest {
 
         val source = ByteArray(16) { it.toByte() }
         messages.emit(ReceivedMessage("message", "hello", source, ByteArray(16), Long.MAX_VALUE))
-        announces.emit(
-            AnnounceEvent(
-                destinationHash = source,
-                identity = Identity(ByteArray(16), ByteArray(32), null),
-                appData = null,
-                hops = 1,
-                timestamp = Long.MAX_VALUE,
-            ),
-        )
+        val announcePublicKey = ByteArray(32) { (it + 1).toByte() }
+        val announceIdentityHash = ByteArray(16) { (it + 32).toByte() }
+        announces.emit(iosDeliveryAnnounce(source, announceIdentityHash, announcePublicKey))
         statuses.emit(DeliveryStatusUpdate("delivered", "delivered", Long.MAX_VALUE))
         statuses.emit(DeliveryStatusUpdate("failed", "failed", Long.MAX_VALUE))
         statuses.emit(DeliveryStatusUpdate("propagated", "propagated", Long.MAX_VALUE))
@@ -91,7 +95,7 @@ class PeerActivityCollectorTest {
         links.emit(LinkEvent.Closed(link, "closed"))
         runCurrent()
 
-        verifyInboundPersistence(persistence, source)
+        verifyInboundPersistence(persistence, source, announceIdentityHash, announcePublicKey)
 
         firstJob.cancel()
         runCurrent()
@@ -101,17 +105,59 @@ class PeerActivityCollectorTest {
         advanceUntilIdle()
     }
 
+    private fun iosDeliveryAnnounce(
+        destinationHash: ByteArray,
+        identityHash: ByteArray,
+        publicKey: ByteArray,
+    ) = AnnounceEvent(
+        destinationHash = destinationHash,
+        identity = Identity(identityHash, publicKey, null),
+        // Canonical LXMF delivery announce: msgpack
+        // [binary display_name, nil stamp_cost, supported_functions].
+        // Leave displayName null to prove service-side persistence can recover
+        // the iOS name directly from app_data below the IPC seam.
+        appData =
+            byteArrayOf(0x93.toByte(), 0xc4.toByte(), 0x08.toByte()) +
+                "iOS Name".encodeToByteArray() +
+                byteArrayOf(0xc0.toByte(), 0x91.toByte(), 0x01.toByte()),
+        hops = 1,
+        timestamp = Long.MAX_VALUE,
+        nodeType = NodeType.PEER,
+        receivingInterface = "Bluetooth_LE",
+        aspect = "lxmf.delivery",
+        displayName = null,
+    )
+
     private fun verifyInboundPersistence(
         persistence: ServicePersistenceManager,
         source: ByteArray,
+        announceIdentityHash: ByteArray,
+        announcePublicKey: ByteArray,
     ) {
         val sourceHex = source.joinToString("") { "%02x".format(it) }
+        val identityHex = announceIdentityHash.joinToString("") { "%02x".format(it) }
         coVerify(exactly = 1) {
             persistence.persistIncomingMessageActivity("message", sourceHex, null, 500L)
         }
-        coVerify(exactly = 1) {
-            persistence.recordPeerActivity(sourceHex, PeerActivityType.ANNOUNCE, 500L)
+        verify(exactly = 1) {
+            persistence.persistAnnounce(
+                destinationHash = sourceHex,
+                peerName = "iOS Name",
+                publicKey = announcePublicKey,
+                appData = any(),
+                hops = 1,
+                timestamp = 500L,
+                nodeType = NodeType.PEER.name,
+                receivingInterface = "Bluetooth_LE",
+                receivingInterfaceType = any(),
+                aspect = "lxmf.delivery",
+                stampCost = null,
+                stampCostFlexibility = null,
+                peeringCost = null,
+                propagationTransferLimitKb = null,
+            )
         }
+        verify(exactly = 1) { persistence.persistPeerIdentity(identityHex, announcePublicKey) }
         coVerify(exactly = 1) { persistence.persistDeliveryProof("delivered", 500L) }
         coVerify(exactly = 0) { persistence.persistDeliveryProof("failed", any()) }
         coVerify(exactly = 0) { persistence.persistDeliveryProof("propagated", any()) }

--- a/rns-host/src/test/kotlin/network/columba/app/rns/host/persistence/ServicePersistenceManagerTest.kt
+++ b/rns-host/src/test/kotlin/network/columba/app/rns/host/persistence/ServicePersistenceManagerTest.kt
@@ -3,6 +3,7 @@ package network.columba.app.rns.host.persistence
 import android.content.Context
 import network.columba.app.data.db.ColumbaDatabase
 import network.columba.app.data.db.dao.AnnounceDao
+import network.columba.app.data.db.dao.BlockedPeerDao
 import network.columba.app.data.db.dao.ContactDao
 import network.columba.app.data.db.dao.ConversationDao
 import network.columba.app.data.db.dao.LocalIdentityDao
@@ -14,6 +15,7 @@ import network.columba.app.data.db.entity.AnnounceEntity
 import network.columba.app.data.db.entity.ConversationEntity
 import network.columba.app.data.db.entity.LocalIdentityEntity
 import network.columba.app.data.db.entity.MessageEntity
+import network.columba.app.data.util.HashUtils
 import network.columba.app.rns.host.di.ServiceDatabaseProvider
 import io.mockk.Runs
 import io.mockk.clearAllMocks
@@ -47,6 +49,7 @@ class ServicePersistenceManagerTest {
     private lateinit var testScope: TestScope
     private lateinit var database: ColumbaDatabase
     private lateinit var announceDao: AnnounceDao
+    private lateinit var blockedPeerDao: BlockedPeerDao
     private lateinit var contactDao: ContactDao
     private lateinit var messageDao: MessageDao
     private lateinit var conversationDao: ConversationDao
@@ -69,6 +72,7 @@ class ServicePersistenceManagerTest {
         testScope = TestScope(UnconfinedTestDispatcher())
         database = mockk()
         announceDao = mockk()
+        blockedPeerDao = mockk()
         contactDao = mockk()
         messageDao = mockk()
         conversationDao = mockk()
@@ -80,6 +84,7 @@ class ServicePersistenceManagerTest {
 
         // Mock database DAOs
         every { database.announceDao() } returns announceDao
+        every { database.blockedPeerDao() } returns blockedPeerDao
         every { database.contactDao() } returns contactDao
         every { database.messageDao() } returns messageDao
         every { database.conversationDao() } returns conversationDao
@@ -88,6 +93,8 @@ class ServicePersistenceManagerTest {
         every { database.peerActivityDao() } returns peerActivityDao
         every { database.peerIconDao() } returns peerIconDao
         coEvery { peerActivityDao.recordActivity(any(), any(), any()) } just Runs
+        coEvery { peerIdentityDao.insertPeerIdentity(any()) } just Runs
+        coEvery { localIdentityDao.getActiveIdentitySync() } returns null
 
         // Mock ServiceDatabaseProvider singleton
         mockkObject(ServiceDatabaseProvider)
@@ -231,6 +238,14 @@ class ServicePersistenceManagerTest {
                     any(),
                 )
             }
+            coVerify {
+                peerIdentityDao.insertPeerIdentity(
+                    match { identity ->
+                        identity.peerHash == HashUtils.computeIdentityHash(testPublicKey) &&
+                            identity.publicKey.contentEquals(testPublicKey)
+                    },
+                )
+            }
         }
 
     @Test
@@ -263,6 +278,90 @@ class ServicePersistenceManagerTest {
 
             // Verify exception was handled (no crash)
             assertTrue("persistAnnounce should handle exception gracefully", result.isSuccess)
+        }
+
+    @Test
+    fun `persistAnnounce preserves valid name and propagation limit when omitted`() =
+        runTest {
+            val existing =
+                AnnounceEntity(
+                    destinationHash = testDestinationHash,
+                    peerName = "Known Peer",
+                    publicKey = testPublicKey,
+                    appData = null,
+                    hops = 1,
+                    lastSeenTimestamp = 100L,
+                    nodeType = "PROPAGATION_NODE",
+                    receivingInterface = "BLE",
+                    propagationTransferLimitKb = 512,
+                )
+            coEvery { announceDao.getAnnounce(testDestinationHash) } returns existing
+            coEvery { announceDao.upsertAnnounceWithSighting(any(), any()) } just Runs
+
+            val persisted =
+                persistenceManager.persistAnnounce(
+                    destinationHash = testDestinationHash,
+                    peerName = "Peer 01020304",
+                    publicKey = testPublicKey,
+                    appData = null,
+                    hops = 2,
+                    timestamp = 200L,
+                    nodeType = "PROPAGATION_NODE",
+                    receivingInterface = "BLE",
+                    receivingInterfaceType = "BLE",
+                    aspect = "lxmf.propagation",
+                    stampCost = null,
+                    stampCostFlexibility = null,
+                    peeringCost = null,
+                    propagationTransferLimitKb = null,
+                )
+
+            assertTrue(persisted)
+            coVerify {
+                announceDao.upsertAnnounceWithSighting(
+                    match { it.peerName == "Known Peer" && it.propagationTransferLimitKb == 512 },
+                    any(),
+                )
+            }
+        }
+
+    @Test
+    fun `persistAnnounce rejects peers blocked for the active identity`() =
+        runTest {
+            val activeIdentity =
+                LocalIdentityEntity(
+                    identityHash = testIdentityHash,
+                    displayName = "Test",
+                    destinationHash = "local_destination",
+                    filePath = "/test/path",
+                    createdTimestamp = 1L,
+                    lastUsedTimestamp = 1L,
+                    isActive = true,
+                )
+            coEvery { localIdentityDao.getActiveIdentitySync() } returns activeIdentity
+            coEvery { blockedPeerDao.isBlocked(testDestinationHash, testIdentityHash) } returns true
+
+            val persisted =
+                persistenceManager.persistAnnounce(
+                    destinationHash = testDestinationHash,
+                    peerName = "Blocked Peer",
+                    publicKey = testPublicKey,
+                    appData = null,
+                    hops = 1,
+                    timestamp = 200L,
+                    nodeType = "PEER",
+                    receivingInterface = "BLE",
+                    receivingInterfaceType = "BLE",
+                    aspect = "lxmf.delivery",
+                    stampCost = null,
+                    stampCostFlexibility = null,
+                    peeringCost = null,
+                    propagationTransferLimitKb = null,
+                )
+
+            assertFalse(persisted)
+            coVerify(exactly = 0) { announceDao.upsertAnnounceWithSighting(any(), any()) }
+            coVerify(exactly = 0) { peerIdentityDao.insertPeerIdentity(any()) }
         }
 
     // ========== persistPeerIdentity() Tests ==========

--- a/rns-host/src/test/kotlin/network/columba/app/rns/host/persistence/ServicePersistenceManagerTest.kt
+++ b/rns-host/src/test/kotlin/network/columba/app/rns/host/persistence/ServicePersistenceManagerTest.kt
@@ -1,6 +1,7 @@
 package network.columba.app.rns.host.persistence
 
 import android.content.Context
+import androidx.room.withTransaction
 import network.columba.app.data.db.ColumbaDatabase
 import network.columba.app.data.db.dao.AnnounceDao
 import network.columba.app.data.db.dao.BlockedPeerDao
@@ -25,7 +26,9 @@ import io.mockk.every
 import io.mockk.just
 import io.mockk.mockk
 import io.mockk.mockkObject
+import io.mockk.mockkStatic
 import io.mockk.unmockkObject
+import io.mockk.unmockkStatic
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.TestScope
 import kotlinx.coroutines.test.UnconfinedTestDispatcher
@@ -99,6 +102,10 @@ class ServicePersistenceManagerTest {
         // Mock ServiceDatabaseProvider singleton
         mockkObject(ServiceDatabaseProvider)
         every { ServiceDatabaseProvider.getDatabase(any()) } returns database
+        mockkStatic("androidx.room.RoomDatabaseKt")
+        coEvery { database.withTransaction<Unit>(any()) } coAnswers {
+            secondArg<suspend () -> Unit>().invoke()
+        }
 
         // Default: don't block unknown senders
         every { settingsAccessor.getBlockUnknownSenders() } returns false
@@ -108,6 +115,7 @@ class ServicePersistenceManagerTest {
 
     @After
     fun tearDown() {
+        unmockkStatic("androidx.room.RoomDatabaseKt")
         unmockkObject(ServiceDatabaseProvider)
         clearAllMocks()
     }
@@ -143,6 +151,7 @@ class ServicePersistenceManagerTest {
             testScope.advanceUntilIdle()
 
             assertTrue("persistAnnounce should complete without throwing", result.isSuccess)
+            coVerify(exactly = 1) { database.withTransaction<Unit>(any()) }
             coVerify { announceDao.upsertAnnounceWithSighting(any(), any()) }
         }
 


### PR DESCRIPTION
## Summary

- persist full peer announces in the service-lifecycle collector instead of relying on the non-replaying UI IPC observer
- recover LXMF display names from canonical announce `app_data` when a backend does not populate `displayName`
- persist peer identity material alongside the announce with structured, completion-bound writes
- enforce blocked-peer admission, reject incomplete announces, and preserve valid names and propagation limits
- add a regression using the canonical iOS/LXMF MessagePack announce shape

## Problem

LXMF display names are advertised through `lxmf.delivery` announces, not ordinary messages. Android's service-owned collector recorded only announce activity, while full announce persistence lived in a UI-process collector. If the UI process was absent or subscribed after the non-replaying event, later messages had no persisted announce name and fell back to `Peer <hash>`.

## Verification

- `PeerActivityCollectorTest` failed before the production change and passes for both backend flavors
- exact CI quality gate: `ktlintCheck detekt cpdCheck lint :app:lintNoSentryKotlinBackendDebug :rns-host:lintPythonBackendDebug --continue`
- full CI module-test command plus final affected-module rerun: 1,838 tests, 0 failures (6 skipped)
- threading architecture audit: 0 violations, 0 warnings
- `assembleNoSentryPythonBackendDebug`: passed
- `assembleNoSentryKotlinBackendDebug`: passed
- both arm64 debug APK signatures verified
- `git diff --check`: passed

## Risk and rollback

Risk is limited to announce persistence in the service process. Existing UI-process persistence may upsert the same destination afterward; the DAO path is already idempotent and local contact aliases continue to take precedence over remotely announced names. Reverting this PR restores the previous UI-owned behavior.

## Device validation

Installed the Python-backend arm64 debug APK in place on a physical Android 15 phone, preserving existing app data. Both UI and Reticulum service processes launched without a fatal exception, service-side announce persistence executed, and the user confirmed a fresh Columba iOS announce/message displayed the expected iOS name instead of the `Peer <hash>` fallback.
