### PR TITLE
fix: harden restored identity recovery

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -539,28 +539,17 @@ jobs:
           emulator-options: -no-window -gpu swiftshader_indirect -noaudio -no-boot-anim -camera-back none -memory 2048
           disable-animations: true
           emulator-boot-timeout: 600
-          script: |
-            echo "Running emulator health check..."
-            adb shell getprop ro.build.version.sdk
-            adb shell pm list packages | head -5
-            echo "Emulator is responsive, starting tests..."
-            # Use test orchestrator for app-test isolation (configured in build.gradle.kts).
-            # Run every independent group even if an earlier group fails, so all reports
-            # and logcat evidence are available from a single emulator session.
-            status=0
-
-            if ! ./gradlew :app:connectedNoSentryKotlinBackendDebugAndroidTest -Pandroid.testInstrumentationRunnerArguments.class=network.columba.app.smoke.SmokeTest,network.columba.app.integration.MessageDataFlowTest,network.columba.app.integration.ConversationCreationFlowTest --stacktrace; then
-              status=1
-            fi
-
-            if ! ./gradlew :app:connectedNoSentryPythonBackendDebugAndroidTest -Pandroid.testInstrumentationRunnerArguments.class=network.columba.app.integration.IdentityRecoveryIpcInstrumentedTest,network.columba.app.integration.IdentityRecoveryPersistenceInstrumentedTest --stacktrace; then
-              status=1
-            fi
-
-            if ! ./gradlew :rns-backend-py:connectedDebugAndroidTest -Pandroid.testInstrumentationRunnerArguments.class=network.columba.app.rns.backend.py.PythonRnsCoreIdentityRecoveryInstrumentedTest --stacktrace; then
-              status=1
-            fi
-
+          # The emulator action executes each literal-script line as a separate shell.
+          # Fold this into one command so status is retained across all test groups.
+          script: >-
+            echo "Running emulator health check...";
+            adb shell getprop ro.build.version.sdk;
+            adb shell pm list packages | head -5;
+            echo "Emulator is responsive, starting tests...";
+            status=0;
+            ./gradlew :app:connectedNoSentryKotlinBackendDebugAndroidTest -Pandroid.testInstrumentationRunnerArguments.class=network.columba.app.smoke.SmokeTest,network.columba.app.integration.MessageDataFlowTest,network.columba.app.integration.ConversationCreationFlowTest --stacktrace || status=1;
+            ./gradlew :app:connectedNoSentryPythonBackendDebugAndroidTest -Pandroid.testInstrumentationRunnerArguments.class=network.columba.app.integration.IdentityRecoveryIpcInstrumentedTest,network.columba.app.integration.IdentityRecoveryPersistenceInstrumentedTest --stacktrace || status=1;
+            ./gradlew :rns-backend-py:connectedDebugAndroidTest -Pandroid.testInstrumentationRunnerArguments.class=network.columba.app.rns.backend.py.PythonRnsCoreIdentityRecoveryInstrumentedTest --stacktrace || status=1;
             exit "$status"
 
       - name: Upload instrumented test results

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -449,11 +449,11 @@ jobs:
           adb kill-server || true
 
   instrumented-tests:
-    name: Instrumented Tests
+    name: Instrumented Tests (Kotlin + Identity Recovery)
     # Run in parallel with other jobs
     needs: [lint, validate-wrapper]
     runs-on: ubuntu-latest
-    timeout-minutes: 45
+    timeout-minutes: 60
 
     steps:
       - name: Checkout code
@@ -467,6 +467,12 @@ jobs:
         with:
           distribution: temurin
           java-version: 25
+
+      - name: Set up Python 3.11
+        # Required by Chaquopy when building the Python-backend recovery tests.
+        uses: actions/setup-python@v7
+        with:
+          python-version: '3.11'
 
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@v6.2.0
@@ -493,6 +499,8 @@ jobs:
           echo "Building APKs before starting emulator..."
           ./gradlew :app:assembleNoSentryKotlinBackendDebugAndroidTest --stacktrace --max-workers=2
           ./gradlew :app:assembleNoSentryKotlinBackendDebug --stacktrace --max-workers=2
+          ./gradlew :app:assembleNoSentryPythonBackendDebugAndroidTest :app:assembleNoSentryPythonBackendDebug --stacktrace --max-workers=2
+          ./gradlew :rns-backend-py:assembleDebugAndroidTest :rns-backend-py:assembleDebug --stacktrace --max-workers=2
           echo "APKs built successfully"
 
       - name: AVD cache
@@ -536,9 +544,24 @@ jobs:
             adb shell getprop ro.build.version.sdk
             adb shell pm list packages | head -5
             echo "Emulator is responsive, starting tests..."
-            # Run smoke tests and integration tests
-            # Use test orchestrator for isolation (configured in build.gradle.kts)
-            ./gradlew :app:connectedNoSentryKotlinBackendDebugAndroidTest -Pandroid.testInstrumentationRunnerArguments.class=network.columba.app.smoke.SmokeTest,network.columba.app.integration.MessageDataFlowTest,network.columba.app.integration.ConversationCreationFlowTest --stacktrace
+            # Use test orchestrator for app-test isolation (configured in build.gradle.kts).
+            # Run every independent group even if an earlier group fails, so all reports
+            # and logcat evidence are available from a single emulator session.
+            status=0
+
+            if ! ./gradlew :app:connectedNoSentryKotlinBackendDebugAndroidTest -Pandroid.testInstrumentationRunnerArguments.class=network.columba.app.smoke.SmokeTest,network.columba.app.integration.MessageDataFlowTest,network.columba.app.integration.ConversationCreationFlowTest --stacktrace; then
+              status=1
+            fi
+
+            if ! ./gradlew :app:connectedNoSentryPythonBackendDebugAndroidTest -Pandroid.testInstrumentationRunnerArguments.class=network.columba.app.integration.IdentityRecoveryIpcInstrumentedTest,network.columba.app.integration.IdentityRecoveryPersistenceInstrumentedTest --stacktrace; then
+              status=1
+            fi
+
+            if ! ./gradlew :rns-backend-py:connectedDebugAndroidTest -Pandroid.testInstrumentationRunnerArguments.class=network.columba.app.rns.backend.py.PythonRnsCoreIdentityRecoveryInstrumentedTest --stacktrace; then
+              status=1
+            fi
+
+            exit "$status"
 
       - name: Upload instrumented test results
         if: always()

