### PR TITLE
Dismiss completed relay transfer progress

### DIFF
--- a/app/src/androidTest/java/network/columba/app/ui/components/TransferProgressComponentsInstrumentedTest.kt
+++ b/app/src/androidTest/java/network/columba/app/ui/components/TransferProgressComponentsInstrumentedTest.kt
@@ -16,6 +16,7 @@ import androidx.compose.ui.graphics.asAndroidBitmap
 import androidx.compose.ui.test.assertIsDisplayed
 import androidx.compose.ui.test.captureToImage
 import androidx.compose.ui.test.junit4.createAndroidComposeRule
+import androidx.compose.ui.test.onAllNodesWithText
 import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.onNodeWithTag
 import androidx.compose.ui.unit.dp
@@ -72,6 +73,23 @@ class TransferProgressComponentsInstrumentedTest {
         composeRule.onNodeWithText("Receiving messages via relay").assertIsDisplayed()
         composeRule.onNodeWithText("1 direct transfer also active").assertIsDisplayed()
         saveScreenshot("transfer-progress-tray.png", "conversation_transfer_tray")
+    }
+
+    @Test
+    fun dismissesCompletedRelayTransferTray() {
+        composeRule.setContent {
+            MaterialTheme {
+                ConversationTransferTray(
+                    incomingTransfers = emptyList(),
+                    syncProgress = SyncProgress.InProgress("receiving", 1f),
+                    modifier = Modifier.width(360.dp).padding(16.dp),
+                )
+            }
+        }
+
+        assertTrue(
+            composeRule.onAllNodesWithText("Receiving messages via relay").fetchSemanticsNodes().isEmpty(),
+        )
     }
 
     private fun saveScreenshot(name: String, tag: String) {

--- a/app/src/main/java/network/columba/app/ui/components/TransferProgressComponents.kt
+++ b/app/src/main/java/network/columba/app/ui/components/TransferProgressComponents.kt
@@ -65,7 +65,9 @@ fun ConversationTransferTray(
     syncProgress: SyncProgress,
     modifier: Modifier = Modifier,
 ) {
-    val relayProgress = (syncProgress as? SyncProgress.InProgress)?.progress
+    val relayProgress = (syncProgress as? SyncProgress.InProgress)
+        ?.progress
+        ?.takeIf { it < 1f }
     val directProgress = incomingTransfers.weightedProgress()
     val progress = relayProgress ?: directProgress ?: return
     val label = if (relayProgress != null) {

--- a/app/src/test/java/network/columba/app/ui/components/TransferProgressComponentsTest.kt
+++ b/app/src/test/java/network/columba/app/ui/components/TransferProgressComponentsTest.kt
@@ -4,6 +4,7 @@ import android.app.Application
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.ui.test.assertIsDisplayed
 import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.onAllNodesWithText
 import androidx.compose.ui.test.onNodeWithContentDescription
 import androidx.compose.ui.test.onNodeWithText
 import network.columba.app.rns.api.model.DeliveryMethod
@@ -12,6 +13,7 @@ import network.columba.app.rns.api.model.TransferPhase
 import network.columba.app.rns.api.model.TransferProgressUpdate
 import network.columba.app.service.SyncProgress
 import network.columba.app.test.RegisterComponentActivityRule
+import org.junit.Assert.assertEquals
 import org.junit.Rule
 import org.junit.Test
 import org.junit.rules.RuleChain
@@ -56,6 +58,23 @@ class TransferProgressComponentsTest {
         composeRule.onNodeWithText("Receiving messages via relay").assertIsDisplayed()
         composeRule.onNodeWithText("41%").assertIsDisplayed()
         composeRule.onNodeWithText("1 direct transfer also active").assertIsDisplayed()
+    }
+
+    @Test
+    fun `tray dismisses relay transfer once byte progress reaches completion`() {
+        composeRule.setContent {
+            MaterialTheme {
+                ConversationTransferTray(
+                    incomingTransfers = emptyList(),
+                    syncProgress = SyncProgress.InProgress("receiving", 1f),
+                )
+            }
+        }
+
+        assertEquals(
+            0,
+            composeRule.onAllNodesWithText("Receiving messages via relay").fetchSemanticsNodes().size,
+        )
     }
 
     @Test


### PR DESCRIPTION
## Summary
- hide relay progress once byte progress reaches completion
- preserve direct-transfer fallback when relay progress is complete
- add JVM Compose and instrumented regression coverage

## Testing
- pre-publication verification completed on exact commit `d2f0d87b565a4f55cdb12594c086367133398c3b`

## Risk / rollback
- narrowly scoped Compose visibility change; revert this PR to restore prior behavior