### PR TITLE
Fix RNode reconnect lifecycle

### DIFF
--- a/rns-backend-py/src/main/python/columba_rnode_interface.py
+++ b/rns-backend-py/src/main/python/columba_rnode_interface.py
@@ -349,6 +349,7 @@ class ColumbaRNodeInterface(Interface):
         self._reconnect_cancelled = threading.Event()
         self._max_reconnect_attempts = 30  # Try for ~5 minutes (30 * 10s)
         self._reconnect_interval = 10.0  # Seconds between reconnection attempts
+        self._long_reconnect_interval = 15 * 60  # Indefinite low-duty recovery cadence
 
         # Error / status callbacks (Kotlin sets these via setOnErrorReceived /
         # setOnOnlineStatusChanged on the constructed interface — optional).
@@ -1458,9 +1459,16 @@ class ColumbaRNodeInterface(Interface):
     def _reconnection_loop(self):
         """Background thread that attempts to reconnect to the RNode."""
         attempt = 0
-        while self._reconnecting and attempt < self._max_reconnect_attempts:
+        while self._reconnecting and not self._reconnect_cancelled.is_set():
             attempt += 1
-            RNS.log(f"Reconnection attempt {attempt}/{self._max_reconnect_attempts} for {self.target_device_name}...", RNS.LOG_INFO)
+            if attempt <= self._max_reconnect_attempts:
+                attempt_label = f"{attempt}/{self._max_reconnect_attempts}"
+            else:
+                attempt_label = f"long-term {attempt - self._max_reconnect_attempts}"
+            RNS.log(
+                f"Reconnection attempt {attempt_label} for {self.target_device_name}...",
+                RNS.LOG_INFO,
+            )
 
             try:
                 if self.start():
@@ -1481,21 +1489,27 @@ class ColumbaRNodeInterface(Interface):
                     RNS.log(f"Successfully reconnected to {self.target_device_name}", RNS.LOG_INFO)
                     return
                 else:
-                    RNS.log(f"Reconnection attempt {attempt} failed, will retry in {self._reconnect_interval}s", RNS.LOG_WARNING)
+                    RNS.log(f"Reconnection attempt {attempt_label} failed", RNS.LOG_WARNING)
             except Exception as e:  # noqa: BLE001
-                RNS.log(f"Reconnection attempt {attempt} error: {e}", RNS.LOG_ERROR)
+                RNS.log(f"Reconnection attempt {attempt_label} error: {e}", RNS.LOG_ERROR)
 
-            # Wait before next attempt (but check if we should stop)
-            for _ in range(int(self._reconnect_interval * 10)):
-                if not self._reconnecting:
-                    return
-                time.sleep(0.1)
+            delay = (
+                self._reconnect_interval
+                if attempt < self._max_reconnect_attempts
+                else self._long_reconnect_interval
+            )
+            if attempt == self._max_reconnect_attempts:
+                RNS.log(
+                    f"Fast reconnect phase exhausted for {self.target_device_name}; "
+                    f"continuing every {int(self._long_reconnect_interval / 60)} minutes",
+                    RNS.LOG_WARNING,
+                )
+            if self._wait_for_reconnect(delay):
+                return
 