--- a/app/src/androidTest/java/network/columba/app/integration/IdentityRecoveryIpcInstrumentedTest.kt
+++ b/app/src/androidTest/java/network/columba/app/integration/IdentityRecoveryIpcInstrumentedTest.kt
@@ -1,0 +1,49 @@
+package network.columba.app.integration
+
+import android.content.Context
+import androidx.test.core.app.ApplicationProvider
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import dagger.hilt.android.EntryPointAccessors
+import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.withTimeout
+import network.columba.app.test.TestController
+import org.junit.Assert.assertArrayEquals
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotNull
+import org.junit.Test
+import org.junit.runner.RunWith
+
+@RunWith(AndroidJUnit4::class)
+class IdentityRecoveryIpcInstrumentedTest {
+    @Test
+    fun createAndImportRoundTripAcrossProductionBinder() = runBlocking {
+        val context = ApplicationProvider.getApplicationContext<Context>()
+        val entryPoint =
+            EntryPointAccessors.fromApplication(
+                context.applicationContext,
+                TestController.TestEntryPoint::class.java,
+            )
+        val core = entryPoint.rnsCore()
+
+        val created =
+            withTimeout(60_000) {
+                core.createIdentityWithName("Disposable recovery IPC fixture")
+            }
+        val identityHash = created["identity_hash"] as? String
+        val destinationHash = created["destination_hash"] as? String
+        val keyData = created["key_data"] as? ByteArray
+        assertEquals(true, created["success"])
+        assertNotNull(identityHash)
+        assertEquals(32, destinationHash?.length)
+        assertEquals(64, keyData?.size)
+
+        val imported =
+            withTimeout(60_000) {
+                core.importIdentityFile(checkNotNull(keyData), "Disposable imported fixture")
+            }
+        assertEquals(true, imported["success"])
+        assertEquals(identityHash, imported["identity_hash"])
+        assertEquals(destinationHash, imported["destination_hash"])
+        assertArrayEquals(keyData, imported["key_data"] as ByteArray)
+    }
+}

--- a/app/src/androidTest/java/network/columba/app/integration/IdentityRecoveryPersistenceInstrumentedTest.kt
+++ b/app/src/androidTest/java/network/columba/app/integration/IdentityRecoveryPersistenceInstrumentedTest.kt
@@ -1,0 +1,205 @@
+package network.columba.app.integration
+
+import android.content.Context
+import androidx.room.Room
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import androidx.test.platform.app.InstrumentationRegistry
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.runBlocking
+import network.columba.app.data.crypto.IdentityKeyEncryptor
+import network.columba.app.data.crypto.IdentityKeyMigrator
+import network.columba.app.data.crypto.IdentityKeyProvider
+import network.columba.app.data.db.ColumbaDatabase
+import network.columba.app.data.db.entity.ConversationEntity
+import network.columba.app.data.db.entity.LocalIdentityEntity
+import network.columba.app.data.db.entity.MessageEntity
+import network.columba.app.data.repository.IdentityRepository
+import org.junit.After
+import org.junit.Assert.assertArrayEquals
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+
+@RunWith(AndroidJUnit4::class)
+class IdentityRecoveryPersistenceInstrumentedTest {
+    private val identityHash = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+    private val destinationHash = "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+    private val peerHash = "cccccccccccccccccccccccccccccccc"
+    private val recoveredKey = ByteArray(64) { index -> (index + 1).toByte() }
+
+    private lateinit var context: Context
+    private lateinit var database: ColumbaDatabase
+    private lateinit var repository: IdentityRepository
+
+    @Before
+    fun setUp() {
+        context = InstrumentationRegistry.getInstrumentation().targetContext
+        database =
+            Room
+                .inMemoryDatabaseBuilder(context, ColumbaDatabase::class.java)
+                .allowMainThreadQueries()
+                .build()
+        val encryptor = IdentityKeyEncryptor()
+        val identityDao = database.localIdentityDao()
+        lateinit var keyProvider: IdentityKeyProvider
+        InstrumentationRegistry.getInstrumentation().runOnMainSync {
+            keyProvider = IdentityKeyProvider(context, identityDao, encryptor)
+        }
+        repository =
+            IdentityRepository(
+                identityDao = identityDao,
+                database = database,
+                context = context,
+                ioDispatcher = Dispatchers.IO,
+                keyEncryptor = encryptor,
+                keyMigrator = IdentityKeyMigrator(context, identityDao, encryptor),
+                keyProvider = keyProvider,
+            )
+    }
+
+    @After
+    fun tearDown() {
+        database.close()
+    }
+
+    @Test
+    fun rewrapPreservesIdentityMetadataConversationAndMessagesAndSurvivesDecrypt() = runBlocking {
+        val restoredIdentity =
+            LocalIdentityEntity(
+                identityHash = identityHash,
+                displayName = "Recovered identity",
+                destinationHash = destinationHash,
+                filePath = "",
+                encryptedKeyData = byteArrayOf(1, 2, 3),
+                keyEncryptionVersion = 1,
+                createdTimestamp = 10L,
+                lastUsedTimestamp = 20L,
+                isActive = true,
+                iconName = "person",
+                iconForegroundColor = "FFFFFF",
+                iconBackgroundColor = "000000",
+            )
+        val conversation =
+            ConversationEntity(
+                peerHash = peerHash,
+                identityHash = identityHash,
+                peerName = "Recovered peer",
+                lastMessage = "third",
+                lastMessageTimestamp = 300L,
+                unreadCount = 2,
+                lastSeenTimestamp = 25L,
+            )
+        val messages =
+            listOf(
+                message("message-1", "first", 100L),
+                message("message-2", "second", 200L),
+                message("message-3", "third", 300L),
+            )
+        database.localIdentityDao().insert(restoredIdentity)
+        database.conversationDao().insertConversation(conversation)
+        messages.forEach { database.messageDao().insertMessage(it) }
+
+        val result = repository.rewrapKeyWithDeviceKey(identityHash, recoveredKey)
+
+        assertTrue(result.isSuccess)
+        val persisted = database.localIdentityDao().getIdentity(identityHash)
+        assertNotNull(persisted)
+        checkNotNull(persisted)
+        assertEquals(restoredIdentity.identityHash, persisted.identityHash)
+        assertEquals(restoredIdentity.displayName, persisted.displayName)
+        assertEquals(restoredIdentity.destinationHash, persisted.destinationHash)
+        assertEquals(restoredIdentity.createdTimestamp, persisted.createdTimestamp)
+        assertEquals(restoredIdentity.lastUsedTimestamp, persisted.lastUsedTimestamp)
+        assertEquals(restoredIdentity.isActive, persisted.isActive)
+        assertEquals(restoredIdentity.iconName, persisted.iconName)
+        assertEquals(restoredIdentity.iconForegroundColor, persisted.iconForegroundColor)
+        assertEquals(restoredIdentity.iconBackgroundColor, persisted.iconBackgroundColor)
+        assertNull(persisted.keyData)
+        assertEquals(IdentityKeyEncryptor.VERSION_DEVICE_ONLY.toInt(), persisted.keyEncryptionVersion)
+        assertNotNull(persisted.encryptedKeyData)
+        assertFalse(persisted.encryptedKeyData!!.contentEquals(restoredIdentity.encryptedKeyData!!))
+
+        val decrypted = repository.getDecryptedKeyData(identityHash).getOrThrow()
+        assertArrayEquals(recoveredKey, decrypted)
+        val freshEncryptor = IdentityKeyEncryptor()
+        lateinit var freshProvider: IdentityKeyProvider
+        InstrumentationRegistry.getInstrumentation().runOnMainSync {
+            freshProvider =
+                IdentityKeyProvider(
+                    context,
+                    database.localIdentityDao(),
+                    freshEncryptor,
+                )
+        }
+        val decryptedAfterProviderRestart = freshProvider.getDecryptedKeyData(identityHash).getOrThrow()
+        assertArrayEquals(recoveredKey, decryptedAfterProviderRestart)
+        val persistedConversation = database.conversationDao().getConversation(peerHash, identityHash)
+        assertEquals(conversation, persistedConversation)
+        val persistedMessages = database.messageDao().getMessagesForConversation(peerHash, identityHash).first()
+        assertEquals(messages, persistedMessages)
+    }
+
+    @Test
+    fun missingIdentityRowFailsRecoveryInsteadOfReportingFalseSuccess() = runBlocking {
+        val result =
+            repository.rewrapKeyWithDeviceKey(
+                "dddddddddddddddddddddddddddddddd",
+                recoveredKey,
+            )
+
+        assertTrue(result.isFailure)
+        assertTrue(result.exceptionOrNull()?.message?.contains("was not found") == true)
+        assertTrue(database.localIdentityDao().getAllIdentities().first().isEmpty())
+    }
+
+    @Test
+    fun misSizedKeysAreRejectedWithoutChangingRestoredIdentity() = runBlocking {
+        val restoredIdentity =
+            LocalIdentityEntity(
+                identityHash = identityHash,
+                displayName = "Recovered identity",
+                destinationHash = destinationHash,
+                filePath = "",
+                encryptedKeyData = byteArrayOf(9, 8, 7),
+                keyEncryptionVersion = 1,
+                createdTimestamp = 10L,
+                lastUsedTimestamp = 20L,
+                isActive = true,
+            )
+        database.localIdentityDao().insert(restoredIdentity)
+
+        val shortResult = repository.rewrapKeyWithDeviceKey(identityHash, ByteArray(63))
+        val overlongResult = repository.rewrapKeyWithDeviceKey(identityHash, ByteArray(65))
+
+        assertTrue(shortResult.isFailure)
+        assertTrue(overlongResult.isFailure)
+        val persisted = checkNotNull(database.localIdentityDao().getIdentity(identityHash))
+        assertEquals(restoredIdentity.displayName, persisted.displayName)
+        assertEquals(restoredIdentity.destinationHash, persisted.destinationHash)
+        assertEquals(restoredIdentity.keyEncryptionVersion, persisted.keyEncryptionVersion)
+        assertArrayEquals(restoredIdentity.encryptedKeyData, persisted.encryptedKeyData)
+    }
+
+    private fun message(
+        id: String,
+        content: String,
+        timestamp: Long,
+    ) =
+        MessageEntity(
+            id = id,
+            conversationHash = peerHash,
+            identityHash = identityHash,
+            content = content,
+            timestamp = timestamp,
+            isFromMe = false,
+            status = "delivered",
+            isRead = false,
+            receivedAt = timestamp + 1,
+        )
+}

