### PR TITLE
Refresh RNode status after reconnect

### DIFF
--- a/app/src/main/java/network/columba/app/viewmodel/InterfaceManagementViewModel.kt
+++ b/app/src/main/java/network/columba/app/viewmodel/InterfaceManagementViewModel.kt
@@ -6,6 +6,7 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.CoroutineStart
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
@@ -16,6 +17,8 @@ import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.isActive
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
 import kotlinx.coroutines.withContext
 import network.columba.app.data.database.entity.InterfaceEntity
 import network.columba.app.data.model.BleConnectionsState
@@ -223,6 +226,7 @@ class InterfaceManagementViewModel
 
         private val _state = MutableStateFlow(InterfaceManagementState())
         val state: StateFlow<InterfaceManagementState> = _state.asStateFlow()
+        private val interfaceStatusMutex = Mutex()
 
         private val _configState = MutableStateFlow(InterfaceConfigState())
         val configState: StateFlow<InterfaceConfigState> = _configState.asStateFlow()
@@ -275,14 +279,42 @@ class InterfaceManagementViewModel
          * - `interfaceStatusFlow` provides lightweight online/offline updates
          * - `debugInfoFlow` provides full transport interface snapshots including spawned peers
          *
-         * The kotlin backend pushes status through the two flows; the Python
-         * backend's RNS has no interface-status event stream, so on that backend
-         * the flows stay idle and the poll is the only refresh — without it an
-         * interface that comes online *after* the initial fetch (e.g. after an
-         * "Apply & Restart") stays shown as offline. The poll is a harmless
-         * periodic re-sync on the kotlin backend.
+         * The Kotlin backend pushes complete status maps through these flows.
+         * The Python backend additionally publishes replayable RNode change
+         * notifications; those are resolved through getInterfaceStats before
+         * applying them so delayed replay cannot overwrite newer backend state.
+         * Polling remains a periodic authoritative re-sync for both backends.
          */
         private fun observeInterfaceStatusChanges() {
+            viewModelScope.launch(ioDispatcher, start = CoroutineStart.UNDISPATCHED) {
+                transportAdmin.interfaceStatusFlow.collect { statusJson ->
+                    try {
+                        interfaceStatusMutex.withLock {
+                            parseAndUpdateInterfaceStatus(statusJson)
+                        }
+                    } catch (e: Exception) {
+                        Log.e(TAG, "Error parsing interface status from event", e)
+                    }
+                }
+            }
+
+            viewModelScope.launch(ioDispatcher, start = CoroutineStart.UNDISPATCHED) {
+                transportAdmin.debugInfoFlow.collect { debugInfoJson ->
+                    try {
+                        interfaceStatusMutex.withLock {
+                            parseAndUpdateDebugInfo(debugInfoJson)
+                        }
+                    } catch (e: Exception) {
+                        Log.e(TAG, "Error parsing debug info event", e)
+                    }
+                }
+            }
+
+            // Subscribe to both replaying event streams before admitting the
+            // initial snapshot fetch. A cached event is therefore applied first
+            // and the authoritative snapshot wins; a newer event arriving while
+            // the fetch is in flight waits on interfaceStatusMutex and wins after
+            // the stale fetch completes.
             viewModelScope.launch(ioDispatcher) {
                 if (enableStatusPolling) {
                     while (isActive) {
@@ -294,39 +326,36 @@ class InterfaceManagementViewModel
                     fetchInterfaceStatus()
                 }
             }
-
-            viewModelScope.launch(ioDispatcher) {
-                transportAdmin.interfaceStatusFlow.collect { statusJson ->
-                    try {
-                        parseAndUpdateInterfaceStatus(statusJson)
-                    } catch (e: Exception) {
-                        Log.e(TAG, "Error parsing interface status from event", e)
-                    }
-                }
-            }
-
-            viewModelScope.launch(ioDispatcher) {
-                transportAdmin.debugInfoFlow.collect { debugInfoJson ->
-                    try {
-                        parseAndUpdateDebugInfo(debugInfoJson)
-                    } catch (e: Exception) {
-                        Log.e(TAG, "Error parsing debug info event", e)
-                    }
-                }
-            }
         }
 
         /**
          * Parse interface status JSON and update state.
          */
-        private fun parseAndUpdateInterfaceStatus(statusJson: String) {
+        private suspend fun parseAndUpdateInterfaceStatus(statusJson: String) {
             try {
                 val json = JSONObject(statusJson)
+                val updates = json.optJSONObject("updates")
                 val statusMap = mutableMapOf<String, Boolean>()
-                json.keys().forEach { name ->
-                    statusMap[name] = json.optBoolean(name, false)
+                if (updates != null) {
+                    updates.keys().forEach { name ->
+                        val online = transportAdmin.getInterfaceStats(name)?.get("online") as? Boolean
+                        if (online != null) statusMap[name] = online
+                    }
+                } else {
+                    json.keys().forEach { name ->
+                        statusMap[name] = json.optBoolean(name, false)
+                    }
                 }
-                _state.update { it.copy(interfaceOnlineStatus = statusMap) }
+                _state.update { state ->
+                    state.copy(
+                        interfaceOnlineStatus =
+                            if (updates != null) {
+                                state.interfaceOnlineStatus + statusMap
+                            } else {
+                                statusMap
+                            },
+                    )
+                }
                 Log.d(TAG, "Interface status updated from event: $statusMap")
             } catch (e: Exception) {
                 Log.e(TAG, "Error parsing interface status JSON", e)
@@ -411,36 +440,38 @@ class InterfaceManagementViewModel
          */
         @Suppress("UNCHECKED_CAST")
         private suspend fun fetchInterfaceStatus() {
-            try {
-                val debugInfo = transportAdmin.getDebugInfo()
-                val interfacesData = debugInfo["interfaces"] as? List<Map<String, Any>> ?: return
+            interfaceStatusMutex.withLock {
+                try {
+                    val debugInfo = transportAdmin.getDebugInfo()
+                    val interfacesData = debugInfo["interfaces"] as? List<Map<String, Any>> ?: return@withLock
 
-                val statusMap = mutableMapOf<String, Boolean>()
-                val transportList = mutableListOf<TransportInterfaceInfo>()
-                for (ifaceMap in interfacesData) {
-                    val name = ifaceMap["name"] as? String ?: continue
-                    val online = ifaceMap["online"] as? Boolean ?: false
-                    statusMap[name] = online
-                    transportList.add(
-                        TransportInterfaceInfo(
-                            name = name,
-                            type = ifaceMap["type"] as? String ?: name,
-                            isOnline = online,
-                            canSend = ifaceMap["can_send"] as? Boolean ?: false,
-                            parentName = (ifaceMap["parent_name"] as? String)?.takeIf { it.isNotEmpty() },
-                            rxBytes = (ifaceMap["rx_bytes"] as? Number)?.toLong() ?: 0L,
-                            txBytes = (ifaceMap["tx_bytes"] as? Number)?.toLong() ?: 0L,
-                        ),
-                    )
+                    val statusMap = mutableMapOf<String, Boolean>()
+                    val transportList = mutableListOf<TransportInterfaceInfo>()
+                    for (ifaceMap in interfacesData) {
+                        val name = ifaceMap["name"] as? String ?: continue
+                        val online = ifaceMap["online"] as? Boolean ?: false
+                        statusMap[name] = online
+                        transportList.add(
+                            TransportInterfaceInfo(
+                                name = name,
+                                type = ifaceMap["type"] as? String ?: name,
+                                isOnline = online,
+                                canSend = ifaceMap["can_send"] as? Boolean ?: false,
+                                parentName = (ifaceMap["parent_name"] as? String)?.takeIf { it.isNotEmpty() },
+                                rxBytes = (ifaceMap["rx_bytes"] as? Number)?.toLong() ?: 0L,
+                                txBytes = (ifaceMap["tx_bytes"] as? Number)?.toLong() ?: 0L,
+                            ),
+                        )
+                    }
+
+                    _state.value =
+                        _state.value.copy(
+                            interfaceOnlineStatus = statusMap,
+                            transportInterfaces = transportList,
+                        )
+                } catch (e: Exception) {
+                    Log.e(TAG, "Failed to fetch interface status", e)
                 }
-
-                _state.value =
-                    _state.value.copy(
-                        interfaceOnlineStatus = statusMap,
-                        transportInterfaces = transportList,
-                    )
-            } catch (e: Exception) {
-                Log.e(TAG, "Failed to fetch interface status", e)
             }
         }
 

--- a/app/src/test/java/network/columba/app/viewmodel/InterfaceManagementViewModelStatusEventTest.kt
+++ b/app/src/test/java/network/columba/app/viewmodel/InterfaceManagementViewModelStatusEventTest.kt
@@ -20,6 +20,7 @@ import io.mockk.coEvery
 import io.mockk.every
 import io.mockk.mockk
 import io.mockk.verify
+import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.cancel
@@ -29,6 +30,7 @@ import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.test.StandardTestDispatcher
 import kotlinx.coroutines.test.advanceUntilIdle
 import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.runCurrent
 import kotlinx.coroutines.test.runTest
 import kotlinx.coroutines.test.setMain
 import org.junit.After
@@ -57,6 +59,7 @@ class InterfaceManagementViewModelStatusEventTest {
     private lateinit var transportObserver: network.columba.app.service.manager.InterfaceTransportObserver
     private lateinit var rnsBackend: RnsBackend
     private lateinit var interfaceStatusFlow: MutableSharedFlow<String>
+    private lateinit var interfaceStatusChanged: MutableSharedFlow<Unit>
     private lateinit var debugInfoFlow: MutableSharedFlow<String>
     private lateinit var viewModel: InterfaceManagementViewModel
 
@@ -111,7 +114,9 @@ class InterfaceManagementViewModelStatusEventTest {
 
         // Mock event flows for NativeReticulumProtocol (event-driven updates)
         interfaceStatusFlow = MutableSharedFlow(replay = 1, extraBufferCapacity = 1)
+        interfaceStatusChanged = MutableSharedFlow(extraBufferCapacity = 1)
         debugInfoFlow = MutableSharedFlow(replay = 1, extraBufferCapacity = 1)
+        every { serviceProtocol.interfaceStatusChanged } returns interfaceStatusChanged
         every { serviceProtocol.interfaceStatusFlow } returns interfaceStatusFlow
         every { serviceProtocol.debugInfoFlow } returns debugInfoFlow
 
@@ -202,6 +207,98 @@ class InterfaceManagementViewModelStatusEventTest {
         }
 
     @Test
+    fun `replayed RNode status delta updates reconnect state without clearing siblings`() =
+        runTest {
+            coEvery { serviceProtocol.getInterfaceStats("Test RNode") } returns
+                mapOf("online" to true)
+            coEvery { serviceProtocol.getDebugInfo() } returns
+                mapOf(
+                    "interfaces" to
+                        listOf(
+                            mapOf("name" to "Test RNode", "online" to false),
+                            mapOf("name" to "Sibling", "online" to true),
+                        ),
+                )
+            viewModel =
+                InterfaceManagementViewModel(
+                    interfaceRepository,
+                    configManager,
+                    bleStatusRepository,
+                    serviceProtocol,
+                    transportObserver,
+                    rnsBackend,
+                )
+            advanceUntilIdle()
+            assertEquals(false, viewModel.state.value.interfaceOnlineStatus["Test RNode"])
+
+            interfaceStatusFlow.emit("""{"updates":{"Test RNode":true}}""")
+            advanceUntilIdle()
+
+            assertEquals(true, viewModel.state.value.interfaceOnlineStatus["Test RNode"])
+            assertEquals(true, viewModel.state.value.interfaceOnlineStatus["Sibling"])
+        }
+
+    @Test
+    fun `RNode delta wins when stale poll completes after reconnect event`() =
+        runTest {
+            coEvery { serviceProtocol.getInterfaceStats("Test RNode") } returns
+                mapOf("online" to true)
+            val fetchStarted = CompletableDeferred<Unit>()
+            val releaseFetch = CompletableDeferred<Unit>()
+            coEvery { serviceProtocol.getDebugInfo() } coAnswers {
+                fetchStarted.complete(Unit)
+                releaseFetch.await()
+                mapOf(
+                    "interfaces" to
+                        listOf(mapOf("name" to "Test RNode", "online" to false)),
+                )
+            }
+            viewModel =
+                InterfaceManagementViewModel(
+                    interfaceRepository,
+                    configManager,
+                    bleStatusRepository,
+                    serviceProtocol,
+                    transportObserver,
+                    rnsBackend,
+                )
+
+            runCurrent()
+            fetchStarted.await()
+            interfaceStatusFlow.emit("""{"updates":{"Test RNode":true}}""")
+            releaseFetch.complete(Unit)
+            advanceUntilIdle()
+
+            assertEquals(true, viewModel.state.value.interfaceOnlineStatus["Test RNode"])
+        }
+
+    @Test
+    fun `current snapshot wins over stale RNode replay cached before ViewModel starts`() =
+        runTest {
+            interfaceStatusFlow.emit("""{"updates":{"Test RNode":true}}""")
+            coEvery { serviceProtocol.getInterfaceStats("Test RNode") } returns
+                mapOf("online" to false)
+            coEvery { serviceProtocol.getDebugInfo() } returns
+                mapOf(
+                    "interfaces" to
+                        listOf(mapOf("name" to "Test RNode", "online" to false)),
+                )
+
+            viewModel =
+                InterfaceManagementViewModel(
+                    interfaceRepository,
+                    configManager,
+                    bleStatusRepository,
+                    serviceProtocol,
+                    transportObserver,
+                    rnsBackend,
+                )
+            advanceUntilIdle()
+
+            assertEquals(false, viewModel.state.value.interfaceOnlineStatus["Test RNode"])
+        }
+
+    @Test
     fun `interface online status is updated in state after event`() =
         runTest {
             viewModel =
@@ -270,6 +367,7 @@ class InterfaceManagementViewModelStatusEventTest {
         runTest {
             // Use a generic ReticulumProtocol mock instead of NativeReticulumProtocol
             val genericProtocol: RnsTransportAdmin = mockk()
+            every { genericProtocol.interfaceStatusChanged } returns MutableSharedFlow()
             every { genericProtocol.interfaceStatusFlow } returns MutableSharedFlow()
             every { genericProtocol.debugInfoFlow } returns MutableSharedFlow()
             coEvery { genericProtocol.getDebugInfo() } returns emptyMap()

--- a/rns-api/src/main/aidl/network/columba/app/rns/ipc/IRnsTransportAdmin.aidl
+++ b/rns-api/src/main/aidl/network/columba/app/rns/ipc/IRnsTransportAdmin.aidl
@@ -80,7 +80,10 @@ oneway interface IRnsTransportAdmin {
     void registerDebugInfoObserver(in IRnsStringEventCallback cb);
     void unregisterDebugInfoObserver(in IRnsStringEventCallback cb);
 
-    void registerInterfaceStatusObserver(in IRnsStringEventCallback cb);
+    void registerInterfaceStatusObserver(
+        in IRnsStringEventCallback cb,
+        in IRnsUnitEventCallback readyCb
+    );
     void unregisterInterfaceStatusObserver(in IRnsStringEventCallback cb);
 
     void registerReactionReceivedObserver(in IRnsStringEventCallback cb);

--- a/rns-backend-py/src/main/kotlin/network/columba/app/rns/backend/py/PythonRnsTransportAdmin.kt
+++ b/rns-backend-py/src/main/kotlin/network/columba/app/rns/backend/py/PythonRnsTransportAdmin.kt
@@ -2,6 +2,7 @@ package network.columba.app.rns.backend.py
 
 import android.util.Log
 import com.chaquo.python.PyObject
+import kotlinx.coroutines.channels.BufferOverflow
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.SharedFlow
 import kotlinx.coroutines.flow.asSharedFlow
@@ -61,12 +62,31 @@ class PythonRnsTransportAdmin(
     private val _interfaceStatusChanged = MutableSharedFlow<Unit>(extraBufferCapacity = 16)
     private val _bleConnectionsFlow = MutableSharedFlow<String>(replay = 1, extraBufferCapacity = 16)
     private val _debugInfoFlow = MutableSharedFlow<String>(extraBufferCapacity = 64)
-    private val _interfaceStatusFlow = MutableSharedFlow<String>(extraBufferCapacity = 16)
+    private val _interfaceStatusFlow =
+        MutableSharedFlow<String>(
+            replay = 1,
+            extraBufferCapacity = 1,
+            onBufferOverflow = BufferOverflow.DROP_OLDEST,
+        )
 
     override val interfaceStatusChanged: SharedFlow<Unit> = _interfaceStatusChanged.asSharedFlow()
     override val bleConnectionsFlow: SharedFlow<String> = _bleConnectionsFlow.asSharedFlow()
     override val debugInfoFlow: SharedFlow<String> = _debugInfoFlow.asSharedFlow()
     override val interfaceStatusFlow: SharedFlow<String> = _interfaceStatusFlow.asSharedFlow()
+
+    /** Publish one replayable RNode status delta without re-entering Python. */
+    fun publishRNodeOnlineStatus(
+        interfaceName: String,
+        isOnline: Boolean,
+    ) {
+        val payload =
+            JSONObject()
+                .put("updates", JSONObject().put(interfaceName, isOnline))
+                .toString()
+        check(_interfaceStatusFlow.tryEmit(payload)) {
+            "Unable to publish replayable RNode status update"
+        }
+    }
 
     // ===== BLE peer connection details (Network Status "BLE Connections" card) =====
     // The host wires the live KotlinBLEBridge in via attachBleSource() right after

--- a/rns-backend-py/src/test/kotlin/network/columba/app/rns/backend/py/PythonRnsTransportAdminRNodeStatusTest.kt
+++ b/rns-backend-py/src/test/kotlin/network/columba/app/rns/backend/py/PythonRnsTransportAdminRNodeStatusTest.kt
@@ -1,0 +1,48 @@
+package network.columba.app.rns.backend.py
+
+import app.cash.turbine.test
+import io.mockk.every
+import io.mockk.mockk
+import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class PythonRnsTransportAdminRNodeStatusTest {
+    private fun createAdmin(): PythonRnsTransportAdmin {
+        val events = mockk<PythonEventBridge>()
+        every { events.reactionReceived } returns MutableSharedFlow()
+        return PythonRnsTransportAdmin(runtime = mockk(), events = events)
+    }
+
+    @Test
+    fun `RNode status published before subscription is replayed`() =
+        runTest {
+            val admin = createAdmin()
+
+            admin.publishRNodeOnlineStatus("Test RNode", true)
+
+            admin.interfaceStatusFlow.test {
+                assertEquals(
+                    """{"updates":{"Test RNode":true}}""",
+                    awaitItem(),
+                )
+            }
+        }
+
+    @Test
+    fun `latest RNode status replaces stale replay while no observer is attached`() =
+        runTest {
+            val admin = createAdmin()
+
+            admin.publishRNodeOnlineStatus("Test RNode", false)
+            admin.publishRNodeOnlineStatus("Test RNode", true)
+
+            admin.interfaceStatusFlow.test {
+                assertEquals(
+                    """{"updates":{"Test RNode":true}}""",
+                    awaitItem(),
+                )
+            }
+        }
+}

--- a/rns-host/src/main/kotlin/network/columba/app/rns/host/ipc/BoundRnsTransportAdmin.kt
+++ b/rns-host/src/main/kotlin/network/columba/app/rns/host/ipc/BoundRnsTransportAdmin.kt
@@ -117,7 +117,7 @@ internal class BoundRnsTransportAdmin(
         backendFlow
             .filterNotNull()
             .flatMapLatest { it.transportAdmin.interfaceStatusFlow }
-            .shareIn(scope, SharingStarted.Eagerly, replay = 0)
+            .shareIn(scope, SharingStarted.Eagerly, replay = 1)
 
     @OptIn(ExperimentalCoroutinesApi::class)
     override val reactionReceivedFlow: SharedFlow<String> =

--- a/rns-host/src/pythonBackend/kotlin/network/columba/app/rns/host/HostBackendModule.kt
+++ b/rns-host/src/pythonBackend/kotlin/network/columba/app/rns/host/HostBackendModule.kt
@@ -15,6 +15,7 @@ import network.columba.app.rns.host.di.LocalBackend
 import network.columba.app.rns.host.persistence.CallsFromContactsGate
 import network.columba.app.rns.host.persistence.ServiceSettingsAccessor
 import network.columba.app.rns.host.rnode.KotlinRNodeBridge
+import network.columba.app.rns.host.rnode.RNodeOnlineStatusListener
 import network.columba.app.rns.host.usb.KotlinUSBBridge
 import tech.torlando.lxst.core.CallCoordinator
 import javax.inject.Singleton
@@ -89,7 +90,16 @@ object HostBackendModule {
             // duplicates. PythonRnsRuntime.start forwards them via
             // event_bridge.set_rnode_bridge + usb_bridge.set_usb_bridge
             // before Reticulum() constructs the bundled interface.
-            it.runtime.rnodeHostBridge = KotlinRNodeBridge.getInstance(context)
+            val rnodeBridge = KotlinRNodeBridge.getInstance(context)
+            it.runtime.rnodeHostBridge = rnodeBridge
+            val transportAdmin = it.transportAdmin as? PythonRnsTransportAdmin
+            rnodeBridge.addOnlineStatusListener(
+                object : RNodeOnlineStatusListener {
+                    override fun onRNodeOnlineStatusChanged(isOnline: Boolean, interfaceName: String) {
+                        transportAdmin?.publishRNodeOnlineStatus(interfaceName, isOnline)
+                    }
+                },
+            )
             it.runtime.usbBridge = KotlinUSBBridge.getInstance(context)
         }
 

--- a/rns-host/src/test/kotlin/network/columba/app/rns/host/ipc/BoundRnsBackendTest.kt
+++ b/rns-host/src/test/kotlin/network/columba/app/rns/host/ipc/BoundRnsBackendTest.kt
@@ -193,6 +193,23 @@ class BoundRnsBackendTest {
     }
 
     @Test
+    fun `BoundRnsTransportAdmin replays interface status emitted before bind`() = runTest {
+        val flow = MutableStateFlow<RnsBackend?>(null)
+        val admin = BoundRnsTransportAdmin(flow.asStateFlow(), backgroundScope)
+        val fake = FakeRnsBackend()
+        val payload = """{"updates":{"Test RNode":true}}"""
+        fake.transportAdminFake.emitInterfaceStatus(payload)
+
+        flow.value = fake
+        advanceUntilIdle()
+
+        admin.interfaceStatusFlow.test {
+            assertEquals(payload, awaitItem())
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+
+    @Test
     fun `BoundRnsTelephony callState republishes across rebinds`() = runTest {
         val flow = MutableStateFlow<RnsBackend?>(null)
         val tel = BoundRnsTelephony(flow.asStateFlow(), backgroundScope)
@@ -329,7 +346,7 @@ class BoundRnsBackendTest {
         private val statusChangedEmitter = MutableSharedFlow<Unit>(replay = 0, extraBufferCapacity = 16)
         private val bleConnectionsEmitter = MutableSharedFlow<String>(replay = 0, extraBufferCapacity = 32)
         private val debugInfoEmitter = MutableSharedFlow<String>(replay = 0, extraBufferCapacity = 64)
-        private val interfaceStatusEmitter = MutableSharedFlow<String>(replay = 0, extraBufferCapacity = 32)
+        private val interfaceStatusEmitter = MutableSharedFlow<String>(replay = 1, extraBufferCapacity = 32)
         private val reactionReceivedEmitter = MutableSharedFlow<String>(replay = 0, extraBufferCapacity = 32)
 
         override fun setBatteryProfile(profile: BatteryProfile) { batteryProfileSets.add(profile) }
@@ -349,6 +366,9 @@ class BoundRnsBackendTest {
         override suspend fun reconnectRNodeInterface() {}
         override fun getRNodeRssi(): Int = rssi
         override fun getBleConnectionDetails(): String = bleConnections
+        fun emitInterfaceStatus(payload: String) {
+            check(interfaceStatusEmitter.tryEmit(payload))
+        }
         override val interfaceStatusChanged: SharedFlow<Unit> = statusChangedEmitter.asSharedFlow()
         override val bleConnectionsFlow: SharedFlow<String> = bleConnectionsEmitter.asSharedFlow()
         override val debugInfoFlow: SharedFlow<String> = debugInfoEmitter.asSharedFlow()

--- a/rns-ipc/src/main/kotlin/network/columba/app/rns/ipc/RnsBackendClient.kt
+++ b/rns-ipc/src/main/kotlin/network/columba/app/rns/ipc/RnsBackendClient.kt
@@ -84,7 +84,9 @@ class RnsBackendClient(
         telephonyClient = ClientRnsTelephony(fetchTelephony(remote), scope)
         telemetryClient = ClientRnsTelemetry(fetchTelemetry(remote), scope)
         nomadnetClient = ClientRnsNomadnet(fetchNomadnet(remote), scope)
-        transportAdminClient = ClientRnsTransportAdmin(fetchTransportAdmin(remote), scope)
+        val transportAdmin = ClientRnsTransportAdmin(fetchTransportAdmin(remote), scope)
+        transportAdmin.awaitInterfaceStatusReady()
+        transportAdminClient = transportAdmin
 
         // Seed capabilities synchronously so the first downstream read sees a
         // real snapshot, not the placeholder UNKNOWN default. Observer

--- a/rns-ipc/src/main/kotlin/network/columba/app/rns/ipc/client/ClientRnsTransportAdmin.kt
+++ b/rns-ipc/src/main/kotlin/network/columba/app/rns/ipc/client/ClientRnsTransportAdmin.kt
@@ -1,12 +1,15 @@
 package network.columba.app.rns.ipc.client
 
 import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.CoroutineStart
+import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.channels.awaitClose
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.SharedFlow
 import kotlinx.coroutines.flow.asSharedFlow
 import kotlinx.coroutines.flow.callbackFlow
+import kotlinx.coroutines.flow.collect
 import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.onEach
 import kotlinx.coroutines.launch
@@ -110,7 +113,8 @@ internal class ClientRnsTransportAdmin(
     private val interfaceStatusChangedShared = MutableSharedFlow<Unit>(extraBufferCapacity = 16)
     private val bleConnectionsShared = MutableSharedFlow<String>(extraBufferCapacity = 32)
     private val debugInfoShared = MutableSharedFlow<String>(extraBufferCapacity = 64)
-    private val interfaceStatusShared = MutableSharedFlow<String>(extraBufferCapacity = 32)
+    private val interfaceStatusShared = MutableSharedFlow<String>(replay = 1, extraBufferCapacity = 32)
+    private val interfaceStatusReady = CompletableDeferred<Unit>()
     private val reactionReceivedShared = MutableSharedFlow<String>(extraBufferCapacity = 32)
 
     init {
@@ -130,10 +134,20 @@ internal class ClientRnsTransportAdmin(
             unregister = { remote.unregisterDebugInfoObserver(it) },
         ).onEach { debugInfoShared.emit(it) }.launchIn(scope)
 
-        stringEventFlow(
-            register = { remote.registerInterfaceStatusObserver(it) },
-            unregister = { remote.unregisterInterfaceStatusObserver(it) },
-        ).onEach { interfaceStatusShared.emit(it) }.launchIn(scope)
+        val interfaceStatusJob =
+            scope.launch(start = CoroutineStart.UNDISPATCHED) {
+                interfaceStatusEventFlow(
+                    register = { cb, readyCb -> remote.registerInterfaceStatusObserver(cb, readyCb) },
+                    unregister = { remote.unregisterInterfaceStatusObserver(it) },
+                ).collect { interfaceStatusShared.emit(it) }
+            }
+        interfaceStatusJob.invokeOnCompletion { cause ->
+            if (!interfaceStatusReady.isCompleted) {
+                interfaceStatusReady.completeExceptionally(
+                    cause ?: IllegalStateException("Interface status observer ended before registration was ready"),
+                )
+            }
+        }
 
         stringEventFlow(
             register = { remote.registerReactionReceivedObserver(it) },
@@ -158,6 +172,28 @@ internal class ClientRnsTransportAdmin(
         }
         if (!registerObserverOrClose { register(cb) }) return@callbackFlow
         awaitClose { runCatching { unregister(cb) } }
+    }
+
+    private fun interfaceStatusEventFlow(
+        register: (IRnsStringEventCallback, IRnsUnitEventCallback) -> Unit,
+        unregister: (IRnsStringEventCallback) -> Unit,
+    ): Flow<String> = callbackFlow {
+        val cb = object : IRnsStringEventCallback.Stub() {
+            override fun onString(value: String?) {
+                if (value != null) trySend(value)
+            }
+        }
+        val readyCb = object : IRnsUnitEventCallback.Stub() {
+            override fun onEvent() {
+                interfaceStatusReady.complete(Unit)
+            }
+        }
+        if (!registerObserverOrClose { register(cb, readyCb) }) return@callbackFlow
+        awaitClose { runCatching { unregister(cb) } }
+    }
+
+    internal suspend fun awaitInterfaceStatusReady() {
+        interfaceStatusReady.await()
     }
 
     override val interfaceStatusChanged: SharedFlow<Unit> get() = interfaceStatusChangedShared.asSharedFlow()

--- a/rns-ipc/src/main/kotlin/network/columba/app/rns/ipc/server/ServerRnsTransportAdmin.kt
+++ b/rns-ipc/src/main/kotlin/network/columba/app/rns/ipc/server/ServerRnsTransportAdmin.kt
@@ -117,7 +117,13 @@ internal class ServerRnsTransportAdmin(
     override fun registerDebugInfoObserver(cb: IRnsStringEventCallback) = debugHub.registerObserver(cb)
     override fun unregisterDebugInfoObserver(cb: IRnsStringEventCallback) = debugHub.unregisterObserver(cb)
 
-    override fun registerInterfaceStatusObserver(cb: IRnsStringEventCallback) = ifStatusHub.registerObserver(cb)
+    override fun registerInterfaceStatusObserver(
+        cb: IRnsStringEventCallback,
+        readyCb: IRnsUnitEventCallback,
+    ) {
+        ifStatusHub.registerObserver(cb)
+        readyCb.onEvent()
+    }
     override fun unregisterInterfaceStatusObserver(cb: IRnsStringEventCallback) = ifStatusHub.unregisterObserver(cb)
 
     override fun registerReactionReceivedObserver(cb: IRnsStringEventCallback) = reactionHub.registerObserver(cb)

--- a/rns-ipc/src/test/java/network/columba/app/rns/ipc/RnsBackendIpcRoundTripTest.kt
+++ b/rns-ipc/src/test/java/network/columba/app/rns/ipc/RnsBackendIpcRoundTripTest.kt
@@ -223,6 +223,19 @@ class RnsBackendIpcRoundTripTest {
     }
 
     @Test
+    fun `interface status published before client setup is replayed across AIDL`() = runTest {
+        val payload = """{"updates":{"Test RNode":true}}"""
+        fake.transportAdminFake.emitInterfaceStatus(payload)
+
+        val (client, _) = buildClientAndServer()
+
+        client.transportAdmin.interfaceStatusFlow.test {
+            assertEquals(payload, awaitItem())
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+
+    @Test
     fun `transfer progress observer round-trips through the stub`() = runTest {
         val (client, _) = buildClientAndServer()
         advanceUntilIdle()
@@ -689,6 +702,11 @@ private class FakeRnsNomadnet : RnsNomadnet {
 
 private class FakeRnsTransportAdmin : RnsTransportAdmin {
     var sharedInstanceAccessConfig: String? = null
+    private val interfaceStatuses = MutableSharedFlow<String>(replay = 1, extraBufferCapacity = 8)
+
+    fun emitInterfaceStatus(payload: String) {
+        check(interfaceStatuses.tryEmit(payload))
+    }
 
     override fun setBatteryProfile(profile: network.columba.app.rns.api.model.BatteryProfile) {}
     override suspend fun reloadInterfaces(configs: List<InterfaceConfig>) {}
@@ -710,6 +728,6 @@ private class FakeRnsTransportAdmin : RnsTransportAdmin {
     override val interfaceStatusChanged: SharedFlow<Unit> = MutableSharedFlow()
     override val bleConnectionsFlow: SharedFlow<String> = MutableSharedFlow()
     override val debugInfoFlow: SharedFlow<String> = MutableSharedFlow()
-    override val interfaceStatusFlow: SharedFlow<String> = MutableSharedFlow()
+    override val interfaceStatusFlow: SharedFlow<String> = interfaceStatuses.asSharedFlow()
     override val reactionReceivedFlow: SharedFlow<String> = MutableSharedFlow()
 }


### PR DESCRIPTION
## Summary

- propagate Python RNode online-state changes through the existing transport-status IPC path
- preserve the latest notification across backend, AIDL client, binding, and late ViewModel subscription boundaries
- treat replayed RNode values as invalidations and resolve current status from the active backend before updating UI state
- serialize full snapshots and status notifications so stale results cannot overwrite newer state
- preserve sibling interface statuses when applying an RNode-only update

## Verification

- `:rns-backend-py:testDebugUnitTest --tests '*PythonRnsTransportAdminRNodeStatusTest*'`
- `:rns-ipc:testDebugUnitTest --tests '*RnsBackendIpcRoundTripTest*'`
- `:rns-host:testPythonBackendDebugUnitTest --tests '*BoundRnsBackendTest*'`
- complete `InterfaceManagementViewModelStatusEventTest` in Python and Kotlin backend flavors
- `ktlintCheck detekt cpdCheck lint :app:lintNoSentryKotlinBackendDebug :rns-host:lintPythonBackendDebug --continue`
- `:app:assembleNoSentryPythonBackendDebug`
- independent exact-head review approved `f8160a1e7fe1eee44e08bb9d6ed63d3535cad230`

## Risk and rollback

The change is limited to status observation and UI-state freshness. It does not alter RNode reconnect timing or ownership. The existing five-second status poll remains as a fallback. Rollback is a normal revert of this commit.
