### PR TITLE
Fix conversation notification dismissal on resume

### DIFF
--- a/app/src/main/java/network/columba/app/ui/screens/MessagingScreen.kt
+++ b/app/src/main/java/network/columba/app/ui/screens/MessagingScreen.kt
@@ -148,6 +148,7 @@ import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.platform.LocalHapticFeedback
 import androidx.compose.ui.platform.LocalSoftwareKeyboardController
 import androidx.compose.ui.platform.LocalViewConfiguration
+import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.semantics.contentDescription
 import androidx.compose.ui.semantics.semantics
@@ -705,7 +706,7 @@ fun MessagingScreen(
 
     // Track IME (keyboard) visibility
     val density = LocalDensity.current
-    val imeBottomInset = WindowInsets.ime.getBottom(density)
+    val imeBottomInset = LocalMessagingImeBottomInsetOverride.current ?: WindowInsets.ime.getBottom(density)
     val imeIsVisible = imeBottomInset > 0
 
     // Attachment panel state machine
@@ -918,6 +919,11 @@ fun MessagingScreen(
             listState.scrollToItem(0) // Instant scroll to index 0 (newest message)
         }
     }
+
+    // A notification can be posted while Columba is backgrounded even when this conversation
+    // remains composed. Re-assert visibility on every resume so that notification is dismissed
+    // and the newly visible messages are marked read.
+    ConversationVisibilityEffect(destinationHash, viewModel::onConversationVisible)
 
     // Load messages for this peer
     LaunchedEffect(destinationHash) {
@@ -1531,7 +1537,12 @@ fun MessagingScreen(
                             voicePlayer.close()
                             val wasVoiceMessage = voiceRecordingState.selectedRecording != null
                             viewModel.sendMessage(destinationHash, messageText)
-                            if (!wasVoiceMessage) inputPanelMode = InputPanelMode.NONE
+                            inputPanelMode =
+                                inputPanelModeAfterSend(
+                                    currentMode = inputPanelMode,
+                                    wasVoiceMessage = wasVoiceMessage,
+                                    imeIsVisible = imeIsVisible,
+                                )
                         }
                     },
                     isSending = isSending,
@@ -1605,7 +1616,12 @@ fun MessagingScreen(
                     InputPanelMode.KEYBOARD -> {
                         // Manual IME spacer replaces .imePadding()
                         val imeHeightDp = with(density) { imeBottomInset.toDp() }
-                        Spacer(modifier = Modifier.height(imeHeightDp))
+                        Spacer(
+                            modifier =
+                                Modifier
+                                    .height(imeHeightDp)
+                                    .testTag("messageKeyboardSpacer"),
+                        )
                     }
                     InputPanelMode.NONE -> {
                         // Nav bar padding only when nothing else is showing
@@ -2946,8 +2962,6 @@ fun EmptyMessagesState() {
         }
     }
 }
