### PR TITLE
chore(deps): bump LXST-kt to v0.0.5

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -22,7 +22,7 @@ desugarJdkLibs = "2.1.5"
 # JitPack-published libraries (formerly git submodules)
 reticulumKt = "v0.0.22"
 lxmfKt = "v0.0.14"
-lxstKt = "v0.0.5"
+lxstKt = "0.0.6"
 
 [libraries]
 # JitPack-published Reticulum/LXMF/LXST stack (migrated from git submodules)

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -22,7 +22,7 @@ desugarJdkLibs = "2.1.5"
 # JitPack-published libraries (formerly git submodules)
 reticulumKt = "v0.0.22"
 lxmfKt = "v0.0.14"
-lxstKt = "v0.0.4"
+lxstKt = "v0.0.5"
 
 [libraries]
 # JitPack-published Reticulum/LXMF/LXST stack (migrated from git submodules)


### PR DESCRIPTION
## Summary

- Bump LXST-kt from `v0.0.4` to `v0.0.5`.
- Consume the merged one-packet Codec2 playback policy from torlando-tech/LXST-kt#16.

## Provenance

- LXST tag: `v0.0.5`
- LXST merge commit: `399f77ad2822060516f5481656e47798a22582bf`
- LXST reviewed head: `106c60cbcf7e017b3a4b55f6191f9c1073198dbe`
- ULBW/VLBW/LBW startup targets: one decoded packet (`400/320/200 ms`).

## Verification

- Version catalog TOML parse: pass.
- `git diff --check`: pass.
- Changed files: one (`gradle/libs.versions.toml`).
- The exact reviewed LXST head previously passed 371 tests, native builds, lint, exact APK installation/read-back, and explicit MainActivity launch through local composite integration.

## Published-artifact check

The lowercase JitPack POM endpoint returned HTTP 404 from this local host with JitPack's cached failed build status. This PR intentionally exercises the public GitHub Actions runners against the tagged coordinate to determine whether resolution is runner-local or service-wide. No local published-artifact build success is claimed.
