### PR TITLE
fix: render NomadNet six-digit true colors

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -538,7 +538,7 @@ jobs:
             echo "Emulator is responsive, starting tests..."
             # Run smoke tests and integration tests
             # Use test orchestrator for isolation (configured in build.gradle.kts)
-            ./gradlew :app:connectedNoSentryKotlinBackendDebugAndroidTest -Pandroid.testInstrumentationRunnerArguments.class=network.columba.app.smoke.SmokeTest,network.columba.app.integration.MessageDataFlowTest,network.columba.app.integration.ConversationCreationFlowTest --stacktrace
+            ./gradlew :app:connectedNoSentryKotlinBackendDebugAndroidTest -Pandroid.testInstrumentationRunnerArguments.class=network.columba.app.smoke.SmokeTest,network.columba.app.integration.MessageDataFlowTest,network.columba.app.integration.ConversationCreationFlowTest,network.columba.app.ui.components.MicronTrueColorRenderingTest --stacktrace
 
       - name: Upload instrumented test results
         if: always()

--- a/app/src/androidTestDebug/java/network/columba/app/ui/components/MicronTrueColorRenderingTest.kt
+++ b/app/src/androidTestDebug/java/network/columba/app/ui/components/MicronTrueColorRenderingTest.kt
@@ -1,0 +1,97 @@
+package network.columba.app.ui.components
+
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Surface
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.toArgb
+import androidx.compose.ui.graphics.toPixelMap
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.captureToImage
+import androidx.compose.ui.test.junit4.createAndroidComposeRule
+import androidx.compose.ui.test.onNodeWithTag
+import androidx.compose.ui.test.onNodeWithText
+import network.columba.app.micron.MicronParser
+import network.columba.app.test.TestHostActivity
+import network.columba.app.viewmodel.NomadNetBrowserViewModel.RenderingMode
+import org.junit.Assert.assertTrue
+import org.junit.Rule
+import org.junit.Test
+
+class MicronTrueColorRenderingTest {
+    @get:Rule
+    val composeTestRule = createAndroidComposeRule<TestHostActivity>()
+
+    @Test
+    fun rngitCodeBlockRendersTrueColorsWithoutVisibleControlPayloads() {
+        val markup =
+            ">Quick Start\n" +
+                "`BT282828`Fddd`FT8b949e# Add tasks`f\n" +
+                "`FTc9d1d9nt add `FTa5d6ff\"Buy groceries\"`f`b"
+        val document = MicronParser.parse(markup)
+
+        composeTestRule.setContent {
+            MaterialTheme {
+                Surface(
+                    modifier = Modifier.fillMaxSize(),
+                    color = Color.Black,
+                ) {
+                    MicronPageContent(
+                        document = document,
+                        formFields = emptyMap(),
+                        renderingMode = RenderingMode.MONOSPACE_SCROLL,
+                        onLinkClick = { _, _ -> },
+                        onFieldUpdate = { _, _ -> },
+                        modifier = Modifier.fillMaxSize(),
+                    )
+                }
+            }
+        }
+        composeTestRule.waitForIdle()
+
+        composeTestRule.onNodeWithText("Quick Start").assertIsDisplayed()
+        composeTestRule.onNodeWithText("# Add tasks").assertIsDisplayed()
+        composeTestRule.onNodeWithText("nt add \"Buy groceries\"").assertIsDisplayed()
+        composeTestRule.onNodeWithText("T282828", substring = true).assertDoesNotExist()
+        composeTestRule.onNodeWithText("T8b949e", substring = true).assertDoesNotExist()
+        composeTestRule.onNodeWithText("Tc9d1d9", substring = true).assertDoesNotExist()
+        composeTestRule.onNodeWithText("Ta5d6ff", substring = true).assertDoesNotExist()
+
+        val pixels =
+            composeTestRule
+                .onNodeWithTag("micron-selection-container")
+                .captureToImage()
+                .toPixelMap()
+        val expectedCodeBackground = Color(0xFF282828).toArgb()
+        var closestColor = 0
+        var closestDistance = Int.MAX_VALUE
+        for (y in 0 until pixels.height) {
+            for (x in 0 until pixels.width) {
+                val color = pixels[x, y].toArgb()
+                val distance = colorDistance(color, expectedCodeBackground)
+                if (distance < closestDistance) {
+                    closestColor = color
+                    closestDistance = distance
+                }
+            }
+        }
+        assertTrue(
+            "Rendered code block should contain the rngit #282828 background; " +
+                "closest captured color was #${closestColor.toUInt().toString(16).padStart(8, '0')} " +
+                "at RGB distance $closestDistance",
+            // Android's display/capture pipeline can shift each channel by one value.
+            closestDistance <= 3,
+        )
+    }
+
+    private fun colorDistance(
+        actual: Int,
+        expected: Int,
+    ): Int {
+        val red = ((actual shr 16) and 0xFF) - ((expected shr 16) and 0xFF)
+        val green = ((actual shr 8) and 0xFF) - ((expected shr 8) and 0xFF)
+        val blue = (actual and 0xFF) - (expected and 0xFF)
+        return red * red + green * green + blue * blue
+    }
+}