-        if self._reconnecting:
-            RNS.log(f"Failed to reconnect to {self.target_device_name} after {attempt} attempts", RNS.LOG_ERROR)
-            with self._reconnect_lock:
-                self._reconnecting = False
-                self._reconnect_requested = False
+    def _wait_for_reconnect(self, delay):
+        """Wait for the next attempt, returning true when lifecycle stop cancels it."""
+        return self._reconnect_cancelled.wait(delay) or not self._reconnecting
 
     def process_held_announces(self):
         """Process any held announces. Required by RNS Transport.

--- a/rns-backend-py/src/main/python/columba_rnode_interface.py
+++ b/rns-backend-py/src/main/python/columba_rnode_interface.py
@@ -338,10 +338,15 @@ class ColumbaRNodeInterface(Interface):
         self._read_thread = None
         self._running = threading.Event()  # Thread-safe flag for read loop control
         self._read_lock = threading.Lock()
+        self._start_lock = threading.Lock()
+        self._online_notification_lock = threading.RLock()
 
         # Auto-reconnection
+        self._reconnect_lock = threading.Lock()
         self._reconnect_thread = None
         self._reconnecting = False
+        self._reconnect_requested = False
+        self._reconnect_cancelled = threading.Event()
         self._max_reconnect_attempts = 30  # Try for ~5 minutes (30 * 10s)
         self._reconnect_interval = 10.0  # Seconds between reconnection attempts
 
@@ -464,6 +469,11 @@ class ColumbaRNodeInterface(Interface):
             raise ValueError(f"Invalid long-term airtime limit: {self.lt_alock}")
 
     def start(self):
+        """Run one complete transport/configuration attempt at a time."""
+        with self._start_lock:
+            return self._start_once()
+
+    def _start_once(self):
         """Start the interface - connect to RNode and configure radio."""
         # Handle USB mode separately
         if self.connection_mode == self.MODE_USB:
@@ -510,16 +520,8 @@ class ColumbaRNodeInterface(Interface):
 
         RNS.log(f"Connecting to RNode '{self.target_device_name}' via {mode_str}...", RNS.LOG_INFO)
 
-        # Connect via Kotlin bridge with specified mode
-        if not self.kotlin_bridge.connect(self.target_device_name, self.connection_mode):
-            RNS.log(f"Failed to connect to {self.target_device_name}", RNS.LOG_ERROR)
-            return False
-
-        # Set up data + connection-state callbacks. KotlinRNodeBridge in this
-        # codebase exposes listener-based registration via add*Listener
-        # methods rather than setOn*; wrap in try/except so a refactor doesn't
-        # block interface start. Polling-based reads in _read_loop are what
-        # actually drives data flow, so missing callbacks are non-fatal.
+        # Install observers before connect(). Kotlin can synchronously report
+        # both connection and immediate disconnection before connect returns.
         try:
             if hasattr(self.kotlin_bridge, "setOnDataReceived"):
                 self.kotlin_bridge.setOnDataReceived(self._on_data_received)
@@ -527,6 +529,16 @@ class ColumbaRNodeInterface(Interface):
                 self.kotlin_bridge.setOnConnectionStateChanged(self._on_connection_state_changed)
         except Exception as e:  # noqa: BLE001
             RNS.log(f"ColumbaRNodeInterface: optional callback registration failed (non-fatal): {e}", RNS.LOG_DEBUG)
+
+        # Connect via Kotlin bridge with specified mode
+        if not self.kotlin_bridge.connect(self.target_device_name, self.connection_mode):
+            RNS.log(f"Failed to connect to {self.target_device_name}", RNS.LOG_ERROR)
+            return False
+
+        if self._reconnect_cancelled.is_set():
+            self.kotlin_bridge.disconnect()
+            return False
+
 
         # Stop any stale read thread before starting a new one.
         # _on_connection_state_changed(False) does NOT clear _running, so an
@@ -551,6 +563,23 @@ class ColumbaRNodeInterface(Interface):
                 )
                 return False
 
+        # A prior connection's protocol responses must not validate this
+        # transport. Require fresh detection, firmware, and radio readback.
+        self.detected = False
+        self.firmware_ok = False
+        self.interface_ready = False
+        self.platform = None
+        self.mcu = None
+        self.maj_version = 0
+        self.min_version = 0
+        with self._read_lock:
+            self.r_frequency = None
+            self.r_bandwidth = None
+            self.r_txpower = None
+            self.r_sf = None
+            self.r_cr = None
+            self.r_state = None
+
         # Start read thread
         self._running.set()
         self._read_thread = threading.Thread(target=self._read_loop, daemon=True)
@@ -560,10 +589,15 @@ class ColumbaRNodeInterface(Interface):
         try:
             time.sleep(1.5)  # Allow BLE connection to fully stabilize
             self._configure_device()
+            if self._reconnect_cancelled.is_set() or not self.online:
+                raise IOError("RNode connection did not reach online state")
             return True
         except Exception as e:  # noqa: BLE001
             RNS.log(f"Failed to configure RNode: {e}", RNS.LOG_ERROR)
-            self.stop()
+            # GATT/RFCOMM transport readiness is not a complete reconnect.
+            # Keep the bounded reconnect owner alive when RNode detection or
+            # radio configuration fails after the transport connected.
+            self.stop(cancel_reconnection=False)
             return False
 
     def _start_usb(self):
@@ -656,10 +690,14 @@ class ColumbaRNodeInterface(Interface):
             RNS.log(f"[{self.name}] After disconnect: online={self.online}, read loop stopped", RNS.LOG_INFO)
             # Note: USB doesn't auto-reconnect - user must re-plug or re-select device
 
-    def stop(self):
-        """Stop the interface and disconnect."""
+    def stop(self, cancel_reconnection=True):
+        """Stop and disconnect, optionally preserving the reconnect owner."""
         self._running.clear()
-        self._reconnecting = False  # Stop any reconnection attempts
+        if cancel_reconnection:
+            with self._reconnect_lock:
+                self._reconnecting = False
+                self._reconnect_requested = False
+                self._reconnect_cancelled.set()
         self._set_online(False)
 
         # Disconnect based on connection mode
@@ -673,19 +711,28 @@ class ColumbaRNodeInterface(Interface):
         if self._read_thread:
             self._read_thread.join(timeout=2.0)
 
-        if self._reconnect_thread:
+        if (
+            cancel_reconnection
+            and self._reconnect_thread
+            and self._reconnect_thread is not threading.current_thread()
+        ):
             self._reconnect_thread.join(timeout=2.0)
 
         RNS.log(f"RNode interface '{self.name}' stopped", RNS.LOG_INFO)
 
     def _configure_device(self):
         """Detect and configure the RNode."""
+        if self._reconnect_cancelled.is_set():
+            raise IOError("RNode connection cancelled")
+
         # Send detect command
         self._detect()
 
         # Wait for detection response
         start_time = time.time()
         while not self.detected and (time.time() - start_time) < self.DETECT_TIMEOUT:
+            if self._reconnect_cancelled.is_set():
+                raise IOError("RNode connection cancelled")
             time.sleep(0.1)
 
         if not self.detected:
@@ -709,6 +756,8 @@ class ColumbaRNodeInterface(Interface):
         # Short bounded wait closes it without inventing an Event mechanism.
         fw_wait_start = time.time()
         while not self.firmware_ok and (time.time() - fw_wait_start) < 1.0:
+            if self._reconnect_cancelled.is_set():
+                raise IOError("RNode connection cancelled")
             time.sleep(0.02)
 
         if not self.firmware_ok:
@@ -721,9 +770,15 @@ class ColumbaRNodeInterface(Interface):
         RNS.log("Configuring RNode radio...", RNS.LOG_VERBOSE)
         self._init_radio()
 
+        if self._reconnect_cancelled.is_set():
+            raise IOError("RNode connection cancelled")
+
         # Validate configuration
         if self._validate_radio_state():
             self.interface_ready = True
+            if self._reconnect_cancelled.is_set():
+                self.interface_ready = False
+                raise IOError("RNode connection cancelled")
             self._set_online(True)
             RNS.log(f"RNode '{self.name}' is online", RNS.LOG_INFO)
 
@@ -1293,8 +1348,9 @@ class ColumbaRNodeInterface(Interface):
         """Callback when Bluetooth connection state changes."""
         if connected:
             RNS.log(f"RNode connected: {device_name}", RNS.LOG_INFO)
-            # Stop any reconnection attempts if we're now connected
-            self._reconnecting = False
+            # Transport connection alone is not successful recovery. The
+            # reconnect loop clears its owner only after start() completes
+            # RNode detection, radio configuration, and online validation.
         else:
             RNS.log(f"RNode disconnected: {device_name}", RNS.LOG_WARNING)
             self._set_online(False)
@@ -1334,45 +1390,69 @@ class ColumbaRNodeInterface(Interface):
 
         @param is_online: New online status
         """