-
-private enum class InputPanelMode { NONE, KEYBOARD, PANEL }
 
 private fun formatTimestamp(timestamp: Long): String {
     val now = System.currentTimeMillis()

--- a/app/src/main/java/network/columba/app/ui/screens/MessagingScreenLifecycle.kt
+++ b/app/src/main/java/network/columba/app/ui/screens/MessagingScreenLifecycle.kt
@@ -1,0 +1,31 @@
+package network.columba.app.ui.screens
+
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.staticCompositionLocalOf
+import androidx.lifecycle.compose.LifecycleResumeEffect
+
+@Composable
+internal fun ConversationVisibilityEffect(
+    destinationHash: String,
+    onConversationVisible: (String) -> Unit,
+) {
+    LifecycleResumeEffect(destinationHash) {
+        onConversationVisible(destinationHash)
+        onPauseOrDispose { }
+    }
+}
+
+internal val LocalMessagingImeBottomInsetOverride = staticCompositionLocalOf<Int?> { null }
+
+internal enum class InputPanelMode { NONE, KEYBOARD, PANEL }
+
+internal fun inputPanelModeAfterSend(
+    currentMode: InputPanelMode,
+    wasVoiceMessage: Boolean,
+    imeIsVisible: Boolean,
+): InputPanelMode =
+    when {
+        wasVoiceMessage -> currentMode
+        imeIsVisible -> InputPanelMode.KEYBOARD
+        else -> InputPanelMode.NONE
+    }

--- a/app/src/main/java/network/columba/app/viewmodel/MessagingViewModel.kt
+++ b/app/src/main/java/network/columba/app/viewmodel/MessagingViewModel.kt
@@ -1179,32 +1179,12 @@ class MessagingViewModel
             _currentConversation.value = destinationHash
             lastDraftText = ""
 
-            // Register this conversation as active (suppresses notifications for this peer)
-            activeConversationManager.setActive(destinationHash)
-
-            // Dismiss the message notification for this conversation now that the user
-            // is viewing it.  This covers both normal in-app entry and notification-tap
-            // entry, because both converge on loadMessages().  Safe and idempotent —
-            // cancelling a nonexistent notification is a no-op.
-            notificationHelper.cancelNotificationForConversation(destinationHash)
-
             // Enable fast polling (1s) for active conversation
             rnsLxmf.setConversationActive(true)
 
             // Request path for this conversation peer if we don't have one
             viewModelScope.launch(Dispatchers.IO) {
                 identityResolutionManager.requestPathForContact(destinationHash)
-            }
-
-            // Mark conversation as read when opening
-            viewModelScope.launch {
-                try {
-                    Log.d(TAG, "Marking conversation $destinationHash as read...")
-                    conversationRepository.markConversationAsRead(destinationHash)
-                    Log.d(TAG, "Conversation marked as read")
-                } catch (e: Exception) {
-                    Log.e(TAG, "Error marking conversation as read", e)
-                }
             }
 
             // Restore draft for this conversation
@@ -1271,6 +1251,13 @@ class MessagingViewModel
             } catch (e: Exception) {
                 Log.e(TAG, "Error saving draft immediately", e)
             }
