### PR TITLE
deps: update LXST-kt to v0.0.7

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -23,7 +23,7 @@ desugarJdkLibs = "2.1.5"
 # JitPack-published libraries (formerly git submodules)
 reticulumKt = "v0.0.22"
 lxmfKt = "v0.0.14"
-lxstKt = "0.0.6"
+lxstKt = "v0.0.7"
 
 [libraries]
 # JitPack-published Reticulum/LXMF/LXST stack (migrated from git submodules)


### PR DESCRIPTION
## Summary

- Update LXST-kt from `0.0.6` to `v0.0.7`.
- Includes native playback geometry recreation and profile-switch lifecycle fixes from torlando-tech/LXST-kt#18.

## Verification

- JitPack POM resolves for `com.github.torlando-tech:LXST-kt:v0.0.7`.
- Gradle dependency insight selects `v0.0.7` for both Python and Kotlin backend runtime classpaths with local overrides disabled.
- `:app:assembleNoSentryPythonBackendDebug` passes.
