### PR TITLE
feat: show LXMF resource transfer progress

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -595,3 +595,82 @@ jobs:
           pkill -9 qemu-system || true
           adb kill-server || true
 
+  transfer-progress-e2e:
+    name: Real LXMF Resource Progress E2E
+    needs: [lint, validate-wrapper]
+    runs-on: ubuntu-latest
+    timeout-minutes: 45
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v7
+        with:
+          fetch-depth: 1
+          persist-credentials: false
+
+      - name: Set up JDK 25
+        uses: actions/setup-java@v5
+        with:
+          distribution: temurin
+          java-version: 25
+
+      - name: Set up Python 3.11
+        uses: actions/setup-python@v7
+        with:
+          python-version: '3.11'
+
+      - name: Setup Gradle
+        uses: gradle/actions/setup-gradle@v6.2.0
+        with:
+          cache-read-only: false
+
+      - name: Install E2E host dependencies
+        run: |
+          python -m pip install --disable-pip-version-check -r tests/transfer_progress_e2e/requirements.txt
+          python -m pytest -q tests/transfer_progress_e2e/test_ui_driver.py
+
+      - name: Grant execute permission for gradlew
+        run: chmod +x gradlew
+
+      - name: Build Python-backend E2E APK
+        run: ./gradlew :app:assembleNoSentryPythonBackendDebug --stacktrace --max-workers=2
+
+      - name: Enable KVM
+        run: |
+          echo 'KERNEL=="kvm", GROUP="kvm", MODE="0666", OPTIONS+="static_node=kvm"' | sudo tee /etc/udev/rules.d/99-kvm4all.rules
+          sudo udevadm control --reload-rules
+          sudo udevadm trigger --name-match=kvm
+
+      - name: Run real two-peer Resource progress E2E
+        uses: reactivecircus/android-emulator-runner@v2.38.0
+        with:
+          api-level: 34
+          arch: x86_64
+          target: google_apis
+          force-avd-creation: true
+          emulator-options: -no-window -gpu swiftshader_indirect -noaudio -no-boot-anim -camera-back none -memory 3072
+          disable-animations: true
+          emulator-boot-timeout: 600
+          script: >-
+            COLUMBA_EMULATOR_SERIAL=emulator-5554
+            COLUMBA_E2E_APK=app/build/outputs/apk/noSentryPythonBackend/debug/app-noSentry-pythonBackend-x86_64-debug.apk
+            COLUMBA_E2E_ARTIFACT_DIR=artifacts/transfer-progress-e2e
+            python -m pytest -v tests/transfer_progress_e2e/test_transfer_progress_e2e.py
+            --junit-xml=artifacts/transfer-progress-e2e/results.xml;
+
+      - name: Upload Resource progress E2E evidence
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: transfer-progress-e2e-evidence
+          path: artifacts/transfer-progress-e2e/
+          retention-days: 14
+          if-no-files-found: error
+
+      - name: Cleanup emulator
+        if: always()
+        run: |
+          adb devices | grep emulator | cut -f1 | xargs -I {} adb -s {} emu kill || true
+          pkill -9 qemu-system || true
+          adb kill-server || true
+

--- a/app/src/androidTest/java/network/columba/app/ui/components/TransferProgressComponentsInstrumentedTest.kt
+++ b/app/src/androidTest/java/network/columba/app/ui/components/TransferProgressComponentsInstrumentedTest.kt
@@ -1,0 +1,116 @@
+package network.columba.app.ui.components
+
+import android.content.ContentValues
+import android.graphics.Bitmap
+import android.os.Environment
+import android.provider.MediaStore
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.width
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.asAndroidBitmap
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.captureToImage
+import androidx.compose.ui.test.junit4.createAndroidComposeRule
+import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.onNodeWithTag
+import androidx.compose.ui.unit.dp
+import androidx.test.platform.app.InstrumentationRegistry
+import network.columba.app.rns.api.model.DeliveryMethod
+import network.columba.app.rns.api.model.Direction
+import network.columba.app.rns.api.model.TransferPhase
+import network.columba.app.rns.api.model.TransferProgressUpdate
+import network.columba.app.service.SyncProgress
+import network.columba.app.test.TestHostActivity
+import org.junit.Assert.assertTrue
+import org.junit.Rule
+import org.junit.Test
+
+class TransferProgressComponentsInstrumentedTest {
+    @get:Rule
+    val composeRule = createAndroidComposeRule<TestHostActivity>()
+
+    @Test
+    fun rendersOutgoingBubbleProgress() {
+        composeRule.setContent {
+            MaterialTheme {
+                Surface(
+                    color = MaterialTheme.colorScheme.primaryContainer,
+                    shape = MaterialTheme.shapes.large,
+                ) {
+                    Column(
+                        modifier = Modifier.width(260.dp).padding(12.dp),
+                        verticalArrangement = Arrangement.spacedBy(8.dp),
+                    ) {
+                        Text("field-notes.pdf")
+                        MessageTransferProgress(outgoing())
+                    }
+                }
+            }
+        }
+
+        composeRule.onNodeWithText("Sending directly").assertIsDisplayed()
+        saveScreenshot("transfer-progress-bubble.png", "message_transfer_progress")
+    }
+
+    @Test
+    fun rendersConversationTransferTray() {
+        composeRule.setContent {
+            MaterialTheme {
+                ConversationTransferTray(
+                    incomingTransfers = listOf(incoming()),
+                    syncProgress = SyncProgress.InProgress("receiving", 0.41f),
+                    modifier = Modifier.width(360.dp).padding(16.dp),
+                )
+            }
+        }
+
+        composeRule.onNodeWithText("Receiving messages via relay").assertIsDisplayed()
+        composeRule.onNodeWithText("1 direct transfer also active").assertIsDisplayed()
+        saveScreenshot("transfer-progress-tray.png", "conversation_transfer_tray")
+    }
+
+    private fun saveScreenshot(name: String, tag: String) {
+        val context = InstrumentationRegistry.getInstrumentation().targetContext
+        val values = ContentValues().apply {
+            put(MediaStore.Images.Media.DISPLAY_NAME, name)
+            put(MediaStore.Images.Media.MIME_TYPE, "image/png")
+            put(
+                MediaStore.Images.Media.RELATIVE_PATH,
+                "${Environment.DIRECTORY_PICTURES}/ColumbaTest",
+            )
+        }
+        val output = checkNotNull(
+            context.contentResolver.insert(MediaStore.Images.Media.EXTERNAL_CONTENT_URI, values),
+        )
+        context.contentResolver.openOutputStream(output).use { stream ->
+            checkNotNull(stream)
+            composeRule.onNodeWithTag(tag).captureToImage().asAndroidBitmap()
+                .compress(Bitmap.CompressFormat.PNG, 100, stream)
+        }
+        assertTrue(output.toString().isNotBlank())
+    }
+
+    private fun outgoing() = TransferProgressUpdate(
+        transferId = "resource-out",
+        messageHash = "aabbcc",
+        direction = Direction.OUT,
+        progress = 0.64f,
+        phase = TransferPhase.TRANSFERRING,
+        totalBytes = 4_800_000,
+        deliveryMethod = DeliveryMethod.DIRECT,
+    )
+
+    private fun incoming() = TransferProgressUpdate(
+        transferId = "resource-in",
+        direction = Direction.IN,
+        progress = 0.38f,
+        phase = TransferPhase.TRANSFERRING,
+        totalBytes = 2_100_000,
+        deliveryMethod = DeliveryMethod.DIRECT,
+    )
+}

--- a/app/src/debug/AndroidManifest.xml
+++ b/app/src/debug/AndroidManifest.xml
@@ -8,7 +8,8 @@
         <!-- Test host for Compose instrumented tests (no launcher icon) -->
         <activity
             android:name="network.columba.app.test.TestHostActivity"
-            android:exported="true" />
+            android:exported="true"
+            android:theme="@style/Theme.Columba" />
 
         <!-- Disable LeakCanary's "Leaks" launcher icon -->
         <activity

--- a/app/src/main/java/network/columba/app/ui/components/TransferProgressComponents.kt
+++ b/app/src/main/java/network/columba/app/ui/components/TransferProgressComponents.kt
@@ -1,0 +1,127 @@
+package network.columba.app.ui.components
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.LinearProgressIndicator
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.pluralStringResource
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.semantics.contentDescription
+import androidx.compose.ui.semantics.semantics
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.unit.dp
+import network.columba.app.R
+import network.columba.app.rns.api.model.DeliveryMethod
+import network.columba.app.rns.api.model.TransferProgressUpdate
+import network.columba.app.service.SyncProgress
+import kotlin.math.roundToInt
+
+@Composable
+fun MessageTransferProgress(
+    update: TransferProgressUpdate,
+    modifier: Modifier = Modifier,
+) {
+    val label = when (update.deliveryMethod) {
+        DeliveryMethod.PROPAGATED -> stringResource(R.string.transfer_sending_to_relay)
+        DeliveryMethod.DIRECT -> stringResource(R.string.transfer_sending_directly)
+        DeliveryMethod.OPPORTUNISTIC, null -> stringResource(R.string.transfer_sending)
+    }
+    val percent = (update.progress.coerceIn(0f, 1f) * 100).roundToInt()
+    val description = stringResource(R.string.transfer_progress_description, label, percent)
+    Column(
+        modifier = modifier
+            .fillMaxWidth()
+            .testTag("message_transfer_progress")
+            .semantics { contentDescription = description },
+        verticalArrangement = Arrangement.spacedBy(4.dp),
+    ) {
+        Row(
+            modifier = Modifier.fillMaxWidth(),
+            horizontalArrangement = Arrangement.SpaceBetween,
+            verticalAlignment = Alignment.CenterVertically,
+        ) {
+            Text(label, style = MaterialTheme.typography.labelSmall)
+            Text(stringResource(R.string.transfer_percent, percent), style = MaterialTheme.typography.labelSmall)
+        }
+        LinearProgressIndicator(
+            progress = { update.progress.coerceIn(0f, 1f) },
+            modifier = Modifier.fillMaxWidth(),
+        )
+    }
+}
+
+@Composable
+fun ConversationTransferTray(
+    incomingTransfers: List<TransferProgressUpdate>,
+    syncProgress: SyncProgress,
+    modifier: Modifier = Modifier,
+) {
+    val relayProgress = (syncProgress as? SyncProgress.InProgress)?.progress
+    val directProgress = incomingTransfers.weightedProgress()
+    val progress = relayProgress ?: directProgress ?: return
+    val label = if (relayProgress != null) {
+        stringResource(R.string.transfer_receiving_via_relay)
+    } else {
+        pluralStringResource(
+            R.plurals.transfer_receiving_directly,
+            incomingTransfers.size,
+            incomingTransfers.size,
+        )
+    }
+    val percent = (progress.coerceIn(0f, 1f) * 100).roundToInt()
+    val description = stringResource(R.string.transfer_progress_description, label, percent)
+
+    Column(
+        modifier = modifier
+            .fillMaxWidth()
+            .testTag("conversation_transfer_tray")
+            .background(MaterialTheme.colorScheme.secondaryContainer, RoundedCornerShape(12.dp))
+            .padding(horizontal = 16.dp, vertical = 10.dp)
+            .semantics { contentDescription = description },
+        verticalArrangement = Arrangement.spacedBy(6.dp),
+    ) {
+        Row(
+            modifier = Modifier.fillMaxWidth(),
+            horizontalArrangement = Arrangement.SpaceBetween,
+            verticalAlignment = Alignment.CenterVertically,
+        ) {
+            Text(label, style = MaterialTheme.typography.labelMedium)
+            Text(stringResource(R.string.transfer_percent, percent), style = MaterialTheme.typography.labelMedium)
+        }
+        LinearProgressIndicator(
+            progress = { progress.coerceIn(0f, 1f) },
+            modifier = Modifier.fillMaxWidth(),
+        )
+        if (relayProgress != null && incomingTransfers.isNotEmpty()) {
+            Text(
+                text = pluralStringResource(
+                    R.plurals.transfer_direct_also_active,
+                    incomingTransfers.size,
+                    incomingTransfers.size,
+                ),
+                style = MaterialTheme.typography.labelSmall,
+                color = MaterialTheme.colorScheme.onSecondaryContainer,
+            )
+        }
+    }
+}
+
+private fun List<TransferProgressUpdate>.weightedProgress(): Float? {
+    val weighted = filter { (it.totalBytes ?: 0L) > 0L }
+    val total = weighted.sumOf { it.totalBytes ?: 0L }
+    return when {
+        isEmpty() -> null
+        weighted.isEmpty() -> map { it.progress }.average().toFloat()
+        total <= 0L -> null
+        else -> weighted.sumOf { (it.progress * (it.totalBytes ?: 0L)).toDouble() }.div(total).toFloat()
+    }
+}