+        }
+
+        /** Re-asserts user-visible conversation state on initial display and foreground return. */
+        fun onConversationVisible(destinationHash: String) {
+            activeConversationManager.setActive(destinationHash)
+            notificationHelper.cancelNotificationForConversation(destinationHash)
+            markAsRead(destinationHash)
         }
 
         fun markAsRead(destinationHash: String) {

--- a/app/src/test/java/network/columba/app/ui/screens/MessagingScreenTest.kt
+++ b/app/src/test/java/network/columba/app/ui/screens/MessagingScreenTest.kt
@@ -2,9 +2,10 @@ package network.columba.app.ui.screens
 
 import android.app.Application
 import android.Manifest
+import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.ui.input.key.Key
-import androidx.compose.ui.test.assertIsDisplayed
 import androidx.compose.ui.test.assert
+import androidx.compose.ui.test.assertIsDisplayed
 import androidx.compose.ui.test.assertIsEnabled
 import androidx.compose.ui.test.ExperimentalTestApi
 import androidx.compose.ui.test.assertIsNotEnabled
@@ -12,6 +13,7 @@ import androidx.compose.ui.test.SemanticsMatcher
 import androidx.compose.ui.test.hasSetTextAction
 import androidx.compose.ui.test.junit4.createComposeRule
 import androidx.compose.ui.test.onNodeWithContentDescription
+import androidx.compose.ui.test.onNodeWithTag
 import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.performClick
 import androidx.compose.ui.test.performKeyInput
@@ -21,6 +23,9 @@ import androidx.compose.ui.test.requestFocus
 import androidx.compose.ui.test.withKeyDown
 import androidx.compose.ui.semantics.SemanticsProperties
 import androidx.paging.PagingData
+import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.compose.LocalLifecycleOwner
+import androidx.lifecycle.testing.TestLifecycleOwner
 import network.columba.app.audio.VoiceMessageRecordingState
 import network.columba.app.service.SyncProgress
 import network.columba.app.test.MessagingTestFixtures
@@ -58,6 +63,30 @@ import org.robolectric.annotation.Config
 @RunWith(RobolectricTestRunner::class)
 @Config(sdk = [34], application = Application::class)
 class MessagingScreenTest {
+    @Test
+    fun `text send keeps keyboard panel while IME remains visible`() {
+        assertEquals(
+            InputPanelMode.KEYBOARD,
+            inputPanelModeAfterSend(
+                currentMode = InputPanelMode.KEYBOARD,
+                wasVoiceMessage = false,
+                imeIsVisible = true,
+            ),
+        )
+    }
+
+    @Test
+    fun `text send clears stale panel mode when IME is hidden`() {
+        assertEquals(
+            InputPanelMode.NONE,
+            inputPanelModeAfterSend(
+                currentMode = InputPanelMode.PANEL,
+                wasVoiceMessage = false,
+                imeIsVisible = false,
+            ),
+        )
+    }
+
     private val registerActivityRule = RegisterComponentActivityRule()
     private val composeRule = createComposeRule()
 
@@ -601,6 +630,66 @@ class MessagingScreenTest {
         // Then
         assertTrue("Send button click should succeed", result.isSuccess)
         verify { mockViewModel.sendMessage(MessagingTestFixtures.Constants.TEST_DESTINATION_HASH, "Test message") }
+    }
+
+    @Test
+    fun inputBar_sendClick_keepsComposerAboveVisibleKeyboard() {
+        composeTestRule.setContent {
+            CompositionLocalProvider(LocalMessagingImeBottomInsetOverride provides 900) {
+                MessagingScreen(
+                    destinationHash = MessagingTestFixtures.Constants.TEST_DESTINATION_HASH,
+                    peerName = MessagingTestFixtures.Constants.TEST_PEER_NAME,
+                    onBackClick = {},
+                    viewModel = mockViewModel,
+                )
+            }
+        }
+
+        composeTestRule.onNodeWithText("Type a message...").performTextInput("Keep composer visible")
+        val spacerBeforeSend = composeTestRule.onNodeWithTag("messageKeyboardSpacer").fetchSemanticsNode()
+        assertTrue(spacerBeforeSend.layoutInfo.coordinates.isAttached)
+
+        composeTestRule.onNodeWithContentDescription("Send message").performClick()
+
+        verify {
+            mockViewModel.sendMessage(
+                MessagingTestFixtures.Constants.TEST_DESTINATION_HASH,
+                "Keep composer visible",
+            )
+        }
+        val spacerAfterSend = composeTestRule.onNodeWithTag("messageKeyboardSpacer").fetchSemanticsNode()
+        assertTrue(spacerAfterSend.layoutInfo.coordinates.isAttached)
+    }
+
+    @Test
+    fun screen_reportsConversationVisibleAgainWhenResumed() {
+        val lifecycleOwner = TestLifecycleOwner(initialState = Lifecycle.State.RESUMED)
+        composeTestRule.setContent {
+            CompositionLocalProvider(LocalLifecycleOwner provides lifecycleOwner) {
+                MessagingScreen(
+                    destinationHash = MessagingTestFixtures.Constants.TEST_DESTINATION_HASH,
+                    peerName = MessagingTestFixtures.Constants.TEST_PEER_NAME,
+                    onBackClick = {},
+                    viewModel = mockViewModel,
+                )
+            }
+        }
+
+        verify(exactly = 1) {
+            mockViewModel.onConversationVisible(MessagingTestFixtures.Constants.TEST_DESTINATION_HASH)
+        }
+
+        composeTestRule.runOnIdle {
+            lifecycleOwner.currentState = Lifecycle.State.STARTED
+        }
+        composeTestRule.runOnIdle {
+            lifecycleOwner.currentState = Lifecycle.State.RESUMED
+        }
+
+        verify(exactly = 2) {
+            mockViewModel.onConversationVisible(MessagingTestFixtures.Constants.TEST_DESTINATION_HASH)
+        }
+        assertEquals(Lifecycle.State.RESUMED, lifecycleOwner.currentState)
     }
 
     @Test

--- a/app/src/test/java/network/columba/app/viewmodel/MessagingViewModelTest.kt
+++ b/app/src/test/java/network/columba/app/viewmodel/MessagingViewModelTest.kt
@@ -390,20 +390,19 @@ class MessagingViewModelTest {
             // Verify: Repository was called with correct peer hash
             coVerify { conversationRepository.getMessagesPaged(testPeerHash) }
 
-            // Verify: Conversation marked as read
-            coVerify { conversationRepository.markConversationAsRead(testPeerHash) }
-
             // Verify: Fast polling enabled
             verify { rnsLxmf.setConversationActive(true) }
         }
 
     @Test
-    fun `loadMessages marks conversation as read`() =
+    fun `conversation visibility dismisses its notification and marks it read`() =
         runViewModelTest {
-            val result = runCatching { viewModel.loadMessages(testPeerHash, testPeerName) }
+            val result = runCatching { viewModel.onConversationVisible(testPeerHash) }
             advanceUntilIdle()
 
-            assertTrue("loadMessages should complete without error", result.isSuccess)
+            assertTrue("Visibility handling should complete without error", result.isSuccess)
+            verify { activeConversationManager.setActive(testPeerHash) }
+            verify { notificationHelper.cancelNotificationForConversation(testPeerHash) }
             coVerify { conversationRepository.markConversationAsRead(testPeerHash) }
         }
 
@@ -696,6 +695,7 @@ class MessagingViewModelTest {
 
             // Load first conversation
             val result1 = runCatching { viewModel.loadMessages(conversation1Hash, "Peer 1") }
+            viewModel.onConversationVisible(conversation1Hash)
             advanceUntilIdle()
 
             assertTrue("First loadMessages should succeed", result1.isSuccess)
@@ -709,6 +709,7 @@ class MessagingViewModelTest {
 
             // Switch to second conversation
             val result2 = runCatching { viewModel.loadMessages(conversation2Hash, "Peer 2") }
+            viewModel.onConversationVisible(conversation2Hash)
             advanceUntilIdle()
 
             assertTrue("Second loadMessages should succeed", result2.isSuccess)
@@ -720,7 +721,7 @@ class MessagingViewModelTest {
             // Verify second conversation was loaded
             coVerify { conversationRepository.getMessagesPaged(conversation2Hash) }
 
-            // Verify both conversations were marked as read
+            // Verify visibility for both conversations marked each one as read
             coVerify { conversationRepository.markConversationAsRead(conversation1Hash) }
             coVerify { conversationRepository.markConversationAsRead(conversation2Hash) }
         }


### PR DESCRIPTION
## Summary

- dismiss a conversation's notification whenever an already-open messaging screen resumes
- centralize visible-conversation activation, notification cancellation, and read marking
- keep the composer attached above a still-visible IME after sending a text message
- add lifecycle and production-connected Compose regressions for both behaviors

## Verification

- physical Samsung SM-G998U1 on Android 15: notification dismissed when app-switching back to an already-open conversation
- physical Samsung SM-G998U1 on Android 15: composer remained directly above the keyboard after sending
- `./gradlew :app:testNoSentryKotlinBackendDebugUnitTest --tests 'network.columba.app.ui.screens.MessagingScreenTest' --tests 'network.columba.app.ui.screens.ConversationVisibilityEffectTest' --tests 'network.columba.app.viewmodel.MessagingViewModelTest' --tests 'network.columba.app.notifications.NotificationHelperTest' --no-daemon`
- `./gradlew ktlintCheck detekt cpdCheck lint :app:lintNoSentryKotlinBackendDebug :rns-host:lintPythonBackendDebug --continue --no-daemon`
- `./gradlew :app:assembleNoSentryKotlinBackendDebug :app:assembleNoSentryPythonBackendDebug --no-daemon`
- `git diff --check`

## Risk and rollback

Risk is limited to messaging-screen lifecycle/read handling and composer panel state after send. Reverting this PR restores the previous behavior.