--- a/app/src/main/java/network/columba/app/ui/screens/IdentityUnlockScreen.kt
+++ b/app/src/main/java/network/columba/app/ui/screens/IdentityUnlockScreen.kt
@@ -150,7 +150,6 @@ fun IdentityUnlockScreen(
                     HashMismatchDialog(
                         imported = state.importedHash,
                         active = state.activeHash,
-                        onConfirm = { viewModel.confirmReplaceMismatched() },
                         onDismiss = { viewModel.cancelHashMismatch() },
                     )
                 }
@@ -304,7 +303,6 @@ private fun ErrorBlock(
 private fun HashMismatchDialog(
     imported: String,
     active: String,
-    onConfirm: () -> Unit,
     onDismiss: () -> Unit,
 ) {
     AlertDialog(
@@ -315,11 +313,10 @@ private fun HashMismatchDialog(
                 "The file you picked holds a different identity than the one on this device.\n\n" +
                     "Imported: ${imported.take(8)}…\n" +
                     "Existing: ${active.take(8)}…\n\n" +
-                    "Replace the existing one? Your restored messages and contacts will stay " +
-                    "but won't be usable with this new identity.",
+                    "The file was not imported. Choose the original identity file that matches " +
+                    "the restored identity.",
             )
         },
-        confirmButton = { TextButton(onClick = onConfirm) { Text("Replace") } },
-        dismissButton = { TextButton(onClick = onDismiss) { Text("Cancel") } },
+        confirmButton = { TextButton(onClick = onDismiss) { Text("Choose another file") } },
     )
 }

--- a/app/src/main/java/network/columba/app/viewmodel/IdentityFileReader.kt
+++ b/app/src/main/java/network/columba/app/viewmodel/IdentityFileReader.kt
@@ -1,0 +1,27 @@
+package network.columba.app.viewmodel
+
+import java.io.InputStream
+
+internal object IdentityFileReader {
+    const val IDENTITY_BYTES = 64
+    private const val PROBE_BYTES = IDENTITY_BYTES + 1
+
+    fun read(input: InputStream): Result<ByteArray> =
+        runCatching {
+            val probe = ByteArray(PROBE_BYTES)
+            var count = 0
+            while (count < probe.size) {
+                val read = input.read(probe, count, probe.size - count)
+                if (read <= 0) break
+                count += read
+            }
+            require(count == IDENTITY_BYTES) {
+                if (count > IDENTITY_BYTES) {
+                    "Invalid identity file: expected 64 bytes, file is larger than 64 bytes"
+                } else {
+                    "Invalid identity file: expected 64 bytes, got $count bytes"
+                }
+            }
+            probe.copyOf(IDENTITY_BYTES)
+        }
+}