--- a/micron/src/main/java/network/columba/app/micron/MicronColor.kt
+++ b/micron/src/main/java/network/columba/app/micron/MicronColor.kt
@@ -45,7 +45,6 @@ sealed class MicronColor {
         /**
          * Parse a Micron color string.
          * - "ddd" → Hex(0xDD, 0xDD, 0xDD)
-         * - "282828" → Hex(0x28, 0x28, 0x28)
          * - "g50" → Grayscale(50)
          */
         @Suppress("ReturnCount")
@@ -58,20 +57,26 @@ sealed class MicronColor {
                 return if (level in 0..MAX_GRAYSCALE) Grayscale(level) else null
             }
 
-            return when (colorStr.length) {
-                3 -> {
-                    val r = colorStr[0].digitToIntOrNull(HEX_RADIX) ?: return null
-                    val g = colorStr[1].digitToIntOrNull(HEX_RADIX) ?: return null
-                    val b = colorStr[2].digitToIntOrNull(HEX_RADIX) ?: return null
-                    Hex(r * HEX_DOUBLER, g * HEX_DOUBLER, b * HEX_DOUBLER)
+            if (colorStr.length != 3) return null
+
+            val r = colorStr[0].digitToIntOrNull(HEX_RADIX) ?: return null
+            val g = colorStr[1].digitToIntOrNull(HEX_RADIX) ?: return null
+            val b = colorStr[2].digitToIntOrNull(HEX_RADIX) ?: return null
+            return Hex(r * HEX_DOUBLER, g * HEX_DOUBLER, b * HEX_DOUBLER)
+        }
+
+        /** Parse the six-digit payload of an inline `FT` or `BT` control. */
+        internal fun parseTrueColor(colorStr: String): MicronColor? {
+            if (colorStr.length != 6) return null
+
+            val components =
+                colorStr.chunked(2).mapNotNull { component ->
+                    component.toIntOrNull(HEX_RADIX)
                 }
-                6 -> {
-                    val r = colorStr.substring(0, 2).toIntOrNull(HEX_RADIX) ?: return null
-                    val g = colorStr.substring(2, 4).toIntOrNull(HEX_RADIX) ?: return null
-                    val b = colorStr.substring(4, 6).toIntOrNull(HEX_RADIX) ?: return null
-                    Hex(r, g, b)
-                }
-                else -> null
+            return if (components.size == 3) {
+                Hex(components[0], components[1], components[2])
+            } else {
+                null
             }
         }
     }

--- a/micron/src/main/java/network/columba/app/micron/MicronColor.kt
+++ b/micron/src/main/java/network/columba/app/micron/MicronColor.kt
@@ -3,8 +3,9 @@ package network.columba.app.micron
 /**
  * Represents a color in Micron markup.
  *
- * Micron supports three color formats:
+ * Micron supports four color formats:
  * - 3-char hex: each digit is doubled (e.g., "ddd" → 0xDD, 0xDD, 0xDD)
+ * - 6-char hex: full RGB true color (e.g., "282828" → 0x28, 0x28, 0x28)
  * - Grayscale: "gNN" where NN is 0-99 (0 = black, 99 = white)
  * - Default: inherit from theme
  */
@@ -42,8 +43,9 @@ sealed class MicronColor {
         private const val MAX_GRAYSCALE = 99
 
         /**
-         * Parse a Micron color string (3 chars after F/B command).
+         * Parse a Micron color string.
          * - "ddd" → Hex(0xDD, 0xDD, 0xDD)
+         * - "282828" → Hex(0x28, 0x28, 0x28)
          * - "g50" → Grayscale(50)
          */
         @Suppress("ReturnCount")
@@ -56,12 +58,21 @@ sealed class MicronColor {
                 return if (level in 0..MAX_GRAYSCALE) Grayscale(level) else null
             }
 
-            // 3-char hex: each digit doubled
-            val r = colorStr[0].digitToIntOrNull(HEX_RADIX) ?: return null
-            val g = colorStr[1].digitToIntOrNull(HEX_RADIX) ?: return null
-            val b = colorStr[2].digitToIntOrNull(HEX_RADIX) ?: return null
-
-            return Hex(r * HEX_DOUBLER, g * HEX_DOUBLER, b * HEX_DOUBLER)
+            return when (colorStr.length) {
+                3 -> {
+                    val r = colorStr[0].digitToIntOrNull(HEX_RADIX) ?: return null
+                    val g = colorStr[1].digitToIntOrNull(HEX_RADIX) ?: return null
+                    val b = colorStr[2].digitToIntOrNull(HEX_RADIX) ?: return null
+                    Hex(r * HEX_DOUBLER, g * HEX_DOUBLER, b * HEX_DOUBLER)
+                }
+                6 -> {
+                    val r = colorStr.substring(0, 2).toIntOrNull(HEX_RADIX) ?: return null
+                    val g = colorStr.substring(2, 4).toIntOrNull(HEX_RADIX) ?: return null
+                    val b = colorStr.substring(4, 6).toIntOrNull(HEX_RADIX) ?: return null
+                    Hex(r, g, b)
+                }
+                else -> null
+            }
         }
     }
 }