--- a/app/src/main/java/network/columba/app/ui/screens/MessagingScreen.kt
+++ b/app/src/main/java/network/columba/app/ui/screens/MessagingScreen.kt
@@ -428,7 +428,7 @@ fun MessagingScreen(
         capabilities.messaging.outgoingResourceProgress == Support.FULL ||
             capabilities.messaging.incomingDirectResourceProgress == Support.FULL
     val activeTransferProgress = if (supportsTransferProgress) transferProgress.values.toList() else emptyList()
-    val incomingTransfers = activeTransferProgress.filter { it.direction == Direction.IN }
+    val incomingTransfers = activeTransferProgress.filter { it.isIncomingForConversation(destinationHash) }
     val isContactSaved by viewModel.isContactSaved.collectAsStateWithLifecycle()
     var showSyncStatusSheet by remember { mutableStateOf(false) }
     val syncStatusSheetState = rememberModalBottomSheetState()

--- a/app/src/main/java/network/columba/app/ui/screens/MessagingScreen.kt
+++ b/app/src/main/java/network/columba/app/ui/screens/MessagingScreen.kt
@@ -171,6 +171,9 @@ import kotlinx.coroutines.withContext
 import network.columba.app.R
 import network.columba.app.service.SyncProgress
 import network.columba.app.service.SyncResult
+import network.columba.app.rns.api.BackendCapabilities.Support
+import network.columba.app.rns.api.model.Direction
+import network.columba.app.rns.api.model.TransferProgressUpdate
 import network.columba.app.ui.components.AttachmentPanel
 import network.columba.app.ui.components.CodecSelectionDialog
 import network.columba.app.ui.components.FileAttachmentCard
@@ -180,7 +183,9 @@ import network.columba.app.ui.components.FullEmojiPickerDialog
 import network.columba.app.ui.components.ImageOptionsSheet
 import network.columba.app.ui.components.ImageQualitySelectionDialog
 import network.columba.app.ui.components.LocationPermissionBottomSheet
+import network.columba.app.ui.components.LocalCapabilities
 import network.columba.app.ui.components.MarkdownMessageText
+import network.columba.app.ui.components.MessageTransferProgress
 import network.columba.app.util.isPyxisUpdateFilename
 import network.columba.app.ui.components.QuickShareLocationBottomSheet
 import network.columba.app.ui.components.ReactionDisplayRow
@@ -191,6 +196,7 @@ import network.columba.app.ui.components.SelectableTextDialog
 import network.columba.app.ui.components.StarToggleButton
 import network.columba.app.ui.components.SwipeableMessageBubble
 import network.columba.app.ui.components.SyncStatusBottomSheet
+import network.columba.app.ui.components.ConversationTransferTray
 import network.columba.app.ui.components.simpleVerticalScrollbar
 import network.columba.app.ui.model.CodecProfile
 import network.columba.app.ui.model.LocationSharingState
@@ -416,6 +422,13 @@ fun MessagingScreen(
     val isProcessingImage by viewModel.isProcessingImage.collectAsStateWithLifecycle()
     val isSyncing by viewModel.isSyncing.collectAsStateWithLifecycle()
     val syncProgress by viewModel.syncProgress.collectAsStateWithLifecycle()
+    val transferProgress by viewModel.transferProgress.collectAsStateWithLifecycle()
+    val capabilities = LocalCapabilities.current
+    val supportsTransferProgress =
+        capabilities.messaging.outgoingResourceProgress == Support.FULL ||
+            capabilities.messaging.incomingDirectResourceProgress == Support.FULL
+    val activeTransferProgress = if (supportsTransferProgress) transferProgress.values.toList() else emptyList()
+    val incomingTransfers = activeTransferProgress.filter { it.direction == Direction.IN }
     val isContactSaved by viewModel.isContactSaved.collectAsStateWithLifecycle()
     var showSyncStatusSheet by remember { mutableStateOf(false) }
     val syncStatusSheetState = rememberModalBottomSheetState()
@@ -1150,6 +1163,12 @@ fun MessagingScreen(
                     ),
             )
 
+            ConversationTransferTray(
+                incomingTransfers = incomingTransfers,
+                syncProgress = syncProgress,
+                modifier = Modifier.padding(horizontal = 16.dp, vertical = 8.dp),
+            )
+
             // Messages + Input area using Google's official pattern
             Column(
                 modifier =
@@ -1270,6 +1289,11 @@ fun MessagingScreen(
                                             myIdentityHash = myIdentityHash,
                                             peerName = peerName,
                                             syncProgress = syncProgress,
+                                            transferProgress =
+                                                activeTransferProgress.firstOrNull {
+                                                    it.direction == Direction.OUT &&
+                                                        it.messageHash?.equals(message.id, ignoreCase = true) == true
+                                                },
                                             isImageLoading = needsImageLoading,
                                             fontScale = messageFontScale,
                                             timestampTick = timestampTick,
@@ -1798,6 +1822,7 @@ fun MessageBubble(
     myIdentityHash: String? = null,
     peerName: String = "",
     syncProgress: SyncProgress = SyncProgress.Idle,
+    transferProgress: TransferProgressUpdate? = null,
     isImageLoading: Boolean = false,
     fontScale: Float = 1.0f,
     @Suppress("UNUSED_PARAMETER") timestampTick: Long = 0L,
@@ -1976,6 +2001,13 @@ fun MessageBubble(
                         }
                     }
                 }
+            }
+
+            transferProgress?.let { progress ->
+                MessageTransferProgress(
+                    update = progress,
+                    modifier = Modifier.widthIn(max = 280.dp).padding(top = 8.dp),
+                )
             }
 
             // Fullscreen dialog for GIF-only messages
@@ -2224,6 +2256,10 @@ fun MessageBubble(
                                 isFromMe = isFromMe,
                                 fontScale = fontScale,
                             )
+                        }
+                        transferProgress?.let { progress ->
+                            Spacer(modifier = Modifier.height(8.dp))
+                            MessageTransferProgress(update = progress)
                         }
                         Spacer(modifier = Modifier.height(4.dp))
                         Row(

--- a/app/src/main/java/network/columba/app/viewmodel/MessagingViewModel.kt
+++ b/app/src/main/java/network/columba/app/viewmodel/MessagingViewModel.kt
@@ -319,6 +319,11 @@ class MessagingViewModel
         // Real-time sync progress for status UI
         val syncProgress: StateFlow<SyncProgress> = propagationNodeManager.syncProgress
 
+        private val _transferProgress =
+            MutableStateFlow<Map<String, network.columba.app.rns.api.model.TransferProgressUpdate>>(emptyMap())
+        val transferProgress: StateFlow<Map<String, network.columba.app.rns.api.model.TransferProgressUpdate>> =
+            _transferProgress.asStateFlow()
+
         // Track which images have been decoded - used to trigger recomposition
         // when images become available. The UI observes this to know when to re-check the cache.
         private val _loadedImageIds = MutableStateFlow<Set<String>>(emptySet())
@@ -816,6 +821,23 @@ class MessagingViewModel
                     throw e
                 } catch (e: Exception) {
                     Log.e(TAG, "Error collecting delivery status updates", e)
+                }
+            }
+
+            viewModelScope.launch {
+                try {
+                    rnsLxmf.observeTransferProgress().collect { update ->
+                        val key = (update.messageHash ?: update.transferId).lowercase()
+                        _transferProgress.value = if (update.isTerminal) {
+                            _transferProgress.value - key
+                        } else {
+                            _transferProgress.value + (key to update)
+                        }
+                    }
+                } catch (e: kotlinx.coroutines.CancellationException) {
+                    throw e
+                } catch (e: Exception) {
+                    Log.e(TAG, "Error collecting Resource transfer progress", e)
                 }
             }
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -94,4 +94,18 @@
     <string name="firmware_flashers_pyxis_preserves_data">Pyxis updates preserve device settings, identities, and conversations.</string>
     <string name="firmware_flashers_open_rnode">Open RNode Flasher</string>
     <string name="markdown_remote_image_not_loaded">Remote image not loaded</string>
+    <string name="transfer_sending">Sending</string>
+    <string name="transfer_sending_directly">Sending directly</string>
+    <string name="transfer_sending_to_relay">Sending to relay</string>
+    <string name="transfer_receiving_via_relay">Receiving messages via relay</string>
+    <plurals name="transfer_receiving_directly">
+        <item quantity="one">Receiving a message directly</item>
+        <item quantity="other">Receiving %1$d messages directly</item>
+    </plurals>
+    <plurals name="transfer_direct_also_active">
+        <item quantity="one">1 direct transfer also active</item>
+        <item quantity="other">%1$d direct transfers also active</item>
+    </plurals>
+    <string name="transfer_percent">%1$d%%</string>
+    <string name="transfer_progress_description">%1$s, %2$d percent</string>
 </resources>

--- a/app/src/test/java/network/columba/app/ui/components/TransferProgressComponentsTest.kt
+++ b/app/src/test/java/network/columba/app/ui/components/TransferProgressComponentsTest.kt
@@ -1,0 +1,95 @@
+package network.columba.app.ui.components
+
+import android.app.Application
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.onNodeWithContentDescription
+import androidx.compose.ui.test.onNodeWithText
+import network.columba.app.rns.api.model.DeliveryMethod
+import network.columba.app.rns.api.model.Direction
+import network.columba.app.rns.api.model.TransferPhase
+import network.columba.app.rns.api.model.TransferProgressUpdate
+import network.columba.app.service.SyncProgress
+import network.columba.app.test.RegisterComponentActivityRule
+import org.junit.Rule
+import org.junit.Test
+import org.junit.rules.RuleChain
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+
+
+@RunWith(RobolectricTestRunner::class)
+@Config(sdk = [34], application = Application::class)
+class TransferProgressComponentsTest {
+    private val activityRule = RegisterComponentActivityRule()
+    private val composeRule = createComposeRule()
+
+    @get:Rule
+    val ruleChain: RuleChain = RuleChain.outerRule(activityRule).around(composeRule)
+
+    @Test
+    fun `bubble progress identifies direct send and percentage`() {
+        composeRule.setContent {
+            MaterialTheme {
+                MessageTransferProgress(outgoing(progress = 0.64f))
+            }
+        }
+
+        composeRule.onNodeWithText("Sending directly").assertIsDisplayed()
+        composeRule.onNodeWithText("64%").assertIsDisplayed()
+        composeRule.onNodeWithContentDescription("Sending directly, 64 percent").assertIsDisplayed()
+    }
+
+    @Test
+    fun `tray labels propagation sync as aggregate relay progress`() {
+        composeRule.setContent {
+            MaterialTheme {
+                ConversationTransferTray(
+                    incomingTransfers = listOf(incoming(progress = 0.38f)),
+                    syncProgress = SyncProgress.InProgress("receiving", 0.41f),
+                )
+            }
+        }
+
+        composeRule.onNodeWithText("Receiving messages via relay").assertIsDisplayed()
+        composeRule.onNodeWithText("41%").assertIsDisplayed()
+        composeRule.onNodeWithText("1 direct transfer also active").assertIsDisplayed()
+    }
+
+    @Test
+    fun `tray labels direct incoming Resource without claiming a peer`() {
+        composeRule.setContent {
+            MaterialTheme {
+                ConversationTransferTray(
+                    incomingTransfers = listOf(incoming(progress = 0.38f)),
+                    syncProgress = SyncProgress.Idle,
+                )
+            }
+        }
+
+        composeRule.onNodeWithText("Receiving a message directly").assertIsDisplayed()
+        composeRule.onNodeWithText("38%").assertIsDisplayed()
+    }
+
+
+    private fun outgoing(progress: Float) = TransferProgressUpdate(
+        transferId = "resource-out",
+        messageHash = "aabbcc",
+        direction = Direction.OUT,
+        progress = progress,
+        phase = TransferPhase.TRANSFERRING,
+        totalBytes = 4_800_000,
+        deliveryMethod = DeliveryMethod.DIRECT,
+    )
+
+    private fun incoming(progress: Float) = TransferProgressUpdate(
+        transferId = "resource-in",
+        direction = Direction.IN,
+        progress = progress,
+        phase = TransferPhase.TRANSFERRING,
+        totalBytes = 2_100_000,
+        deliveryMethod = DeliveryMethod.DIRECT,
+    )
+}

--- a/app/src/test/java/network/columba/app/viewmodel/MessagingViewModelImageLoadingTest.kt
+++ b/app/src/test/java/network/columba/app/viewmodel/MessagingViewModelImageLoadingTest.kt
@@ -191,6 +191,7 @@ class MessagingViewModelImageLoadingTest {
         coEvery { rnsLxmf.getLxmfIdentity() } returns Result.success(testIdentity)
         every { rnsLxmf.setConversationActive(any()) } just Runs
         every { rnsLxmf.observeDeliveryStatus() } returns flowOf()
+        every { rnsLxmf.observeTransferProgress() } returns flowOf()
         every { rnsTransportAdmin.reactionReceivedFlow } returns MutableSharedFlow()
     }
 

--- a/app/src/test/java/network/columba/app/viewmodel/MessagingViewModelTest.kt
+++ b/app/src/test/java/network/columba/app/viewmodel/MessagingViewModelTest.kt
@@ -18,7 +18,11 @@ import network.columba.app.data.repository.ReplyPreview
 import network.columba.app.repository.SettingsRepository
 import network.columba.app.rns.api.model.Identity
 import network.columba.app.rns.api.model.DeliveryStatusUpdate
+import network.columba.app.rns.api.model.DeliveryMethod
+import network.columba.app.rns.api.model.Direction
 import network.columba.app.rns.api.model.MessageReceipt
+import network.columba.app.rns.api.model.TransferPhase
+import network.columba.app.rns.api.model.TransferProgressUpdate
 import network.columba.app.rns.api.RnsCore
 import network.columba.app.rns.api.RnsLxmf
 import network.columba.app.rns.api.RnsTransportAdmin