--- a/app/src/main/java/network/columba/app/viewmodel/IdentityUnlockViewModel.kt
+++ b/app/src/main/java/network/columba/app/viewmodel/IdentityUnlockViewModel.kt
@@ -51,9 +51,8 @@ class IdentityUnlockViewModel
         /**
          * Parse the imported identity file and, if its hash matches the active
          * identity, re-wrap the key with the new device's Keystore and clear
-         * the `needs_identity_unlock` flag. Hash mismatch surfaces a confirm
-         * prompt via [IdentityUnlockUiState.HashMismatch]; the user can confirm
-         * (replaces the active row) or cancel.
+         * the `needs_identity_unlock` flag. A hash mismatch is fail-closed: the
+         * imported file is rejected without mutating the restored identity row.
          */
         fun importIdentityFile(fileUri: Uri) {
             viewModelScope.launch {
@@ -97,14 +96,6 @@ class IdentityUnlockViewModel
                             return@launch
                         }
 
-                val destHash =
-                    parse["destination_hash"] as? String
-                        ?: run {
-                            _uiState.value =
-                                IdentityUnlockUiState.Error("No destination hash in parse result")
-                            return@launch
-                        }
-
                 if (importedHash != active.identityHash) {
                     Log.w(
                         TAG,
@@ -115,80 +106,11 @@ class IdentityUnlockViewModel
                         IdentityUnlockUiState.HashMismatch(
                             importedHash = importedHash,
                             activeHash = active.identityHash,
-                            keyData = keyData,
-                            destHash = destHash,
                         )
                     return@launch
                 }
 
                 completeRewrap(active.identityHash, keyData)
-            }
-        }
-
-        /**
-         * Called after the user explicitly confirms importing an identity whose
-         * hash doesn't match the existing active row. We delete the orphaned
-         * row, then create a fresh one from the imported bytes and set it
-         * active. Conversations tied to the old hash are left in Room but will
-         * appear dormant (no active identity can decrypt them); a future PR
-         * could offer to purge them.
-         */
-        fun confirmReplaceMismatched() {
-            val current = _uiState.value
-            if (current !is IdentityUnlockUiState.HashMismatch) return
-            viewModelScope.launch {
-                _uiState.value = IdentityUnlockUiState.Loading("Replacing identity...")
-
-                // `importedHash`, `keyData`, and `destHash` are all carried
-                // through `HashMismatch` from the initial parse — no need to
-                // re-invoke the protocol here. Re-parsing with the already-
-                // extracted 64-byte `keyData` would fail anyway since
-                // `importIdentityFile` expects raw file bytes, not pre-parsed
-                // key material.
-                val active = identityRepository.getActiveIdentitySync()
-                if (active != null) {
-                    identityRepository
-                        .deleteIdentity(active.identityHash)
-                        .onFailure {
-                            _uiState.value =
-                                IdentityUnlockUiState.Error(
-                                    "Couldn't remove old identity row: ${it.message}",
-                                )
-                            return@launch
-                        }
-                }
-
-                val result =
-                    identityRepository.createIdentity(
-                        identityHash = current.importedHash,
-                        displayName = active?.displayName ?: "Imported Identity",
-                        destinationHash = current.destHash,
-                        filePath = "",
-                        keyData = current.keyData,
-                    )
-                result
-                    .onSuccess {
-                        // If switch fails the new row exists but isActive=0,
-                        // so the next boot sees no active identity and Chats
-                        // silently breaks. Surface the failure and leave the
-                        // unlock flag set so we route back here next launch.
-                        val switched =
-                            identityRepository.switchActiveIdentity(current.importedHash)
-                        switched.onFailure { e ->
-                            _uiState.value =
-                                IdentityUnlockUiState.Error(
-                                    "Couldn't activate imported identity: ${e.message}",
-                                )
-                            return@launch
-                        }
-                        settingsRepository.setNeedsIdentityUnlock(false)
-                        _uiState.value = IdentityUnlockUiState.Restored
-                    }.onFailure { e ->
-                        _uiState.value =
-                            IdentityUnlockUiState.Error(
-                                "Couldn't save imported identity: ${e.message}",
-                            )
-                    }
             }
         }
 
@@ -303,26 +225,7 @@ sealed class IdentityUnlockUiState {
     data class HashMismatch(
         val importedHash: String,
         val activeHash: String,
-        val keyData: ByteArray,
-        val destHash: String,
-    ) : IdentityUnlockUiState() {
-        override fun equals(other: Any?): Boolean {
-            if (this === other) return true
-            if (other !is HashMismatch) return false
-            return importedHash == other.importedHash &&
-                activeHash == other.activeHash &&
-                keyData.contentEquals(other.keyData) &&
-                destHash == other.destHash
-        }
-
-        override fun hashCode(): Int {
-            var result = importedHash.hashCode()
-            result = 31 * result + activeHash.hashCode()
-            result = 31 * result + keyData.contentHashCode()
-            result = 31 * result + destHash.hashCode()
-            return result
-        }
-    }
+    ) : IdentityUnlockUiState()
 
     object Restored : IdentityUnlockUiState()
 

--- a/app/src/main/java/network/columba/app/viewmodel/IdentityUnlockViewModel.kt
+++ b/app/src/main/java/network/columba/app/viewmodel/IdentityUnlockViewModel.kt
@@ -7,12 +7,14 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import dagger.hilt.android.lifecycle.HiltViewModel
 import dagger.hilt.android.qualifiers.ApplicationContext
+import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
 import network.columba.app.data.db.entity.LocalIdentityEntity
 import network.columba.app.data.repository.IdentityRepository
 import network.columba.app.repository.SettingsRepository
@@ -64,18 +66,13 @@ class IdentityUnlockViewModel
                 }
 
                 val fileData =
