### PR TITLE
fix: prevent replayed announces from refreshing Last seen

### DIFF
--- a/app/src/test/java/network/columba/app/rns/host/persistence/ServicePersistenceManagerDatabaseTest.kt
+++ b/app/src/test/java/network/columba/app/rns/host/persistence/ServicePersistenceManagerDatabaseTest.kt
@@ -12,6 +12,7 @@ import io.mockk.mockk
 import io.mockk.mockkObject
 import io.mockk.unmockkObject
 import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.test.TestScope
 import kotlinx.coroutines.test.UnconfinedTestDispatcher
 import kotlinx.coroutines.test.advanceUntilIdle
@@ -99,6 +100,8 @@ class ServicePersistenceManagerDatabaseTest : DatabaseTest() {
                 stampCostFlexibility = null,
                 peeringCost = null,
                 propagationTransferLimitKb = null,
+                announcePacketHash = "00112233",
+                isPathResponse = false,
             )
             advanceUntilIdle()
             Thread.sleep(100) // Allow Room's IO dispatcher to complete
@@ -113,6 +116,126 @@ class ServicePersistenceManagerDatabaseTest : DatabaseTest() {
             val activity = database.peerActivityDao().getActivity(destinationHash)
             assertEquals(saved?.lastSeenTimestamp, activity?.lastReceivedAt)
             assertEquals("ANNOUNCE", activity?.activityType)
+        }
+
+    @Test
+    fun `path response updates announce metadata without advancing peer activity`() =
+        testScope.runTest {
+            val destinationHash = "path_response_peer"
+            insertTestIdentity()
+            contactDao.insertContact(
+                ContactEntity(
+                    destinationHash = destinationHash,
+                    identityHash = TEST_IDENTITY_HASH,
+                    publicKey = testPublicKey,
+                    addedTimestamp = 500L,
+                    addedVia = "MANUAL",
+                ),
+            )
+
+            database.peerActivityDao().recordActivity(
+                destinationHash = destinationHash,
+                receivedAt = 1_000L,
+                activityType = "MESSAGE",
+            )
+
+            assertTrue(
+                persistenceManager.persistAnnounce(
+                    destinationHash = destinationHash,
+                    peerName = "Cached Peer",
+                    publicKey = testPublicKey,
+                    appData = testAppData,
+                    hops = 3,
+                    timestamp = 2_000L,
+                    nodeType = "PEER",
+                    receivingInterface = "TCP",
+                    receivingInterfaceType = "TCP",
+                    aspect = "lxmf.delivery",
+                    stampCost = null,
+                    stampCostFlexibility = null,
+                    peeringCost = null,
+                    propagationTransferLimitKb = null,
+                    announcePacketHash = "aabbccdd",
+                    isPathResponse = true,
+                ),
+            )
+
+            val announce = announceDao.getAnnounce(destinationHash)
+            assertNotNull(announce)
+            assertEquals("Cached Peer", announce?.peerName)
+            assertEquals(3, announce?.hops)
+            assertEquals(0L, announce?.lastSeenTimestamp)
+            val activity = database.peerActivityDao().getActivity(destinationHash)
+            assertEquals(1_000L, activity?.lastReceivedAt)
+            assertEquals("MESSAGE", activity?.activityType)
+            val identityHash = network.columba.app.data.util.HashUtils.computeIdentityHash(testPublicKey)
+            assertEquals(0L, peerIdentityDao.getPeerIdentity(identityHash)?.lastSeenTimestamp)
+            val contact = contactDao.getEnrichedContacts(TEST_IDENTITY_HASH, currentTime = 2_000L).first().single()
+            assertEquals(1_000L, contact.lastSeenTimestamp)
+        }
+
+    @Test
+    fun `replayed announce packet updates peer activity only once`() =
+        testScope.runTest {
+            val destinationHash = "replayed_announce_peer"
+
+            suspend fun persist(timestamp: Long) =
+                persistenceManager.persistAnnounce(
+                    destinationHash = destinationHash,
+                    peerName = "Peer",
+                    publicKey = testPublicKey,
+                    appData = testAppData,
+                    hops = 1,
+                    timestamp = timestamp,
+                    nodeType = "PEER",
+                    receivingInterface = "TCP",
+                    receivingInterfaceType = "TCP",
+                    aspect = "lxmf.delivery",
+                    stampCost = null,
+                    stampCostFlexibility = null,
+                    peeringCost = null,
+                    propagationTransferLimitKb = null,
+                    announcePacketHash = "11223344",
+                    isPathResponse = false,
+                )
+
+            assertTrue(persist(1_000L))
+            assertTrue(persist(9_000L))
+
+            val activity = database.peerActivityDao().getActivity(destinationHash)
+            assertEquals(1_000L, activity?.lastReceivedAt)
+            assertEquals("ANNOUNCE", activity?.activityType)
+            assertEquals(1_000L, announceDao.getAnnounce(destinationHash)?.lastSeenTimestamp)
+        }
+
+    @Test
+    fun `hashless announce updates metadata without advancing peer activity`() =
+        testScope.runTest {
+            val destinationHash = "hashless_announce_peer"
+
+            assertTrue(
+                persistenceManager.persistAnnounce(
+                    destinationHash = destinationHash,
+                    peerName = "Peer",
+                    publicKey = testPublicKey,
+                    appData = testAppData,
+                    hops = 1,
+                    timestamp = 4_000L,
+                    nodeType = "PEER",
+                    receivingInterface = "TCP",
+                    receivingInterfaceType = "TCP",
+                    aspect = "lxmf.delivery",
+                    stampCost = null,
+                    stampCostFlexibility = null,
+                    peeringCost = null,
+                    propagationTransferLimitKb = null,
+                    announcePacketHash = null,
+                    isPathResponse = false,
+                ),
+            )
+
+            assertNotNull(announceDao.getAnnounce(destinationHash))
+            assertNull(database.peerActivityDao().getActivity(destinationHash))
         }
 
     // Note: "persistAnnounce preserves favorite status on update" test was removed.