-        with self._read_lock:
-            old_status = self.online
-            self.online = is_online
-        if old_status != is_online:
-            # Existing in-Python observer chain (callbacks registered by other
-            # python-side code that wants the live online state).
-            if self._on_online_status_changed:
-                try:
-                    self._on_online_status_changed(is_online)
-                except Exception as e:  # noqa: BLE001
-                    RNS.log(f"Error in online status callback: {e}", RNS.LOG_ERROR)
-            # Notify the Kotlin RNodeBridge so ServiceNotificationManager can
-            # raise / dismiss its "RNode Disconnected" heads-up notification.
-            # ReticulumService.onCreate registers an RNodeOnlineStatusListener
-            # against the bridge singleton.
-            #
-            # USB-mode interfaces don't share the BLE/Classic kotlin_bridge —
-            # for those, KotlinUSBBridge fires its own UsbConnectionListener
-            # on ACTION_USB_DEVICE_DETACHED system broadcast, which converges
-            # in the same notification path. Filter here to avoid invoking a
-            # bridge method that doesn't exist on KotlinUSBBridge.
-            if self.connection_mode != self.MODE_USB and self.kotlin_bridge is not None:
-                try:
-                    self.kotlin_bridge.notifyOnlineStatusChanged(is_online, self.name)
-                except Exception as e:  # noqa: BLE001
-                    RNS.log(
-                        f"Failed to notify kotlin bridge of online status change: {e}",
-                        RNS.LOG_DEBUG,
-                    )
+        # Serialize state mutation and observer publication so stop() cannot
+        # return before an older online=True notification finishes and then
+        # publish a stale True after the terminal False transition.
+        with self._online_notification_lock:
+            with self._read_lock:
+                if is_online and self._reconnect_cancelled.is_set():
+                    return False
+                old_status = self.online
+                self.online = is_online
+            if old_status != is_online:
+                # Existing in-Python observer chain (callbacks registered by other
+                # python-side code that wants the live online state).
+                if self._on_online_status_changed:
+                    try:
+                        self._on_online_status_changed(is_online)
+                    except Exception as e:  # noqa: BLE001
+                        RNS.log(f"Error in online status callback: {e}", RNS.LOG_ERROR)
+                # The Python observer may synchronously stop the interface and
+                # publish a newer state through this reentrant method. Do not
+                # send the superseded outer transition to Kotlin afterward.
+                with self._read_lock:
+                    transition_is_current = self.online == is_online
+                # Notify the Kotlin RNodeBridge so ServiceNotificationManager can
+                # raise / dismiss its "RNode Disconnected" heads-up notification.
+                # ReticulumService.onCreate registers an RNodeOnlineStatusListener
+                # against the bridge singleton.
+                #
+                # USB-mode interfaces don't share the BLE/Classic kotlin_bridge —
+                # for those, KotlinUSBBridge fires its own UsbConnectionListener
+                # on ACTION_USB_DEVICE_DETACHED system broadcast, which converges
+                # in the same notification path. Filter here to avoid invoking a
+                # bridge method that doesn't exist on KotlinUSBBridge.
+                if (
+                    transition_is_current
+                    and self.connection_mode != self.MODE_USB
+                    and self.kotlin_bridge is not None
+                ):
+                    try:
+                        self.kotlin_bridge.notifyOnlineStatusChanged(is_online, self.name)
+                    except Exception as e:  # noqa: BLE001
+                        RNS.log(
+                            f"Failed to notify kotlin bridge of online status change: {e}",
+                            RNS.LOG_DEBUG,
+                        )
+        return True
 
     def _start_reconnection_loop(self):
         """Start a background thread to attempt reconnection."""
-        if self._reconnecting:
-            RNS.log("Reconnection already in progress", RNS.LOG_DEBUG)
-            return
+        with self._reconnect_lock:
+            if self._reconnect_cancelled.is_set():
+                RNS.log("Ignoring reconnect request after explicit stop", RNS.LOG_DEBUG)
+                return
+            if self._reconnecting:
+                # Preserve a disconnect which arrives while the current owner
+                # is between successful start() and ownership teardown.
+                self._reconnect_requested = True
+                RNS.log("Reconnection already in progress", RNS.LOG_DEBUG)
+                return
 
-        self._reconnecting = True
-        self._reconnect_thread = threading.Thread(target=self._reconnection_loop, daemon=True)
-        self._reconnect_thread.start()
+            self._reconnect_requested = False
+            self._reconnecting = True
+            self._reconnect_thread = threading.Thread(target=self._reconnection_loop, daemon=True)
+            self._reconnect_thread.start()
         RNS.log(f"Started auto-reconnection loop for {self.target_device_name}", RNS.LOG_INFO)
 
     def _reconnection_loop(self):
@@ -1384,8 +1464,21 @@ class ColumbaRNodeInterface(Interface):
 
             try:
                 if self.start():
+                    with self._reconnect_lock:
+                        if self._reconnect_requested and not self._reconnect_cancelled.is_set():
+                            self._reconnect_requested = False
+                            retry_after_disconnect = True
+                        else:
+                            self._reconnecting = False
+                            retry_after_disconnect = False
+                    if retry_after_disconnect:
+                        RNS.log(
+                            f"Connection to {self.target_device_name} dropped during "
+                            "reconnect completion; retrying",
+                            RNS.LOG_WARNING,
+                        )
+                        continue
                     RNS.log(f"Successfully reconnected to {self.target_device_name}", RNS.LOG_INFO)
-                    self._reconnecting = False
                     return
                 else:
                     RNS.log(f"Reconnection attempt {attempt} failed, will retry in {self._reconnect_interval}s", RNS.LOG_WARNING)
@@ -1400,7 +1493,9 @@ class ColumbaRNodeInterface(Interface):
 
         if self._reconnecting:
             RNS.log(f"Failed to reconnect to {self.target_device_name} after {attempt} attempts", RNS.LOG_ERROR)