-                    try {
-                        context.contentResolver
-                            .openInputStream(fileUri)
-                            ?.use { it.readBytes() }
-                            ?: run {
-                                _uiState.value =
-                                    IdentityUnlockUiState.Error("Couldn't open file")
-                                return@launch
-                            }
-                    } catch (e: Exception) {
-                        _uiState.value =
-                            IdentityUnlockUiState.Error("Couldn't read file: ${e.message}")
+                    withContext(Dispatchers.IO) {
+                        context.contentResolver.openInputStream(fileUri)?.use(IdentityFileReader::read)
+                    }?.getOrElse { e ->
+                        _uiState.value = IdentityUnlockUiState.Error(e.message ?: "Couldn't read file")
+                        return@launch
+                    } ?: run {
+                        _uiState.value = IdentityUnlockUiState.Error("Couldn't open file")
                         return@launch
                     }
 

--- a/app/src/test/java/network/columba/app/ui/screens/IdentityUnlockScreenTest.kt
+++ b/app/src/test/java/network/columba/app/ui/screens/IdentityUnlockScreenTest.kt
@@ -1,0 +1,58 @@
+package network.columba.app.ui.screens
+
+import android.app.Application
+import androidx.compose.ui.test.assertCountEquals
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.onAllNodesWithText
+import androidx.compose.ui.test.onNodeWithText
+import io.mockk.Runs
+import io.mockk.every
+import io.mockk.just
+import io.mockk.mockk
+import kotlinx.coroutines.flow.MutableStateFlow
+import network.columba.app.test.RegisterComponentActivityRule
+import network.columba.app.viewmodel.IdentityUnlockUiState
+import network.columba.app.viewmodel.IdentityUnlockViewModel
+import org.junit.Rule
+import org.junit.Test
+import org.junit.rules.RuleChain
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+
+@RunWith(RobolectricTestRunner::class)
+@Config(sdk = [34], application = Application::class)
+class IdentityUnlockScreenTest {
+    private val registerActivityRule = RegisterComponentActivityRule()
+    private val composeRule = createComposeRule()
+
+    @get:Rule
+    val ruleChain: RuleChain = RuleChain.outerRule(registerActivityRule).around(composeRule)
+
+    @Test
+    fun hashMismatchIsFailClosedAndDoesNotOfferReplacement() {
+        val viewModel = mockk<IdentityUnlockViewModel>()
+        every { viewModel.uiState } returns
+            MutableStateFlow(
+                IdentityUnlockUiState.HashMismatch(
+                    importedHash = "11111111111111111111111111111111",
+                    activeHash = "22222222222222222222222222222222",
+                ),
+            )
+        every { viewModel.activeIdentity } returns MutableStateFlow(null)
+        every { viewModel.cancelHashMismatch() } just Runs
+
+        composeRule.setContent {
+            IdentityUnlockScreen(
+                onResolved = {},
+                viewModel = viewModel,
+            )
+        }
+        composeRule.waitForIdle()
+
+        composeRule.onNodeWithText("Different identity").assertIsDisplayed()
+        composeRule.onNodeWithText("Choose another file").assertIsDisplayed()
+        composeRule.onAllNodesWithText("Replace").assertCountEquals(0)
+    }
+}

--- a/app/src/test/java/network/columba/app/viewmodel/IdentityFileReaderTest.kt
+++ b/app/src/test/java/network/columba/app/viewmodel/IdentityFileReaderTest.kt
@@ -1,0 +1,70 @@
+package network.columba.app.viewmodel
+
+import org.junit.Assert.assertArrayEquals
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import java.io.ByteArrayInputStream
+import java.io.InputStream
+
+class IdentityFileReaderTest {
+    @Test
+    fun `accepts exactly 64 raw identity bytes`() {
+        val bytes = ByteArray(64) { it.toByte() }
+
+        val result = IdentityFileReader.read(ByteArrayInputStream(bytes))
+
+        assertTrue(result.isSuccess)
+        assertArrayEquals(bytes, result.getOrThrow())
+    }
+
+    @Test
+    fun `reports exact size for a short identity file`() {
+        val result = IdentityFileReader.read(ByteArrayInputStream(ByteArray(32)))
+
+        assertTrue(result.isFailure)
+        assertEquals(
+            "Invalid identity file: expected 64 bytes, got 32 bytes",
+            result.exceptionOrNull()?.message,
+        )
+    }
+
+    @Test
+    fun `rejects a large file after reading only 65 bytes`() {
+        val input = CountingInputStream(337_172_840L)
+
+        val result = IdentityFileReader.read(input)
+
+        assertTrue(result.isFailure)
+        assertEquals(65L, input.bytesRead)
+        assertEquals(
+            "Invalid identity file: expected 64 bytes, file is larger than 64 bytes",
+            result.exceptionOrNull()?.message,
+        )
+    }
+
+    private class CountingInputStream(
+        private val size: Long,
+    ) : InputStream() {
+        var bytesRead = 0L
+            private set
+
+        override fun read(): Int {
+            if (bytesRead >= size) return -1
+            bytesRead++
+            return 0
+        }
+
+        override fun read(
+            buffer: ByteArray,
+            offset: Int,
+            length: Int,
+        ): Int {
+            if (bytesRead >= size) return -1
+            val count = minOf(length.toLong(), size - bytesRead).toInt()
+            buffer.fill(0, offset, offset + count)
+            bytesRead += count
+            return count
+        }
+    }
+}

--- a/app/src/test/java/network/columba/app/viewmodel/IdentityUnlockViewModelTest.kt
+++ b/app/src/test/java/network/columba/app/viewmodel/IdentityUnlockViewModelTest.kt
@@ -1,0 +1,261 @@
+package network.columba.app.viewmodel
+
+import android.content.ContentResolver
+import android.content.Context
+import android.net.Uri
+import androidx.arch.core.executor.testing.InstantTaskExecutorRule
+import io.mockk.Runs
+import io.mockk.clearAllMocks
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.every
+import io.mockk.just
+import io.mockk.mockk
+import io.mockk.verify
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.filter
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.setMain
+import kotlinx.coroutines.withTimeout
+import network.columba.app.data.db.entity.LocalIdentityEntity
+import network.columba.app.data.repository.IdentityRepository
+import network.columba.app.repository.SettingsRepository
+import network.columba.app.rns.api.RnsCore
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import java.io.ByteArrayInputStream
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class IdentityUnlockViewModelTest {
+    @get:Rule
+    val instantExecutorRule = InstantTaskExecutorRule()
+
+    private val mainDispatcher = UnconfinedTestDispatcher()
+    private val keyData = ByteArray(64) { index -> index.toByte() }
+    private val activeHash = "bab3608daf86147268c8ef9bf62c0e08"
+    private val destinationHash = "73908a7266dd03521b47f2473f38481b"
+
+    private lateinit var context: Context
+    private lateinit var contentResolver: ContentResolver
+    private lateinit var uri: Uri
+    private lateinit var identityRepository: IdentityRepository
+    private lateinit var settingsRepository: SettingsRepository
+    private lateinit var rnsCore: RnsCore
+
+    @Before
+    fun setUp() {
+        Dispatchers.setMain(mainDispatcher)
+        context = mockk()
+        contentResolver = mockk()
+        uri = mockk()
+        identityRepository = mockk()
+        settingsRepository = mockk()
+        rnsCore = mockk()
+        every { context.contentResolver } returns contentResolver
+        coEvery { settingsRepository.setNeedsIdentityUnlock(any()) } just Runs
+    }
+
+    @After
+    fun tearDown() {
+        Dispatchers.resetMain()
+        clearAllMocks()
+    }
+
+    @Test
+    fun `matching identity rewraps existing row and clears recovery flag`() = runBlocking {
+        val active = activeIdentity()
+        stubActive(active)
+        stubFile(keyData)
+        coEvery { rnsCore.importIdentityFile(keyData, active.displayName) } returns successResult(activeHash)
+        coEvery { identityRepository.rewrapKeyWithDeviceKey(activeHash, keyData) } returns Result.success(Unit)
+        val viewModel = createViewModel()
+
+        viewModel.importIdentityFile(uri)
+
+        assertEquals(IdentityUnlockUiState.Restored, viewModel.awaitTerminalState())
+        coVerify(exactly = 1) { identityRepository.rewrapKeyWithDeviceKey(activeHash, keyData) }
+        coVerify(exactly = 1) { settingsRepository.setNeedsIdentityUnlock(false) }
+        verifyNoDestructiveIdentityCalls()
+    }
+
+    @Test
+    fun `matching identity rewrap failure leaves recovery flag set`() = runBlocking {
+        val active = activeIdentity()
+        stubActive(active)
+        stubFile(keyData)
+        coEvery { rnsCore.importIdentityFile(keyData, active.displayName) } returns successResult(activeHash)
+        coEvery { identityRepository.rewrapKeyWithDeviceKey(activeHash, keyData) } returns
+            Result.failure(IllegalStateException("keystore unavailable"))
+        val viewModel = createViewModel()
+
+        viewModel.importIdentityFile(uri)
+
+        val state = viewModel.awaitTerminalState()
+        assertTrue(state is IdentityUnlockUiState.Error)
+        assertEquals("Couldn't save identity key: keystore unavailable", (state as IdentityUnlockUiState.Error).message)
+        coVerify(exactly = 0) { settingsRepository.setNeedsIdentityUnlock(false) }
+        verifyNoDestructiveIdentityCalls()
+    }
+
+    @Test
+    fun `mismatched identity is rejected without any persistence mutation`() = runBlocking {
+        val active = activeIdentity()
+        val importedHash = "11111111111111111111111111111111"
+        stubActive(active)
+        stubFile(keyData)
+        coEvery { rnsCore.importIdentityFile(keyData, active.displayName) } returns successResult(importedHash)
+        val viewModel = createViewModel()
+
+        viewModel.importIdentityFile(uri)
+
+        assertEquals(
+            IdentityUnlockUiState.HashMismatch(importedHash, activeHash),
+            viewModel.awaitTerminalState(),
+        )
+        coVerify(exactly = 0) { identityRepository.rewrapKeyWithDeviceKey(any(), any()) }
+        coVerify(exactly = 0) { settingsRepository.setNeedsIdentityUnlock(any()) }
+        verifyNoDestructiveIdentityCalls()
+
+        viewModel.cancelHashMismatch()
+        assertEquals(IdentityUnlockUiState.Idle, viewModel.uiState.value)
+        verifyNoDestructiveIdentityCalls()
+    }
+
+    @Test
+    fun `short identity file is rejected before backend or persistence`() = runBlocking {
+        stubActive(activeIdentity())
+        stubFile(ByteArray(63))
+        val viewModel = createViewModel()
+
+        viewModel.importIdentityFile(uri)
+
+        val state = viewModel.awaitTerminalState()
+        assertTrue(state is IdentityUnlockUiState.Error)
+        assertEquals(
+            "Invalid identity file: expected 64 bytes, got 63 bytes",
+            (state as IdentityUnlockUiState.Error).message,
+        )
+        coVerify(exactly = 0) { rnsCore.importIdentityFile(any(), any()) }
+        verifyNoPersistenceCalls()
+    }
+
+    @Test
+    fun `overlong identity file is rejected before backend or persistence`() = runBlocking {
+        stubActive(activeIdentity())
+        stubFile(ByteArray(65))
+        val viewModel = createViewModel()
+
+        viewModel.importIdentityFile(uri)
+
+        val state = viewModel.awaitTerminalState()
+        assertTrue(state is IdentityUnlockUiState.Error)
+        assertEquals(
+            "Invalid identity file: expected 64 bytes, file is larger than 64 bytes",
+            (state as IdentityUnlockUiState.Error).message,
+        )
+        coVerify(exactly = 0) { rnsCore.importIdentityFile(any(), any()) }
+        verifyNoPersistenceCalls()
+    }
+
+    @Test
+    fun `backend parse error is surfaced without persistence mutation`() = runBlocking {
+        val active = activeIdentity()
+        stubActive(active)
+        stubFile(keyData)
+        coEvery { rnsCore.importIdentityFile(keyData, active.displayName) } returns
+            mapOf("success" to false, "error" to "Invalid private key data")
+        val viewModel = createViewModel()
+
+        viewModel.importIdentityFile(uri)
+
+        val state = viewModel.awaitTerminalState()
+        assertTrue(state is IdentityUnlockUiState.Error)
+        assertEquals("Invalid private key data", (state as IdentityUnlockUiState.Error).message)
+        verifyNoPersistenceCalls()
+    }
+
+    @Test
+    fun `missing active identity rejects import before opening selected file`() = runBlocking {
+        stubActive(null)
+        val viewModel = createViewModel()
+
+        viewModel.importIdentityFile(uri)
+
+        val state = viewModel.awaitTerminalState()
+        assertTrue(state is IdentityUnlockUiState.Error)
+        assertEquals("No active identity to restore into", (state as IdentityUnlockUiState.Error).message)
+        verify(exactly = 0) { contentResolver.openInputStream(any()) }
+        coVerify(exactly = 0) { rnsCore.importIdentityFile(any(), any()) }
+        verifyNoPersistenceCalls()
+    }
+
+    private fun activeIdentity() =
+        LocalIdentityEntity(
+            identityHash = activeHash,
+            displayName = "Recovered identity",
+            destinationHash = destinationHash,
+            filePath = "",
+            encryptedKeyData = byteArrayOf(1, 2, 3),
+            keyEncryptionVersion = 1,
+            createdTimestamp = 1L,
+            lastUsedTimestamp = 2L,
+            isActive = true,
+        )
+
+    private fun stubActive(active: LocalIdentityEntity?) {
+        every { identityRepository.activeIdentity } returns flowOf(active)
+        coEvery { identityRepository.getActiveIdentitySync() } returns active
+    }
+
+    private fun stubFile(bytes: ByteArray) {
+        every { contentResolver.openInputStream(uri) } answers { ByteArrayInputStream(bytes) }
+    }
+
+    private fun successResult(identityHash: String): Map<String, Any> =
+        mapOf(
+            "success" to true,
+            "identity_hash" to identityHash,
+            "destination_hash" to destinationHash,
+            "key_data" to keyData,
+        )
+
+    private fun createViewModel() =
+        IdentityUnlockViewModel(
+            context = context,
+            identityRepository = identityRepository,
+            settingsRepository = settingsRepository,
+            rnsCore = rnsCore,
+        )
+
+    private suspend fun IdentityUnlockViewModel.awaitTerminalState(): IdentityUnlockUiState =
+        withTimeout(3_000) {
+            uiState
+                .filter { state ->
+                    state !is IdentityUnlockUiState.Idle &&
+                        state !is IdentityUnlockUiState.Loading
+                }.first()
+        }
+
+    private fun verifyNoPersistenceCalls() {
+        coVerify(exactly = 0) { identityRepository.rewrapKeyWithDeviceKey(any(), any()) }
+        coVerify(exactly = 0) { settingsRepository.setNeedsIdentityUnlock(any()) }
+        verifyNoDestructiveIdentityCalls()
+    }
+
+    private fun verifyNoDestructiveIdentityCalls() {
+        coVerify(exactly = 0) { identityRepository.deleteIdentity(any()) }
+        coVerify(exactly = 0) {
+            identityRepository.createIdentity(any(), any(), any(), any(), any())
+        }
+        coVerify(exactly = 0) { identityRepository.switchActiveIdentity(any()) }
+    }
+}

--- a/data/src/main/java/network/columba/app/data/db/dao/LocalIdentityDao.kt
+++ b/data/src/main/java/network/columba/app/data/db/dao/LocalIdentityDao.kt
@@ -159,7 +159,7 @@ interface LocalIdentityDao {
         identityHash: String,
         encryptedKeyData: ByteArray,
         version: Int,
-    )
+    ): Int
 
     /**
      * Downgrade from password protection to device-only encryption.

--- a/data/src/main/java/network/columba/app/data/repository/IdentityRepository.kt
+++ b/data/src/main/java/network/columba/app/data/repository/IdentityRepository.kt
@@ -404,12 +404,16 @@ class IdentityRepository
                 if (keyData.size != 64) return
 
                 val encrypted = keyEncryptor.encryptWithDeviceKey(keyData)
-                identityDao.updateEncryptedKeyData(
+                val updatedRows = identityDao.updateEncryptedKeyData(
                     identityHash = identity.identityHash,
                     encryptedKeyData = encrypted,
                     version = IdentityKeyEncryptor.VERSION_DEVICE_ONLY.toInt(),
                 )
-                Log.i(TAG, "Opportunistic key backup saved for $hashPrefix...")
+                if (updatedRows == 1) {
+                    Log.i(TAG, "Opportunistic key backup saved for $hashPrefix...")
+                } else {
+                    Log.w(TAG, "Opportunistic key backup skipped: identity $hashPrefix... no longer exists")
+                }
             } catch (e: Exception) {
                 Log.w(TAG, "Opportunistic key backup failed for $hashPrefix...", e)
             }
@@ -589,11 +593,14 @@ class IdentityRepository
                         )
                     }
                     val encrypted = keyEncryptor.encryptWithDeviceKey(keyData)
-                    identityDao.updateEncryptedKeyData(
+                    val updatedRows = identityDao.updateEncryptedKeyData(
                         identityHash = identityHash,
                         encryptedKeyData = encrypted,
                         version = IdentityKeyEncryptor.VERSION_DEVICE_ONLY.toInt(),
                     )
+                    check(updatedRows == 1) {
+                        "Identity row $identityHash was not found during key recovery"
+                    }
                     Result.success(Unit)
                 } catch (e: Exception) {
                     Log.e(TAG, "Failed to re-wrap key for ${identityHash.take(8)}...", e)

--- a/data/src/test/java/network/columba/app/data/crypto/IdentityKeyMigratorTest.kt
+++ b/data/src/test/java/network/columba/app/data/crypto/IdentityKeyMigratorTest.kt
@@ -67,7 +67,7 @@ class IdentityKeyMigratorTest {
         every { encryptor.secureWipe(any()) } returns Unit
 
         // Setup DAO mutation stubs (non-relaxed mock requires explicit stubs)
-        coEvery { identityDao.updateEncryptedKeyData(any(), any(), any()) } returns Unit
+        coEvery { identityDao.updateEncryptedKeyData(any(), any(), any()) } returns 1
         coEvery { identityDao.clearUnencryptedKeyData(any()) } returns Unit
 
         migrator = IdentityKeyMigrator(context, identityDao, encryptor)

--- a/rns-backend-py/build.gradle.kts
+++ b/rns-backend-py/build.gradle.kts
@@ -174,6 +174,11 @@ dependencies {
     testImplementation(libs.robolectric)
     testImplementation(libs.test.core)
     testImplementation("org.json:json:20240303")
+
+    androidTestImplementation(libs.junit.android)
+    androidTestImplementation(libs.test.core)
+    androidTestImplementation("androidx.test:runner:1.6.2")
+    androidTestImplementation(libs.coroutines.test)
 }
 
 ksp {

--- a/rns-backend-py/src/androidTest/kotlin/network/columba/app/rns/backend/py/PythonRnsCoreIdentityRecoveryInstrumentedTest.kt
+++ b/rns-backend-py/src/androidTest/kotlin/network/columba/app/rns/backend/py/PythonRnsCoreIdentityRecoveryInstrumentedTest.kt
@@ -1,0 +1,50 @@
+package network.columba.app.rns.backend.py
+
+import androidx.test.core.app.ApplicationProvider
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import kotlinx.coroutines.runBlocking
+import org.junit.Assert.assertArrayEquals
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNotNull
+import org.junit.Test
+import org.junit.runner.RunWith
+
+@RunWith(AndroidJUnit4::class)
+class PythonRnsCoreIdentityRecoveryInstrumentedTest {
+    @Test
+    fun createAndImportIdentityWithoutInitializedTransport() =
+        runBlocking {
+            val runtime =
+                PythonRnsRuntime(
+                    ApplicationProvider.getApplicationContext(),
+                )
+            val transport = checkNotNull(runtime.rnsModule["Transport"])
+            val hasTransportOwner =
+                runtime.python.builtins
+                    .callAttr("hasattr", transport, "owner")
+                    .toJava(Boolean::class.javaObjectType)
+
+            assertFalse("Test precondition: RNS.Transport must not be initialized", hasTransportOwner)
+            assertFalse("Test must not start Reticulum", runtime.isRunning)
+
+            val core = PythonRnsCore(runtime, PythonEventBridge())
+            val created = core.createIdentityWithName("Recovery fixture")
+
+            assertEquals(true, created["success"])
+            val identityHash = created["identity_hash"] as? String
+            val destinationHash = created["destination_hash"] as? String
+            val keyData = created["key_data"] as? ByteArray
+            assertNotNull(identityHash)
+            assertEquals(32, destinationHash?.length)
+            assertEquals(64, keyData?.size)
+
+            val imported = core.importIdentityFile(checkNotNull(keyData), "Imported recovery fixture")
+
+            assertEquals(true, imported["success"])
+            assertEquals(identityHash, imported["identity_hash"])
+            assertEquals(destinationHash, imported["destination_hash"])
+            assertArrayEquals(keyData, imported["key_data"] as ByteArray)
+            assertFalse("Identity recovery must not start Reticulum", runtime.isRunning)
+        }
+}

--- a/rns-backend-py/src/main/kotlin/network/columba/app/rns/backend/py/PythonRnsCore.kt
+++ b/rns-backend-py/src/main/kotlin/network/columba/app/rns/backend/py/PythonRnsCore.kt
@@ -175,11 +175,15 @@ class PythonRnsCore(
      * silently with "No identity_hash in result" surfaced only to the UI
      * dialog (no logcat).
      *
-     * `destination_hash` is the LXMF delivery destination hash for this
-     * identity — derivable purely from identity + aspect tuple, but we go
-     * through `RNS.Destination(...)` so the destination becomes a real RNS
-     * object the runtime can announce later. The kotlin backend computes the
-     * same hash via `NativeDestination.create(..., "lxmf", "delivery")`.
+     * `destination_hash` is the deterministic LXMF delivery destination hash for
+     * this identity. Identity creation/import must work before Reticulum and
+     * `RNS.Transport` are initialized, which is required by the cloud-restore
+     * unlock flow. Compute it through Reticulum's pure hash helper instead of
+     * constructing `RNS.Destination(...)`, whose constructor registers with the
+     * live Transport and fails when `Transport.owner` is absent. The runtime
+     * creates the real delivery destination later during normal initialization.
+     * The kotlin backend computes the same hash locally via
+     * `NativeDestination.create(..., "lxmf", "delivery")`.
      */
     private fun buildIdentityResult(
         pyId: PyObject,
@@ -187,15 +191,14 @@ class PythonRnsCore(
         displayName: String,
     ): Map<String, Any> {
         val destClass = runtime.rnsModule["Destination"] ?: error("RNS.Destination missing")
-        val pyDelivery = runtime.rnsModule.callAttr(
-            "Destination",
-            pyId,
-            destClass["IN"],
-            destClass["SINGLE"],
-            "lxmf",
-            "delivery",
-        )
-        val destinationHashHex = pyDelivery["hash"]?.toJava(ByteArray::class.java)?.toHex().orEmpty()
+        val destinationHashHex =
+            destClass
+                .callAttr(
+                    "hash_from_name_and_identity",
+                    "lxmf.delivery",
+                    pyId,
+                ).toJava(ByteArray::class.java)
+                .toHex()
         return mapOf(
             "success" to true,
             "identity_hash" to model.hash.toHex(),

--- a/rns-ipc/src/main/kotlin/network/columba/app/rns/ipc/BundleKeys.kt
+++ b/rns-ipc/src/main/kotlin/network/columba/app/rns/ipc/BundleKeys.kt
@@ -13,6 +13,8 @@ internal object BundleKeys {
     const val IDENTITY = "identity"
     const val KEY_DATA = "key_data"
     const val DISPLAY_NAME = "display_name"
+    const val SUCCESS = "success"
+    const val ERROR = "error"
     // Identity create / import result keys. Names must match what
     // IdentityManagerViewModel reads from the reconstructed Map (see
     // IdentityManagerViewModel.kt:96-103) — previously the bundle was

--- a/rns-ipc/src/main/kotlin/network/columba/app/rns/ipc/client/ClientRnsCore.kt
+++ b/rns-ipc/src/main/kotlin/network/columba/app/rns/ipc/client/ClientRnsCore.kt
@@ -318,7 +318,11 @@ internal class ClientRnsCore(
     }
 
     private fun identityKeyMapFromBundle(bundle: android.os.Bundle): Map<String, Any> {
-        val map = LinkedHashMap<String, Any>(6)
+        val map = LinkedHashMap<String, Any>(8)
+        if (bundle.containsKey(BundleKeys.SUCCESS)) {
+            map[BundleKeys.SUCCESS] = bundle.getBoolean(BundleKeys.SUCCESS)
+        }
+        bundle.getString(BundleKeys.ERROR)?.let { map[BundleKeys.ERROR] = it }
         bundle.getByteArray(BundleKeys.KEY_DATA)?.let { map[BundleKeys.KEY_DATA] = it }
         bundle.getString(BundleKeys.DISPLAY_NAME)?.let { map[BundleKeys.DISPLAY_NAME] = it }
         bundle.getString(BundleKeys.IDENTITY_HASH)?.let { map[BundleKeys.IDENTITY_HASH] = it }

--- a/rns-ipc/src/main/kotlin/network/columba/app/rns/ipc/server/ServerRnsCore.kt
+++ b/rns-ipc/src/main/kotlin/network/columba/app/rns/ipc/server/ServerRnsCore.kt
@@ -248,6 +248,8 @@ private fun Map<String, Any>.toIdentityKeyBundle(): Bundle {
     // "No identity_hash in result" because (a) the bundle didn't carry
     // identity_hash at all, (b) it didn't carry destination_hash or
     // file_path either.
+    (this[BundleKeys.SUCCESS] as? Boolean)?.let { bundle.putBoolean(BundleKeys.SUCCESS, it) }
+    (this[BundleKeys.ERROR] as? String)?.let { bundle.putString(BundleKeys.ERROR, it) }
     (this[BundleKeys.KEY_DATA] as? ByteArray)?.let { bundle.putByteArray(BundleKeys.KEY_DATA, it) }
     (this[BundleKeys.DISPLAY_NAME] as? String)?.let { bundle.putString(BundleKeys.DISPLAY_NAME, it) }
     (this[BundleKeys.IDENTITY_HASH] as? String)?.let { bundle.putString(BundleKeys.IDENTITY_HASH, it) }

--- a/rns-ipc/src/test/java/network/columba/app/rns/ipc/RnsBackendIpcRoundTripTest.kt
+++ b/rns-ipc/src/test/java/network/columba/app/rns/ipc/RnsBackendIpcRoundTripTest.kt
@@ -117,6 +117,48 @@ class RnsBackendIpcRoundTripTest {
     }
 
     @Test
+    fun `identity import success map round-trips through the stub`() = runTest {
+        val (client, _) = buildClientAndServer()
+        val keyData = ByteArray(64) { it.toByte() }
+        val publicKey = ByteArray(64) { (it + 1).toByte() }
+        fake.core.nextImportResult =
+            mapOf(
+                "success" to true,
+                "identity_hash" to "bab3608daf86147268c8ef9bf62c0e08",
+                "destination_hash" to "73908a7266dd03521b47f2473f38481b",
+                "display_name" to "Anonymous Peer",
+                "public_key" to publicKey,
+                "key_data" to keyData,
+                "file_path" to "",
+            )
+
+        val result = client.core.importIdentityFile(keyData, "Anonymous Peer")
+        advanceUntilIdle()
+
+        assertEquals(true, result["success"])
+        assertEquals("bab3608daf86147268c8ef9bf62c0e08", result["identity_hash"])
+        assertEquals("73908a7266dd03521b47f2473f38481b", result["destination_hash"])
+        assertArrayEquals(keyData, result["key_data"] as ByteArray)
+        assertArrayEquals(publicKey, result["public_key"] as ByteArray)
+    }
+
+    @Test
+    fun `identity import error map round-trips through the stub`() = runTest {
+        val (client, _) = buildClientAndServer()
+        fake.core.nextImportResult =
+            mapOf(
+                "success" to false,
+                "error" to "Invalid identity data",
+            )
+
+        val result = client.core.importIdentityFile(ByteArray(64), "Anonymous Peer")
+        advanceUntilIdle()
+
+        assertEquals(false, result["success"])
+        assertEquals("Invalid identity data", result["error"])
+    }
+
+    @Test
     fun `suspend Result-VoiceCallState getCallState marshals the payload`() = runTest {
         val (client, _) = buildClientAndServer()
         advanceUntilIdle()
@@ -358,7 +400,7 @@ private class FakeRnsBackend : RnsBackend {
     )
 
     override val capabilities: StateFlow<BackendCapabilities> get() = capabilitiesState.asStateFlow()
-    override val core: RnsCore = FakeRnsCore()
+    override val core: FakeRnsCore = FakeRnsCore()
     override val lxmf: FakeRnsLxmf = FakeRnsLxmf()
     override val telephony: FakeRnsTelephony = FakeRnsTelephony()
     override val telemetry: RnsTelemetry = FakeRnsTelemetry()
@@ -510,6 +552,7 @@ private class FakeRnsLxmf : RnsLxmf {
 
 /** Minimal stubs for the unused-in-tests sub-interfaces. */
 private class FakeRnsCore : RnsCore {
+    var nextImportResult: Map<String, Any> = emptyMap()
     private val status = MutableStateFlow<NetworkStatus>(NetworkStatus.READY)
     override val networkStatus: StateFlow<NetworkStatus> get() = status.asStateFlow()
     override suspend fun initialize(config: ReticulumConfig) = Result.success(Unit)
@@ -519,7 +562,7 @@ private class FakeRnsCore : RnsCore {
     override suspend fun saveIdentity(identity: Identity, path: String) = Result.success(Unit)
     override suspend fun recallIdentity(hash: ByteArray): Identity? = null
     override suspend fun createIdentityWithName(displayName: String): Map<String, Any> = emptyMap()
-    override suspend fun importIdentityFile(fileData: ByteArray, displayName: String): Map<String, Any> = emptyMap()
+    override suspend fun importIdentityFile(fileData: ByteArray, displayName: String): Map<String, Any> = nextImportResult
     override suspend fun exportIdentityFile(keyData: ByteArray, filePath: String): ByteArray = ByteArray(0)
     override suspend fun getFullIdentityKey(): ByteArray? = null
     override suspend fun createDestination(


### PR DESCRIPTION
## Summary
- derive Python identity destination hashes without requiring initialized Reticulum transport
- preserve identity import success/error data across Binder IPC
- bound raw identity reads to exactly 64 bytes and make mismatch recovery fail closed
- require exactly one Room row to be re-wrapped before clearing recovery state
- add ViewModel, UI, IPC, real Chaquopy, Room, Keystore, and production Binder regressions
- run the Python identity recovery instrumentation on the CI emulator lane

## Verification
- focused app identity recovery unit and UI tests
- `rns-ipc` round-trip tests
- data key migration tests
- app/data/IPC ktlint and detekt
- Python app and backend instrumentation APK assembly
- physical Galaxy S21 Ultra Binder, Chaquopy, Room, Keystore, restart, and database-preservation tests

## Risk and rollback
The recovery path now rejects mismatched identity files instead of deleting the recovered row. Reverting this PR restores the previous recovery behavior and removes the added CI selection. No private identity material is included in tests or logs.