@@ -189,6 +193,7 @@ class MessagingViewModelTest {
 
         // Mock delivery status observer (returns empty flow by default)
         every { rnsLxmf.observeDeliveryStatus() } returns flowOf()
+        every { rnsLxmf.observeTransferProgress() } returns flowOf()
 
         // Mock reaction received flow (returns empty flow by default)
         every { rnsTransportAdmin.reactionReceivedFlow } returns MutableSharedFlow()
@@ -4829,6 +4834,30 @@ class MessagingViewModelTest {
         }
 
     // Note: onCleared() tests removed - method is protected and cannot be called directly
+
+    @Test
+    fun `resource progress is exposed while active and removed at terminal state`() = runTest {
+        val progressFlow = MutableSharedFlow<TransferProgressUpdate>(extraBufferCapacity = 4)
+        every { rnsLxmf.observeTransferProgress() } returns progressFlow
+        val viewModel = createTestViewModel()
+        advanceUntilIdle()
+        val active = TransferProgressUpdate(
+            transferId = "resource-1",
+            messageHash = "aabbcc",
+            direction = Direction.OUT,
+            progress = 0.64f,
+            phase = TransferPhase.TRANSFERRING,
+            deliveryMethod = DeliveryMethod.DIRECT,
+        )
+
+        progressFlow.emit(active)
+        advanceUntilIdle()
+        assertEquals(active, viewModel.transferProgress.value["aabbcc"])
+
+        progressFlow.emit(active.copy(progress = 1f, phase = TransferPhase.COMPLETE))
+        advanceUntilIdle()
+        assertTrue(viewModel.transferProgress.value.isEmpty())
+    }
     // The behavior is indirectly tested via the ViewModel lifecycle in integration tests
 
     // ========== TOTAL ATTACHMENT SIZE TESTS ==========

--- a/rns-api/src/main/aidl/network/columba/app/rns/api/model/TransferProgressUpdate.aidl
+++ b/rns-api/src/main/aidl/network/columba/app/rns/api/model/TransferProgressUpdate.aidl
@@ -1,0 +1,3 @@
+package network.columba.app.rns.api.model;
+
+parcelable TransferProgressUpdate;

--- a/rns-api/src/main/aidl/network/columba/app/rns/ipc/IRnsLxmf.aidl
+++ b/rns-api/src/main/aidl/network/columba/app/rns/ipc/IRnsLxmf.aidl
@@ -28,6 +28,7 @@ import network.columba.app.rns.ipc.callback.IRnsMessageCallback;
 import network.columba.app.rns.ipc.callback.IRnsPropagationStateCallback;
 import network.columba.app.rns.ipc.callback.IRnsResultCallback;
 import network.columba.app.rns.ipc.callback.IRnsStringCallback;
+import network.columba.app.rns.ipc.callback.IRnsTransferProgressCallback;
 
 oneway interface IRnsLxmf {
     // ==================== Send ====================
@@ -68,6 +69,10 @@ oneway interface IRnsLxmf {
     // Flow<DeliveryStatusUpdate>: observer register/unregister.
     void registerDeliveryStatusObserver(in IRnsDeliveryStatusCallback cb);
     void unregisterDeliveryStatusObserver(in IRnsDeliveryStatusCallback cb);
+
+    // Flow<TransferProgressUpdate>: ephemeral Resource progress.
+    void registerTransferProgressObserver(in IRnsTransferProgressCallback cb);
+    void unregisterTransferProgressObserver(in IRnsTransferProgressCallback cb);
 
     // ==================== LXMF identity access ====================
 

--- a/rns-api/src/main/aidl/network/columba/app/rns/ipc/callback/IRnsTransferProgressCallback.aidl
+++ b/rns-api/src/main/aidl/network/columba/app/rns/ipc/callback/IRnsTransferProgressCallback.aidl
@@ -1,0 +1,7 @@
+package network.columba.app.rns.ipc.callback;
+
+import network.columba.app.rns.api.model.TransferProgressUpdate;
+
+oneway interface IRnsTransferProgressCallback {
+    void onTransferProgress(in TransferProgressUpdate update);
+}

--- a/rns-api/src/main/java/network/columba/app/rns/api/BackendCapabilities.kt
+++ b/rns-api/src/main/java/network/columba/app/rns/api/BackendCapabilities.kt
@@ -26,6 +26,7 @@ data class BackendCapabilities(
     val interfaces: InterfaceCaps,
     val telemetry: TelemetryCaps,
     val performance: PerformanceCaps,
+    val messaging: MessagingCaps = MessagingCaps(),
 ) : Parcelable {
     /**
      * Versions of the underlying protocol libraries. Co-located with
@@ -82,6 +83,13 @@ data class BackendCapabilities(
         val storeOwnTelemetry: Support,
         val allowedRequestersFilter: Support,
         val degradationHint: String? = null,
+    ) : Parcelable
+
+    /** Live LXMF Resource progress. Propagation-node sync has its own existing state flow. */
+    @Parcelize
+    data class MessagingCaps(
+        val outgoingResourceProgress: Support = Support.UNSUPPORTED,
+        val incomingDirectResourceProgress: Support = Support.UNSUPPORTED,
     ) : Parcelable
 
     /**

--- a/rns-api/src/main/java/network/columba/app/rns/api/RnsLxmf.kt
+++ b/rns-api/src/main/java/network/columba/app/rns/api/RnsLxmf.kt
@@ -2,6 +2,7 @@ package network.columba.app.rns.api
 
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.SharedFlow
+import kotlinx.coroutines.flow.emptyFlow
 import network.columba.app.rns.api.model.DeliveryMethod
 import network.columba.app.rns.api.model.DeliveryStatusUpdate
 import network.columba.app.rns.api.model.Destination
@@ -10,6 +11,7 @@ import network.columba.app.rns.api.model.Identity
 import network.columba.app.rns.api.model.MessageReceipt
 import network.columba.app.rns.api.model.PropagationState
 import network.columba.app.rns.api.model.ReceivedMessage
+import network.columba.app.rns.api.model.TransferProgressUpdate
 
 /**
  * LXMF messaging surface: send/receive messages, observe delivery state,
@@ -98,6 +100,9 @@ interface RnsLxmf {
      * Emits DeliveryStatusUpdate events when messages are delivered or fail.
      */
     fun observeDeliveryStatus(): Flow<DeliveryStatusUpdate>
+
+    /** Ephemeral per-Resource progress. Unsupported backends emit nothing. */
+    fun observeTransferProgress(): Flow<TransferProgressUpdate> = emptyFlow()
 
     // ==================== LXMF identity access ====================
 

--- a/rns-api/src/main/java/network/columba/app/rns/api/model/TransferProgressUpdate.kt
+++ b/rns-api/src/main/java/network/columba/app/rns/api/model/TransferProgressUpdate.kt
@@ -1,0 +1,30 @@
+package network.columba.app.rns.api.model
+
+import android.os.Parcelable
+import kotlinx.parcelize.Parcelize
+
+/** Ephemeral progress for one LXMF Resource transfer. Never persisted as message state. */
+@Parcelize
+data class TransferProgressUpdate(
+    /** Resource hash when available; otherwise the outgoing message hash. */
+    val transferId: String,
+    /** LXMF message hash for outgoing transfers. Incoming Resources have no message hash until decoded. */
+    val messageHash: String? = null,
+    val direction: Direction,
+    /** Inclusive 0.0 to 1.0 progress reported by LXMF/RNS. */
+    val progress: Float,
+    val phase: TransferPhase,
+    val totalBytes: Long? = null,
+    val deliveryMethod: DeliveryMethod? = null,
+) : Parcelable {
+    val isTerminal: Boolean
+        get() = phase == TransferPhase.COMPLETE || phase == TransferPhase.FAILED
+}
+
+@Parcelize
+enum class TransferPhase : Parcelable {
+    PREPARING,
+    TRANSFERRING,
+    COMPLETE,
+    FAILED,
+}

--- a/rns-api/src/main/java/network/columba/app/rns/api/model/TransferProgressUpdate.kt
+++ b/rns-api/src/main/java/network/columba/app/rns/api/model/TransferProgressUpdate.kt
@@ -10,6 +10,8 @@ data class TransferProgressUpdate(
     val transferId: String,
     /** LXMF message hash for outgoing transfers. Incoming Resources have no message hash until decoded. */
     val messageHash: String? = null,
+    /** Sender's LXMF delivery destination for incoming direct Resources, when the link identifies it. */
+    val sourceDestinationHash: String? = null,
     val direction: Direction,
     /** Inclusive 0.0 to 1.0 progress reported by LXMF/RNS. */
     val progress: Float,
@@ -19,6 +21,10 @@ data class TransferProgressUpdate(
 ) : Parcelable {
     val isTerminal: Boolean
         get() = phase == TransferPhase.COMPLETE || phase == TransferPhase.FAILED
+
+    fun isIncomingForConversation(destinationHash: String): Boolean =
+        direction == Direction.IN &&
+            sourceDestinationHash?.equals(destinationHash, ignoreCase = true) == true
 }
 
 @Parcelize

--- a/rns-api/src/test/java/network/columba/app/rns/api/BackendCapabilitiesTest.kt
+++ b/rns-api/src/test/java/network/columba/app/rns/api/BackendCapabilitiesTest.kt
@@ -2,6 +2,7 @@ package network.columba.app.rns.api
 
 import network.columba.app.rns.api.BackendCapabilities.BackendId
 import network.columba.app.rns.api.BackendCapabilities.InterfaceCaps
+import network.columba.app.rns.api.BackendCapabilities.MessagingCaps
 import network.columba.app.rns.api.BackendCapabilities.PerformanceCaps
 import network.columba.app.rns.api.BackendCapabilities.Support
 import network.columba.app.rns.api.BackendCapabilities.TelemetryCaps
@@ -19,6 +20,8 @@ class BackendCapabilitiesTest {
         assert(caps.interfaces.hotReloadInterfaces)
         assertEquals(Support.FULL, caps.performance.batteryProfileTuning)
         assertEquals(Support.FULL, caps.telemetry.collectorHostMode)
+        assertEquals(Support.UNSUPPORTED, caps.messaging.outgoingResourceProgress)
+        assertEquals(Support.UNSUPPORTED, caps.messaging.incomingDirectResourceProgress)
         assert(!caps.performance.sharedInstanceAvailabilityChecks)
         assert(!caps.performance.shareInstanceHosting)
     }
@@ -31,6 +34,8 @@ class BackendCapabilitiesTest {
         assertEquals(Support.UNSUPPORTED, caps.performance.batteryProfileTuning)
         // Telemetry collector host mode is the well-tested reference path on python.
         assertEquals(Support.FULL, caps.telemetry.collectorHostMode)
+        assertEquals(Support.FULL, caps.messaging.outgoingResourceProgress)
+        assertEquals(Support.FULL, caps.messaging.incomingDirectResourceProgress)
         assert(caps.performance.sharedInstanceAvailabilityChecks)
         assert(caps.performance.shareInstanceHosting)
     }
@@ -86,6 +91,10 @@ class BackendCapabilitiesTest {
                     storeOwnTelemetry = Support.FULL,
                     allowedRequestersFilter = Support.FULL,
                 ),
+            messaging = MessagingCaps(
+                outgoingResourceProgress = Support.UNSUPPORTED,
+                incomingDirectResourceProgress = Support.UNSUPPORTED,
+            ),
             performance =
                 PerformanceCaps(
                     batteryProfileTuning = Support.FULL,
@@ -105,6 +114,10 @@ class BackendCapabilitiesTest {
                     storeOwnTelemetry = Support.FULL,
                     allowedRequestersFilter = Support.FULL,
                 ),
+            messaging = MessagingCaps(
+                outgoingResourceProgress = Support.FULL,
+                incomingDirectResourceProgress = Support.FULL,
+            ),
             performance =
                 PerformanceCaps(
                     batteryProfileTuning = Support.UNSUPPORTED,

--- a/rns-api/src/test/java/network/columba/app/rns/api/model/TransferProgressUpdateTest.kt
+++ b/rns-api/src/test/java/network/columba/app/rns/api/model/TransferProgressUpdateTest.kt
@@ -1,0 +1,39 @@
+package network.columba.app.rns.api.model
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Test
+
+class TransferProgressUpdateTest {
+    @Test
+    fun `outgoing resource progress is keyed by message hash`() {
+        val update = TransferProgressUpdate(
+            transferId = "resource-1",
+            messageHash = "aabbcc",
+            direction = Direction.OUT,
+            progress = 0.64f,
+            phase = TransferPhase.TRANSFERRING,
+            totalBytes = 4_800_000L,
+            deliveryMethod = DeliveryMethod.DIRECT,
+        )
+
+        assertEquals("aabbcc", update.messageHash)
+        assertEquals(0.64f, update.progress)
+        assertEquals(Direction.OUT, update.direction)
+    }
+
+    @Test
+    fun `incoming resource progress does not claim a message identity`() {
+        val update = TransferProgressUpdate(
+            transferId = "resource-2",
+            messageHash = null,
+            direction = Direction.IN,
+            progress = 0.38f,
+            phase = TransferPhase.TRANSFERRING,
+            totalBytes = 2_100_000L,
+        )
+
+        assertNull(update.messageHash)
+        assertEquals(Direction.IN, update.direction)
+    }
+}

--- a/rns-api/src/test/java/network/columba/app/rns/api/model/TransferProgressUpdateTest.kt
+++ b/rns-api/src/test/java/network/columba/app/rns/api/model/TransferProgressUpdateTest.kt
@@ -1,7 +1,9 @@
 package network.columba.app.rns.api.model
 
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
 import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
 import org.junit.Test
 
 class TransferProgressUpdateTest {
@@ -27,6 +29,7 @@ class TransferProgressUpdateTest {
         val update = TransferProgressUpdate(
             transferId = "resource-2",
             messageHash = null,
+            sourceDestinationHash = "deadbeef",
             direction = Direction.IN,
             progress = 0.38f,
             phase = TransferPhase.TRANSFERRING,
@@ -34,6 +37,10 @@ class TransferProgressUpdateTest {
         )
 
         assertNull(update.messageHash)
+        assertEquals("deadbeef", update.sourceDestinationHash)
         assertEquals(Direction.IN, update.direction)
+        assertTrue(update.isIncomingForConversation("DEADBEEF"))
+        assertFalse(update.isIncomingForConversation("cafebabe"))
+        assertFalse(update.copy(sourceDestinationHash = null).isIncomingForConversation("deadbeef"))
     }
 }

--- a/rns-backend-kt/src/main/kotlin/network/columba/app/rns/backend/kt/NativeCapabilities.kt
+++ b/rns-backend-kt/src/main/kotlin/network/columba/app/rns/backend/kt/NativeCapabilities.kt
@@ -3,6 +3,7 @@ package network.columba.app.rns.backend.kt
 import network.columba.app.rns.api.BackendCapabilities
 import network.columba.app.rns.api.BackendCapabilities.BackendId
 import network.columba.app.rns.api.BackendCapabilities.InterfaceCaps
+import network.columba.app.rns.api.BackendCapabilities.MessagingCaps
 import network.columba.app.rns.api.BackendCapabilities.PerformanceCaps
 import network.columba.app.rns.api.BackendCapabilities.Support
 import network.columba.app.rns.api.BackendCapabilities.TelemetryCaps
@@ -38,6 +39,10 @@ val NATIVE_CAPABILITIES: BackendCapabilities = BackendCapabilities(
         storeOwnTelemetry = Support.FULL,
         allowedRequestersFilter = Support.FULL,
         degradationHint = "lxmf-kt FIELD_TELEMETRY_STREAM encoder pending parity test against upstream Python LXMF",
+    ),
+    messaging = MessagingCaps(
+        outgoingResourceProgress = Support.UNSUPPORTED,
+        incomingDirectResourceProgress = Support.UNSUPPORTED,
     ),
     performance = PerformanceCaps(
         batteryProfileTuning = Support.FULL,

--- a/rns-backend-py/src/main/kotlin/network/columba/app/rns/backend/py/PythonCapabilities.kt
+++ b/rns-backend-py/src/main/kotlin/network/columba/app/rns/backend/py/PythonCapabilities.kt
@@ -3,6 +3,7 @@ package network.columba.app.rns.backend.py
 import network.columba.app.rns.api.BackendCapabilities
 import network.columba.app.rns.api.BackendCapabilities.BackendId
 import network.columba.app.rns.api.BackendCapabilities.InterfaceCaps
+import network.columba.app.rns.api.BackendCapabilities.MessagingCaps
 import network.columba.app.rns.api.BackendCapabilities.PerformanceCaps
 import network.columba.app.rns.api.BackendCapabilities.Support
 import network.columba.app.rns.api.BackendCapabilities.TelemetryCaps
@@ -68,6 +69,10 @@ val PYTHON_CAPABILITIES: BackendCapabilities = BackendCapabilities(
         collectorHostMode = Support.FULL,
         storeOwnTelemetry = Support.FULL,
         allowedRequestersFilter = Support.FULL,
+    ),
+    messaging = MessagingCaps(
+        outgoingResourceProgress = Support.FULL,
+        incomingDirectResourceProgress = Support.FULL,
     ),
     performance = PerformanceCaps(
         batteryProfileTuning = Support.UNSUPPORTED,

--- a/rns-backend-py/src/main/kotlin/network/columba/app/rns/backend/py/PythonRnsLxmf.kt
+++ b/rns-backend-py/src/main/kotlin/network/columba/app/rns/backend/py/PythonRnsLxmf.kt
@@ -346,6 +346,7 @@ class PythonRnsLxmf(
                 TransferProgressUpdate(
                     transferId = transferId,
                     messageHash = null,
+                    sourceDestinationHash = resource.incomingSourceDestinationHash(),
                     direction = Direction.IN,
                     progress = resource.pyDoubleCall("get_progress").coerceIn(0.0, 1.0).toFloat(),
                     phase = TransferPhase.TRANSFERRING,
@@ -354,6 +355,21 @@ class PythonRnsLxmf(
                 )
             }.getOrNull()
         }
+    }
+
+    private fun PyObject.incomingSourceDestinationHash(): String? {
+        val link = callAttr("get_link")?.takeUnless { it.toString() == "None" }
+        val remoteIdentity =
+            link?.callAttr("get_remote_identity")?.takeUnless { it.toString() == "None" }
+        val destinationClass = runtime.rnsModule["Destination"]
+        val fullName = "${LxmfFields.APP_NAME}.${LxmfFields.DELIVERY_ASPECT}"
+        return if (remoteIdentity == null || destinationClass == null) {
+            null
+        } else {
+            destinationClass.callAttr("hash_from_name_and_identity", fullName, remoteIdentity)
+        }
+            ?.toJava(ByteArray::class.java)
+            ?.toHex()
     }
 
     private fun PyObject.pyInt(name: String): Int? =

--- a/rns-backend-py/src/main/kotlin/network/columba/app/rns/backend/py/PythonRnsLxmf.kt
+++ b/rns-backend-py/src/main/kotlin/network/columba/app/rns/backend/py/PythonRnsLxmf.kt
@@ -36,6 +36,28 @@ import network.columba.app.rns.api.util.ReactionWireCodec
 import network.columba.app.rns.api.util.hexToBytes
 import network.columba.app.rns.api.util.toHex
 
+internal enum class OutgoingTransferPollAction {
+    WAIT,
+    PUBLISH,
+    STOP,
+}
+
+internal fun outgoingTransferPollAction(
+    representation: Int?,
+    state: Int,
+): OutgoingTransferPollAction = when {
+    representation == PythonRnsLxmf.LXMF_REPRESENTATION_RESOURCE -> OutgoingTransferPollAction.PUBLISH
+    representation == PythonRnsLxmf.LXMF_REPRESENTATION_PACKET -> OutgoingTransferPollAction.STOP
+    state in setOf(
+        PythonRnsLxmf.LXMF_STATE_SENT,
+        PythonRnsLxmf.LXMF_STATE_DELIVERED,
+        PythonRnsLxmf.LXMF_STATE_REJECTED,
+        PythonRnsLxmf.LXMF_STATE_CANCELLED,
+        PythonRnsLxmf.LXMF_STATE_FAILED,
+    ) -> OutgoingTransferPollAction.STOP
+    else -> OutgoingTransferPollAction.WAIT
+}
+
 /**
  * `RnsLxmf` over upstream Python LXMF, driven through Chaquopy.
  *
@@ -57,14 +79,18 @@ class PythonRnsLxmf(
     private val runtime: PythonRnsRuntime,
     private val events: PythonEventBridge,
 ) : RnsLxmf {
-    private companion object {
+    internal companion object {
         const val TAG = "PythonRnsLxmf"
 
         // LXMF.LXMessage delivery-method ints (LXMF/LXMessage.py).
         const val LXMF_METHOD_OPPORTUNISTIC = 0x01
         const val LXMF_METHOD_DIRECT = 0x02
         const val LXMF_METHOD_PROPAGATED = 0x03
+        const val LXMF_REPRESENTATION_UNKNOWN = 0x00
+        const val LXMF_REPRESENTATION_PACKET = 0x01
         const val LXMF_REPRESENTATION_RESOURCE = 0x02
+        const val LXMF_STATE_OUTBOUND = 0x01
+        const val LXMF_STATE_SENDING = 0x02
         const val LXMF_STATE_SENT = 0x04
         const val LXMF_STATE_DELIVERED = 0x08
         const val LXMF_STATE_REJECTED = 0xFD
@@ -265,9 +291,9 @@ class PythonRnsLxmf(
         router.callAttr("handle_outbound", lxmessage)
 
         val hashBytes = lxmessage["hash"]?.toJava(ByteArray::class.java) ?: ByteArray(0)
-        if (lxmessage.pyInt("representation") == LXMF_REPRESENTATION_RESOURCE) {
-            startOutgoingTransferPoll(hashBytes.toHex(), lxmessage)
-        }
+        // handle_outbound() queues work on a Python thread. The representation is
+        // still UNKNOWN here and becomes PACKET or RESOURCE when LXMessage.send() runs.
+        startOutgoingTransferPoll(hashBytes.toHex(), lxmessage)
         return MessageReceipt(
             messageHash = hashBytes,
             timestamp = System.currentTimeMillis(),
@@ -283,7 +309,16 @@ class PythonRnsLxmf(
         backgroundScope.launch {
             var last: TransferProgressUpdate? = null
             while (isActive) {
-                val update = runCatching { outgoingTransferUpdate(messageHash, lxmessage) }
+                val state = lxmessage.pyInt("state") ?: 0
+                when (outgoingTransferPollAction(lxmessage.pyInt("representation"), state)) {
+                    OutgoingTransferPollAction.WAIT -> {
+                        delay(TRANSFER_POLL_INTERVAL_MS)
+                        continue
+                    }
+                    OutgoingTransferPollAction.STOP -> break
+                    OutgoingTransferPollAction.PUBLISH -> Unit
+                }
+                val update = runCatching { outgoingTransferUpdate(messageHash, lxmessage, state) }
                     .onFailure { Log.w(TAG, "Unable to read outgoing Resource progress", it) }
                     .getOrNull()
                 if (update != null && update != last) {
@@ -296,8 +331,11 @@ class PythonRnsLxmf(
         }
     }
 
-    private fun outgoingTransferUpdate(messageHash: String, lxmessage: PyObject): TransferProgressUpdate {
-        val state = lxmessage.pyInt("state") ?: 0
+    private fun outgoingTransferUpdate(
+        messageHash: String,
+        lxmessage: PyObject,
+        state: Int,
+    ): TransferProgressUpdate {
         val progress = lxmessage.pyDouble("progress").coerceIn(0.0, 1.0).toFloat()
         val resource = lxmessage["resource_representation"]?.takeUnless { it.toString() == "None" }
         return TransferProgressUpdate(

--- a/rns-backend-py/src/main/kotlin/network/columba/app/rns/backend/py/PythonRnsLxmf.kt
+++ b/rns-backend-py/src/main/kotlin/network/columba/app/rns/backend/py/PythonRnsLxmf.kt
@@ -12,6 +12,8 @@ import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.SharedFlow
 import kotlinx.coroutines.flow.asSharedFlow
+import kotlinx.coroutines.flow.flow
+import kotlinx.coroutines.flow.merge
 import kotlinx.coroutines.isActive
 import kotlinx.coroutines.launch
 import network.columba.app.rns.api.RnsError
@@ -27,6 +29,8 @@ import network.columba.app.rns.api.model.Identity
 import network.columba.app.rns.api.model.MessageReceipt
 import network.columba.app.rns.api.model.PropagationState
 import network.columba.app.rns.api.model.ReceivedMessage
+import network.columba.app.rns.api.model.TransferPhase
+import network.columba.app.rns.api.model.TransferProgressUpdate
 import network.columba.app.rns.api.util.LxmfFields
 import network.columba.app.rns.api.util.ReactionWireCodec
 import network.columba.app.rns.api.util.hexToBytes
@@ -60,6 +64,12 @@ class PythonRnsLxmf(
         const val LXMF_METHOD_OPPORTUNISTIC = 0x01
         const val LXMF_METHOD_DIRECT = 0x02
         const val LXMF_METHOD_PROPAGATED = 0x03
+        const val LXMF_REPRESENTATION_RESOURCE = 0x02
+        const val LXMF_STATE_SENT = 0x04
+        const val LXMF_STATE_DELIVERED = 0x08
+        const val LXMF_STATE_REJECTED = 0xFD
+        const val LXMF_STATE_CANCELLED = 0xFE
+        const val LXMF_STATE_FAILED = 0xFF
 
         /** Bound on how long to wait for a recipient identity to resolve via a path request. */
         const val PATH_RESOLVE_TIMEOUT_MS = 10_000L
@@ -67,6 +77,7 @@ class PythonRnsLxmf(
 
         /** Live-poll cadence for upstream `propagation_transfer_state`. */
         const val PROPAGATION_POLL_INTERVAL_MS = 500L
+        const val TRANSFER_POLL_INTERVAL_MS = 500L
     }
 
     /**
@@ -90,6 +101,9 @@ class PythonRnsLxmf(
         MutableSharedFlow<PropagationState>(replay = 1, extraBufferCapacity = 8)
     override val propagationStateFlow: SharedFlow<PropagationState> =
         _propagationStateFlow.asSharedFlow()
+
+    private val outgoingTransferProgress =
+        MutableSharedFlow<TransferProgressUpdate>(replay = 8, extraBufferCapacity = 64)
 
     /** Mirrors `NativeRnsBackendImpl` — a polling hint with no LXMF-side effect on this backend. */
     @Volatile
@@ -251,12 +265,120 @@ class PythonRnsLxmf(
         router.callAttr("handle_outbound", lxmessage)
 
         val hashBytes = lxmessage["hash"]?.toJava(ByteArray::class.java) ?: ByteArray(0)
+        if (lxmessage.pyInt("representation") == LXMF_REPRESENTATION_RESOURCE) {
+            startOutgoingTransferPoll(hashBytes.toHex(), lxmessage)
+        }
         return MessageReceipt(
             messageHash = hashBytes,
             timestamp = System.currentTimeMillis(),
             destinationHash = recipientDest["hash"]?.toJava(ByteArray::class.java)
                 ?: destinationHash,
         )
+    }
+
+    override fun observeTransferProgress(): Flow<TransferProgressUpdate> =
+        merge(outgoingTransferProgress.asSharedFlow(), incomingTransferProgress())
+
+    private fun startOutgoingTransferPoll(messageHash: String, lxmessage: PyObject) {
+        backgroundScope.launch {
+            var last: TransferProgressUpdate? = null
+            while (isActive) {
+                val update = runCatching { outgoingTransferUpdate(messageHash, lxmessage) }
+                    .onFailure { Log.w(TAG, "Unable to read outgoing Resource progress", it) }
+                    .getOrNull()
+                if (update != null && update != last) {
+                    outgoingTransferProgress.emit(update)
+                    last = update
+                }
+                if (update?.isTerminal == true) break
+                delay(TRANSFER_POLL_INTERVAL_MS)
+            }
+        }
+    }
+
+    private fun outgoingTransferUpdate(messageHash: String, lxmessage: PyObject): TransferProgressUpdate {
+        val state = lxmessage.pyInt("state") ?: 0
+        val progress = lxmessage.pyDouble("progress").coerceIn(0.0, 1.0).toFloat()
+        val resource = lxmessage["resource_representation"]?.takeUnless { it.toString() == "None" }
+        return TransferProgressUpdate(
+            transferId = resource?.get("hash")?.toJava(ByteArray::class.java)?.toHex() ?: messageHash,
+            messageHash = messageHash,
+            direction = Direction.OUT,
+            progress = progress,
+            phase = when (state) {
+                LXMF_STATE_SENT, LXMF_STATE_DELIVERED -> TransferPhase.COMPLETE
+                LXMF_STATE_REJECTED, LXMF_STATE_CANCELLED, LXMF_STATE_FAILED -> TransferPhase.FAILED
+                else -> if (progress > 0f) TransferPhase.TRANSFERRING else TransferPhase.PREPARING
+            },
+            totalBytes = resource?.pyLongCall("get_transfer_size"),
+            deliveryMethod = lxmfDeliveryMethod(lxmessage.pyInt("method")),
+        )
+    }
+
+    private fun incomingTransferProgress(): Flow<TransferProgressUpdate> = flow {
+        val previous = LinkedHashMap<String, TransferProgressUpdate>()
+        while (kotlin.coroutines.coroutineContext.isActive) {
+            val current = runCatching { readIncomingTransfers() }
+                .onFailure { Log.w(TAG, "Unable to read inbound Resources", it) }
+                .getOrNull()
+            if (current != null) {
+                val currentById = current.associateBy { it.transferId }
+                current.forEach { update ->
+                    if (previous[update.transferId] != update) emit(update)
+                }
+                previous.values
+                    .filter { it.transferId !in currentById }
+                    .forEach { emit(it.copy(progress = 1f, phase = TransferPhase.COMPLETE)) }
+                previous.clear()
+                previous.putAll(currentById)
+            }
+            delay(TRANSFER_POLL_INTERVAL_MS)
+        }
+    }
+
+    private fun readIncomingTransfers(): List<TransferProgressUpdate> {
+        val router = runtime.lxmRouter ?: return emptyList()
+        val resources = router.callAttr("inbound_resources") ?: return emptyList()
+        return resources.asList().mapNotNull { resource ->
+            runCatching {
+                val transferId = resource["hash"]?.toJava(ByteArray::class.java)?.toHex()
+                    ?: return@runCatching null
+                TransferProgressUpdate(
+                    transferId = transferId,
+                    messageHash = null,
+                    direction = Direction.IN,
+                    progress = resource.pyDoubleCall("get_progress").coerceIn(0.0, 1.0).toFloat(),
+                    phase = TransferPhase.TRANSFERRING,
+                    totalBytes = resource.pyLongCall("get_transfer_size"),
+                    deliveryMethod = DeliveryMethod.DIRECT,
+                )
+            }.getOrNull()
+        }
+    }
+
+    private fun PyObject.pyInt(name: String): Int? =
+        get(name)?.let { value ->
+            runCatching { value.toJava(Int::class.javaObjectType) }.getOrNull()
+                ?: runCatching { value.toJava(Long::class.javaObjectType).toInt() }.getOrNull()
+        }
+
+    private fun PyObject.pyDouble(name: String): Double =
+        get(name)?.let { runCatching { it.toJava(Double::class.javaObjectType) }.getOrNull() } ?: 0.0
+
+    private fun PyObject.pyDoubleCall(name: String): Double =
+        callAttr(name)?.let { runCatching { it.toJava(Double::class.javaObjectType) }.getOrNull() } ?: 0.0
+
+    private fun PyObject.pyLongCall(name: String): Long? =
+        callAttr(name)?.takeUnless { it.toString() == "None" }?.let { value ->
+            runCatching { value.toJava(Long::class.javaObjectType) }.getOrNull()
+                ?: runCatching { value.toJava(Int::class.javaObjectType).toLong() }.getOrNull()
+        }
+
+    private fun lxmfDeliveryMethod(method: Int?): DeliveryMethod? = when (method) {
+        LXMF_METHOD_OPPORTUNISTIC -> DeliveryMethod.OPPORTUNISTIC
+        LXMF_METHOD_DIRECT -> DeliveryMethod.DIRECT
+        LXMF_METHOD_PROPAGATED -> DeliveryMethod.PROPAGATED
+        else -> null
     }
 
     /**

--- a/rns-backend-py/src/test/kotlin/network/columba/app/rns/backend/py/OutgoingTransferPollActionTest.kt
+++ b/rns-backend-py/src/test/kotlin/network/columba/app/rns/backend/py/OutgoingTransferPollActionTest.kt
@@ -1,0 +1,42 @@
+package network.columba.app.rns.backend.py
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class OutgoingTransferPollActionTest {
+    @Test
+    fun `waits for asynchronous Resource representation selection`() {
+        assertEquals(
+            OutgoingTransferPollAction.WAIT,
+            outgoingTransferPollAction(
+                representation = PythonRnsLxmf.LXMF_REPRESENTATION_UNKNOWN,
+                state = PythonRnsLxmf.LXMF_STATE_OUTBOUND,
+            ),
+        )
+        assertEquals(
+            OutgoingTransferPollAction.PUBLISH,
+            outgoingTransferPollAction(
+                representation = PythonRnsLxmf.LXMF_REPRESENTATION_RESOURCE,
+                state = PythonRnsLxmf.LXMF_STATE_SENDING,
+            ),
+        )
+    }
+
+    @Test
+    fun `stops for packet and terminal messages without publishing progress`() {
+        assertEquals(
+            OutgoingTransferPollAction.STOP,
+            outgoingTransferPollAction(
+                representation = PythonRnsLxmf.LXMF_REPRESENTATION_PACKET,
+                state = PythonRnsLxmf.LXMF_STATE_SENDING,
+            ),
+        )
+        assertEquals(
+            OutgoingTransferPollAction.STOP,
+            outgoingTransferPollAction(
+                representation = PythonRnsLxmf.LXMF_REPRESENTATION_UNKNOWN,
+                state = PythonRnsLxmf.LXMF_STATE_FAILED,
+            ),
+        )
+    }
+}

--- a/rns-host/src/main/kotlin/network/columba/app/rns/host/ipc/BoundRnsLxmf.kt
+++ b/rns-host/src/main/kotlin/network/columba/app/rns/host/ipc/BoundRnsLxmf.kt
@@ -21,6 +21,7 @@ import network.columba.app.rns.api.model.Identity
 import network.columba.app.rns.api.model.MessageReceipt
 import network.columba.app.rns.api.model.PropagationState
 import network.columba.app.rns.api.model.ReceivedMessage
+import network.columba.app.rns.api.model.TransferProgressUpdate
 
 /**
  * UI-side proxy that delegates every [RnsLxmf] member to the currently-bound
@@ -96,6 +97,10 @@ internal class BoundRnsLxmf(
     @OptIn(ExperimentalCoroutinesApi::class)
     override fun observeDeliveryStatus(): Flow<DeliveryStatusUpdate> =
         backendFlow.filterNotNull().flatMapLatest { it.lxmf.observeDeliveryStatus() }
+
+    @OptIn(ExperimentalCoroutinesApi::class)
+    override fun observeTransferProgress(): Flow<TransferProgressUpdate> =
+        backendFlow.filterNotNull().flatMapLatest { it.lxmf.observeTransferProgress() }
 
     override suspend fun getLxmfIdentity(): Result<Identity> = awaitBound().lxmf.getLxmfIdentity()
 

--- a/rns-host/src/test/kotlin/network/columba/app/rns/host/ipc/BoundRnsBackendTest.kt
+++ b/rns-host/src/test/kotlin/network/columba/app/rns/host/ipc/BoundRnsBackendTest.kt
@@ -48,6 +48,8 @@ import network.columba.app.rns.api.model.PropagationState
 import network.columba.app.rns.api.model.ReceivedMessage
 import network.columba.app.rns.api.model.ReceivedPacket
 import network.columba.app.rns.api.model.ReticulumConfig
+import network.columba.app.rns.api.model.TransferPhase
+import network.columba.app.rns.api.model.TransferProgressUpdate
 import network.columba.app.rns.api.model.VoiceCallState
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNotNull
@@ -82,6 +84,30 @@ import kotlinx.coroutines.flow.first
 @OptIn(ExperimentalCoroutinesApi::class)
 @RunWith(RobolectricTestRunner::class)
 class BoundRnsBackendTest {
+    @Test
+    fun `BoundRnsLxmf republishes transfer progress after binding`() = runTest {
+        val flow = MutableStateFlow<RnsBackend?>(null)
+        val lxmf = BoundRnsLxmf(flow.asStateFlow(), backgroundScope)
+        val fake = FakeRnsBackend()
+        val update = TransferProgressUpdate(
+            transferId = "resource-id",
+            messageHash = "message-id",
+            direction = Direction.OUT,
+            progress = 0.25f,
+            phase = TransferPhase.TRANSFERRING,
+            totalBytes = 1_024L,
+            deliveryMethod = DeliveryMethod.DIRECT,
+        )
+
+        lxmf.observeTransferProgress().test {
+            flow.value = fake
+            advanceUntilIdle()
+            fake.lxmfFake.transferProgressEmitter.emit(update)
+            assertEquals(update, awaitItem())
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+
     @Test
     fun `BoundRnsCore suspend call awaits binding then forwards`() = runTest {
         val flow = MutableStateFlow<RnsBackend?>(null)
@@ -206,7 +232,8 @@ class BoundRnsBackendTest {
 
         override val capabilities: StateFlow<BackendCapabilities> = capabilitiesEmitter.asStateFlow()
         override val core: RnsCore = coreFake
-        override val lxmf: RnsLxmf = StubRnsLxmf()
+        val lxmfFake = StubRnsLxmf()
+        override val lxmf: RnsLxmf = lxmfFake
         override val telephony: RnsTelephony = telephonyFake
         override val telemetry: RnsTelemetry = StubRnsTelemetry()
         override val nomadnet: RnsNomadnet = StubRnsNomadnet()
@@ -331,11 +358,14 @@ class BoundRnsBackendTest {
     // FakeRnsBackend can be a concrete RnsBackend without `by lazy { error(...) }`
     // surprises during construction.
     private class StubRnsLxmf : RnsLxmf {
+        val transferProgressEmitter = MutableSharedFlow<TransferProgressUpdate>(extraBufferCapacity = 1)
+
         override suspend fun sendLxmfMessage(destinationHash: ByteArray, content: String, sourceIdentity: Identity, imageData: ByteArray?, imageFormat: String?, fileAttachments: List<Pair<String, ByteArray>>?): Result<MessageReceipt> = error("not used")
         override suspend fun sendLxmfMessageWithMethod(destinationHash: ByteArray, content: String, sourceIdentity: Identity, deliveryMethod: DeliveryMethod, tryPropagationOnFail: Boolean, imageData: ByteArray?, imageFormat: String?, fileAttachments: List<Pair<String, ByteArray>>?, replyToMessageId: String?, replyQuotedContent: String?, iconAppearance: IconAppearance?, extraFields: Map<Int, Any>?): Result<MessageReceipt> = error("not used")
         override suspend fun sendReaction(destinationHash: ByteArray, targetMessageId: String, emoji: String, sourceIdentity: Identity): Result<MessageReceipt> = error("not used")
         override fun observeMessages() = kotlinx.coroutines.flow.emptyFlow<ReceivedMessage>()
         override fun observeDeliveryStatus() = kotlinx.coroutines.flow.emptyFlow<DeliveryStatusUpdate>()
+        override fun observeTransferProgress() = transferProgressEmitter.asSharedFlow()
         override suspend fun getLxmfIdentity(): Result<Identity> = error("not used")
         override suspend fun getLxmfDestination(): Result<Destination> = error("not used")
         override suspend fun setOutboundPropagationNode(destHash: ByteArray?) = Result.success(Unit)

--- a/rns-ipc/src/main/kotlin/network/columba/app/rns/ipc/client/ClientRnsLxmf.kt
+++ b/rns-ipc/src/main/kotlin/network/columba/app/rns/ipc/client/ClientRnsLxmf.kt
@@ -24,6 +24,7 @@ import network.columba.app.rns.api.model.Identity
 import network.columba.app.rns.api.model.MessageReceipt
 import network.columba.app.rns.api.model.PropagationState
 import network.columba.app.rns.api.model.ReceivedMessage
+import network.columba.app.rns.api.model.TransferProgressUpdate
 import network.columba.app.rns.ipc.AttachmentBlob
 import network.columba.app.rns.ipc.BundleKeys
 import network.columba.app.rns.ipc.FieldsBlob
@@ -31,6 +32,7 @@ import network.columba.app.rns.ipc.IRnsLxmf
 import network.columba.app.rns.ipc.callback.IRnsDeliveryStatusCallback
 import network.columba.app.rns.ipc.callback.IRnsMessageCallback
 import network.columba.app.rns.ipc.callback.IRnsPropagationStateCallback
+import network.columba.app.rns.ipc.callback.IRnsTransferProgressCallback
 import java.io.File
 
 internal class ClientRnsLxmf(
@@ -165,6 +167,16 @@ internal class ClientRnsLxmf(
         }
         if (!registerObserverOrClose { remote.registerDeliveryStatusObserver(cb) }) return@callbackFlow
         awaitClose { runCatching { remote.unregisterDeliveryStatusObserver(cb) } }
+    }
+
+    override fun observeTransferProgress(): Flow<TransferProgressUpdate> = callbackFlow {
+        val cb = object : IRnsTransferProgressCallback.Stub() {
+            override fun onTransferProgress(update: TransferProgressUpdate?) {
+                if (update != null) trySend(update)
+            }
+        }
+        if (!registerObserverOrClose { remote.registerTransferProgressObserver(cb) }) return@callbackFlow
+        awaitClose { runCatching { remote.unregisterTransferProgressObserver(cb) } }
     }
 
     override suspend fun getLxmfIdentity(): Result<Identity> = runCatching {

--- a/rns-ipc/src/main/kotlin/network/columba/app/rns/ipc/server/ServerRnsLxmf.kt
+++ b/rns-ipc/src/main/kotlin/network/columba/app/rns/ipc/server/ServerRnsLxmf.kt
@@ -13,6 +13,7 @@ import network.columba.app.rns.api.model.Identity
 import network.columba.app.rns.api.model.PropagationState
 import network.columba.app.rns.api.model.ReceivedMessage
 import network.columba.app.rns.api.model.DeliveryStatusUpdate
+import network.columba.app.rns.api.model.TransferProgressUpdate
 import network.columba.app.rns.ipc.AttachmentBlob
 import network.columba.app.rns.ipc.BundleKeys
 import network.columba.app.rns.ipc.FieldsBlob
@@ -22,6 +23,7 @@ import network.columba.app.rns.ipc.callback.IRnsMessageCallback
 import network.columba.app.rns.ipc.callback.IRnsPropagationStateCallback
 import network.columba.app.rns.ipc.callback.IRnsResultCallback
 import network.columba.app.rns.ipc.callback.IRnsStringCallback
+import network.columba.app.rns.ipc.callback.IRnsTransferProgressCallback
 import java.io.File
 import java.io.IOException
 
@@ -80,6 +82,12 @@ internal class ServerRnsLxmf(
         upstream = { impl.propagationStateFlow },
         callbackBinder = { it.asBinder() },
         emit = { cb, value -> cb.onPropagationState(value) },
+    )
+    private val transferProgressHub = ObserverHub<TransferProgressUpdate, IRnsTransferProgressCallback>(
+        scope = scope,
+        upstream = { impl.observeTransferProgress() },
+        callbackBinder = { it.asBinder() },
+        emit = { cb, value -> cb.onTransferProgress(value) },
     )
 
     override fun sendLxmfMessage(
@@ -154,6 +162,11 @@ internal class ServerRnsLxmf(
 
     override fun registerDeliveryStatusObserver(cb: IRnsDeliveryStatusCallback) = deliveryHub.registerObserver(cb)
     override fun unregisterDeliveryStatusObserver(cb: IRnsDeliveryStatusCallback) = deliveryHub.unregisterObserver(cb)
+
+    override fun registerTransferProgressObserver(cb: IRnsTransferProgressCallback) =
+        transferProgressHub.registerObserver(cb)
+    override fun unregisterTransferProgressObserver(cb: IRnsTransferProgressCallback) =
+        transferProgressHub.unregisterObserver(cb)
 
     override fun getLxmfIdentity(cb: IRnsResultCallback) = dispatch(cb, scope) {
         val identity = impl.getLxmfIdentity().getOrThrow()

--- a/rns-ipc/src/test/java/network/columba/app/rns/ipc/RnsBackendIpcRoundTripTest.kt
+++ b/rns-ipc/src/test/java/network/columba/app/rns/ipc/RnsBackendIpcRoundTripTest.kt
@@ -228,8 +228,9 @@ class RnsBackendIpcRoundTripTest {
         advanceUntilIdle()
         val update = TransferProgressUpdate(
             transferId = "resource-1",
-            messageHash = "aabbcc",
-            direction = Direction.OUT,
+            messageHash = null,
+            sourceDestinationHash = "aabbcc",
+            direction = Direction.IN,
             progress = 0.64f,
             phase = TransferPhase.TRANSFERRING,
             totalBytes = 4_800_000L,

--- a/rns-ipc/src/test/java/network/columba/app/rns/ipc/RnsBackendIpcRoundTripTest.kt
+++ b/rns-ipc/src/test/java/network/columba/app/rns/ipc/RnsBackendIpcRoundTripTest.kt
@@ -49,6 +49,8 @@ import network.columba.app.rns.api.model.PropagationState
 import network.columba.app.rns.api.model.ReceivedMessage
 import network.columba.app.rns.api.model.ReceivedPacket
 import network.columba.app.rns.api.model.ReticulumConfig
+import network.columba.app.rns.api.model.TransferPhase
+import network.columba.app.rns.api.model.TransferProgressUpdate
 import network.columba.app.rns.api.model.VoiceCallState
 import kotlinx.coroutines.flow.Flow
 import org.junit.After
@@ -216,6 +218,29 @@ class RnsBackendIpcRoundTripTest {
             fake.lxmf.incomingMessages.emit(message)
             advanceUntilIdle()
             assertEquals(message, awaitItem())
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+
+    @Test
+    fun `transfer progress observer round-trips through the stub`() = runTest {
+        val (client, _) = buildClientAndServer()
+        advanceUntilIdle()
+        val update = TransferProgressUpdate(
+            transferId = "resource-1",
+            messageHash = "aabbcc",
+            direction = Direction.OUT,
+            progress = 0.64f,
+            phase = TransferPhase.TRANSFERRING,
+            totalBytes = 4_800_000L,
+            deliveryMethod = DeliveryMethod.DIRECT,
+        )
+
+        client.lxmf.observeTransferProgress().test {
+            advanceUntilIdle()
+            fake.lxmf.transferProgress.emit(update)
+            advanceUntilIdle()
+            assertEquals(update, awaitItem())
             cancelAndIgnoreRemainingEvents()
         }
     }
@@ -470,6 +495,7 @@ private class FakeRnsTelephony : RnsTelephony {
 private class FakeRnsLxmf : RnsLxmf {
     val incomingMessages: MutableSharedFlow<ReceivedMessage> = MutableSharedFlow(extraBufferCapacity = 8)
     private val deliveryStatus: MutableSharedFlow<DeliveryStatusUpdate> = MutableSharedFlow(extraBufferCapacity = 8)
+    val transferProgress: MutableSharedFlow<TransferProgressUpdate> = MutableSharedFlow(extraBufferCapacity = 8)
     private val propagation: MutableSharedFlow<PropagationState> = MutableSharedFlow(extraBufferCapacity = 8)
 
     // Last-send capture so tests can assert exactly what reached the backend
@@ -531,6 +557,7 @@ private class FakeRnsLxmf : RnsLxmf {
 
     override fun observeMessages(): Flow<ReceivedMessage> = incomingMessages
     override fun observeDeliveryStatus(): Flow<DeliveryStatusUpdate> = deliveryStatus
+    override fun observeTransferProgress(): Flow<TransferProgressUpdate> = transferProgress
 
     override suspend fun getLxmfIdentity(): Result<Identity> = Result.failure(NotImplementedError())
     override suspend fun getLxmfDestination(): Result<Destination> = Result.failure(NotImplementedError())

--- a/tests/transfer_progress_e2e/README.md
+++ b/tests/transfer_progress_e2e/README.md
@@ -1,0 +1,34 @@
+# Real LXMF Resource progress E2E
+
+This suite proves the complete production path that previously dropped outgoing transfer progress:
+
+1. A host-side Python LXMF recipient starts on a private Reticulum TCP server.
+2. A throttled TCP proxy keeps the genuine RNS Resource active long enough to observe multiple polls.
+3. A fresh Python-backend Columba APK runs on an Android emulator.
+4. The harness completes onboarding, configures the TCP interface, adds the real recipient through the Contacts UI, selects a 1 MiB file through Android DocumentsUI, and sends it from the production conversation UI.
+5. The test requires `Sending directly`, a genuine percentage between 1 and 99, and the attachment name in the outgoing bubble.
+6. The host recipient must receive the exact filename, byte count, SHA-256, and a valid LXMF message hash.
+
+The screenshot, logcat, receiver log, proxy log, and JUnit XML are uploaded by CI as `transfer-progress-e2e-evidence`.
+
+## Local run
+
+Prerequisites:
+
+- Python 3.11
+- Android SDK emulator with an API 34 Google APIs x86_64 image
+- A running emulator at `emulator-5554`
+- The Python-backend x86_64 debug APK
+
+```bash
+python3.11 -m venv .scratch/transfer-progress-e2e-venv
+.scratch/transfer-progress-e2e-venv/bin/pip install -r tests/transfer_progress_e2e/requirements.txt
+./gradlew :app:assembleNoSentryPythonBackendDebug
+COLUMBA_EMULATOR_SERIAL=emulator-5554 \
+COLUMBA_E2E_APK=app/build/outputs/apk/noSentryPythonBackend/debug/app-noSentry-pythonBackend-x86_64-debug.apk \
+COLUMBA_E2E_ARTIFACT_DIR=.scratch/transfer-progress-e2e-artifacts \
+.scratch/transfer-progress-e2e-venv/bin/python -m pytest -v \
+  tests/transfer_progress_e2e/test_transfer_progress_e2e.py
+```
+
+The harness disables every default app interface before adding the private test TCP interface. It then uses only loopback and the Android emulator's `10.0.2.2` host alias. It does not depend on or connect to public Reticulum hubs, propagation nodes, saved identities, or repository secrets.

--- a/tests/transfer_progress_e2e/__init__.py
+++ b/tests/transfer_progress_e2e/__init__.py
@@ -1,0 +1,1 @@
+"""Deterministic two-peer LXMF transfer-progress E2E harness."""

--- a/tests/transfer_progress_e2e/conftest.py
+++ b/tests/transfer_progress_e2e/conftest.py
@@ -1,0 +1,9 @@
+"""Keep the standalone E2E helpers importable in isolated CI virtual environments."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))

--- a/tests/transfer_progress_e2e/host_receiver.py
+++ b/tests/transfer_progress_e2e/host_receiver.py
@@ -1,0 +1,112 @@
+#!/usr/bin/env python3
+"""Deterministic host-side LXMF recipient for the Android progress E2E test."""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import signal
+import threading
+import time
+from pathlib import Path
+from typing import Any, cast
+
+import LXMF
+import RNS
+
+
+class Receiver:
+    def __init__(self, root: Path, port: int, result_path: Path):
+        self.root = root
+        self.result_path = result_path
+        self.stop = threading.Event()
+        self._write_config(port)
+        self.reticulum = RNS.Reticulum(str(root / "reticulum"))
+        self.router = LXMF.LXMRouter(
+            storagepath=str(root / "lxmf"),
+            delivery_limit=8 * 1024,
+        )
+        self.identity = RNS.Identity()
+        self.destination = cast(
+            Any,
+            self.router.register_delivery_identity(
+                self.identity,
+                display_name="Columba CI Receiver",
+                stamp_cost=None,
+            ),
+        )
+        if self.destination is None:
+            raise RuntimeError("LXMF delivery destination registration failed")
+        self.router.register_delivery_callback(self._received)
+
+    def _write_config(self, port: int) -> None:
+        config_dir = self.root / "reticulum"
+        config_dir.mkdir(parents=True, exist_ok=True)
+        (config_dir / "config").write_text(
+            """[reticulum]
+  enable_transport = Yes
+  share_instance = No
+
+[logging]
+  loglevel = 6
+
+[interfaces]
+  [[Columba E2E TCP Server]]
+    type = TCPServerInterface
+    enabled = Yes
+    listen_ip = 127.0.0.1
+    listen_port = {port}
+""".format(port=port),
+            encoding="utf-8",
+        )
+
+    def _received(self, message) -> None:
+        attachments = message.fields.get(LXMF.FIELD_FILE_ATTACHMENTS, [])
+        first = attachments[0] if attachments else None
+        if not first or len(first) != 2:
+            result = {"error": "missing_file_attachment", "message_hash": message.hash.hex()}
+        else:
+            name, data = first
+            data = bytes(data)
+            if isinstance(name, bytes):
+                name = name.decode("utf-8", errors="replace")
+            result = {
+                "filename": str(name),
+                "size": len(data),
+                "sha256": hashlib.sha256(data).hexdigest(),
+                "message_hash": message.hash.hex(),
+            }
+        self.result_path.parent.mkdir(parents=True, exist_ok=True)
+        self.result_path.write_text(json.dumps(result, sort_keys=True), encoding="utf-8")
+        print(f"RECEIVED {json.dumps(result, sort_keys=True)}", flush=True)
+
+    def run(self, destination_path: Path) -> None:
+        destination_path.parent.mkdir(parents=True, exist_ok=True)
+        destination_path.write_text(self.destination.hash.hex(), encoding="ascii")
+        print(f"DESTINATION {self.destination.hash.hex()}", flush=True)
+        next_announce = 0.0
+        while not self.stop.wait(0.2):
+            now = time.monotonic()
+            if now >= next_announce:
+                self.router.announce(self.destination.hash)
+                print("ANNOUNCED", flush=True)
+                next_announce = now + 2.0
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--root", type=Path, required=True)
+    parser.add_argument("--port", type=int, default=4243)
+    parser.add_argument("--destination-file", type=Path, required=True)
+    parser.add_argument("--result-file", type=Path, required=True)
+    args = parser.parse_args()
+
+    receiver = Receiver(args.root, args.port, args.result_file)
+    signal.signal(signal.SIGTERM, lambda *_: receiver.stop.set())
+    signal.signal(signal.SIGINT, lambda *_: receiver.stop.set())
+    receiver.run(args.destination_file)
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/transfer_progress_e2e/requirements.txt
+++ b/tests/transfer_progress_e2e/requirements.txt
@@ -1,0 +1,13 @@
+git+https://github.com/torlando-tech/Reticulum@5b3a6ee4f25e2925cf84d4a2b108e6a708fbd395
+git+https://github.com/torlando-tech/LXMF@8912186e48b482a76bf04e2ac4b6c8940991aecc
+cffi==2.1.1
+cryptography==50.0.0
+iniconfig==2.3.0
+packaging==26.3
+pluggy==1.6.0
+pycparser==3.0
+Pygments==2.20.0
+pyserial==3.5
+pytest==9.1.1
+pytest-timeout==2.4.0
+u-msgpack-python==2.8.0

--- a/tests/transfer_progress_e2e/test_transfer_progress_e2e.py
+++ b/tests/transfer_progress_e2e/test_transfer_progress_e2e.py
@@ -95,6 +95,31 @@ def dismiss_optional(driver: AdbUiDriver, text: str, *, timeout: float = 12) -> 
         pass
 
 
+def complete_onboarding(driver: AdbUiDriver, timeout: float = 90) -> None:
+    """Keep advancing onboarding until the production chat list is visible."""
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        try:
+            snapshot = driver.snapshot()
+        except (subprocess.CalledProcessError, ET.ParseError):
+            time.sleep(0.5)
+            continue
+        try:
+            snapshot.require_text("Chats")
+            return
+        except LookupError:
+            pass
+        for label in ("Not Now", "Skip"):
+            try:
+                driver.tap(snapshot.require_text(label))
+                break
+            except LookupError:
+                continue
+        time.sleep(0.5)
+    driver.screenshot("onboarding-timeout.png")
+    raise TimeoutError("Onboarding did not reach the Chats screen")
+
+
 def stop_process(process: subprocess.Popen[str] | None) -> None:
     if process is None or process.poll() is not None:
         return
@@ -216,9 +241,7 @@ def test_real_resource_progress_reaches_outgoing_bubble(tmp_path: Path) -> None:
         driver.adb("shell", "pm", "clear", PKG)
         driver.adb("logcat", "-c")
         driver.adb("shell", "am", "start", "-n", ACTIVITY)
-        dismiss_optional(driver, "Not Now")
-        driver.click_text("Skip", timeout=30)
-        driver.wait_text("Chats", timeout=60)
+        complete_onboarding(driver)
 
         tcp_host = os.environ.get("COLUMBA_E2E_HOST", "10.0.2.2")
         broadcast_and_wait(

--- a/tests/transfer_progress_e2e/test_transfer_progress_e2e.py
+++ b/tests/transfer_progress_e2e/test_transfer_progress_e2e.py
@@ -9,7 +9,9 @@ import subprocess
 import sys
 import time
 import xml.etree.ElementTree as ET
+from dataclasses import dataclass
 from pathlib import Path
+from typing import TextIO
 
 import pytest
 
@@ -21,6 +23,17 @@ ACTIVITY = f"{PKG}/network.columba.app.MainActivity"
 RECEIVER = f"{PKG}/network.columba.app.test.TestReceiver"
 FILE_NAME = "columba-progress-e2e.bin"
 FILE_SIZE = 1024 * 1024
+
+
+@dataclass(frozen=True)
+class HostPeer:
+    receiver: subprocess.Popen[str]
+    proxy: subprocess.Popen[str]
+    receiver_log: TextIO
+    proxy_log: TextIO
+    destination: str
+    result_file: Path
+    proxy_port: int
 
 
 def free_port() -> int:
@@ -131,7 +144,7 @@ def stop_process(process: subprocess.Popen[str] | None) -> None:
         process.wait(timeout=5)
 
 
-def start_host_peer(root: Path, artifact_dir: Path):
+def start_host_peer(root: Path, artifact_dir: Path) -> HostPeer:
     receiver_port = free_port()
     proxy_port = free_port()
     while proxy_port == receiver_port:
@@ -176,6 +189,7 @@ def start_host_peer(root: Path, artifact_dir: Path):
             text=True,
         )
         wait_file(destination_file, 20)
+        destination = destination_file.read_text(encoding="ascii").strip()
         time.sleep(1)
         if receiver.poll() is not None or proxy.poll() is not None:
             raise RuntimeError("Host LXMF receiver or throttled proxy exited during startup")
@@ -186,7 +200,15 @@ def start_host_peer(root: Path, artifact_dir: Path):
         proxy_log.close()
         raise
     assert receiver is not None and proxy is not None
-    return receiver, proxy, receiver_log, proxy_log, destination_file, result_file, proxy_port
+    return HostPeer(
+        receiver=receiver,
+        proxy=proxy,
+        receiver_log=receiver_log,
+        proxy_log=proxy_log,
+        destination=destination,
+        result_file=result_file,
+        proxy_port=proxy_port,
+    )
 
 
 def enter_field(driver: AdbUiDriver, placeholder: str, value: str) -> None:
@@ -220,21 +242,44 @@ def click_description_until_text(
     raise TimeoutError(f"Tapping {description!r} never revealed {expected_text!r}")
 
 
+def outgoing_resource_percentage(snapshot: UiSnapshot) -> int | None:
+    try:
+        snapshot.require_text(FILE_NAME)
+    except LookupError:
+        return None
+    return snapshot.semantic_percentage("Sending directly")
+
+
+def capture_verified_progress(driver: AdbUiDriver, timeout: float = 45) -> int:
+    """Capture a screenshot bracketed by matching intermediate UI semantics."""
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        try:
+            before = outgoing_resource_percentage(driver.snapshot())
+            if before is None:
+                time.sleep(0.2)
+                continue
+            screenshot = driver.screenshot("outgoing-resource-progress.png")
+            after = outgoing_resource_percentage(driver.snapshot())
+            if after is not None and screenshot.stat().st_size > 10_000:
+                return after
+        except (OSError, subprocess.SubprocessError, ET.ParseError):
+            pass
+        time.sleep(0.2)
+    raise TimeoutError("Could not capture verified outgoing Resource progress")
+
+
 @pytest.mark.timeout(300)
 def test_real_resource_progress_reaches_outgoing_bubble(tmp_path: Path) -> None:
     apk = Path(os.environ["COLUMBA_E2E_APK"]).resolve()
     serial = os.environ.get("COLUMBA_EMULATOR_SERIAL", "emulator-5554")
-    if (
-        not serial.startswith("emulator-")
-        and os.environ.get("COLUMBA_E2E_ALLOW_PHYSICAL") != "1"
-    ):
-        pytest.fail("Refusing to clear app data on a non-emulator Android target")
+    if not serial.startswith("emulator-"):
+        pytest.fail("This destructive E2E requires a disposable Android emulator")
     artifact_dir = Path(os.environ.get("COLUMBA_E2E_ARTIFACT_DIR", "artifacts/transfer-progress-e2e"))
     artifact_dir.mkdir(parents=True, exist_ok=True)
     driver = AdbUiDriver(serial, artifact_dir)
-    processes = start_host_peer(tmp_path, artifact_dir)
-    receiver, proxy, receiver_log, proxy_log, destination_file, result_file, proxy_port = processes
-    destination = destination_file.read_text(encoding="ascii").strip()
+    peer = start_host_peer(tmp_path, artifact_dir)
+    destination = peer.destination
 
     try:
         driver.adb("install", "-r", str(apk), timeout=180)
@@ -257,7 +302,7 @@ def test_real_resource_progress_reaches_outgoing_bubble(tmp_path: Path) -> None:
             timeout=45,
             name="transfer_progress_e2e",
             host=tcp_host,
-            port=str(proxy_port),
+            port=str(peer.proxy_port),
         )
         time.sleep(1)
         driver.adb("shell", "am", "force-stop", PKG)
@@ -309,26 +354,11 @@ def test_real_resource_progress_reaches_outgoing_bubble(tmp_path: Path) -> None:
         driver.wait_text(FILE_NAME, timeout=30)
         driver.click_description("Send message")
 
-        def live_progress(snapshot: UiSnapshot):
-            try:
-                snapshot.require_text(FILE_NAME)
-            except LookupError:
-                return None
-            percentage = snapshot.semantic_percentage("Sending directly")
-            return (snapshot, percentage) if percentage is not None else None
-
-        _, percentage = driver.wait_for(
-            live_progress,
-            timeout=45,
-            interval=0.25,
-            description="genuine outgoing Resource progress",
-        )
-        screenshot = driver.screenshot("outgoing-resource-progress.png")
-        assert screenshot.stat().st_size > 10_000
+        percentage = capture_verified_progress(driver)
         assert 0 < percentage < 100
 
-        wait_file(result_file, 90)
-        received = json.loads(result_file.read_text(encoding="utf-8"))
+        wait_file(peer.result_file, 90)
+        received = json.loads(peer.result_file.read_text(encoding="utf-8"))
         assert received["filename"] == FILE_NAME
         assert received["size"] == FILE_SIZE
         assert received["sha256"] == expected_sha
@@ -341,7 +371,7 @@ def test_real_resource_progress_reaches_outgoing_bubble(tmp_path: Path) -> None:
             driver.adb("shell", "rm", "-f", "/sdcard/columba-e2e-window.xml")
         except (OSError, subprocess.SubprocessError):
             pass
-        for process in (proxy, receiver):
+        for process in (peer.proxy, peer.receiver):
             stop_process(process)
-        receiver_log.close()
-        proxy_log.close()
+        peer.receiver_log.close()
+        peer.proxy_log.close()

--- a/tests/transfer_progress_e2e/test_transfer_progress_e2e.py
+++ b/tests/transfer_progress_e2e/test_transfer_progress_e2e.py
@@ -1,0 +1,324 @@
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+import re
+import socket
+import subprocess
+import sys
+import time
+import xml.etree.ElementTree as ET
+from pathlib import Path
+
+import pytest
+
+from ui_driver import AdbUiDriver, UiSnapshot
+
+
+PKG = "network.columba.app.debug"
+ACTIVITY = f"{PKG}/network.columba.app.MainActivity"
+RECEIVER = f"{PKG}/network.columba.app.test.TestReceiver"
+FILE_NAME = "columba-progress-e2e.bin"
+FILE_SIZE = 1024 * 1024
+
+
+def free_port() -> int:
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as sock:
+        sock.bind(("127.0.0.1", 0))
+        return int(sock.getsockname()[1])
+
+
+def wait_file(path: Path, timeout: float) -> None:
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        if path.is_file() and path.stat().st_size:
+            return
+        time.sleep(0.2)
+    raise TimeoutError(f"Timed out waiting for {path}")
+
+
+def logcat(driver: AdbUiDriver) -> str:
+    return driver.adb("logcat", "-d", "-v", "brief").stdout
+
+
+def broadcast(driver: AdbUiDriver, action: str, **extras: str) -> None:
+    args = ["shell", "am", "broadcast", "-n", RECEIVER, "-a", f"network.columba.test.{action}"]
+    for key, value in extras.items():
+        args.extend(("--es", key, value))
+    driver.adb(*args)
+
+
+def wait_for_log_reply(
+    driver: AdbUiDriver,
+    action: str,
+    pattern: str,
+    *,
+    timeout: float = 120,
+    **extras: str,
+) -> re.Match[str]:
+    deadline = time.monotonic() + timeout
+    compiled = re.compile(pattern)
+    while time.monotonic() < deadline:
+        broadcast(driver, action, **extras)
+        time.sleep(1.5)
+        match = compiled.search(logcat(driver))
+        if match is not None:
+            return match
+        time.sleep(0.5)
+    raise TimeoutError(f"No {action} reply matching {pattern!r}")
+
+
+def broadcast_and_wait(
+    driver: AdbUiDriver,
+    action: str,
+    pattern: str,
+    *,
+    timeout: float = 30,
+    **extras: str,
+) -> re.Match[str]:
+    broadcast(driver, action, **extras)
+    deadline = time.monotonic() + timeout
+    compiled = re.compile(pattern)
+    while time.monotonic() < deadline:
+        match = compiled.search(logcat(driver))
+        if match is not None:
+            return match
+        time.sleep(0.5)
+    raise TimeoutError(f"No {action} completion matching {pattern!r}")
+
+
+def dismiss_optional(driver: AdbUiDriver, text: str, *, timeout: float = 12) -> None:
+    try:
+        driver.click_text(text, timeout=timeout)
+    except TimeoutError:
+        pass
+
+
+def stop_process(process: subprocess.Popen[str] | None) -> None:
+    if process is None or process.poll() is not None:
+        return
+    process.terminate()
+    try:
+        process.wait(timeout=10)
+    except subprocess.TimeoutExpired:
+        process.kill()
+        process.wait(timeout=5)
+
+
+def start_host_peer(root: Path, artifact_dir: Path):
+    receiver_port = free_port()
+    proxy_port = free_port()
+    while proxy_port == receiver_port:
+        proxy_port = free_port()
+    destination_file = root / "destination.txt"
+    result_file = root / "received.json"
+    receiver_log = (artifact_dir / "receiver.log").open("w", encoding="utf-8")
+    proxy_log = (artifact_dir / "proxy.log").open("w", encoding="utf-8")
+    receiver: subprocess.Popen[str] | None = None
+    proxy: subprocess.Popen[str] | None = None
+    try:
+        receiver = subprocess.Popen(
+            [
+                sys.executable,
+                "tests/transfer_progress_e2e/host_receiver.py",
+                "--root",
+                str(root / "receiver"),
+                "--port",
+                str(receiver_port),
+                "--destination-file",
+                str(destination_file),
+                "--result-file",
+                str(result_file),
+            ],
+            stdout=receiver_log,
+            stderr=subprocess.STDOUT,
+            text=True,
+        )
+        proxy = subprocess.Popen(
+            [
+                sys.executable,
+                "tests/transfer_progress_e2e/throttled_proxy.py",
+                "--listen-port",
+                str(proxy_port),
+                "--upstream-port",
+                str(receiver_port),
+                "--bytes-per-second",
+                "131072",
+            ],
+            stdout=proxy_log,
+            stderr=subprocess.STDOUT,
+            text=True,
+        )
+        wait_file(destination_file, 20)
+        time.sleep(1)
+        if receiver.poll() is not None or proxy.poll() is not None:
+            raise RuntimeError("Host LXMF receiver or throttled proxy exited during startup")
+    except Exception:
+        stop_process(proxy)
+        stop_process(receiver)
+        receiver_log.close()
+        proxy_log.close()
+        raise
+    assert receiver is not None and proxy is not None
+    return receiver, proxy, receiver_log, proxy_log, destination_file, result_file, proxy_port
+
+
+def enter_field(driver: AdbUiDriver, placeholder: str, value: str) -> None:
+    driver.tap(driver.wait_text(placeholder))
+    driver.replace_focused_text(value)
+    driver.back()
+
+
+def click_description_until_text(
+    driver: AdbUiDriver,
+    description: str,
+    expected_text: str,
+    *,
+    timeout: float = 30,
+) -> None:
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        snapshot: UiSnapshot | None = None
+        try:
+            snapshot = driver.snapshot()
+            snapshot.require_text(expected_text)
+            return
+        except (LookupError, subprocess.CalledProcessError, ET.ParseError):
+            pass
+        if snapshot is not None:
+            try:
+                driver.tap(snapshot.require_description(description))
+            except LookupError:
+                pass
+        time.sleep(0.5)
+    raise TimeoutError(f"Tapping {description!r} never revealed {expected_text!r}")
+
+
+@pytest.mark.timeout(300)
+def test_real_resource_progress_reaches_outgoing_bubble(tmp_path: Path) -> None:
+    apk = Path(os.environ["COLUMBA_E2E_APK"]).resolve()
+    serial = os.environ.get("COLUMBA_EMULATOR_SERIAL", "emulator-5554")
+    if (
+        not serial.startswith("emulator-")
+        and os.environ.get("COLUMBA_E2E_ALLOW_PHYSICAL") != "1"
+    ):
+        pytest.fail("Refusing to clear app data on a non-emulator Android target")
+    artifact_dir = Path(os.environ.get("COLUMBA_E2E_ARTIFACT_DIR", "artifacts/transfer-progress-e2e"))
+    artifact_dir.mkdir(parents=True, exist_ok=True)
+    driver = AdbUiDriver(serial, artifact_dir)
+    processes = start_host_peer(tmp_path, artifact_dir)
+    receiver, proxy, receiver_log, proxy_log, destination_file, result_file, proxy_port = processes
+    destination = destination_file.read_text(encoding="ascii").strip()
+
+    try:
+        driver.adb("install", "-r", str(apk), timeout=180)
+        driver.adb("shell", "pm", "clear", PKG)
+        driver.adb("logcat", "-c")
+        driver.adb("shell", "am", "start", "-n", ACTIVITY)
+        dismiss_optional(driver, "Not Now")
+        driver.click_text("Skip", timeout=30)
+        driver.wait_text("Chats", timeout=60)
+
+        tcp_host = os.environ.get("COLUMBA_E2E_HOST", "10.0.2.2")
+        broadcast_and_wait(
+            driver,
+            "DISABLE_ALL_INTERFACES",
+            r"interfaces_disabled\s+count=\d+\s+applied=(?:true|false)",
+            timeout=45,
+        )
+        broadcast_and_wait(
+            driver,
+            "ADD_TCP_CLIENT",
+            r"interface_added\s+name=transfer_progress_e2e\s+.*applied=(?:true|false)",
+            timeout=45,
+            name="transfer_progress_e2e",
+            host=tcp_host,
+            port=str(proxy_port),
+        )
+        time.sleep(1)
+        driver.adb("shell", "am", "force-stop", PKG)
+        driver.adb("shell", "am", "start", "-n", ACTIVITY)
+        dismiss_optional(driver, "Not Now")
+        driver.wait_text("Chats", timeout=60)
+
+        wait_for_log_reply(driver, "GET_DEST", r"\bdest=([0-9a-f]{32})", timeout=120)
+        wait_for_log_reply(
+            driver,
+            "HAS_PATH",
+            rf"has_path\s+to={destination}\s+result=1",
+            timeout=90,
+            to=destination,
+        )
+
+        driver.click_text("Contacts")
+        time.sleep(1)
+        driver.wait_text("Contacts", timeout=15)
+        click_description_until_text(driver, "Add contact", "Manual Entry")
+        driver.click_text("Manual Entry")
+        enter_field(driver, "Identity or Address", destination)
+        enter_field(driver, "Nickname (optional)", "CI_Receiver")
+        driver.click_text("Add")
+        driver.click_text("CI_Receiver", timeout=45)
+        driver.click_text("Start Chat")
+        driver.wait_description("Attach", timeout=30)
+
+        payload = hashlib.shake_256(b"columba-transfer-progress-e2e").digest(FILE_SIZE)
+        payload_path = tmp_path / FILE_NAME
+        payload_path.write_bytes(payload)
+        expected_sha = hashlib.sha256(payload).hexdigest()
+        driver.adb("push", str(payload_path), f"/sdcard/Download/{FILE_NAME}", timeout=60)
+        driver.adb(
+            "shell",
+            "am",
+            "broadcast",
+            "-a",
+            "android.intent.action.MEDIA_SCANNER_SCAN_FILE",
+            "-d",
+            f"file:///sdcard/Download/{FILE_NAME}",
+        )
+        time.sleep(1)
+
+        driver.click_description("Attach")
+        time.sleep(0.75)
+        click_description_until_text(driver, "File", FILE_NAME, timeout=30)
+        driver.click_text(FILE_NAME, timeout=30)
+        driver.wait_text(FILE_NAME, timeout=30)
+        driver.click_description("Send message")
+
+        def live_progress(snapshot: UiSnapshot):
+            try:
+                snapshot.require_text(FILE_NAME)
+            except LookupError:
+                return None
+            percentage = snapshot.semantic_percentage("Sending directly")
+            return (snapshot, percentage) if percentage is not None else None
+
+        _, percentage = driver.wait_for(
+            live_progress,
+            timeout=45,
+            interval=0.25,
+            description="genuine outgoing Resource progress",
+        )
+        screenshot = driver.screenshot("outgoing-resource-progress.png")
+        assert screenshot.stat().st_size > 10_000
+        assert 0 < percentage < 100
+
+        wait_file(result_file, 90)
+        received = json.loads(result_file.read_text(encoding="utf-8"))
+        assert received["filename"] == FILE_NAME
+        assert received["size"] == FILE_SIZE
+        assert received["sha256"] == expected_sha
+        assert re.fullmatch(r"[0-9a-f]{64}", received["message_hash"])
+    finally:
+        try:
+            driver.screenshot("final-screen.png")
+            (artifact_dir / "logcat.log").write_text(logcat(driver), encoding="utf-8")
+            driver.adb("shell", "rm", "-f", f"/sdcard/Download/{FILE_NAME}")
+            driver.adb("shell", "rm", "-f", "/sdcard/columba-e2e-window.xml")
+        except (OSError, subprocess.SubprocessError):
+            pass
+        for process in (proxy, receiver):
+            stop_process(process)
+        receiver_log.close()
+        proxy_log.close()

--- a/tests/transfer_progress_e2e/test_ui_driver.py
+++ b/tests/transfer_progress_e2e/test_ui_driver.py
@@ -20,10 +20,9 @@ def test_snapshot_finds_text_and_content_description() -> None:
     assert snapshot.require_description("Attach").center == (950, 1750)
 
 
-def test_snapshot_extracts_live_percentage() -> None:
+def test_snapshot_extracts_semantic_percentage() -> None:
     snapshot = UiSnapshot.parse(SAMPLE_XML)
 
-    assert snapshot.live_percentage() == 10
     assert snapshot.semantic_percentage("Sending directly") == 10
 
 

--- a/tests/transfer_progress_e2e/test_ui_driver.py
+++ b/tests/transfer_progress_e2e/test_ui_driver.py
@@ -1,0 +1,33 @@
+from __future__ import annotations
+
+from ui_driver import UiSnapshot
+
+
+SAMPLE_XML = """<?xml version='1.0' encoding='UTF-8' standalone='yes' ?>
+<hierarchy rotation="0">
+  <node text="" content-desc="Attach" bounds="[900,1700][1000,1800]" clickable="true" />
+  <node text="" content-desc="Sending directly, 10 percent" bounds="[480,1180][1020,1300]" clickable="false" />
+  <node text="Sending directly" content-desc="" bounds="[500,1200][850,1260]" clickable="false" />
+  <node text="10%" content-desc="" bounds="[900,1200][1000,1260]" clickable="false" />
+</hierarchy>
+"""
+
+
+def test_snapshot_finds_text_and_content_description() -> None:
+    snapshot = UiSnapshot.parse(SAMPLE_XML)
+
+    assert snapshot.require_text("Sending directly").center == (675, 1230)
+    assert snapshot.require_description("Attach").center == (950, 1750)
+
+
+def test_snapshot_extracts_live_percentage() -> None:
+    snapshot = UiSnapshot.parse(SAMPLE_XML)
+
+    assert snapshot.live_percentage() == 10
+    assert snapshot.semantic_percentage("Sending directly") == 10
+
+
+def test_snapshot_rejects_percentage_from_unrelated_semantics() -> None:
+    snapshot = UiSnapshot.parse(SAMPLE_XML)
+
+    assert snapshot.semantic_percentage("Receiving messages") is None

--- a/tests/transfer_progress_e2e/throttled_proxy.py
+++ b/tests/transfer_progress_e2e/throttled_proxy.py
@@ -1,0 +1,67 @@
+#!/usr/bin/env python3
+"""Small bidirectional TCP relay with deterministic per-direction bandwidth."""
+
+from __future__ import annotations
+
+import argparse
+import socket
+import threading
+import time
+
+
+def relay(source: socket.socket, destination: socket.socket, bytes_per_second: int) -> None:
+    try:
+        while True:
+            data = source.recv(4096)
+            if not data:
+                return
+            destination.sendall(data)
+            time.sleep(len(data) / bytes_per_second)
+    finally:
+        try:
+            destination.shutdown(socket.SHUT_WR)
+        except OSError:
+            pass
+
+
+def handle(client: socket.socket, upstream_host: str, upstream_port: int, rate: int) -> None:
+    with client, socket.create_connection((upstream_host, upstream_port), timeout=10) as upstream:
+        left = threading.Thread(target=relay, args=(client, upstream, rate), daemon=True)
+        right = threading.Thread(target=relay, args=(upstream, client, rate), daemon=True)
+        left.start()
+        right.start()
+        left.join()
+        right.join()
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--listen-host", default="127.0.0.1")
+    parser.add_argument("--listen-port", type=int, default=4242)
+    parser.add_argument("--upstream-host", default="127.0.0.1")
+    parser.add_argument("--upstream-port", type=int, default=4243)
+    parser.add_argument("--bytes-per-second", type=int, default=131_072)
+    args = parser.parse_args()
+
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as server:
+        server.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+        server.bind((args.listen_host, args.listen_port))
+        server.listen()
+        print(
+            f"PROXY_READY host={args.listen_host} port={args.listen_port} "
+            f"upstream={args.upstream_host}:{args.upstream_port} "
+            f"rate={args.bytes_per_second}",
+            flush=True,
+        )
+        while True:
+            client, address = server.accept()
+            print(f"PROXY_ACCEPTED client={address[0]}:{address[1]}", flush=True)
+            threading.Thread(
+                target=handle,
+                args=(client, args.upstream_host, args.upstream_port, args.bytes_per_second),
+                daemon=True,
+            ).start()
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/transfer_progress_e2e/ui_driver.py
+++ b/tests/transfer_progress_e2e/ui_driver.py
@@ -1,0 +1,196 @@
+"""Host-side UIAutomator helpers for the transfer-progress E2E test."""
+
+from __future__ import annotations
+
+import re
+import subprocess
+import tempfile
+import time
+import xml.etree.ElementTree as ET
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Callable, TypeVar
+
+
+_BOUNDS = re.compile(r"\[(\d+),(\d+)]\[(\d+),(\d+)]")
+_PERCENT = re.compile(r"^(\d{1,3})%$")
+T = TypeVar("T")
+
+
+@dataclass(frozen=True)
+class UiNode:
+    text: str
+    description: str
+    bounds: tuple[int, int, int, int]
+
+    @property
+    def center(self) -> tuple[int, int]:
+        left, top, right, bottom = self.bounds
+        return ((left + right) // 2, (top + bottom) // 2)
+
+
+@dataclass(frozen=True)
+class UiSnapshot:
+    nodes: tuple[UiNode, ...]
+
+    @classmethod
+    def parse(cls, xml: str) -> "UiSnapshot":
+        root = ET.fromstring(xml)
+        nodes: list[UiNode] = []
+        for element in root.iter("node"):
+            match = _BOUNDS.fullmatch(element.attrib.get("bounds", ""))
+            if match is None:
+                continue
+            left, top, right, bottom = (int(value) for value in match.groups())
+            nodes.append(
+                UiNode(
+                    text=element.attrib.get("text", ""),
+                    description=element.attrib.get("content-desc", ""),
+                    bounds=(left, top, right, bottom),
+                )
+            )
+        return cls(tuple(nodes))
+
+    def require_text(self, text: str, *, contains: bool = False) -> UiNode:
+        for node in self.nodes:
+            if (contains and text in node.text) or (not contains and node.text == text):
+                return node
+        raise LookupError(f"UI text not found: {text!r}")
+
+    def require_description(self, description: str, *, contains: bool = False) -> UiNode:
+        for node in self.nodes:
+            value = node.description
+            if (contains and description in value) or (not contains and value == description):
+                return node
+        raise LookupError(f"UI description not found: {description!r}")
+
+    def live_percentage(self) -> int | None:
+        for node in self.nodes:
+            match = _PERCENT.fullmatch(node.text)
+            if match is not None:
+                value = int(match.group(1))
+                if 0 < value < 100:
+                    return value
+        return None
+
+    def semantic_percentage(self, label: str) -> int | None:
+        pattern = re.compile(rf"^{re.escape(label)}, (\d{{1,3}}) percent$")
+        for node in self.nodes:
+            match = pattern.fullmatch(node.description)
+            if match is not None:
+                value = int(match.group(1))
+                if 0 < value < 100:
+                    return value
+        return None
+
+
+class AdbUiDriver:
+    def __init__(self, serial: str, artifact_dir: Path):
+        self.serial = serial
+        self.artifact_dir = artifact_dir
+        self.artifact_dir.mkdir(parents=True, exist_ok=True)
+        self._dump_path = Path(tempfile.mkdtemp(prefix="columba-e2e-ui-")) / "window.xml"
+
+    def adb(
+        self,
+        *args: str,
+        timeout: float = 30,
+        capture_output: bool = True,
+    ) -> subprocess.CompletedProcess[str]:
+        return subprocess.run(
+            ["adb", "-s", self.serial, *args],
+            check=True,
+            text=True,
+            capture_output=capture_output,
+            timeout=timeout,
+        )
+
+    def snapshot(self) -> UiSnapshot:
+        remote = "/sdcard/columba-e2e-window.xml"
+        self.adb("shell", "uiautomator", "dump", remote)
+        self.adb("pull", remote, str(self._dump_path))
+        return UiSnapshot.parse(self._dump_path.read_text(encoding="utf-8"))
+
+    def wait_for(
+        self,
+        predicate: Callable[[UiSnapshot], T | None],
+        *,
+        timeout: float = 30,
+        interval: float = 0.35,
+        description: str,
+    ) -> T:
+        deadline = time.monotonic() + timeout
+        last_snapshot: UiSnapshot | None = None
+        while time.monotonic() < deadline:
+            try:
+                last_snapshot = self.snapshot()
+            except (subprocess.CalledProcessError, ET.ParseError):
+                time.sleep(interval)
+                continue
+            result = predicate(last_snapshot)
+            if result is not None:
+                return result
+            time.sleep(interval)
+        self.screenshot("timeout.png")
+        visible = [] if last_snapshot is None else [
+            node.text or node.description for node in last_snapshot.nodes if node.text or node.description
+        ]
+        raise TimeoutError(f"Timed out waiting for {description}; visible={visible[-30:]}")
+
+    def wait_text(self, text: str, *, timeout: float = 30, contains: bool = False) -> UiNode:
+        def find(snapshot: UiSnapshot) -> UiNode | None:
+            try:
+                return snapshot.require_text(text, contains=contains)
+            except LookupError:
+                return None
+
+        return self.wait_for(find, timeout=timeout, description=f"text {text!r}")
+
+    def wait_description(
+        self,
+        description: str,
+        *,
+        timeout: float = 30,
+        contains: bool = False,
+    ) -> UiNode:
+        def find(snapshot: UiSnapshot) -> UiNode | None:
+            try:
+                return snapshot.require_description(description, contains=contains)
+            except LookupError:
+                return None
+
+        return self.wait_for(find, timeout=timeout, description=f"description {description!r}")
+
+    def tap(self, node: UiNode) -> None:
+        x, y = node.center
+        self.adb("shell", "input", "tap", str(x), str(y))
+
+    def click_text(self, text: str, *, timeout: float = 30, contains: bool = False) -> None:
+        self.tap(self.wait_text(text, timeout=timeout, contains=contains))
+
+    def click_description(
+        self,
+        description: str,
+        *,
+        timeout: float = 30,
+        contains: bool = False,
+    ) -> None:
+        self.tap(self.wait_description(description, timeout=timeout, contains=contains))
+
+    def replace_focused_text(self, value: str) -> None:
+        self.adb("shell", "input", "keycombination", "113", "29")
+        self.adb("shell", "input", "text", value)
+
+    def back(self) -> None:
+        self.adb("shell", "input", "keyevent", "BACK")
+
+    def screenshot(self, name: str) -> Path:
+        destination = self.artifact_dir / name
+        with destination.open("wb") as output:
+            subprocess.run(
+                ["adb", "-s", self.serial, "exec-out", "screencap", "-p"],
+                check=True,
+                stdout=output,
+                timeout=30,
+            )
+        return destination

--- a/tests/transfer_progress_e2e/ui_driver.py
+++ b/tests/transfer_progress_e2e/ui_driver.py
@@ -4,7 +4,6 @@ from __future__ import annotations
 
 import re
 import subprocess
-import tempfile
 import time
 import xml.etree.ElementTree as ET
 from dataclasses import dataclass
@@ -13,7 +12,6 @@ from typing import Callable, TypeVar
 
 
 _BOUNDS = re.compile(r"\[(\d+),(\d+)]\[(\d+),(\d+)]")
-_PERCENT = re.compile(r"^(\d{1,3})%$")
 T = TypeVar("T")
 
 
@@ -64,15 +62,6 @@ class UiSnapshot:
                 return node
         raise LookupError(f"UI description not found: {description!r}")
 
-    def live_percentage(self) -> int | None:
-        for node in self.nodes:
-            match = _PERCENT.fullmatch(node.text)
-            if match is not None:
-                value = int(match.group(1))
-                if 0 < value < 100:
-                    return value
-        return None
-
     def semantic_percentage(self, label: str) -> int | None:
         pattern = re.compile(rf"^{re.escape(label)}, (\d{{1,3}}) percent$")
         for node in self.nodes:
@@ -89,7 +78,7 @@ class AdbUiDriver:
         self.serial = serial
         self.artifact_dir = artifact_dir
         self.artifact_dir.mkdir(parents=True, exist_ok=True)
-        self._dump_path = Path(tempfile.mkdtemp(prefix="columba-e2e-ui-")) / "window.xml"
+        self._dump_path = self.artifact_dir / "window.xml"
 
     def adb(
         self,


### PR DESCRIPTION
## Summary

- expose ephemeral LXMF Resource progress through the backend API and Binder service boundary
- poll existing Python LXMF outgoing messages and inbound Resources without replacing upstream callbacks
- show outgoing progress in the message bubble and incoming/relay progress in a conversation-level tray
- capability-gate direct Resource progress to the Python backend while preserving aggregate propagation sync on both backends

## Verification

- `./gradlew ktlintCheck detekt`
- focused `rns-api`, `rns-ipc`, ViewModel, and Compose unit tests
- full `MessagingViewModelTest` and `MessagingViewModelImageLoadingTest` classes
- `assembleNoSentryPythonBackendDebug`
- `assembleNoSentryKotlinBackendDebug`
- two physical-device Compose instrumentation tests on an SM-G998U1
- inspected the Kotlin APK and confirmed no Chaquopy or Python runtime payload
- installed and launched the Python-backend APK without an immediate fatal exception

## Manual validation before merge

A live-device smoke test with genuine direct and propagated Resource transfers remains intentionally pending.

Fixes #1018