### PR TITLE
Fix stale conversation timestamps

### DIFF
--- a/app/src/main/java/network/columba/app/ui/screens/MessagingScreen.kt
+++ b/app/src/main/java/network/columba/app/ui/screens/MessagingScreen.kt
@@ -2026,7 +2026,7 @@ fun MessageBubble(
     transferProgress: TransferProgressUpdate? = null,
     isImageLoading: Boolean = false,
     fontScale: Float = 1.0f,
-    @Suppress("UNUSED_PARAMETER") timestampTick: Long = 0L,
+    timestampTick: Long = System.currentTimeMillis(),
     voicePlayerState: VoiceMessagePlayerState = VoiceMessagePlayerState(),
     voiceMetadata: VoiceMessageMetadata? = null,
     onVoiceMetadataNeeded: (AudioAttachmentUi) -> Unit = {},
@@ -2194,7 +2194,7 @@ fun MessageBubble(
                         verticalAlignment = Alignment.CenterVertically,
                     ) {
                         Text(
-                            text = formatTimestamp(message.receivedAt ?: message.timestamp),
+                            text = formatTimestamp(message.receivedAt ?: message.timestamp, timestampTick),
                             style = MaterialTheme.typography.labelSmall,
                             color = Color.White,
                         )
@@ -2500,7 +2500,7 @@ fun MessageBubble(
                             verticalAlignment = Alignment.CenterVertically,
                         ) {
                             Text(
-                                text = formatTimestamp(message.receivedAt ?: message.timestamp),
+                                text = formatTimestamp(message.receivedAt ?: message.timestamp, timestampTick),
                                 style = MaterialTheme.typography.labelSmall,
                                 color =
                                     if (isFromMe) {
@@ -2962,8 +2962,10 @@ fun EmptyMessagesState() {
     }
 }
 
-private fun formatTimestamp(timestamp: Long): String {
-    val now = System.currentTimeMillis()
+private fun formatTimestamp(
+    timestamp: Long,
+    now: Long,
+): String {
     val diff = now - timestamp
 
     return when {

--- a/app/src/test/java/network/columba/app/ui/screens/MessageBubbleTest.kt
+++ b/app/src/test/java/network/columba/app/ui/screens/MessageBubbleTest.kt
@@ -1,6 +1,7 @@
 package network.columba.app.ui.screens
 
 import android.app.Application
+import androidx.compose.runtime.mutableLongStateOf
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.luminance
 import androidx.compose.ui.platform.LocalClipboardManager
@@ -68,6 +69,32 @@ class MessageBubbleTest {
         composeTestRule.onNodeWithText("Voice message").assertIsDisplayed()
         composeTestRule.onNodeWithContentDescription("Play voice message").performClick()
         assertTrue(toggled)
+    }
+
+    @Test
+    fun `timestamp tick refreshes an already composed message bubble`() {
+        val messageTimestamp = System.currentTimeMillis()
+        val timestampTick = mutableLongStateOf(messageTimestamp)
+        val message = MessagingTestFixtures.createSentMessage(timestamp = messageTimestamp)
+
+        composeTestRule.setContent {
+            val clipboardManager = LocalClipboardManager.current
+            MessageBubble(
+                message = message,
+                isFromMe = true,
+                clipboardManager = clipboardManager,
+                timestampTick = timestampTick.longValue,
+            )
+        }
+
+        composeTestRule.onNodeWithText("Just now").assertIsDisplayed()
+
+        composeTestRule.runOnIdle {
+            timestampTick.longValue = messageTimestamp + 60_000L
+        }
+
+        composeTestRule.onNodeWithText("1 min ago").assertIsDisplayed()
+        composeTestRule.onNodeWithText("Just now").assertDoesNotExist()
     }
 
     // ========== Missing Image Placeholder Tests ==========


### PR DESCRIPTION
## Summary

- make message bubbles consume the lifecycle-aware timestamp tick
- refresh regular and image-message timestamps when an open conversation resumes
- add a regression test proving an already-composed bubble advances from `Just now` to `1 min ago`

## Root cause

`MessageBubble` accepted `timestampTick`, but did not read it. Compose could therefore skip the bubble when only the clock changed, leaving relative timestamps stale while the conversation remained composed across app switches.

## Verification

- `MessageBubbleTest` passed, including the new red-then-green regression
- `MessagingScreenTest.screen_reportsConversationVisibleAgainWhenResumed` passed
- Kotlin and Python backend variants compiled
- repository CI quality command passed: ktlint, detekt, CPD, Android lint, Kotlin flavor lint, and Python host flavor lint
- physical Android test: sent a message, backgrounded Columba for 65 seconds, returned to the retained conversation, and observed `Just now` update immediately to `1 min ago`

## Risk and rollback

The change is limited to timestamp presentation. Reverting the single commit restores the prior behavior.