-            self._reconnecting = False
+            with self._reconnect_lock:
+                self._reconnecting = False
+                self._reconnect_requested = False
 
     def process_held_announces(self):
         """Process any held announces. Required by RNS Transport.

--- a/rns-backend-py/src/test/python/test_columba_rnode_reconnect.py
+++ b/rns-backend-py/src/test/python/test_columba_rnode_reconnect.py
@@ -1,0 +1,371 @@
+import importlib.util
+import sys
+import threading
+import time
+import types
+import unittest
+from pathlib import Path
+from unittest import mock
+
+
+INTERFACE_PATH = (
+    Path(__file__).resolve().parents[2]
+    / "main/python/columba_rnode_interface.py"
+)
+
+
+class BaseInterface:
+    MODE_FULL = 0
+    MODE_GATEWAY = 1
+    MODE_ACCESS_POINT = 2
+    MODE_POINT_TO_POINT = 3
+    MODE_ROAMING = 4
+    MODE_BOUNDARY = 5
+
+    def __init__(self):
+        pass
+
+
+class ScriptedBleBridge:
+    """Mock the Kotlin BLE bridge across successive transport attempts."""
+
+    def __init__(self, interface, connect_results):
+        self.interface = interface
+        self.connect_results = iter(connect_results)
+        self.connect_calls = 0
+        self.disconnect_calls = 0
+        self.online_notifications = []
+        self.callback_registered_at_connect = []
+        self.connected = False
+        self.connection_callback = None
+
+    def isConnected(self):
+        return self.connected
+
+    def getConnectedDeviceName(self):
+        return "Test RNode" if self.connected else None
+
+    def connect(self, device_name, mode):
+        self.connect_calls += 1
+        self.callback_registered_at_connect.append(self.connection_callback is not None)
+        self.connected = next(self.connect_results)
+        if self.connected and self.connection_callback is not None:
+            # Kotlin reports GATT transport readiness before Python finishes
+            # RNode detection and radio configuration.
+            self.connection_callback(True, device_name)
+        return self.connected
+
+    def setOnConnectionStateChanged(self, callback):
+        self.connection_callback = callback
+
+    def setOnDataReceived(self, callback):
+        pass
+
+    def read(self):
+        return b""
+
+    def disconnect(self):
+        self.disconnect_calls += 1
+        self.connected = False
+
+    def notifyOnlineStatusChanged(self, is_online, interface_name):
+        self.online_notifications.append(is_online)
+
+
+class RNodeReconnectTests(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        rns = types.ModuleType("RNS")
+        rns.LOG_DEBUG = 7
+        rns.LOG_INFO = 6
+        rns.LOG_WARNING = 4
+        rns.LOG_ERROR = 3
+        rns.log = lambda *args, **kwargs: None
+        rns.Reticulum = types.SimpleNamespace(ANNOUNCE_CAP=2, MTU=500)
+        rns.Transport = types.SimpleNamespace(inbound=lambda *args: None)
+
+        interfaces = types.ModuleType("RNS.Interfaces")
+        interface_module = types.ModuleType("RNS.Interfaces.Interface")
+        interface_module.Interface = BaseInterface
+        rns.Interfaces = interfaces
+
+        sys.modules["RNS"] = rns
+        sys.modules["RNS.Interfaces"] = interfaces
+        sys.modules["RNS.Interfaces.Interface"] = interface_module
+
+        spec = importlib.util.spec_from_file_location(
+            "columba_rnode_reconnect_test", INTERFACE_PATH
+        )
+        assert spec is not None and spec.loader is not None
+        cls.module = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(cls.module)
+        cls.Interface = cls.module.ColumbaRNodeInterface
+
+    def new_interface(self):
+        interface = self.Interface.__new__(self.Interface)
+        interface.name = "Test RNode"
+        interface.connection_mode = self.Interface.MODE_BLE
+        interface.target_device_name = "Test RNode"
+        interface._running = threading.Event()
+        interface._read_thread = None
+        interface._read_lock = threading.Lock()
+        interface._start_lock = threading.Lock()
+        interface._online_notification_lock = threading.RLock()
+        interface._reconnect_lock = threading.Lock()
+        interface._reconnect_thread = threading.current_thread()
+        interface._reconnecting = True
+        interface._reconnect_requested = False
+        interface._reconnect_cancelled = threading.Event()
+        interface._max_reconnect_attempts = 3
+        interface._reconnect_interval = 0
+        interface.online = False
+        interface.detected = False
+        interface._on_online_status_changed = None
+        interface.usb_bridge = None
+        return interface
+
+    def test_ble_reconnect_survives_transport_and_configuration_failures(self):
+        interface = self.new_interface()
+        bridge = ScriptedBleBridge(interface, [False, True, True])
+        interface.kotlin_bridge = bridge
+        configuration_attempts = 0
+
+        def configure_device():
+            nonlocal configuration_attempts
+            configuration_attempts += 1
+            if configuration_attempts == 1:
+                raise IOError("RNode did not answer detection after GATT connected")
+            interface._set_online(True)
+
+        interface._configure_device = configure_device
+        real_sleep = time.sleep
+
+        # Keep the production start/reconnect path while collapsing hardware
+        # stabilization and polling delays to make the regression deterministic.
+        with mock.patch.object(
+            self.module.time,
+            "sleep",
+            side_effect=lambda _seconds: real_sleep(0.001),
+        ):
+            interface._reconnection_loop()
+
+        self.assertEqual(3, bridge.connect_calls)
+        self.assertEqual(2, configuration_attempts)
+        self.assertTrue(all(bridge.callback_registered_at_connect))
+        self.assertTrue(interface.online)
+        self.assertFalse(interface._reconnecting)
+
+        interface.stop()
+
+    def test_ble_reconnect_stops_at_existing_attempt_limit(self):
+        interface = self.new_interface()
+        bridge = ScriptedBleBridge(interface, [False, False, False])
+        interface.kotlin_bridge = bridge
+        real_sleep = time.sleep
+
+        with mock.patch.object(
+            self.module.time,
+            "sleep",
+            side_effect=lambda _seconds: real_sleep(0.001),
+        ):
+            interface._reconnection_loop()
+
+        self.assertEqual(3, bridge.connect_calls)
+        self.assertFalse(interface.online)
+        self.assertFalse(interface._reconnecting)
+
+    def test_explicit_stop_cancels_reconnect_without_joining_itself(self):
+        interface = self.new_interface()
+        bridge = ScriptedBleBridge(interface, [False, False, False])
+        interface.kotlin_bridge = bridge
+
+        interface.stop()
+
+        self.assertFalse(interface._reconnecting)
+        self.assertEqual(1, bridge.disconnect_calls)
+
+    def test_ble_reconnect_requires_fresh_protocol_state(self):
+        interface = self.new_interface()
+        interface.kotlin_bridge = ScriptedBleBridge(interface, [True])
+        interface.detected = True
+        interface.firmware_ok = True
+        interface.interface_ready = True
+        interface.r_frequency = 915000000
+        interface.r_bandwidth = 125000
+        interface.r_txpower = 7
+        interface.r_sf = 7
+        interface.r_cr = 5
+        interface.r_state = 1
+
+        def assert_fresh_state():
+            self.assertFalse(interface.detected)
+            self.assertFalse(interface.firmware_ok)
+            self.assertFalse(interface.interface_ready)
+            self.assertIsNone(interface.r_frequency)
+            self.assertIsNone(interface.r_bandwidth)
+            self.assertIsNone(interface.r_txpower)
+            self.assertIsNone(interface.r_sf)
+            self.assertIsNone(interface.r_cr)
+            self.assertIsNone(interface.r_state)
+            interface._set_online(True)
+
+        interface._configure_device = assert_fresh_state
+        real_sleep = time.sleep
+
+        with mock.patch.object(
+            self.module.time,
+            "sleep",
+            side_effect=lambda _seconds: real_sleep(0.001),
+        ):
+            self.assertTrue(interface.start())
+
+        interface.stop()
+
+    def test_explicit_stop_prevents_in_flight_reconnect_from_returning_online(self):
+        interface = self.new_interface()
+        interface.kotlin_bridge = ScriptedBleBridge(interface, [True])
+
+        def configure_after_stop():
+            interface.stop()
+            interface._set_online(True)
+
+        interface._configure_device = configure_after_stop
+        real_sleep = time.sleep
+
+        with mock.patch.object(
+            self.module.time,
+            "sleep",
+            side_effect=lambda _seconds: real_sleep(0.001),
+        ):
+            self.assertFalse(interface.start())
+
+        self.assertFalse(interface.online)
+        self.assertFalse(interface._reconnecting)
+
+    def test_late_disconnect_after_explicit_stop_does_not_restart_reconnect(self):
+        interface = self.new_interface()
+        bridge = ScriptedBleBridge(interface, [True])
+        interface.kotlin_bridge = bridge
+
+        interface.stop()
+        interface._on_connection_state_changed(False, "Test RNode")
+
+        self.assertTrue(interface._reconnect_cancelled.is_set())
+        self.assertFalse(interface._reconnecting)
+        self.assertIs(interface._reconnect_thread, threading.current_thread())
+
+    def test_explicit_stop_orders_false_after_in_flight_true_notification(self):
+        interface = self.new_interface()
+        interface._reconnect_thread = None
+        bridge = ScriptedBleBridge(interface, [True])
+        interface.kotlin_bridge = bridge
+        true_entered = threading.Event()
+        release_true = threading.Event()
+        stop_returned = threading.Event()
+        notifications = []
+
+        def online_callback(is_online):
+            if is_online:
+                true_entered.set()
+                release_true.wait(timeout=1)
+            notifications.append(is_online)
+
+        interface._on_online_status_changed = online_callback
+        online_thread = threading.Thread(target=interface._set_online, args=(True,))
+        online_thread.start()
+        self.assertTrue(true_entered.wait(timeout=1))
+
+        stop_thread = threading.Thread(
+            target=lambda: (interface.stop(), stop_returned.set())
+        )
+        stop_thread.start()
+
+        self.assertFalse(stop_returned.wait(timeout=0.05))
+        release_true.set()
+        online_thread.join(timeout=1)
+        stop_thread.join(timeout=1)
+
+        self.assertTrue(stop_returned.is_set())
+        self.assertEqual([True, False], notifications)
+        self.assertFalse(interface.online)
+
+    def test_online_observer_can_stop_interface_synchronously(self):
+        interface = self.new_interface()
+        interface._reconnect_thread = None
+        interface.kotlin_bridge = ScriptedBleBridge(interface, [True])
+        notifications = []
+
+        def online_callback(is_online):
+            notifications.append(is_online)
+            if is_online:
+                interface.stop()
+
+        interface._on_online_status_changed = online_callback
+        online_thread = threading.Thread(target=interface._set_online, args=(True,))
+        online_thread.start()
+        online_thread.join(timeout=1)
+
+        self.assertFalse(online_thread.is_alive())
+        self.assertEqual([True, False], notifications)
+        self.assertEqual([False], interface.kotlin_bridge.online_notifications)
+        self.assertFalse(interface.online)
+        self.assertTrue(interface._reconnect_cancelled.is_set())
+
+    def test_disconnect_during_success_teardown_is_not_lost(self):
+        interface = self.new_interface()
+        interface.kotlin_bridge = ScriptedBleBridge(interface, [True])
+        attempts = 0
+
+        def start():
+            nonlocal attempts
+            attempts += 1
+            interface._set_online(True)
+            if attempts == 1:
+                interface._on_connection_state_changed(False, "Test RNode")
+            return True
+
+        interface.start = start
+        interface._reconnection_loop()
+
+        self.assertEqual(2, attempts)
+        self.assertTrue(interface.online)
+        self.assertFalse(interface._reconnecting)
+
+    def test_start_attempts_are_single_flight(self):
+        interface = self.new_interface()
+        first_entered = threading.Event()
+        release_first = threading.Event()
+        active = 0
+        max_active = 0
+        active_lock = threading.Lock()
+
+        def start_once():
+            nonlocal active, max_active
+            with active_lock:
+                active += 1
+                max_active = max(max_active, active)
+            first_entered.set()
+            release_first.wait(timeout=1)
+            with active_lock:
+                active -= 1
+            return True
+
+        interface._start_once = start_once
+        first = threading.Thread(target=interface.start)
+        second = threading.Thread(target=interface.start)
+        first.start()
+        self.assertTrue(first_entered.wait(timeout=1))
+        second.start()
+        time.sleep(0.05)
+        self.assertEqual(1, max_active)
+        release_first.set()
+        first.join(timeout=1)
+        second.join(timeout=1)
+
+        self.assertFalse(first.is_alive())
+        self.assertFalse(second.is_alive())
+        self.assertEqual(1, max_active)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/rns-backend-py/src/test/python/test_columba_rnode_reconnect.py
+++ b/rns-backend-py/src/test/python/test_columba_rnode_reconnect.py
@@ -157,20 +157,25 @@ class RNodeReconnectTests(unittest.TestCase):
 
         interface.stop()
 
-    def test_ble_reconnect_stops_at_existing_attempt_limit(self):
+    def test_ble_reconnect_enters_fifteen_minute_long_term_cadence(self):
         interface = self.new_interface()
+        interface._long_reconnect_interval = 15 * 60
         bridge = ScriptedBleBridge(interface, [False, False, False])
         interface.kotlin_bridge = bridge
-        real_sleep = time.sleep
+        waits = []
 
-        with mock.patch.object(
-            self.module.time,
-            "sleep",
-            side_effect=lambda _seconds: real_sleep(0.001),
-        ):
-            interface._reconnection_loop()
+        def wait_for_reconnect(delay):
+            waits.append(delay)
+            if delay == 15 * 60:
+                interface.stop()
+                return True
+            return False
+
+        interface._wait_for_reconnect = wait_for_reconnect
+        interface._reconnection_loop()
 
         self.assertEqual(3, bridge.connect_calls)
+        self.assertEqual([0, 0, 15 * 60], waits)
         self.assertFalse(interface.online)
         self.assertFalse(interface._reconnecting)
 

--- a/rns-host/src/main/kotlin/network/columba/app/rns/host/call/rnode/BluetoothLeConnection.kt
+++ b/rns-host/src/main/kotlin/network/columba/app/rns/host/call/rnode/BluetoothLeConnection.kt
@@ -110,7 +110,9 @@ class BluetoothLeConnection(
 
         val device: BluetoothDevice? =
             try {
-                adapter.bondedDevices.find { it.address == deviceAddress }
+                adapter.bondedDevices.find {
+                    it.address == deviceAddress || it.name == deviceAddress
+                }
             } catch (e: SecurityException) {
                 Log.e(TAG, "Missing BLUETOOTH_CONNECT permission", e)
                 null

--- a/rns-host/src/main/kotlin/network/columba/app/rns/host/call/rnode/BluetoothLeConnection.kt
+++ b/rns-host/src/main/kotlin/network/columba/app/rns/host/call/rnode/BluetoothLeConnection.kt
@@ -9,12 +9,7 @@ import android.bluetooth.BluetoothGattCharacteristic
 import android.bluetooth.BluetoothGattDescriptor
 import android.bluetooth.BluetoothManager
 import android.bluetooth.BluetoothProfile
-import android.bluetooth.le.ScanCallback
-import android.bluetooth.le.ScanFilter
-import android.bluetooth.le.ScanResult
-import android.bluetooth.le.ScanSettings
 import android.content.Context
-import android.os.ParcelUuid
 import android.util.Log
 import java.io.IOException
 import java.io.InputStream
@@ -52,7 +47,6 @@ class BluetoothLeConnection(
         private val NUS_TX_CHAR_UUID: UUID = UUID.fromString("6e400003-b5a3-f393-e0a9-e50e24dcca9e") // Notify FROM device
         private val CCCD_UUID: UUID = UUID.fromString("00002902-0000-1000-8000-00805f9b34fb")
 
-        private const val BLE_SCAN_TIMEOUT_MS = 10_000L
         private const val BLE_CONNECT_TIMEOUT_MS = 15_000L
         private const val BLE_CONNECT_MAX_RETRIES = 3
         private const val BLE_RETRY_DELAY_MS = 1_000L
@@ -99,7 +93,7 @@ class BluetoothLeConnection(
     /**
      * Connect to the RNode BLE device.
      *
-     * Scans for or finds the device by address, connects GATT, negotiates MTU,
+     * Finds the paired device by address, connects GATT, negotiates MTU,
      * discovers NUS service, and enables TX notifications. Retries up to 3 times
      * for transient BLE failures (e.g., GATT error 133).
      *
@@ -114,7 +108,7 @@ class BluetoothLeConnection(
     private fun findDevice(): BluetoothDevice {
         val adapter = bluetoothAdapter ?: throw IOException("Bluetooth not available")
 
-        var device: BluetoothDevice? =
+        val device: BluetoothDevice? =
             try {
                 adapter.bondedDevices.find { it.address == deviceAddress }
             } catch (e: SecurityException) {
@@ -122,12 +116,7 @@ class BluetoothLeConnection(
                 null
             }
 
-        if (device == null) {
-            Log.d(TAG, "Device not bonded, scanning for: $deviceAddress")
-            device = scanForDevice(deviceAddress)
-        }
-
-        return device ?: throw IOException("BLE device not found: $deviceAddress")
+        return device ?: throw IOException("Paired BLE device not found: $deviceAddress")
     }
 
     private fun connectWithRetries(device: BluetoothDevice): Pair<InputStream, OutputStream> {
@@ -191,64 +180,6 @@ class BluetoothLeConnection(
         }
     }
 
-    /**
-     * Scan for a BLE device by address or name.
-     */
-    private fun scanForDevice(address: String): BluetoothDevice? {
-        val scanner =
-            bluetoothAdapter?.bluetoothLeScanner ?: run {
-                Log.e(TAG, "BLE scanner not available")
-                return null
-            }
-
-        var result: BluetoothDevice? = null
-
-        val scanCallback =
-            object : ScanCallback() {
-                override fun onScanResult(
-                    callbackType: Int,
-                    scanResult: ScanResult,
-                ) {
-                    val dev = scanResult.device
-                    // Match by address or by name
-                    if (dev.address == address || dev.name == address) {
-                        Log.d(TAG, "Found BLE device: ${dev.name} (${dev.address})")
-                        result = dev
-                    }
-                }
-
-                override fun onScanFailed(errorCode: Int) {
-                    Log.e(TAG, "BLE scan failed: $errorCode")
-                }
-            }
-
-        val filter =
-            ScanFilter
-                .Builder()
-                .setServiceUuid(ParcelUuid(NUS_SERVICE_UUID))
-                .build()
-
-        val settings =
-            ScanSettings
-                .Builder()
-                .setScanMode(ScanSettings.SCAN_MODE_LOW_LATENCY)
-                .build()
-
-        try {
-            scanner.startScan(listOf(filter), settings, scanCallback)
-
-            val startTime = System.currentTimeMillis()
-            while (result == null && (System.currentTimeMillis() - startTime) < BLE_SCAN_TIMEOUT_MS) {
-                Thread.sleep(100)
-            }
-
-            scanner.stopScan(scanCallback)
-        } catch (e: SecurityException) {
-            Log.e(TAG, "Missing BLUETOOTH_SCAN permission", e)
-        }
-
-        return result
-    }
 
     /**
      * GATT callback handling the full lifecycle:

--- a/rns-host/src/main/kotlin/network/columba/app/rns/host/rnode/KotlinRNodeBridge.kt
+++ b/rns-host/src/main/kotlin/network/columba/app/rns/host/rnode/KotlinRNodeBridge.kt
@@ -11,13 +11,7 @@ import android.bluetooth.BluetoothGattDescriptor
 import android.bluetooth.BluetoothManager
 import android.bluetooth.BluetoothProfile
 import android.bluetooth.BluetoothSocket
-import android.bluetooth.le.BluetoothLeScanner
-import android.bluetooth.le.ScanCallback
-import android.bluetooth.le.ScanFilter
-import android.bluetooth.le.ScanResult
-import android.bluetooth.le.ScanSettings
 import android.content.Context
-import android.os.ParcelUuid
 import android.util.Log
 import com.chaquo.python.PyObject
 import kotlinx.coroutines.CoroutineScope
@@ -122,7 +116,6 @@ class KotlinRNodeBridge(
         private const val STREAM_BUFFER_SIZE = 2048
 
         // BLE timeouts and retry settings
-        private const val BLE_SCAN_TIMEOUT_MS = 10000L
         private const val BLE_CONNECT_TIMEOUT_MS = 15000L
         private const val BLE_CONNECT_MAX_RETRIES = 3
         private const val BLE_RETRY_DELAY_MS = 1000L
@@ -179,10 +172,6 @@ class KotlinRNodeBridge(
     private var bleRxCharacteristic: BluetoothGattCharacteristic? = null
     private var bleTxCharacteristic: BluetoothGattCharacteristic? = null
     private var bleMtu: Int = 20 // Default BLE MTU (will be negotiated higher)
-    private val bleScanner: BluetoothLeScanner? by lazy { bluetoothAdapter?.bluetoothLeScanner }
-
-    @Volatile
-    private var bleScanResult: BluetoothDevice? = null
 
     @Volatile
     private var bleConnected = false
@@ -535,8 +524,9 @@ class KotlinRNodeBridge(
     ): Boolean {
         Log.d(TAG, "████ RNODE BLE CONNECT ████ deviceName=$deviceName")
 
-        // First check bonded devices
-        var device: BluetoothDevice? =
+        // Runtime connections only target devices paired by the setup wizard.
+        // Do not fall back to low-latency scanning during automatic reconnect.
+        val device: BluetoothDevice? =
             try {
                 adapter.bondedDevices.find { it.name == deviceName }
             } catch (e: SecurityException) {
@@ -544,14 +534,8 @@ class KotlinRNodeBridge(
                 null
             }
 
-        // If not bonded, try to scan for the device
         if (device == null) {
-            Log.d(TAG, "Device not bonded, scanning for BLE device: $deviceName")
-            device = scanForBleDevice(deviceName)
-        }
-
-        if (device == null) {
-            Log.e(TAG, "████ RNODE BLE FAILED ████ device not found: $deviceName")
+            Log.e(TAG, "████ RNODE BLE FAILED ████ paired device not found: $deviceName")
             return false
         }
 
@@ -633,65 +617,6 @@ class KotlinRNodeBridge(
         }
     }
 
-    /**
-     * Scan for a BLE device by name.
-     */
-    private fun scanForBleDevice(deviceName: String): BluetoothDevice? {
-        val scanner =
-            bleScanner ?: run {
-                Log.e(TAG, "BLE scanner not available")
-                return null
-            }
-
-        bleScanResult = null
-
-        val scanCallback =
-            object : ScanCallback() {
-                override fun onScanResult(
-                    callbackType: Int,
-                    result: ScanResult,
-                ) {
-                    val name = result.device.name ?: return
-                    if (name == deviceName) {
-                        Log.d(TAG, "Found BLE device: $name (${result.device.address})")
-                        bleScanResult = result.device
-                    }
-                }
-
-                override fun onScanFailed(errorCode: Int) {
-                    Log.e(TAG, "BLE scan failed: $errorCode")
-                }
-            }
-
-        // Start scan with filter for Nordic UART Service
-        val filter =
-            ScanFilter
-                .Builder()
-                .setServiceUuid(ParcelUuid(NUS_SERVICE_UUID))
-                .build()
-
-        val settings =
-            ScanSettings
-                .Builder()
-                .setScanMode(ScanSettings.SCAN_MODE_LOW_LATENCY)
-                .build()
-
-        try {
-            scanner.startScan(listOf(filter), settings, scanCallback)
-
-            // Wait for result
-            val startTime = System.currentTimeMillis()
-            while (bleScanResult == null && (System.currentTimeMillis() - startTime) < BLE_SCAN_TIMEOUT_MS) {
-                Thread.sleep(100)
-            }
-
-            scanner.stopScan(scanCallback)
-        } catch (e: SecurityException) {
-            Log.e(TAG, "Missing BLUETOOTH_SCAN permission", e)
-        }
-
-        return bleScanResult
-    }
 
     /**
      * BLE GATT callback for connection events.

--- a/rns-host/src/test/kotlin/network/columba/app/rns/host/call/rnode/BluetoothLeConnectionTest.kt
+++ b/rns-host/src/test/kotlin/network/columba/app/rns/host/call/rnode/BluetoothLeConnectionTest.kt
@@ -1,16 +1,37 @@
 package network.columba.app.rns.host.call.rnode
 
 import android.bluetooth.BluetoothAdapter
+import android.bluetooth.BluetoothDevice
 import android.bluetooth.BluetoothManager
 import android.content.Context
 import io.mockk.every
 import io.mockk.mockk
 import io.mockk.verify
 import org.junit.Assert.assertThrows
+import org.junit.Assert.assertSame
 import org.junit.Test
 import java.io.IOException
 
 class BluetoothLeConnectionTest {
+    @Test
+    fun `runtime connection resolves paired RNode by configured name`() {
+        val context = mockk<Context>(relaxed = true)
+        val manager = mockk<BluetoothManager>(relaxed = true)
+        val adapter = mockk<BluetoothAdapter>(relaxed = true)
+        val device = mockk<BluetoothDevice>()
+        every { context.getSystemService(Context.BLUETOOTH_SERVICE) } returns manager
+        every { manager.adapter } returns adapter
+        every { device.name } returns "RNode 1234"
+        every { device.address } returns "AA:BB:CC:DD:EE:FF"
+        every { adapter.bondedDevices } returns setOf(device)
+
+        val connection = BluetoothLeConnection(context, "RNode 1234")
+        val findDevice = connection.javaClass.getDeclaredMethod("findDevice").apply { isAccessible = true }
+
+        assertSame(device, findDevice.invoke(connection))
+        verify(exactly = 0) { adapter.bluetoothLeScanner }
+    }
+
     @Test
     fun `runtime connection rejects unbonded RNode without scanning`() {
         val context = mockk<Context>(relaxed = true)

--- a/rns-host/src/test/kotlin/network/columba/app/rns/host/call/rnode/BluetoothLeConnectionTest.kt
+++ b/rns-host/src/test/kotlin/network/columba/app/rns/host/call/rnode/BluetoothLeConnectionTest.kt
@@ -1,0 +1,28 @@
+package network.columba.app.rns.host.call.rnode
+
+import android.bluetooth.BluetoothAdapter
+import android.bluetooth.BluetoothManager
+import android.content.Context
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import org.junit.Assert.assertThrows
+import org.junit.Test
+import java.io.IOException
+
+class BluetoothLeConnectionTest {
+    @Test
+    fun `runtime connection rejects unbonded RNode without scanning`() {
+        val context = mockk<Context>(relaxed = true)
+        val manager = mockk<BluetoothManager>(relaxed = true)
+        val adapter = mockk<BluetoothAdapter>(relaxed = true)
+        every { context.getSystemService(Context.BLUETOOTH_SERVICE) } returns manager
+        every { manager.adapter } returns adapter
+        every { adapter.bondedDevices } returns emptySet()
+
+        val connection = BluetoothLeConnection(context, "AA:BB:CC:DD:EE:FF")
+
+        assertThrows(IOException::class.java) { connection.connect() }
+        verify(exactly = 0) { adapter.bluetoothLeScanner }
+    }
+}

--- a/rns-host/src/test/kotlin/network/columba/app/rns/host/rnode/KotlinRNodeBridgeOnlineStatusTest.kt
+++ b/rns-host/src/test/kotlin/network/columba/app/rns/host/rnode/KotlinRNodeBridgeOnlineStatusTest.kt
@@ -6,6 +6,7 @@ import android.content.Context
 import io.mockk.clearAllMocks
 import io.mockk.every
 import io.mockk.mockk
+import io.mockk.verify
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.isActive
 import org.junit.After
@@ -44,6 +45,16 @@ class KotlinRNodeBridgeOnlineStatusTest {
         every { mockContext.getSystemService(Context.BLUETOOTH_SERVICE) } returns mockBluetoothManager
         every { mockBluetoothManager.adapter } returns mockBluetoothAdapter
         every { mockBluetoothAdapter.isEnabled } returns true
+    }
+
+    @Test
+    fun `runtime BLE connect rejects unbonded RNode without scanning`() {
+        every { mockBluetoothAdapter.bondedDevices } returns emptySet()
+        val bridge = KotlinRNodeBridge(mockContext)
+
+        assertFalse(bridge.connect("RNode 1234", "ble"))
+
+        verify(exactly = 0) { mockBluetoothAdapter.bluetoothLeScanner }
     }
 
     @After


### PR DESCRIPTION
## Summary

- keep BLE reconnect ownership active until RNode detection, firmware validation, radio configuration, and online publication complete
- make reconnect cancellation, observer publication, callback re-entry, and concurrent disconnect handling race-safe
- use paired RNodes only for runtime BLE connections while preserving setup-wizard discovery
- continue recovery indefinitely at a 15-minute cadence after the existing 30-attempt fast phase
- apply bonded-only runtime behavior consistently to Python and Kotlin backends

## Verification

- `python3 -m unittest -v rns-backend-py/src/test/python/test_columba_rnode_reconnect.py` (10 passed)
- `python3 -m unittest discover -s rns-backend-py/src/test/python -p 'test_*.py'` (16 passed)
- focused Python and Kotlin backend RNode bridge tests
- `:rns-backend-py:testDebugUnitTest`
- `:app:assembleNoSentryPythonBackendDebug`
- `:app:assembleNoSentryKotlinBackendDebug`
- canonical PR quality command: ktlint, detekt, CPD, Android lint (500 tasks successful)
- physical Python-backend smoke on Samsung SM-G998U1; reconnect behavior reported working

## Risk and limitations

- no measured battery-current or mAh evidence; the 15-minute cadence is source- and test-verified
- setup-wizard scanning remains available, but configured runtime connections now fail fast if Android no longer has the RNode bond
- physical validation covered the Python backend; Kotlin backend behavior is covered by focused tests and APK assembly