--- a/data/src/main/java/network/columba/app/data/db/dao/AnnounceDao.kt
+++ b/data/src/main/java/network/columba/app/data/db/dao/AnnounceDao.kt
@@ -47,6 +47,22 @@ interface AnnounceDao {
         hops: Int,
     ): Int
 
+    @Query(
+        """
+        UPDATE announce_interface_sightings
+        SET receivingInterface = :receivingInterface,
+            hops = :hops
+        WHERE destinationHash = :destinationHash
+          AND interfaceType = :interfaceType
+        """,
+    )
+    suspend fun updateInterfaceSightingMetadata(
+        destinationHash: String,
+        interfaceType: String,
+        receivingInterface: String?,
+        hops: Int,
+    ): Int
+
     /** Equal or older observations retain the existing newest metadata. */
     @Transaction
     suspend fun upsertInterfaceSighting(sighting: AnnounceInterfaceSightingEntity) {
@@ -57,6 +73,20 @@ interface AnnounceDao {
                 interfaceType = sighting.interfaceType,
                 receivingInterface = sighting.receivingInterface,
                 lastSeenTimestamp = sighting.lastSeenTimestamp,
+                hops = sighting.hops,
+            )
+        }
+    }
+
+    /** Update path metadata without claiming a newer peer sighting. */
+    @Transaction
+    suspend fun upsertInterfaceSightingMetadata(sighting: AnnounceInterfaceSightingEntity) {
+        val inserted = insertInterfaceSighting(sighting.copy(lastSeenTimestamp = 0L))
+        if (inserted == -1L) {
+            updateInterfaceSightingMetadata(
+                destinationHash = sighting.destinationHash,
+                interfaceType = sighting.interfaceType,
+                receivingInterface = sighting.receivingInterface,
                 hops = sighting.hops,
             )
         }

--- a/rns-api/src/main/java/network/columba/app/rns/api/model/AnnounceEvent.kt
+++ b/rns-api/src/main/java/network/columba/app/rns/api/model/AnnounceEvent.kt
@@ -50,6 +50,8 @@ data class AnnounceEvent(
     val stampCost: Int? = null, // Pre-parsed by LXMF stamp cost functions
     val stampCostFlexibility: Int? = null, // For propagation nodes only
     val peeringCost: Int? = null, // For propagation nodes only
+    val announcePacketHash: ByteArray? = null,
+    val isPathResponse: Boolean = false,
 ) : Parcelable {
     @Suppress("CyclomaticComplexMethod")
     override fun equals(other: Any?): Boolean {
@@ -75,6 +77,13 @@ data class AnnounceEvent(
         if (stampCost != other.stampCost) return false
         if (stampCostFlexibility != other.stampCostFlexibility) return false
         if (peeringCost != other.peeringCost) return false
+        if (announcePacketHash != null) {
+            if (other.announcePacketHash == null) return false
+            if (!announcePacketHash.contentEquals(other.announcePacketHash)) return false
+        } else if (other.announcePacketHash != null) {
+            return false
+        }
+        if (isPathResponse != other.isPathResponse) return false
 
         return true
     }
@@ -92,6 +101,8 @@ data class AnnounceEvent(
         result = 31 * result + (stampCost?.hashCode() ?: 0)
         result = 31 * result + (stampCostFlexibility?.hashCode() ?: 0)
         result = 31 * result + (peeringCost?.hashCode() ?: 0)
+        result = 31 * result + (announcePacketHash?.contentHashCode() ?: 0)
+        result = 31 * result + isPathResponse.hashCode()
         return result
     }
 }

--- a/rns-api/src/test/java/network/columba/app/rns/api/ParcelRoundTripTest.kt
+++ b/rns-api/src/test/java/network/columba/app/rns/api/ParcelRoundTripTest.kt
@@ -3,15 +3,18 @@ package network.columba.app.rns.api
 import android.os.Parcel
 import android.os.Parcelable
 import network.columba.app.rns.api.model.AnnounceRestoreEntry
+import network.columba.app.rns.api.model.AnnounceEvent
 import network.columba.app.rns.api.model.CallState
 import network.columba.app.rns.api.model.FileAttachment
 import network.columba.app.rns.api.model.InterfaceConfig
+import network.columba.app.rns.api.model.Identity
 import network.columba.app.rns.api.model.Link
 import network.columba.app.rns.api.model.LinkEvent
 import network.columba.app.rns.api.model.LinkStatus
 import network.columba.app.rns.api.model.LocationTelemetry
 import network.columba.app.rns.api.model.NetworkStatus
 import network.columba.app.rns.api.model.NetworkRestriction
+import network.columba.app.rns.api.model.NodeType
 import network.columba.app.rns.api.model.PeerIdentityEntry
 import org.junit.Assert.assertArrayEquals
 import org.junit.Assert.assertEquals
@@ -298,6 +301,26 @@ class ParcelRoundTripTest {
         val original = AnnounceRestoreEntry("cafef00d", ByteArray(64) { (it * 2).toByte() })
         val restored = roundTripViaFramework(original)
         assertEquals(original, restored)
+    }
+
+    @Test
+    fun `AnnounceEvent provenance round-trips`() {
+        val original =
+            AnnounceEvent(
+                destinationHash = byteArrayOf(1, 2),
+                identity = Identity(byteArrayOf(3, 4), byteArrayOf(5, 6), null),
+                appData = byteArrayOf(7, 8),
+                hops = 2,
+                timestamp = 123L,
+                nodeType = NodeType.PEER,
+                announcePacketHash = byteArrayOf(9, 10),
+                isPathResponse = true,
+            )
+        val restored = roundTripViaFramework(original)
+
+        assertEquals(original, restored)
+        assertArrayEquals(original.announcePacketHash, restored.announcePacketHash)
+        assertTrue(restored.isPathResponse)
     }
 
     @Test

--- a/rns-api/src/test/java/network/columba/app/rns/api/model/DataModelsTest.kt
+++ b/rns-api/src/test/java/network/columba/app/rns/api/model/DataModelsTest.kt
@@ -265,6 +265,8 @@ class DataModelsTest {
                 appData = appData,
                 hops = 3,
                 timestamp = 12345L,
+                announcePacketHash = byteArrayOf(1, 2, 3, 4),
+                isPathResponse = true,
             )
 
         val event2 =
@@ -274,6 +276,8 @@ class DataModelsTest {
                 appData = appData.copyOf(),
                 hops = 3,
                 timestamp = 12345L,
+                announcePacketHash = byteArrayOf(1, 2, 3, 4),
+                isPathResponse = true,
             )
 
         assertEquals(event1, event2)

--- a/rns-backend-kt/src/main/kotlin/network/columba/app/rns/backend/kt/NativeRnsBackendImpl.kt
+++ b/rns-backend-kt/src/main/kotlin/network/columba/app/rns/backend/kt/NativeRnsBackendImpl.kt
@@ -775,13 +775,18 @@ class NativeRnsBackendImpl(
                     hops: Int,
                     receivingInterfaceName: String?,
                     matchedAspect: String?,
-                    // Added to RichAnnounceHandler in reticulum-kt v0.0.22 (conformance
-                    // work). Columba's announce handling doesn't need the announce-packet
-                    // hash, but the override must match the interface signature.
                     announcePacketHash: ByteArray?,
                 ): Boolean {
                     if (matchedAspect == null) return false // unknown aspect — not an app we handle
-                    handleAnnounce(matchedAspect, destinationHash, announcedIdentity, appData, hops, receivingInterfaceName)
+                    handleAnnounce(
+                        matchedAspect,
+                        destinationHash,
+                        announcedIdentity,
+                        appData,
+                        hops,
+                        receivingInterfaceName,
+                        announcePacketHash,
+                    )
                     return true
                 }
             },
@@ -871,6 +876,7 @@ class NativeRnsBackendImpl(
         appData: ByteArray?,
         announceHops: Int = 0,
         receivingInterfaceName: String? = null,
+        announcePacketHash: ByteArray? = null,
     ) {
         val destHex = destinationHash.toHex()
         if (blockedDestinations.contains(destHex) || blackholedIdentities.contains(announcedIdentity.hexHash)) return
@@ -894,6 +900,7 @@ class NativeRnsBackendImpl(
                 stampCostFlexibility = stampMeta.second,
                 peeringCost = stampMeta.third,
                 receivingInterface = receivingInterfaceName,
+                announcePacketHash = announcePacketHash,
             )
 
         _announces.tryEmit(event)

--- a/rns-backend-py/src/main/kotlin/network/columba/app/rns/backend/py/PythonEventBridge.kt
+++ b/rns-backend-py/src/main/kotlin/network/columba/app/rns/backend/py/PythonEventBridge.kt
@@ -199,6 +199,8 @@ class PythonEventBridge {
                 stampCostFlexibility = stampFlex,
                 peeringCost = peeringCost,
                 receivingInterface = payload.dictStr("receiving_interface"),
+                announcePacketHash = payload.dictBytes("announce_packet_hash"),
+                isPathResponse = payload.dictBool("is_path_response"),
             )
             _announces.tryEmit(event)
         }.onFailure { Log.e(TAG, "announce translation failed", it) }

--- a/rns-backend-py/src/main/python/event_bridge.py
+++ b/rns-backend-py/src/main/python/event_bridge.py
@@ -625,7 +625,14 @@ class _AnnounceHandler:
     aspect_filter = None
     receive_path_responses = True
 
-    def received_announce(self, destination_hash, announced_identity, app_data, announce_packet_hash=None):
+    def received_announce(
+        self,
+        destination_hash,
+        announced_identity,
+        app_data,
+        announce_packet_hash=None,
+        is_path_response=False,
+    ):
         enrichment = _announce_enrichment(destination_hash, announced_identity, app_data)
         # Only surface announces for aspects Columba tracks. This matches the
         # kotlin backend's RichAnnounceHandler, which returns False (drops the
@@ -663,6 +670,7 @@ class _AnnounceHandler:
             "public_key": _hex(announced_identity.get_public_key()) if announced_identity is not None else None,
             "app_data": _hex(app_data),
             "announce_packet_hash": _hex(announce_packet_hash),
+            "is_path_response": bool(is_path_response),
             "receiving_interface": recv_iface_name,
         }
         payload.update(enrichment)