--- a/micron/src/main/java/network/columba/app/micron/MicronParser.kt
+++ b/micron/src/main/java/network/columba/app/micron/MicronParser.kt
@@ -15,7 +15,8 @@ package network.columba.app.micron
  *
  * Inline formatting uses backtick + command character:
  * - `` `! `` bold, `` `* `` italic, `` `_ `` underline
- * - `` `Fxxx `` foreground color, `` `Bxxx `` background color
+ * - `` `Fxxx `` / `` `FTxxxxxx `` foreground color
+ * - `` `Bxxx `` / `` `BTxxxxxx `` background color
  * - `` `f `` reset foreground, `` `b `` reset background
  * - `` `c `` center, `` `l `` left, `` `r `` right, `` `a `` default alignment
  * - `` ` `` (backtick + backtick or end of token) reset all formatting
@@ -369,13 +370,16 @@ object MicronParser {
             // Reset background color
             'b' -> FormatResult(style.copy(background = MicronColor.Default), alignment, afterCmd)
 
-            // Foreground color: Fxxx (3 chars)
+            // Foreground color: Fxxx (3 chars) or FTxxxxxx (6-char true color)
             'F' -> {
-                if (afterCmd + 3 <= line.length) {
-                    val colorStr = line.substring(afterCmd, afterCmd + 3)
+                val isTrueColor = afterCmd < line.length && line[afterCmd] == 'T'
+                val colorStart = afterCmd + if (isTrueColor) 1 else 0
+                val colorLength = if (isTrueColor) 6 else 3
+                if (colorStart + colorLength <= line.length) {
+                    val colorStr = line.substring(colorStart, colorStart + colorLength)
                     val color = MicronColor.parse(colorStr)
                     if (color != null) {
-                        FormatResult(style.copy(foreground = color), alignment, afterCmd + 3)
+                        FormatResult(style.copy(foreground = color), alignment, colorStart + colorLength)
                     } else {
                         null
                     }
@@ -384,13 +388,16 @@ object MicronParser {
                 }
             }
 
-            // Background color: Bxxx (3 chars)
+            // Background color: Bxxx (3 chars) or BTxxxxxx (6-char true color)
             'B' -> {
-                if (afterCmd + 3 <= line.length) {
-                    val colorStr = line.substring(afterCmd, afterCmd + 3)
+                val isTrueColor = afterCmd < line.length && line[afterCmd] == 'T'
+                val colorStart = afterCmd + if (isTrueColor) 1 else 0
+                val colorLength = if (isTrueColor) 6 else 3
+                if (colorStart + colorLength <= line.length) {
+                    val colorStr = line.substring(colorStart, colorStart + colorLength)
                     val color = MicronColor.parse(colorStr)
                     if (color != null) {
-                        FormatResult(style.copy(background = color), alignment, afterCmd + 3)
+                        FormatResult(style.copy(background = color), alignment, colorStart + colorLength)
                     } else {
                         null
                     }

--- a/micron/src/main/java/network/columba/app/micron/MicronParser.kt
+++ b/micron/src/main/java/network/columba/app/micron/MicronParser.kt
@@ -377,7 +377,12 @@ object MicronParser {
                 val colorLength = if (isTrueColor) 6 else 3
                 if (colorStart + colorLength <= line.length) {
                     val colorStr = line.substring(colorStart, colorStart + colorLength)
-                    val color = MicronColor.parse(colorStr)
+                    val color =
+                        if (isTrueColor) {
+                            MicronColor.parseTrueColor(colorStr)
+                        } else {
+                            MicronColor.parse(colorStr)
+                        }
                     if (color != null) {
                         FormatResult(style.copy(foreground = color), alignment, colorStart + colorLength)
                     } else {
@@ -395,7 +400,12 @@ object MicronParser {
                 val colorLength = if (isTrueColor) 6 else 3
                 if (colorStart + colorLength <= line.length) {
                     val colorStr = line.substring(colorStart, colorStart + colorLength)
-                    val color = MicronColor.parse(colorStr)
+                    val color =
+                        if (isTrueColor) {
+                            MicronColor.parseTrueColor(colorStr)
+                        } else {
+                            MicronColor.parse(colorStr)
+                        }
                     if (color != null) {
                         FormatResult(style.copy(background = color), alignment, colorStart + colorLength)
                     } else {

--- a/micron/src/test/java/network/columba/app/micron/MicronParserTest.kt
+++ b/micron/src/test/java/network/columba/app/micron/MicronParserTest.kt
@@ -256,7 +256,11 @@ class MicronParserTest {
 
         assertEquals("# Add tasks\nnt add \"Buy groceries\"", renderedText)
 
-        val comment = doc.lines[0].elements.filterIsInstance<MicronElement.Text>().single()
+        val comment =
+            doc.lines[0]
+                .elements
+                .filterIsInstance<MicronElement.Text>()
+                .single()
         val command =
             doc.lines[1]
                 .elements

--- a/micron/src/test/java/network/columba/app/micron/MicronParserTest.kt
+++ b/micron/src/test/java/network/columba/app/micron/MicronParserTest.kt
@@ -59,6 +59,14 @@ class MicronParserTest {
         assertEquals(MicronColor.Hex(0xDD, 0xDD, 0xDD), doc.pageForeground)
     }
 
+    @Test
+    fun `page directives do not accept inline true-color payloads`() {
+        val doc = MicronParser.parse("#!bg=282828\n#!fg=8b949e\ntext")
+
+        assertNull(doc.pageBackground)
+        assertNull(doc.pageForeground)
+    }
+
     // ==================== Cache Directive ====================
 
     @Test

--- a/micron/src/test/java/network/columba/app/micron/MicronParserTest.kt
+++ b/micron/src/test/java/network/columba/app/micron/MicronParserTest.kt
@@ -243,6 +243,38 @@ class MicronParserTest {
     }
 
     @Test
+    fun `rngit true colors render without leaking control payloads`() {
+        val markup =
+            "`BT282828`Fddd`FT8b949e# Add tasks`f\n" +
+                "`FTc9d1d9nt add `FTa5d6ff\"Buy groceries\"`f`b"
+
+        val doc = MicronParser.parse(markup)
+        val renderedText =
+            doc.lines.joinToString("\n") { line ->
+                line.elements.filterIsInstance<MicronElement.Text>().joinToString("") { it.content }
+            }
+
+        assertEquals("# Add tasks\nnt add \"Buy groceries\"", renderedText)
+
+        val comment = doc.lines[0].elements.filterIsInstance<MicronElement.Text>().single()
+        val command =
+            doc.lines[1]
+                .elements
+                .filterIsInstance<MicronElement.Text>()
+                .first { it.content == "nt add " }
+        val argument =
+            doc.lines[1]
+                .elements
+                .filterIsInstance<MicronElement.Text>()
+                .first { it.content == "\"Buy groceries\"" }
+
+        assertEquals(MicronColor.Hex(0x8B, 0x94, 0x9E), comment.style.foreground)
+        assertEquals(MicronColor.Hex(0x28, 0x28, 0x28), comment.style.background)
+        assertEquals(MicronColor.Hex(0xC9, 0xD1, 0xD9), command.style.foreground)
+        assertEquals(MicronColor.Hex(0xA5, 0xD6, 0xFF), argument.style.foreground)
+    }
+
+    @Test
     fun `foreground grayscale`() {
         val doc = MicronParser.parse("`Fg50Gray text")
         val elements = doc.lines[0].elements

--- a/micron/src/test/java/network/columba/app/micron/MicronParserTest.kt
+++ b/micron/src/test/java/network/columba/app/micron/MicronParserTest.kt
@@ -320,9 +320,47 @@ class MicronParserTest {
     }
 
     @Test
+    fun `truncated true-color controls fall back without changing style`() {
+        val foreground = MicronParser.parse("`FT12")
+        val background = MicronParser.parse("`BT12")
+        val bareForeground = MicronParser.parse("`F")
+        val bareBackground = MicronParser.parse("`B")
+        val foregroundText = foreground.singleText()
+        val backgroundText = background.singleText()
+        val bareForegroundText = bareForeground.singleText()
+        val bareBackgroundText = bareBackground.singleText()
+
+        assertEquals("T12", foregroundText.content)
+        assertEquals(MicronStyle(), foregroundText.style)
+        assertEquals("T12", backgroundText.content)
+        assertEquals(MicronStyle(), backgroundText.style)
+        assertEquals("", bareForegroundText.content)
+        assertEquals("", bareBackgroundText.content)
+    }
+
+    @Test
+    fun `malformed true-color payloads fall back without changing style`() {
+        val foreground = MicronParser.parse("`FTzzzzzztext")
+        val background = MicronParser.parse("`BTggggggtext")
+        val foregroundText = foreground.singleText()
+        val backgroundText = background.singleText()
+
+        assertEquals("Tzzzzzztext", foregroundText.content)
+        assertEquals(MicronStyle(), foregroundText.style)
+        assertEquals("Tggggggtext", backgroundText.content)
+        assertEquals(MicronStyle(), backgroundText.style)
+    }
+
+    @Test
     fun `color ddd expands correctly`() {
         val color = MicronColor.parse("ddd")
         assertEquals(MicronColor.Hex(0xDD, 0xDD, 0xDD), color)
+    }
+
+    @Test
+    fun `inline true-color parser rejects wrong length and invalid hex`() {
+        assertNull(MicronColor.parseTrueColor("fff"))
+        assertNull(MicronColor.parseTrueColor("gg0000"))
     }
 
     // ==================== Alignment ====================
@@ -1087,4 +1125,6 @@ class MicronParserTest {
         val divider = doc.lines[0].elements[0] as MicronElement.Divider
         assertEquals('\u2500', divider.character)
     }
+
+    private fun MicronDocument.singleText(): MicronElement.Text = lines.single().elements.single() as MicronElement.Text
 }


### PR DESCRIPTION
## Summary
- parse six-digit Micron foreground and background colors emitted by NomadNet
- consume complete true-color control sequences instead of leaking fragments into rendered text
- add parser regressions and a Compose rendering regression
- select the physical rendering regression in the existing CI emulator lane

## Verification
- Micron unit suite
- Micron and app ktlint/detekt
- Kotlin instrumentation APK assembly
- physical Galaxy S21 Ultra true-color rendering regression

## Risk and rollback
The parser change is limited to six-digit color controls while preserving existing short color behavior. Reverting this PR restores the previous parser and removes the added CI test selection.