--- a/rns-backend-py/src/test/python/test_event_bridge_announce_provenance.py
+++ b/rns-backend-py/src/test/python/test_event_bridge_announce_provenance.py
@@ -1,0 +1,81 @@
+import importlib.util
+import sys
+import types
+import unittest
+from pathlib import Path
+
+
+EVENT_BRIDGE_PATH = Path(__file__).resolve().parents[2] / "main/python/event_bridge.py"
+
+
+class FakeCallback:
+    def __init__(self):
+        self.payloads = []
+
+    def onEvent(self, payload):
+        self.payloads.append(payload)
+
+
+class FakeIdentity:
+    hash = b"identity"
+
+    def get_public_key(self):
+        return b"public-key"
+
+
+class AnnounceProvenanceBridgeTests(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        rns = types.ModuleType("RNS")
+        setattr(rns, "LOG_DEBUG", 1)
+        setattr(rns, "LOG_ERROR", 3)
+        setattr(rns, "log", lambda *args, **kwargs: None)
+        setattr(rns, "Destination", types.SimpleNamespace(
+            hash_from_name_and_identity=lambda aspect, identity: b"destination"
+            if aspect == "lxmf.delivery"
+            else b"other"
+        ))
+        setattr(rns, "Transport", types.SimpleNamespace(
+            PATHFINDER_M=128,
+            hops_to=lambda destination_hash: 1,
+            path_table={},
+        ))
+        sys.modules["RNS"] = rns
+
+        lxmf = types.ModuleType("LXMF")
+        setattr(
+            lxmf,
+            "LXStamper",
+            types.SimpleNamespace(set_external_generator=lambda *args: None),
+        )
+        sys.modules["LXMF"] = lxmf
+
+        spec = importlib.util.spec_from_file_location(
+            "event_bridge_announce_provenance_test", EVENT_BRIDGE_PATH
+        )
+        assert spec is not None and spec.loader is not None
+        cls.module = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(cls.module)
+
+    def test_announce_callback_forwards_packet_hash_and_path_response(self):
+        callback = FakeCallback()
+        setattr(self.module, "_on_announce", callback)
+
+        self.module._AnnounceHandler().received_announce(
+            b"destination",
+            FakeIdentity(),
+            b"app-data",
+            b"packet-hash",
+            True,
+        )
+
+        self.assertEqual(1, len(callback.payloads))
+        self.assertEqual(
+            "7061636b65742d68617368",
+            callback.payloads[0]["announce_packet_hash"],
+        )
+        self.assertTrue(callback.payloads[0]["is_path_response"])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/rns-host/src/main/kotlin/network/columba/app/rns/host/persistence/PeerActivityCollector.kt
+++ b/rns-host/src/main/kotlin/network/columba/app/rns/host/persistence/PeerActivityCollector.kt
@@ -117,9 +117,9 @@ internal class PeerActivityCollector(
             return
         }
 
-        // Persist below the IPC boundary. Announce events are non-replaying;
-        // relying on the UI-process MessageCollector loses the display name
-        // whenever the UI is absent or attaches after this event.
+        // Persist metadata below the IPC boundary so the display name is not
+        // lost while the UI is absent. Persistence separately admits only
+        // non-path-response packet hashes to durable peer activity.
         persistence.persistAnnounce(
             destinationHash = destinationHash,
             peerName = peerName,
@@ -135,6 +135,8 @@ internal class PeerActivityCollector(
             stampCostFlexibility = announce.stampCostFlexibility,
             peeringCost = announce.peeringCost,
             propagationTransferLimitKb = null,
+            announcePacketHash = announce.announcePacketHash?.toHex(),
+            isPathResponse = announce.isPathResponse,
         )
     }
 

--- a/rns-host/src/main/kotlin/network/columba/app/rns/host/persistence/ServicePersistenceManager.kt
+++ b/rns-host/src/main/kotlin/network/columba/app/rns/host/persistence/ServicePersistenceManager.kt
@@ -103,7 +103,7 @@ class ServicePersistenceManager(
      *
      * This preserves existing favorite status and icon appearance.
      */
-    @Suppress("LongParameterList") // Parameters mirror AnnounceEntity fields for direct persistence
+    @Suppress("LongParameterList", "LongMethod") // Parameters and transaction mirror announce persistence fields.
     suspend fun persistAnnounce(
         destinationHash: String,
         peerName: String,
@@ -119,6 +119,8 @@ class ServicePersistenceManager(
         stampCostFlexibility: Int?,
         peeringCost: Int?,
         propagationTransferLimitKb: Int?,
+        announcePacketHash: String? = null,
+        isPathResponse: Boolean = false,
     ): Boolean =
         try {
             val normalizedHash = destinationHash.lowercase()
@@ -140,6 +142,17 @@ class ServicePersistenceManager(
                         declaredInterfaceType.takeUnless { it == InterfaceType.UNKNOWN }
                             ?: InterfaceType.fromName(receivingInterface)
                     val identityHash = HashUtils.computeIdentityHash(publicKey)
+                    val advancesLastSeen =
+                        !isPathResponse &&
+                            !announcePacketHash.isNullOrBlank() &&
+                            peerActivityDao.recordActivityOnce(
+                                eventId = "announce:$announcePacketHash",
+                                destinationHash = normalizedHash,
+                                receivedAt = timestamp,
+                                activityType = PeerActivityType.ANNOUNCE,
+                            )
+                    val lastSeenTimestamp =
+                        if (advancesLastSeen) timestamp else existing?.lastSeenTimestamp ?: 0L
 
                     val entity =
                         AnnounceEntity(
@@ -148,7 +161,7 @@ class ServicePersistenceManager(
                             publicKey = publicKey,
                             appData = appData,
                             hops = hops,
-                            lastSeenTimestamp = timestamp,
+                            lastSeenTimestamp = lastSeenTimestamp,
                             nodeType = nodeType,
                             receivingInterface = receivingInterface,
                             receivingInterfaceType = canonicalInterfaceType.storageName,
@@ -167,21 +180,23 @@ class ServicePersistenceManager(
                             destinationHash = normalizedHash,
                             interfaceType = canonicalInterfaceType.storageName,
                             receivingInterface = receivingInterface,
-                            lastSeenTimestamp = timestamp,
+                            lastSeenTimestamp = lastSeenTimestamp,
                             hops = hops,
                         )
 
-                    announceDao.upsertAnnounceWithSighting(entity, sighting)
-                    peerActivityDao.recordActivity(
-                        destinationHash = normalizedHash,
-                        receivedAt = timestamp,
-                        activityType = PeerActivityType.ANNOUNCE,
-                    )
+                    announceDao.upsertAnnounce(entity)
+                    if (advancesLastSeen) {
+                        announceDao.upsertInterfaceSighting(sighting)
+                    } else {
+                        announceDao.upsertInterfaceSightingMetadata(sighting)
+                    }
+                    val existingPeerIdentity = peerIdentityDao.getPeerIdentity(identityHash)
                     peerIdentityDao.insertPeerIdentity(
                         PeerIdentityEntity(
                             peerHash = identityHash,
                             publicKey = publicKey,
-                            lastSeenTimestamp = timestamp,
+                            lastSeenTimestamp =
+                                if (advancesLastSeen) timestamp else existingPeerIdentity?.lastSeenTimestamp ?: 0L,
                         ),
                     )
                 }

--- a/rns-host/src/test/kotlin/network/columba/app/rns/host/persistence/PeerActivityCollectorTest.kt
+++ b/rns-host/src/test/kotlin/network/columba/app/rns/host/persistence/PeerActivityCollectorTest.kt
@@ -61,7 +61,7 @@ class PeerActivityCollectorTest {
         coEvery { persistence.persistTelemetryActivity(any(), any(), any(), any()) } returns true
         coEvery {
             persistence.persistAnnounce(
-                any(), any(), any(), any(), any(), any(), any(), any(), any(), any(), any(), any(), any(), any(),
+                any(), any(), any(), any(), any(), any(), any(), any(), any(), any(), any(), any(), any(), any(), any(), any(),
             )
         } returns true
 
@@ -123,6 +123,8 @@ class PeerActivityCollectorTest {
         receivingInterface = "Bluetooth_LE",
         aspect = "lxmf.delivery",
         displayName = null,
+        announcePacketHash = byteArrayOf(1, 2, 3, 4),
+        isPathResponse = false,
     )
 
     private fun verifyInboundPersistence(
@@ -150,6 +152,8 @@ class PeerActivityCollectorTest {
                 stampCostFlexibility = null,
                 peeringCost = null,
                 propagationTransferLimitKb = null,
+                announcePacketHash = "01020304",
+                isPathResponse = false,
             )
         }
         coVerify(exactly = 0) {

--- a/rns-host/src/test/kotlin/network/columba/app/rns/host/persistence/ServicePersistenceManagerTest.kt
+++ b/rns-host/src/test/kotlin/network/columba/app/rns/host/persistence/ServicePersistenceManagerTest.kt
@@ -96,6 +96,11 @@ class ServicePersistenceManagerTest {
         every { database.peerActivityDao() } returns peerActivityDao
         every { database.peerIconDao() } returns peerIconDao
         coEvery { peerActivityDao.recordActivity(any(), any(), any()) } just Runs
+        coEvery { peerActivityDao.recordActivityOnce(any(), any(), any(), any()) } returns false
+        coEvery { announceDao.upsertAnnounce(any()) } just Runs
+        coEvery { announceDao.upsertInterfaceSighting(any()) } just Runs
+        coEvery { announceDao.upsertInterfaceSightingMetadata(any()) } just Runs
+        coEvery { peerIdentityDao.getPeerIdentity(any()) } returns null
         coEvery { peerIdentityDao.insertPeerIdentity(any()) } just Runs
         coEvery { localIdentityDao.getActiveIdentitySync() } returns null
 
@@ -126,7 +131,7 @@ class ServicePersistenceManagerTest {
     fun `persistAnnounce saves new announce to database`() =
         runTest {
             coEvery { announceDao.getAnnounce(testDestinationHash) } returns null
-            coEvery { announceDao.upsertAnnounceWithSighting(any(), any()) } just Runs
+            coEvery { announceDao.upsertAnnounce(any()) } just Runs
 
             val result =
                 runCatching {
@@ -152,7 +157,7 @@ class ServicePersistenceManagerTest {
 
             assertTrue("persistAnnounce should complete without throwing", result.isSuccess)
             coVerify(exactly = 1) { database.withTransaction<Unit>(any()) }
-            coVerify { announceDao.upsertAnnounceWithSighting(any(), any()) }
+            coVerify { announceDao.upsertAnnounce(any()) }
         }
 
     @Test
@@ -173,7 +178,7 @@ class ServicePersistenceManagerTest {
                 )
 
             coEvery { announceDao.getAnnounce(testDestinationHash) } returns existingAnnounce
-            coEvery { announceDao.upsertAnnounceWithSighting(any(), any()) } just Runs
+            coEvery { announceDao.upsertAnnounce(any()) } just Runs
 
             val result =
                 runCatching {
@@ -199,11 +204,10 @@ class ServicePersistenceManagerTest {
 
             assertTrue("persistAnnounce should complete without throwing", result.isSuccess)
             coVerify {
-                announceDao.upsertAnnounceWithSighting(
+                announceDao.upsertAnnounce(
                     match { entity ->
                         entity.isFavorite && entity.peerName == "New Name"
                     },
-                    any(),
                 )
             }
         }
@@ -212,7 +216,7 @@ class ServicePersistenceManagerTest {
     fun `persistAnnounce sets computedIdentityHash from publicKey`() =
         runTest {
             coEvery { announceDao.getAnnounce(testDestinationHash) } returns null
-            coEvery { announceDao.upsertAnnounceWithSighting(any(), any()) } just Runs
+            coEvery { announceDao.upsertAnnounce(any()) } just Runs
 
             val result =
                 runCatching {
@@ -238,13 +242,12 @@ class ServicePersistenceManagerTest {
 
             assertTrue("persistAnnounce should complete without throwing", result.isSuccess)
             coVerify {
-                announceDao.upsertAnnounceWithSighting(
+                announceDao.upsertAnnounce(
                     match { entity ->
                         entity.computedIdentityHash != null &&
                             entity.computedIdentityHash!!.length == 32 &&
                             entity.computedIdentityHash == entity.computedIdentityHash!!.lowercase()
                     },
-                    any(),
                 )
             }
             coVerify {
@@ -305,7 +308,7 @@ class ServicePersistenceManagerTest {
                     propagationTransferLimitKb = 512,
                 )
             coEvery { announceDao.getAnnounce(testDestinationHash) } returns existing
-            coEvery { announceDao.upsertAnnounceWithSighting(any(), any()) } just Runs
+            coEvery { announceDao.upsertAnnounce(any()) } just Runs
 
             val persisted =
                 persistenceManager.persistAnnounce(
@@ -327,9 +330,8 @@ class ServicePersistenceManagerTest {
 
             assertTrue(persisted)
             coVerify {
-                announceDao.upsertAnnounceWithSighting(
+                announceDao.upsertAnnounce(
                     match { it.peerName == "Known Peer" && it.propagationTransferLimitKb == 512 },
-                    any(),
                 )
             }
         }
@@ -369,7 +371,7 @@ class ServicePersistenceManagerTest {
                 )
 
             assertFalse(persisted)
-            coVerify(exactly = 0) { announceDao.upsertAnnounceWithSighting(any(), any()) }
+            coVerify(exactly = 0) { announceDao.upsertAnnounce(any()) }
             coVerify(exactly = 0) { peerIdentityDao.insertPeerIdentity(any()) }
         }
 


### PR DESCRIPTION
## Summary

- preserve Reticulum announce packet identity and path-response provenance across the Python/Kotlin boundary
- prevent cached path responses, hashless announces, and duplicate announce packets from advancing user-visible Last seen timestamps
- continue updating routing and discovery metadata without treating replayed announces as presence evidence
- durably deduplicate ordinary announces through the existing `peer_activity_events` admission mechanism

## Regression coverage

- verifies the five-argument Python announce callback and bridge payload
- verifies announce provenance survives Kotlin Parcelable transport
- verifies cached path responses update announce metadata while preserving existing peer and contact Last seen values
- verifies repeated packet hashes advance activity only once
- verifies hashless announces fail closed for presence

## Verification

- all 17 Python backend tests
- focused Python-backend host persistence and collector tests
- 35 Room-backed `ServicePersistenceManagerDatabaseTest` cases
- `AnnounceDaoTest`
- `ktlintCheck`
- `detekt`
- Android lint for data, API, Python backend, and host modules
- `assembleNoSentryPythonBackendDebug`
- physical install and launch on Samsung SM-G998U1, Android 15, with app data preserved and zero immediate fatal exceptions

## Risk and rollback

The change keeps path-response announce handling enabled for routing and metadata. Only presence-bearing timestamps are gated by provenance and durable packet admission. Rollback is the single PR commit; no database schema migration is introduced.