### PR TITLE
fix(rnode): recover stale Android BLE bonds

### DIFF
--- a/app/src/main/java/network/columba/app/MainActivity.kt
+++ b/app/src/main/java/network/columba/app/MainActivity.kt
@@ -1899,6 +1899,11 @@ fun ColumbaNavigation(
                                             navController.navigate("rnode_wizard")
                                         }
                                     },
+                                    onNavigateToRNodePairingRepair = { interfaceId ->
+                                        navController.navigate(
+                                            "rnode_wizard?interfaceId=$interfaceId&repairPairing=true",
+                                        )
+                                    },
                                     onNavigateToTcpClientWizard = { interfaceId ->
                                         if (interfaceId != null) {
                                             navController.navigate("tcp_client_wizard?interfaceId=$interfaceId")
@@ -2016,6 +2021,10 @@ fun ColumbaNavigation(
                                             type = NavType.LongType
                                             defaultValue = -1L
                                         },
+                                        navArgument("repairPairing") {
+                                            type = NavType.BoolType
+                                            defaultValue = false
+                                        },
                                         navArgument("connectionType") {
                                             type = NavType.StringType
                                             nullable = true
@@ -2061,6 +2070,7 @@ fun ColumbaNavigation(
                                     ),
                             ) { backStackEntry ->
                                 val interfaceId = backStackEntry.arguments?.getLong("interfaceId") ?: -1L
+                                val repairPairing = backStackEntry.arguments?.getBoolean("repairPairing") ?: false
                                 val connectionType = backStackEntry.arguments?.getString("connectionType")
                                 val transportMode = backStackEntry.arguments?.getBoolean("transportMode") ?: false
                                 val usbDeviceId = backStackEntry.arguments?.getInt("usbDeviceId") ?: -1
@@ -2073,6 +2083,7 @@ fun ColumbaNavigation(
                                 val loraCr = backStackEntry.arguments?.getInt("loraCr") ?: -1
                                 network.columba.app.ui.screens.rnode.RNodeWizardScreen(
                                     editingInterfaceId = if (interfaceId >= 0) interfaceId else null,
+                                    repairPairing = repairPairing,
                                     preselectedConnectionType = connectionType,
                                     preselectedUsbDeviceId = if (usbDeviceId >= 0) usbDeviceId else null,
                                     preselectedUsbVendorId = if (usbVendorId >= 0) usbVendorId else null,

--- a/app/src/main/java/network/columba/app/navigation/AppDestination.kt
+++ b/app/src/main/java/network/columba/app/navigation/AppDestination.kt
@@ -68,11 +68,11 @@ enum class AppDestination(
         completionTargetRoute = "interface_management",
     ),
     RNODE_WIZARD(
-        routePattern = "rnode_wizard?interfaceId={interfaceId}&connectionType={connectionType}" +
+        routePattern = "rnode_wizard?interfaceId={interfaceId}&repairPairing={repairPairing}&connectionType={connectionType}" +
             "&transportMode={transportMode}&usbDeviceId={usbDeviceId}&usbVendorId={usbVendorId}" +
             "&usbProductId={usbProductId}&usbDeviceName={usbDeviceName}&loraFrequency={loraFrequency}" +
             "&loraBandwidth={loraBandwidth}&loraSf={loraSf}&loraCr={loraCr}",
-        sampleRoute = "rnode_wizard?interfaceId=-1&connectionType=&transportMode=false&usbDeviceId=-1" +
+        sampleRoute = "rnode_wizard?interfaceId=-1&repairPairing=false&connectionType=&transportMode=false&usbDeviceId=-1" +
             "&usbVendorId=-1&usbProductId=-1&usbDeviceName=&loraFrequency=-1" +
             "&loraBandwidth=-1&loraSf=-1&loraCr=-1",
         completionContract = CompletionContract.SHOW_RESULT,

--- a/app/src/main/java/network/columba/app/repository/InterfaceRepository.kt
+++ b/app/src/main/java/network/columba/app/repository/InterfaceRepository.kt
@@ -260,6 +260,7 @@ class InterfaceRepository
 
                     "RNode" -> {
                         val targetDeviceName = json.optString("target_device_name", "")
+                        val targetDeviceAddress = json.optString("target_device_address", "").ifEmpty { null }
                         val connectionMode = json.optString("connection_mode", "classic")
                         var tcpHost: String? = json.optString("tcp_host", "").ifEmpty { null }
                         val tcpPort = json.optInt("tcp_port", 7633)
@@ -310,6 +311,7 @@ class InterfaceRepository
                             name = entity.name,
                             enabled = entity.enabled,
                             targetDeviceName = targetDeviceName,
+                            targetDeviceAddress = targetDeviceAddress,
                             connectionMode = connectionMode,
                             tcpHost = tcpHost,
                             tcpPort = tcpPort,

--- a/app/src/main/java/network/columba/app/service/InterfaceConfigManager.kt
+++ b/app/src/main/java/network/columba/app/service/InterfaceConfigManager.kt
@@ -30,6 +30,11 @@ import network.columba.app.rns.host.persistence.ReticulumConfigSnapshot
 import javax.inject.Inject
 import javax.inject.Singleton
 
+data class PendingInterfaceChanges(
+    val hasPendingChanges: Boolean = false,
+    val interfaceIds: Set<Long> = emptySet(),
+)
+
 /**
  * Manager for applying interface configuration changes to the running Reticulum instance.
  *
@@ -66,6 +71,9 @@ class InterfaceConfigManager
         companion object {
             private const val TAG = "InterfaceConfigManager"
             private const val APPLY_CHANGES_TIMEOUT_MS = 60_000L
+            private const val PREFS_NAME = "columba_prefs"
+            private const val KEY_HAS_PENDING_INTERFACE_CHANGES = "has_pending_interface_changes"
+            private const val KEY_PENDING_INTERFACE_IDS = "pending_interface_ids"
         }
 
         /**
@@ -461,25 +469,45 @@ class InterfaceConfigManager
          * Used when interfaces are modified outside of InterfaceManagementViewModel
          * (e.g., from RNode wizard).
          */
-        fun setPendingChanges(hasPending: Boolean) {
-            context
-                .getSharedPreferences("columba_prefs", Context.MODE_PRIVATE)
-                .edit()
-                .putBoolean("has_pending_interface_changes", hasPending)
-                .apply()
+        @Synchronized
+        fun setPendingChanges(
+            hasPending: Boolean,
+            interfaceId: Long? = null,
+        ) {
+            val prefs = context.getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE)
+            val editor = prefs.edit().putBoolean(KEY_HAS_PENDING_INTERFACE_CHANGES, hasPending)
+            if (!hasPending) {
+                editor.remove(KEY_PENDING_INTERFACE_IDS)
+            } else if (interfaceId != null) {
+                val pendingIds = prefs.getStringSet(KEY_PENDING_INTERFACE_IDS, emptySet()).orEmpty().toMutableSet()
+                pendingIds += interfaceId.toString()
+                editor.putStringSet(KEY_PENDING_INTERFACE_IDS, pendingIds)
+            }
+            editor.apply()
         }
 
         /**
-         * Check if there are pending interface changes and clear the flag.
-         * @return true if there were pending changes, false otherwise
+         * Consume externally written pending state, including the identities of
+         * interfaces whose pre-update runtime diagnostics are now stale.
          */
-        fun checkAndClearPendingChanges(): Boolean {
-            val prefs = context.getSharedPreferences("columba_prefs", Context.MODE_PRIVATE)
-            val hasPending = prefs.getBoolean("has_pending_interface_changes", false)
-            if (hasPending) {
-                prefs.edit().putBoolean("has_pending_interface_changes", false).apply()
+        @Synchronized
+        fun consumePendingChanges(): PendingInterfaceChanges {
+            val prefs = context.getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE)
+            val hasPending = prefs.getBoolean(KEY_HAS_PENDING_INTERFACE_CHANGES, false)
+            val interfaceIds =
+                prefs
+                    .getStringSet(KEY_PENDING_INTERFACE_IDS, emptySet())
+                    .orEmpty()
+                    .mapNotNull(String::toLongOrNull)
+                    .toSet()
+            if (hasPending || interfaceIds.isNotEmpty()) {
+                prefs
+                    .edit()
+                    .putBoolean(KEY_HAS_PENDING_INTERFACE_CHANGES, false)
+                    .remove(KEY_PENDING_INTERFACE_IDS)
+                    .apply()
             }
-            return hasPending
+            return PendingInterfaceChanges(hasPending, interfaceIds)
         }
 
         /**

--- a/app/src/main/java/network/columba/app/ui/screens/InterfaceManagementScreen.kt
+++ b/app/src/main/java/network/columba/app/ui/screens/InterfaceManagementScreen.kt
@@ -68,6 +68,7 @@ import androidx.compose.material3.TopAppBar
 import androidx.compose.material3.TopAppBarDefaults
 import androidx.compose.material3.rememberModalBottomSheetState
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
@@ -83,6 +84,9 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.LifecycleEventObserver
+import androidx.lifecycle.compose.LocalLifecycleOwner
 import kotlinx.coroutines.delay
 import network.columba.app.R
 import network.columba.app.data.database.entity.InterfaceEntity
@@ -113,6 +117,18 @@ fun InterfaceManagementScreen(
     val context = LocalContext.current
     val state by viewModel.state.collectAsState()
     val configState by viewModel.configState.collectAsState()
+    val lifecycleOwner = LocalLifecycleOwner.current
+
+    DisposableEffect(lifecycleOwner, viewModel) {
+        val observer =
+            LifecycleEventObserver { _, event ->
+                if (event == Lifecycle.Event.ON_RESUME) {
+                    viewModel.refreshExternalPendingChanges()
+                }
+            }
+        lifecycleOwner.lifecycle.addObserver(observer)
+        onDispose { lifecycleOwner.lifecycle.removeObserver(observer) }
+    }
 
     // State for delete confirmation dialog
     var interfaceToDelete by remember { mutableStateOf<InterfaceEntity?>(null) }
@@ -312,9 +328,13 @@ fun InterfaceManagementScreen(
                             state.interfaces.forEach { iface ->
                                 val isOnline = state.interfaceOnlineStatus[iface.name]
                                 val statusReason =
-                                    state.transportInterfaces
-                                        .firstOrNull { it.name == iface.name }
-                                        ?.statusReason
+                                    effectiveRuntimeStatusReason(
+                                        statusReason =
+                                            state.transportInterfaces
+                                                .firstOrNull { it.name == iface.name }
+                                                ?.statusReason,
+                                        hasPendingChanges = state.hasPendingChanges,
+                                    )
                                 // Count spawned peers for this interface
                                 val spawnedPeers =
                                     state.transportInterfaces.filter {
@@ -583,6 +603,11 @@ fun InterfaceManagementScreen(
         )
     }
 }
+
+internal fun effectiveRuntimeStatusReason(
+    statusReason: String?,
+    hasPendingChanges: Boolean,
+): String? = statusReason.takeUnless { hasPendingChanges }
 
 @OptIn(ExperimentalFoundationApi::class)
 @Composable

--- a/app/src/main/java/network/columba/app/ui/screens/InterfaceManagementScreen.kt
+++ b/app/src/main/java/network/columba/app/ui/screens/InterfaceManagementScreen.kt
@@ -310,6 +310,10 @@ fun InterfaceManagementScreen(
                         ) {
                             state.interfaces.forEach { iface ->
                                 val isOnline = state.interfaceOnlineStatus[iface.name]
+                                val statusReason =
+                                    state.transportInterfaces
+                                        .firstOrNull { it.name == iface.name }
+                                        ?.statusReason
                                 // Count spawned peers for this interface
                                 val spawnedPeers =
                                     state.transportInterfaces.filter {
@@ -332,8 +336,12 @@ fun InterfaceManagementScreen(
                                             blePermissionsGranted = state.blePermissionsGranted,
                                             currentTransport = state.currentTransport,
                                             isOnline = isOnline,
+                                            statusReason = statusReason,
                                             peerCount = spawnedPeers.size,
                                             onErrorClick = { errorDialogInterface = iface },
+                                            onRepairPairing = {
+                                                onNavigateToRNodeWizard(iface.id)
+                                            },
                                             onRequestPermissions =
                                                 if (iface.isBleInterface()) {
                                                     { permissionLauncher.launch(BlePermissionManager.getRequiredPermissions().toTypedArray()) }
@@ -588,14 +596,25 @@ fun InterfaceCard(
     blePermissionsGranted: Boolean,
     currentTransport: CurrentTransport = CurrentTransport.NONE,
     isOnline: Boolean? = null,
+    statusReason: String? = null,
     peerCount: Int = 0,
     onErrorClick: (() -> Unit)? = null,
     onRequestPermissions: (() -> Unit)? = null,
+    onRepairPairing: (() -> Unit)? = null,
 ) {
     val toggleEnabled = interfaceEntity.shouldToggleBeEnabled(bluetoothState, blePermissionsGranted)
     val errorMessage = interfaceEntity.getErrorMessage(bluetoothState, blePermissionsGranted, isOnline)
     val online = isOnline == true && interfaceEntity.enabled
-    val statusColor = if (online) Color(0xFF4CAF50) else MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.5f)
+    val pairingRequired =
+        interfaceEntity.enabled &&
+            interfaceEntity.type == "RNode" &&
+            statusReason == "pairing_required"
+    val statusColor =
+        when {
+            online -> Color(0xFF4CAF50)
+            pairingRequired -> MaterialTheme.colorScheme.error
+            else -> MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.5f)
+        }
     val restrictionView = interfaceEntity.restrictionView(currentTransport)
     // Whether the card's right-column status reads "Restricted" instead of "Offline".
     // Only applies when the runtime filter would actually drop this interface — i.e.
@@ -702,6 +721,27 @@ fun InterfaceCard(
                                 contentPadding = PaddingValues(horizontal = 8.dp, vertical = 0.dp),
                             ) {
                                 Text("Grant", style = MaterialTheme.typography.labelSmall)
+                            }
+                        }
+                    }
+                } else if (pairingRequired) {
+                    Row(verticalAlignment = Alignment.CenterVertically) {
+                        Icon(
+                            Icons.Default.Warning,
+                            contentDescription = null,
+                            modifier = Modifier.size(14.dp),
+                            tint = MaterialTheme.colorScheme.error,
+                        )
+                        Spacer(modifier = Modifier.width(4.dp))
+                        Text(
+                            text = stringResource(R.string.rnode_pairing_required),
+                            style = MaterialTheme.typography.bodySmall,
+                            color = MaterialTheme.colorScheme.error,
+                        )
+                        if (onRepairPairing != null) {
+                            Spacer(modifier = Modifier.width(8.dp))
+                            TextButton(onClick = onRepairPairing) {
+                                Text(stringResource(R.string.repair_rnode_pairing))
                             }
                         }
                     }

--- a/app/src/main/java/network/columba/app/ui/screens/InterfaceManagementScreen.kt
+++ b/app/src/main/java/network/columba/app/ui/screens/InterfaceManagementScreen.kt
@@ -104,6 +104,7 @@ import network.columba.app.viewmodel.InterfaceManagementViewModel
 fun InterfaceManagementScreen(
     onNavigateBack: () -> Unit,
     onNavigateToRNodeWizard: (interfaceId: Long?) -> Unit = {},
+    onNavigateToRNodePairingRepair: (interfaceId: Long) -> Unit = {},
     onNavigateToTcpClientWizard: (interfaceId: Long?) -> Unit = {},
     onNavigateToInterfaceStats: (interfaceId: Long) -> Unit = {},
     onNavigateToDiscoveredInterfaces: () -> Unit = {},
@@ -340,7 +341,7 @@ fun InterfaceManagementScreen(
                                             peerCount = spawnedPeers.size,
                                             onErrorClick = { errorDialogInterface = iface },
                                             onRepairPairing = {
-                                                onNavigateToRNodeWizard(iface.id)
+                                                onNavigateToRNodePairingRepair(iface.id)
                                             },
                                             onRequestPermissions =
                                                 if (iface.isBleInterface()) {

--- a/app/src/main/java/network/columba/app/ui/screens/InterfaceManagementScreen.kt
+++ b/app/src/main/java/network/columba/app/ui/screens/InterfaceManagementScreen.kt
@@ -333,7 +333,9 @@ fun InterfaceManagementScreen(
                                             state.transportInterfaces
                                                 .firstOrNull { it.name == iface.name }
                                                 ?.statusReason,
+                                        interfaceId = iface.id,
                                         hasPendingChanges = state.hasPendingChanges,
+                                        pendingInterfaceIds = state.pendingInterfaceIds,
                                     )
                                 // Count spawned peers for this interface
                                 val spawnedPeers =
@@ -606,8 +608,10 @@ fun InterfaceManagementScreen(
 
 internal fun effectiveRuntimeStatusReason(
     statusReason: String?,
+    interfaceId: Long,
     hasPendingChanges: Boolean,
-): String? = statusReason.takeUnless { hasPendingChanges }
+    pendingInterfaceIds: Set<Long>,
+): String? = statusReason.takeUnless { hasPendingChanges && interfaceId in pendingInterfaceIds }
 
 @OptIn(ExperimentalFoundationApi::class)
 @Composable

--- a/app/src/main/java/network/columba/app/ui/screens/rnode/DeviceDiscoveryStep.kt
+++ b/app/src/main/java/network/columba/app/ui/screens/rnode/DeviceDiscoveryStep.kt
@@ -43,6 +43,7 @@ import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.OutlinedButton
 import androidx.compose.material3.OutlinedCard
 import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
@@ -313,6 +314,45 @@ private fun BluetoothDeviceDiscovery(
     state: RNodeWizardState,
 ) {
     Column {
+        if (state.isPairingRepairMode) {
+            Surface(
+                color = MaterialTheme.colorScheme.errorContainer,
+                shape = MaterialTheme.shapes.medium,
+                modifier = Modifier.fillMaxWidth(),
+            ) {
+                Column(modifier = Modifier.padding(16.dp)) {
+                    Text(
+                        text = stringResource(R.string.rnode_pairing_required),
+                        style = MaterialTheme.typography.titleMedium,
+                        color = MaterialTheme.colorScheme.onErrorContainer,
+                    )
+                    Spacer(Modifier.height(8.dp))
+                    Text(
+                        text =
+                            stringResource(
+                                R.string.rnode_pairing_repair_explanation,
+                                state.pairingRepairDeviceName.orEmpty(),
+                            ),
+                        style = MaterialTheme.typography.bodyMedium,
+                        color = MaterialTheme.colorScheme.onErrorContainer,
+                    )
+                    Spacer(Modifier.height(8.dp))
+                    Text(
+                        text = stringResource(R.string.rnode_pairing_repair_heltec_v3),
+                        style = MaterialTheme.typography.bodyMedium,
+                        color = MaterialTheme.colorScheme.onErrorContainer,
+                    )
+                    Spacer(Modifier.height(8.dp))
+                    Text(
+                        text = stringResource(R.string.rnode_pairing_repair_select_device),
+                        style = MaterialTheme.typography.bodyMedium,
+                        color = MaterialTheme.colorScheme.onErrorContainer,
+                    )
+                }
+            }
+            Spacer(Modifier.height(16.dp))
+        }
+
         // Scanning indicator
         if (state.isScanning) {
             LinearProgressIndicator(modifier = Modifier.fillMaxWidth())
@@ -510,8 +550,10 @@ private fun BluetoothDeviceDiscovery(
             Spacer(Modifier.height(16.dp))
         }
 
-        // Current device (in edit mode)
-        if (state.isEditMode && state.selectedDevice != null && !state.showManualEntry) {
+        // Current device (in ordinary edit mode only)
+        val currentDevice = state.selectedDevice
+        val showCurrentDevice = state.isEditMode && !state.isPairingRepairMode && !state.showManualEntry
+        if (showCurrentDevice && currentDevice != null) {
             Text(
                 "Current Device",
                 style = MaterialTheme.typography.labelMedium,
@@ -519,11 +561,11 @@ private fun BluetoothDeviceDiscovery(
             )
             Spacer(Modifier.height(8.dp))
             BluetoothDeviceCard(
-                device = state.selectedDevice!!,
+                device = currentDevice,
                 isSelected = true,
                 onSelect = { },
                 onPair = { },
-                onSetType = { viewModel.setDeviceType(state.selectedDevice!!, it) },
+                onSetType = { viewModel.setDeviceType(currentDevice, it) },
                 isPairingInProgress = false,
             )
             Spacer(Modifier.height(16.dp))
@@ -543,8 +585,12 @@ private fun BluetoothDeviceDiscovery(
             items(
                 items =
                     state.discoveredDevices.filter {
-                        // In edit mode, don't show the current device in the list
-                        !(state.isEditMode && it.name == state.selectedDevice?.name)
+                        // Ordinary edit mode shows the current device separately. Repair keeps it in this list.
+                        !(
+                            state.isEditMode &&
+                                !state.isPairingRepairMode &&
+                                it.name == currentDevice?.name
+                        )
                     },
                 key = { it.address },
             ) { device ->

--- a/app/src/main/java/network/columba/app/ui/screens/rnode/DeviceDiscoveryStep.kt
+++ b/app/src/main/java/network/columba/app/ui/screens/rnode/DeviceDiscoveryStep.kt
@@ -315,6 +315,11 @@ private fun BluetoothDeviceDiscovery(
     viewModel: RNodeWizardViewModel,
     state: RNodeWizardState,
 ) {
+    val repairCandidateAddresses =
+        state.discoveredDevices
+            .filter { it.name == state.pairingRepairDeviceName }
+            .map { it.address.uppercase() }
+            .distinct()
     Column {
         if (state.isPairingRepairMode && state.selectedDevice?.isPaired != true) {
             Surface(
@@ -590,8 +595,11 @@ private fun BluetoothDeviceDiscovery(
                         if (state.isPairingRepairMode) {
                             it.name == state.pairingRepairDeviceName &&
                                 (
-                                    state.pairingRepairDeviceAddress == null ||
-                                        state.pairingRepairDeviceAddress.equals(it.address, ignoreCase = true)
+                                    state.pairingRepairDeviceAddress?.equals(it.address, ignoreCase = true)
+                                        ?: (
+                                            !state.isScanning &&
+                                                repairCandidateAddresses == listOf(it.address.uppercase())
+                                        )
                                 )
                         } else {
                             // Ordinary edit mode shows the current device separately.

--- a/app/src/main/java/network/columba/app/ui/screens/rnode/DeviceDiscoveryStep.kt
+++ b/app/src/main/java/network/columba/app/ui/screens/rnode/DeviceDiscoveryStep.kt
@@ -314,7 +314,7 @@ private fun BluetoothDeviceDiscovery(
     state: RNodeWizardState,
 ) {
     Column {
-        if (state.isPairingRepairMode) {
+        if (state.isPairingRepairMode && state.selectedDevice?.isPaired != true) {
             Surface(
                 color = MaterialTheme.colorScheme.errorContainer,
                 shape = MaterialTheme.shapes.medium,

--- a/app/src/main/java/network/columba/app/ui/screens/rnode/DeviceDiscoveryStep.kt
+++ b/app/src/main/java/network/columba/app/ui/screens/rnode/DeviceDiscoveryStep.kt
@@ -338,7 +338,7 @@ private fun BluetoothDeviceDiscovery(
                     )
                     Spacer(Modifier.height(8.dp))
                     Text(
-                        text = stringResource(R.string.rnode_pairing_repair_heltec_v3),
+                        text = stringResource(R.string.rnode_pairing_repair_pairing_mode),
                         style = MaterialTheme.typography.bodyMedium,
                         color = MaterialTheme.colorScheme.onErrorContainer,
                     )

--- a/app/src/main/java/network/columba/app/ui/screens/rnode/DeviceDiscoveryStep.kt
+++ b/app/src/main/java/network/columba/app/ui/screens/rnode/DeviceDiscoveryStep.kt
@@ -588,7 +588,11 @@ private fun BluetoothDeviceDiscovery(
                 items =
                     state.discoveredDevices.filter {
                         if (state.isPairingRepairMode) {
-                            it.name == state.pairingRepairDeviceName
+                            it.name == state.pairingRepairDeviceName &&
+                                (
+                                    state.pairingRepairDeviceAddress == null ||
+                                        state.pairingRepairDeviceAddress.equals(it.address, ignoreCase = true)
+                                )
                         } else {
                             // Ordinary edit mode shows the current device separately.
                             !(state.isEditMode && it.name == currentDevice?.name)

--- a/app/src/main/java/network/columba/app/ui/screens/rnode/DeviceDiscoveryStep.kt
+++ b/app/src/main/java/network/columba/app/ui/screens/rnode/DeviceDiscoveryStep.kt
@@ -134,43 +134,45 @@ fun DeviceDiscoveryStep(viewModel: RNodeWizardViewModel) {
                 .fillMaxSize()
                 .padding(16.dp),
     ) {
-        // Connection type selector
-        Text(
-            "Connection Method",
-            style = MaterialTheme.typography.labelMedium,
-            color = MaterialTheme.colorScheme.onSurfaceVariant,
-        )
-        Spacer(Modifier.height(8.dp))
-        Row(
-            modifier = Modifier.fillMaxWidth(),
-            horizontalArrangement = Arrangement.spacedBy(8.dp),
-        ) {
-            FilterChip(
-                selected = state.connectionType == RNodeConnectionType.BLUETOOTH,
-                onClick = { viewModel.setConnectionType(RNodeConnectionType.BLUETOOTH) },
-                label = { Text("Bluetooth") },
-                leadingIcon = {
-                    Icon(Icons.Default.Bluetooth, contentDescription = null, Modifier.size(18.dp))
-                },
+        if (!state.isPairingRepairMode) {
+            // Connection type selector
+            Text(
+                "Connection Method",
+                style = MaterialTheme.typography.labelMedium,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
             )
-            FilterChip(
-                selected = state.connectionType == RNodeConnectionType.TCP_WIFI,
-                onClick = { viewModel.setConnectionType(RNodeConnectionType.TCP_WIFI) },
-                label = { Text("WiFi / TCP") },
-                leadingIcon = {
-                    Icon(Icons.Default.Wifi, contentDescription = null, Modifier.size(18.dp))
-                },
-            )
-            FilterChip(
-                selected = state.connectionType == RNodeConnectionType.USB_SERIAL,
-                onClick = { viewModel.setConnectionType(RNodeConnectionType.USB_SERIAL) },
-                label = { Text("USB") },
-                leadingIcon = {
-                    Icon(Icons.Default.Usb, contentDescription = null, Modifier.size(18.dp))
-                },
-            )
+            Spacer(Modifier.height(8.dp))
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                horizontalArrangement = Arrangement.spacedBy(8.dp),
+            ) {
+                FilterChip(
+                    selected = state.connectionType == RNodeConnectionType.BLUETOOTH,
+                    onClick = { viewModel.setConnectionType(RNodeConnectionType.BLUETOOTH) },
+                    label = { Text("Bluetooth") },
+                    leadingIcon = {
+                        Icon(Icons.Default.Bluetooth, contentDescription = null, Modifier.size(18.dp))
+                    },
+                )
+                FilterChip(
+                    selected = state.connectionType == RNodeConnectionType.TCP_WIFI,
+                    onClick = { viewModel.setConnectionType(RNodeConnectionType.TCP_WIFI) },
+                    label = { Text("WiFi / TCP") },
+                    leadingIcon = {
+                        Icon(Icons.Default.Wifi, contentDescription = null, Modifier.size(18.dp))
+                    },
+                )
+                FilterChip(
+                    selected = state.connectionType == RNodeConnectionType.USB_SERIAL,
+                    onClick = { viewModel.setConnectionType(RNodeConnectionType.USB_SERIAL) },
+                    label = { Text("USB") },
+                    leadingIcon = {
+                        Icon(Icons.Default.Usb, contentDescription = null, Modifier.size(18.dp))
+                    },
+                )
+            }
+            Spacer(Modifier.height(16.dp))
         }
-        Spacer(Modifier.height(16.dp))
 
         // Show content based on connection type
         when (state.connectionType) {
@@ -611,32 +613,34 @@ private fun BluetoothDeviceDiscovery(
                 )
             }
 
-            // Manual entry option
-            item {
-                OutlinedCard(
-                    onClick = { viewModel.showManualEntry() },
-                    modifier = Modifier.fillMaxWidth(),
-                ) {
-                    Row(
-                        modifier = Modifier.padding(16.dp),
-                        verticalAlignment = Alignment.CenterVertically,
+            if (!state.isPairingRepairMode) {
+                // Manual entry option
+                item {
+                    OutlinedCard(
+                        onClick = { viewModel.showManualEntry() },
+                        modifier = Modifier.fillMaxWidth(),
                     ) {
-                        Icon(
-                            Icons.Default.Edit,
-                            contentDescription = null,
-                            tint = MaterialTheme.colorScheme.onSurfaceVariant,
-                        )
-                        Spacer(Modifier.width(16.dp))
-                        Column {
-                            Text(
-                                "Enter device manually",
-                                style = MaterialTheme.typography.titleMedium,
+                        Row(
+                            modifier = Modifier.padding(16.dp),
+                            verticalAlignment = Alignment.CenterVertically,
+                        ) {
+                            Icon(
+                                Icons.Default.Edit,
+                                contentDescription = null,
+                                tint = MaterialTheme.colorScheme.onSurfaceVariant,
                             )
-                            Text(
-                                "If your device isn't listed",
-                                style = MaterialTheme.typography.bodySmall,
-                                color = MaterialTheme.colorScheme.onSurfaceVariant,
-                            )
+                            Spacer(Modifier.width(16.dp))
+                            Column {
+                                Text(
+                                    "Enter device manually",
+                                    style = MaterialTheme.typography.titleMedium,
+                                )
+                                Text(
+                                    "If your device isn't listed",
+                                    style = MaterialTheme.typography.bodySmall,
+                                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                                )
+                            }
                         }
                     }
                 }

--- a/app/src/main/java/network/columba/app/ui/screens/rnode/DeviceDiscoveryStep.kt
+++ b/app/src/main/java/network/columba/app/ui/screens/rnode/DeviceDiscoveryStep.kt
@@ -643,7 +643,7 @@ private fun BluetoothDeviceDiscovery(
             }
 
             // USB-assisted pairing section
-            if (!state.showManualEntry) {
+            if (!state.showManualEntry && !state.isPairingRepairMode) {
                 item {
                     Spacer(Modifier.height(16.dp))
                     Text(

--- a/app/src/main/java/network/columba/app/ui/screens/rnode/DeviceDiscoveryStep.kt
+++ b/app/src/main/java/network/columba/app/ui/screens/rnode/DeviceDiscoveryStep.kt
@@ -315,11 +315,6 @@ private fun BluetoothDeviceDiscovery(
     viewModel: RNodeWizardViewModel,
     state: RNodeWizardState,
 ) {
-    val repairCandidateAddresses =
-        state.discoveredDevices
-            .filter { it.name == state.pairingRepairDeviceName }
-            .map { it.address.uppercase() }
-            .distinct()
     Column {
         if (state.isPairingRepairMode && state.selectedDevice?.isPaired != true) {
             Surface(
@@ -344,17 +339,25 @@ private fun BluetoothDeviceDiscovery(
                         color = MaterialTheme.colorScheme.onErrorContainer,
                     )
                     Spacer(Modifier.height(8.dp))
-                    Text(
-                        text = stringResource(R.string.rnode_pairing_repair_pairing_mode),
-                        style = MaterialTheme.typography.bodyMedium,
-                        color = MaterialTheme.colorScheme.onErrorContainer,
-                    )
-                    Spacer(Modifier.height(8.dp))
-                    Text(
-                        text = stringResource(R.string.rnode_pairing_repair_select_device),
-                        style = MaterialTheme.typography.bodyMedium,
-                        color = MaterialTheme.colorScheme.onErrorContainer,
-                    )
+                    if (state.pairingRepairDeviceAddress == null) {
+                        Text(
+                            text = stringResource(R.string.rnode_pairing_repair_identity_unavailable),
+                            style = MaterialTheme.typography.bodyMedium,
+                            color = MaterialTheme.colorScheme.onErrorContainer,
+                        )
+                    } else {
+                        Text(
+                            text = stringResource(R.string.rnode_pairing_repair_pairing_mode),
+                            style = MaterialTheme.typography.bodyMedium,
+                            color = MaterialTheme.colorScheme.onErrorContainer,
+                        )
+                        Spacer(Modifier.height(8.dp))
+                        Text(
+                            text = stringResource(R.string.rnode_pairing_repair_select_device),
+                            style = MaterialTheme.typography.bodyMedium,
+                            color = MaterialTheme.colorScheme.onErrorContainer,
+                        )
+                    }
                 }
             }
             Spacer(Modifier.height(16.dp))
@@ -594,13 +597,7 @@ private fun BluetoothDeviceDiscovery(
                     state.discoveredDevices.filter {
                         if (state.isPairingRepairMode) {
                             it.name == state.pairingRepairDeviceName &&
-                                (
-                                    state.pairingRepairDeviceAddress?.equals(it.address, ignoreCase = true)
-                                        ?: (
-                                            !state.isScanning &&
-                                                repairCandidateAddresses == listOf(it.address.uppercase())
-                                        )
-                                )
+                                state.pairingRepairDeviceAddress?.equals(it.address, ignoreCase = true) == true
                         } else {
                             // Ordinary edit mode shows the current device separately.
                             !(state.isEditMode && it.name == currentDevice?.name)

--- a/app/src/main/java/network/columba/app/ui/screens/rnode/DeviceDiscoveryStep.kt
+++ b/app/src/main/java/network/columba/app/ui/screens/rnode/DeviceDiscoveryStep.kt
@@ -600,7 +600,11 @@ private fun BluetoothDeviceDiscovery(
                                 state.pairingRepairDeviceAddress?.equals(it.address, ignoreCase = true) == true
                         } else {
                             // Ordinary edit mode shows the current device separately.
-                            !(state.isEditMode && it.name == currentDevice?.name)
+                            !(
+                                state.isEditMode &&
+                                    currentDevice != null &&
+                                    it.address.equals(currentDevice.address, ignoreCase = true)
+                            )
                         }
                     },
                 key = { it.address },

--- a/app/src/main/java/network/columba/app/ui/screens/rnode/DeviceDiscoveryStep.kt
+++ b/app/src/main/java/network/columba/app/ui/screens/rnode/DeviceDiscoveryStep.kt
@@ -585,12 +585,12 @@ private fun BluetoothDeviceDiscovery(
             items(
                 items =
                     state.discoveredDevices.filter {
-                        // Ordinary edit mode shows the current device separately. Repair keeps it in this list.
-                        !(
-                            state.isEditMode &&
-                                !state.isPairingRepairMode &&
-                                it.name == currentDevice?.name
-                        )
+                        if (state.isPairingRepairMode) {
+                            it.name == state.pairingRepairDeviceName
+                        } else {
+                            // Ordinary edit mode shows the current device separately.
+                            !(state.isEditMode && it.name == currentDevice?.name)
+                        }
                     },
                 key = { it.address },
             ) { device ->

--- a/app/src/main/java/network/columba/app/ui/screens/rnode/DeviceDiscoveryStep.kt
+++ b/app/src/main/java/network/columba/app/ui/screens/rnode/DeviceDiscoveryStep.kt
@@ -55,8 +55,10 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
+import network.columba.app.R
 import network.columba.app.data.model.BluetoothType
 import network.columba.app.data.model.DiscoveredRNode
 import network.columba.app.data.model.DiscoveredUsbDevice
@@ -907,7 +909,7 @@ private fun BluetoothDeviceCard(
                                     )
                                     Spacer(Modifier.width(2.dp))
                                     Text(
-                                        "Paired",
+                                        stringResource(R.string.rnode_paired_in_android),
                                         style = MaterialTheme.typography.labelSmall,
                                         color =
                                             if (isSelected) {

--- a/app/src/main/java/network/columba/app/ui/screens/rnode/RNodeWizardScreen.kt
+++ b/app/src/main/java/network/columba/app/ui/screens/rnode/RNodeWizardScreen.kt
@@ -75,7 +75,7 @@ fun RNodeWizardScreen(
         }
     }
 
-    if (repairPairing && !state.isPairingRepairMode) {
+    if (repairPairing && (!state.isPairingRepairMode || state.pairingRepairDeviceName.isNullOrBlank())) {
         Scaffold(
             topBar = {
                 TopAppBar(

--- a/app/src/main/java/network/columba/app/ui/screens/rnode/RNodeWizardScreen.kt
+++ b/app/src/main/java/network/columba/app/ui/screens/rnode/RNodeWizardScreen.kt
@@ -6,11 +6,13 @@ import androidx.compose.animation.slideInHorizontally
 import androidx.compose.animation.slideOutHorizontally
 import androidx.compose.animation.togetherWith
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.navigationBarsPadding
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
 import androidx.compose.material3.AlertDialog
+import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
@@ -23,6 +25,7 @@ import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.Alignment
 import androidx.hilt.navigation.compose.hiltViewModel
 import network.columba.app.ui.components.WizardBottomBar
 import network.columba.app.viewmodel.RNodeWizardViewModel
@@ -70,6 +73,29 @@ fun RNodeWizardScreen(
         if (editingInterfaceId != null && editingInterfaceId >= 0) {
             viewModel.loadExistingConfig(editingInterfaceId, repairPairing)
         }
+    }
+
+    if (repairPairing && !state.isPairingRepairMode) {
+        Scaffold(
+            topBar = {
+                TopAppBar(
+                    title = { Text("Repair RNode Pairing") },
+                    navigationIcon = {
+                        IconButton(onClick = onNavigateBack) {
+                            Icon(Icons.AutoMirrored.Filled.ArrowBack, contentDescription = "Back")
+                        }
+                    },
+                )
+            },
+        ) { innerPadding ->
+            Box(
+                modifier = Modifier.fillMaxSize().padding(innerPadding),
+                contentAlignment = Alignment.Center,
+            ) {
+                CircularProgressIndicator()
+            }
+        }
+        return
     }
 
     // Apply USB pre-selection if provided

--- a/app/src/main/java/network/columba/app/ui/screens/rnode/RNodeWizardScreen.kt
+++ b/app/src/main/java/network/columba/app/ui/screens/rnode/RNodeWizardScreen.kt
@@ -32,6 +32,7 @@ import network.columba.app.viewmodel.WizardStep
 @Composable
 fun RNodeWizardScreen(
     editingInterfaceId: Long? = null,
+    repairPairing: Boolean = false,
     preselectedConnectionType: String? = null,
     preselectedUsbDeviceId: Int? = null,
     preselectedUsbVendorId: Int? = null,
@@ -65,9 +66,9 @@ fun RNodeWizardScreen(
     }
 
     // Load existing config if editing
-    LaunchedEffect(editingInterfaceId) {
+    LaunchedEffect(editingInterfaceId, repairPairing) {
         if (editingInterfaceId != null && editingInterfaceId >= 0) {
-            viewModel.loadExistingConfig(editingInterfaceId)
+            viewModel.loadExistingConfig(editingInterfaceId, repairPairing)
         }
     }
 
@@ -125,6 +126,7 @@ fun RNodeWizardScreen(
                             WizardStep.DEVICE_DISCOVERY ->
                                 when {
                                     state.transportMode -> "Configure Transport"
+                                    state.isPairingRepairMode -> "Repair RNode Pairing"
                                     state.isEditMode -> "Change RNode Device"
                                     else -> "Select RNode Device"
                                 }

--- a/app/src/main/java/network/columba/app/viewmodel/InterfaceManagementViewModel.kt
+++ b/app/src/main/java/network/columba/app/viewmodel/InterfaceManagementViewModel.kt
@@ -51,6 +51,7 @@ data class InterfaceManagementState(
     val errorMessage: String? = null,
     val successMessage: String? = null,
     val hasPendingChanges: Boolean = false,
+    val pendingInterfaceIds: Set<Long> = emptySet(),
     val isApplyingChanges: Boolean = false,
     val applyChangesError: String? = null,
     val showBlePermissionRequest: Boolean = false,
@@ -266,8 +267,12 @@ class InterfaceManagementViewModel
          * Check if there are pending changes set by external sources (e.g., RNode wizard).
          */
         fun refreshExternalPendingChanges() {
-            if (configManager.checkAndClearPendingChanges()) {
+            val pendingChanges = configManager.consumePendingChanges()
+            if (pendingChanges.hasPendingChanges) {
                 Log.d(TAG, "Found pending changes from external source — hot-reloading")
+                _state.update {
+                    it.copy(pendingInterfaceIds = it.pendingInterfaceIds + pendingChanges.interfaceIds)
+                }
                 syncNativeInterfaces()
             }
         }
@@ -1296,6 +1301,7 @@ class InterfaceManagementViewModel
                                     _state.value.copy(
                                         isApplyingChanges = false,
                                         hasPendingChanges = false,
+                                        pendingInterfaceIds = emptySet(),
                                         applyChangesError = null,
                                     )
                                 // Force-refresh the interface status list shortly
@@ -1322,6 +1328,7 @@ class InterfaceManagementViewModel
                         _state.value =
                             _state.value.copy(
                                 hasPendingChanges = false,
+                                pendingInterfaceIds = emptySet(),
                                 isApplyingChanges = false,
                             )
                         showSuccess("Configuration applied successfully")

--- a/app/src/main/java/network/columba/app/viewmodel/InterfaceManagementViewModel.kt
+++ b/app/src/main/java/network/columba/app/viewmodel/InterfaceManagementViewModel.kt
@@ -88,6 +88,7 @@ data class TransportInterfaceInfo(
     val parentName: String?,
     val rxBytes: Long = 0,
     val txBytes: Long = 0,
+    val statusReason: String? = null,
 )
 
 /**
@@ -382,6 +383,7 @@ class InterfaceManagementViewModel
                         parentName = iface.optString("parent_name").takeIf { it.isNotBlank() },
                         rxBytes = iface.optLong("rx_bytes", 0L),
                         txBytes = iface.optLong("tx_bytes", 0L),
+                        statusReason = iface.optString("status_reason").takeIf { it.isNotBlank() },
                     ),
                 )
             }
@@ -460,6 +462,7 @@ class InterfaceManagementViewModel
                                 parentName = (ifaceMap["parent_name"] as? String)?.takeIf { it.isNotEmpty() },
                                 rxBytes = (ifaceMap["rx_bytes"] as? Number)?.toLong() ?: 0L,
                                 txBytes = (ifaceMap["tx_bytes"] as? Number)?.toLong() ?: 0L,
+                                statusReason = (ifaceMap["status_reason"] as? String)?.takeIf { it.isNotBlank() },
                             ),
                         )
                     }

--- a/app/src/main/java/network/columba/app/viewmodel/InterfaceManagementViewModel.kt
+++ b/app/src/main/java/network/columba/app/viewmodel/InterfaceManagementViewModel.kt
@@ -240,7 +240,7 @@ class InterfaceManagementViewModel
             loadInterfaces()
             observeBluetoothState()
             observeTransportChanges()
-            checkExternalPendingChanges()
+            refreshExternalPendingChanges()
             observeInterfaceStatusChanges()
             loadDiscoveredInterfacesCount()
         }
@@ -265,7 +265,7 @@ class InterfaceManagementViewModel
         /**
          * Check if there are pending changes set by external sources (e.g., RNode wizard).
          */
-        private fun checkExternalPendingChanges() {
+        fun refreshExternalPendingChanges() {
             if (configManager.checkAndClearPendingChanges()) {
                 Log.d(TAG, "Found pending changes from external source — hot-reloading")
                 syncNativeInterfaces()

--- a/app/src/main/java/network/columba/app/viewmodel/RNodeWizardViewModel.kt
+++ b/app/src/main/java/network/columba/app/viewmodel/RNodeWizardViewModel.kt
@@ -3582,8 +3582,10 @@ class RNodeWizardViewModel
                         Log.d(TAG, "Created new RNode interface")
                     }
 
-                    // Mark pending changes for InterfaceManagementScreen to show "Apply" button
-                    configManager.setPendingChanges(true)
+                    // Mark pending changes for InterfaceManagementScreen to show "Apply" button.
+                    // Preserve the edited interface ID so only its pre-update runtime
+                    // diagnostic is considered stale before Apply & Restart.
+                    configManager.setPendingChanges(true, state.editingInterfaceId)
 
                     _state.update { it.copy(saveSuccess = true, isSaving = false) }
                 } catch (e: Exception) {

--- a/app/src/main/java/network/columba/app/viewmodel/RNodeWizardViewModel.kt
+++ b/app/src/main/java/network/columba/app/viewmodel/RNodeWizardViewModel.kt
@@ -108,6 +108,8 @@ data class RNodeWizardState(
     // Edit mode
     val editingInterfaceId: Long? = null,
     val isEditMode: Boolean = false,
+    val isPairingRepairMode: Boolean = false,
+    val pairingRepairDeviceName: String? = null,
     // Transport mode - sends TNC KISS commands instead of saving interface config
     val transportMode: Boolean = false,
     val transportConfiguring: Boolean = false,
@@ -345,7 +347,10 @@ class RNodeWizardViewModel
          * Initialize wizard for editing an existing RNode interface.
          */
         @Suppress("LongMethod", "CyclomaticComplexMethod") // Complex config mapping is inherent
-        fun loadExistingConfig(interfaceId: Long) {
+        fun loadExistingConfig(
+            interfaceId: Long,
+            repairPairing: Boolean = false,
+        ) {
             viewModelScope.launch {
                 try {
                     val entity = interfaceRepository.getInterfaceById(interfaceId).first()
@@ -405,8 +410,15 @@ class RNodeWizardViewModel
                         state.copy(
                             editingInterfaceId = interfaceId,
                             isEditMode = true,
-                            // Skip straight to review — user doesn't need to re-walk the wizard
-                            currentStep = WizardStep.REVIEW_CONFIGURE,
+                            isPairingRepairMode = repairPairing,
+                            pairingRepairDeviceName = config.targetDeviceName.takeIf { repairPairing },
+                            // Editing skips to review. Pairing repair must begin at device discovery.
+                            currentStep =
+                                if (repairPairing) {
+                                    WizardStep.DEVICE_DISCOVERY
+                                } else {
+                                    WizardStep.REVIEW_CONFIGURE
+                                },
                             showAdvancedSettings = true,
                             // Connection type
                             connectionType = connectionType,
@@ -417,7 +429,7 @@ class RNodeWizardViewModel
                             selectedUsbDevice = usbDevice,
                             // Pre-populate Bluetooth device (for Bluetooth mode)
                             selectedDevice =
-                                if (isTcp || isUsb) {
+                                if (isTcp || isUsb || repairPairing) {
                                     null
                                 } else {
                                     DiscoveredRNode(
@@ -571,8 +583,10 @@ class RNodeWizardViewModel
                     WizardStep.DEVICE_DISCOVERY -> {
                         // Stop RSSI polling when leaving device discovery to prevent memory leaks
                         stopRssiPolling()
-                        // If we have pending LoRa params from discovered interface, skip to review
-                        if (currentState.hasPendingParams) {
+                        // Repair preserves the existing radio configuration and only replaces the bond.
+                        if (currentState.isPairingRepairMode) {
+                            WizardStep.REVIEW_CONFIGURE
+                        } else if (currentState.hasPendingParams) {
                             _state.update { it.copy(skippedRegionSelection = true) }
                             WizardStep.REVIEW_CONFIGURE
                         } else {

--- a/app/src/main/java/network/columba/app/viewmodel/RNodeWizardViewModel.kt
+++ b/app/src/main/java/network/columba/app/viewmodel/RNodeWizardViewModel.kt
@@ -458,7 +458,7 @@ class RNodeWizardViewModel
                                 } else {
                                     DiscoveredRNode(
                                         name = config.targetDeviceName,
-                                        address = "",
+                                        address = config.targetDeviceAddress.orEmpty(),
                                         type = if (isBle) BluetoothType.BLE else BluetoothType.CLASSIC,
                                         rssi = null,
                                         isPaired = true,
@@ -717,7 +717,8 @@ class RNodeWizardViewModel
             if (state.currentStep != WizardStep.DEVICE_DISCOVERY || !state.isPairingRepairMode) {
                 return false
             }
-            return state.isPairingInProgress || state.selectedDevice?.isPaired != true
+            val device = state.selectedDevice
+            return state.isPairingInProgress || device?.isPaired != true || !hasCurrentAndroidBond(device)
         }
 
         private fun canProceedFromDeviceDiscovery(state: RNodeWizardState): Boolean =
@@ -1345,7 +1346,7 @@ class RNodeWizardViewModel
                             .filter { it.name == state.pairingRepairDeviceName }
                             .map { it.address.uppercase() }
                             .distinct()
-                    matchingAddresses.isEmpty() || matchingAddresses == listOf(device.address.uppercase())
+                    !state.isScanning && matchingAddresses == listOf(device.address.uppercase())
                 }
             }
         }
@@ -3710,6 +3711,18 @@ class RNodeWizardViewModel
                                 NetworkRestriction.fromValue(state.networkRestriction)
                                     ?: NetworkRestriction.ANY,
                         )
+
+                    if (state.isPairingRepairMode && !hasCurrentAndroidBond(state.selectedDevice!!)) {
+                        _state.update {
+                            it.copy(
+                                isSaving = false,
+                                selectedDevice = state.selectedDevice.copy(isPaired = false),
+                                pairingError = "Android pairing was lost. Pair the configured RNode again.",
+                                saveError = "Android pairing was lost before the repair could be saved.",
+                            )
+                        }
+                        return@launch
+                    }
 
                     if (state.editingInterfaceId != null) {
                         // Update existing interface

--- a/app/src/main/java/network/columba/app/viewmodel/RNodeWizardViewModel.kt
+++ b/app/src/main/java/network/columba/app/viewmodel/RNodeWizardViewModel.kt
@@ -405,6 +405,8 @@ class RNodeWizardViewModel
                             repairPairing -> false
                             else -> !config.targetDeviceAddress.isNullOrBlank()
                         }
+                    val requiresExplicitBluetoothSelection =
+                        !isTcp && !isUsb && !repairPairing && !shouldPreselectBluetoothDevice
 
                     // Determine connection type
                     val connectionType =
@@ -444,7 +446,7 @@ class RNodeWizardViewModel
                             pairingRepairDeviceAddress = repairDeviceAddress.takeIf { repairPairing },
                             // Editing skips to review. Pairing repair must begin at device discovery.
                             currentStep =
-                                if (repairPairing) {
+                                if (repairPairing || requiresExplicitBluetoothSelection) {
                                     WizardStep.DEVICE_DISCOVERY
                                 } else {
                                     WizardStep.REVIEW_CONFIGURE
@@ -616,8 +618,8 @@ class RNodeWizardViewModel
                     WizardStep.DEVICE_DISCOVERY -> {
                         // Stop RSSI polling when leaving device discovery to prevent memory leaks
                         stopRssiPolling()
-                        // Repair preserves the existing radio configuration and only replaces the bond.
-                        if (currentState.isPairingRepairMode) {
+                        // Repair and ordinary edits preserve the loaded radio profile.
+                        if (currentState.isPairingRepairMode || currentState.isEditMode) {
                             _state.update { it.copy(skippedRegionSelection = true) }
                             WizardStep.REVIEW_CONFIGURE
                         } else if (currentState.hasPendingParams) {
@@ -710,12 +712,15 @@ class RNodeWizardViewModel
                     true // Default preset is pre-selected, user can always proceed
                 WizardStep.FREQUENCY_SLOT ->
                     true // Slot always has a valid selection
-                WizardStep.REVIEW_CONFIGURE ->
-                    if (state.transportMode) {
-                        validateConfigurationSilent()
-                    } else {
-                        state.interfaceName.isNotBlank() && validateConfigurationSilent()
-                    }
+                WizardStep.REVIEW_CONFIGURE -> {
+                    val fieldsValid =
+                        if (state.transportMode) {
+                            validateConfigurationSilent()
+                        } else {
+                            state.interfaceName.isNotBlank() && validateConfigurationSilent()
+                        }
+                    fieldsValid && hasRequiredBluetoothEditIdentity(state)
+                }
             }
         }
 
@@ -747,6 +752,11 @@ class RNodeWizardViewModel
                         state.manualDeviceNameError == null
                 )
         }
+
+        private fun hasRequiredBluetoothEditIdentity(state: RNodeWizardState): Boolean =
+            !state.isEditMode ||
+                state.connectionType != RNodeConnectionType.BLUETOOTH ||
+                !state.selectedDevice?.address.isNullOrBlank()
 
         private fun applyFrequencyRegionSettings() {
             val region = _state.value.selectedFrequencyRegion ?: return
@@ -3571,6 +3581,12 @@ class RNodeWizardViewModel
         @Suppress("CyclomaticComplexMethod", "LongMethod")
         fun saveConfiguration() {
             if (!validateConfiguration()) return
+            if (!hasRequiredBluetoothEditIdentity(_state.value)) {
+                _state.update {
+                    it.copy(saveError = "Select the original RNode before updating this interface.")
+                }
+                return
+            }
 
             viewModelScope.launch {
                 _state.update { it.copy(isSaving = true, saveError = null) }

--- a/app/src/main/java/network/columba/app/viewmodel/RNodeWizardViewModel.kt
+++ b/app/src/main/java/network/columba/app/viewmodel/RNodeWizardViewModel.kt
@@ -243,6 +243,9 @@ data class RNodeWizardState(
         } else {
             interfaceName
         }
+
+    fun interfaceNameAfterSelecting(device: DiscoveredRNode): String =
+        if (isPairingRepairMode) interfaceName else defaultInterfaceNameFor(device)
 }
 
 /**
@@ -1308,7 +1311,7 @@ class RNodeWizardViewModel
                 it.copy(
                     selectedDevice = device,
                     showManualEntry = false,
-                    interfaceName = it.defaultInterfaceNameFor(device),
+                    interfaceName = it.interfaceNameAfterSelecting(device),
                 )
             }
         }
@@ -1446,7 +1449,7 @@ class RNodeWizardViewModel
                                     isAssociating = false,
                                     pendingAssociationIntent = null,
                                     showManualEntry = false,
-                                    interfaceName = it.defaultInterfaceNameFor(device),
+                                    interfaceName = it.interfaceNameAfterSelecting(device),
                                 )
                             }
                             // Cache the device type since it's now confirmed
@@ -3157,7 +3160,7 @@ class RNodeWizardViewModel
                                             state.discoveredDevices.map {
                                                 if (it.address == device.address) updatedDevice else it
                                             },
-                                        interfaceName = state.defaultInterfaceNameFor(updatedDevice),
+                                        interfaceName = state.interfaceNameAfterSelecting(updatedDevice),
                                     )
                                 }
                                 Log.d(TAG, "Pairing successful for ${device.name}")

--- a/app/src/main/java/network/columba/app/viewmodel/RNodeWizardViewModel.kt
+++ b/app/src/main/java/network/columba/app/viewmodel/RNodeWizardViewModel.kt
@@ -1543,6 +1543,7 @@ class RNodeWizardViewModel
         }
 
         fun showManualEntry() {
+            if (_state.value.isPairingRepairMode) return
             _state.update {
                 it.copy(
                     showManualEntry = true,
@@ -1592,6 +1593,7 @@ class RNodeWizardViewModel
          * Clears device selection when switching modes.
          */
         fun setConnectionType(type: RNodeConnectionType) {
+            if (_state.value.isPairingRepairMode) return
             _state.update {
                 // Auto-generate interface name based on connection type if not manually customized
                 // Update if it's the default or matches an auto-generated pattern
@@ -1786,6 +1788,7 @@ class RNodeWizardViewModel
          * If permission is needed, requests it first.
          */
         fun selectUsbDevice(device: network.columba.app.data.model.DiscoveredUsbDevice) {
+            if (_state.value.isPairingRepairMode) return
             if (device.hasPermission) {
                 _state.update {
                     // Auto-generate interface name if user hasn't customized it
@@ -1860,6 +1863,7 @@ class RNodeWizardViewModel
             productId: Int,
             deviceName: String,
         ) {
+            if (_state.value.isPairingRepairMode) return
             Log.d(TAG, "Pre-selecting USB device: $deviceId ($deviceName)")
 
             // Switch to USB connection type

--- a/app/src/main/java/network/columba/app/viewmodel/RNodeWizardViewModel.kt
+++ b/app/src/main/java/network/columba/app/viewmodel/RNodeWizardViewModel.kt
@@ -578,11 +578,7 @@ class RNodeWizardViewModel
 
         fun goToNextStep() {
             val currentState = _state.value
-            if (
-                currentState.currentStep == WizardStep.DEVICE_DISCOVERY &&
-                currentState.isPairingRepairMode &&
-                currentState.selectedDevice?.isPaired != true
-            ) {
+            if (pairingRepairCannotAdvance(currentState)) {
                 return
             }
             val nextStep =
@@ -693,6 +689,13 @@ class RNodeWizardViewModel
             }
         }
 
+        private fun pairingRepairCannotAdvance(state: RNodeWizardState): Boolean {
+            if (state.currentStep != WizardStep.DEVICE_DISCOVERY || !state.isPairingRepairMode) {
+                return false
+            }
+            return state.isPairingInProgress || state.selectedDevice?.isPaired != true
+        }
+
         private fun canProceedFromDeviceDiscovery(state: RNodeWizardState): Boolean =
             when (state.connectionType) {
                 RNodeConnectionType.TCP_WIFI -> state.tcpHost.isNotBlank()
@@ -703,7 +706,7 @@ class RNodeWizardViewModel
 
         private fun canProceedWithBluetooth(state: RNodeWizardState): Boolean =
             if (state.isPairingRepairMode) {
-                state.selectedDevice?.isPaired == true
+                !state.isPairingInProgress && state.selectedDevice?.isPaired == true
             } else {
                 state.selectedDevice != null ||
                     (
@@ -3011,6 +3014,7 @@ class RNodeWizardViewModel
                 _state.update {
                     it.copy(
                         isPairingInProgress = true,
+                        selectedDevice = null,
                         pairingError = null,
                         pairingTimeRemaining = 0,
                         lastPairingDeviceAddress = device.address,

--- a/app/src/main/java/network/columba/app/viewmodel/RNodeWizardViewModel.kt
+++ b/app/src/main/java/network/columba/app/viewmodel/RNodeWizardViewModel.kt
@@ -2920,6 +2920,11 @@ class RNodeWizardViewModel
          * just auto-discovers and selects the USB device first.
          */
         fun startUsbAssistedPairing() {
+            if (_state.value.isPairingRepairMode) return
+            launchUsbAssistedPairing()
+        }
+
+        private fun launchUsbAssistedPairing() =
             viewModelScope.launch {
                 Log.d(TAG, "USB-assisted pairing from Bluetooth tab: scanning for USB devices")
 
@@ -3008,7 +3013,6 @@ class RNodeWizardViewModel
                         )
                     }
                 }
-            }
         }
 
         // Pairing handler to auto-confirm Just Works pairing

--- a/app/src/main/java/network/columba/app/viewmodel/RNodeWizardViewModel.kt
+++ b/app/src/main/java/network/columba/app/viewmodel/RNodeWizardViewModel.kt
@@ -578,6 +578,13 @@ class RNodeWizardViewModel
 
         fun goToNextStep() {
             val currentState = _state.value
+            if (
+                currentState.currentStep == WizardStep.DEVICE_DISCOVERY &&
+                currentState.isPairingRepairMode &&
+                currentState.selectedDevice?.isPaired != true
+            ) {
+                return
+            }
             val nextStep =
                 when (currentState.currentStep) {
                     WizardStep.DEVICE_DISCOVERY -> {
@@ -585,6 +592,7 @@ class RNodeWizardViewModel
                         stopRssiPolling()
                         // Repair preserves the existing radio configuration and only replaces the bond.
                         if (currentState.isPairingRepairMode) {
+                            _state.update { it.copy(skippedRegionSelection = true) }
                             WizardStep.REVIEW_CONFIGURE
                         } else if (currentState.hasPendingParams) {
                             _state.update { it.copy(skippedRegionSelection = true) }
@@ -641,7 +649,9 @@ class RNodeWizardViewModel
                     WizardStep.MODEM_PRESET -> WizardStep.REGION_SELECTION
                     WizardStep.FREQUENCY_SLOT -> WizardStep.MODEM_PRESET
                     WizardStep.REVIEW_CONFIGURE ->
-                        if (currentState.skippedRegionSelection) {
+                        if (currentState.isPairingRepairMode) {
+                            WizardStep.DEVICE_DISCOVERY
+                        } else if (currentState.skippedRegionSelection) {
                             // Came from discovered interface params: go back to device selection
                             WizardStep.DEVICE_DISCOVERY
                         } else if (currentState.isCustomMode || currentState.selectedPreset != null) {
@@ -667,20 +677,7 @@ class RNodeWizardViewModel
         fun canProceed(): Boolean {
             val state = _state.value
             return when (state.currentStep) {
-                WizardStep.DEVICE_DISCOVERY ->
-                    when (state.connectionType) {
-                        RNodeConnectionType.TCP_WIFI ->
-                            state.tcpHost.isNotBlank()
-                        RNodeConnectionType.BLUETOOTH ->
-                            state.selectedDevice != null ||
-                                (
-                                    state.showManualEntry &&
-                                        state.manualDeviceName.isNotBlank() &&
-                                        state.manualDeviceNameError == null
-                                )
-                        RNodeConnectionType.USB_SERIAL ->
-                            state.selectedUsbDevice != null && state.selectedUsbDevice.hasPermission
-                    }
+                WizardStep.DEVICE_DISCOVERY -> canProceedFromDeviceDiscovery(state)
                 WizardStep.REGION_SELECTION ->
                     state.selectedFrequencyRegion != null || state.isCustomMode || state.selectedPreset != null
                 WizardStep.MODEM_PRESET ->
@@ -695,6 +692,26 @@ class RNodeWizardViewModel
                     }
             }
         }
+
+        private fun canProceedFromDeviceDiscovery(state: RNodeWizardState): Boolean =
+            when (state.connectionType) {
+                RNodeConnectionType.TCP_WIFI -> state.tcpHost.isNotBlank()
+                RNodeConnectionType.BLUETOOTH -> canProceedWithBluetooth(state)
+                RNodeConnectionType.USB_SERIAL ->
+                    state.selectedUsbDevice != null && state.selectedUsbDevice.hasPermission
+            }
+
+        private fun canProceedWithBluetooth(state: RNodeWizardState): Boolean =
+            if (state.isPairingRepairMode) {
+                state.selectedDevice?.isPaired == true
+            } else {
+                state.selectedDevice != null ||
+                    (
+                        state.showManualEntry &&
+                            state.manualDeviceName.isNotBlank() &&
+                            state.manualDeviceNameError == null
+                    )
+            }
 
         private fun applyFrequencyRegionSettings() {
             val region = _state.value.selectedFrequencyRegion ?: return

--- a/app/src/main/java/network/columba/app/viewmodel/RNodeWizardViewModel.kt
+++ b/app/src/main/java/network/columba/app/viewmodel/RNodeWizardViewModel.kt
@@ -1340,14 +1340,7 @@ class RNodeWizardViewModel
                 !state.isPairingRepairMode -> true
                 device.name != state.pairingRepairDeviceName -> false
                 expectedAddress != null -> expectedAddress.equals(device.address, ignoreCase = true)
-                else -> {
-                    val matchingAddresses =
-                        state.discoveredDevices
-                            .filter { it.name == state.pairingRepairDeviceName }
-                            .map { it.address.uppercase() }
-                            .distinct()
-                    !state.isScanning && matchingAddresses == listOf(device.address.uppercase())
-                }
+                else -> false
             }
         }
 

--- a/app/src/main/java/network/columba/app/viewmodel/RNodeWizardViewModel.kt
+++ b/app/src/main/java/network/columba/app/viewmodel/RNodeWizardViewModel.kt
@@ -351,6 +351,18 @@ class RNodeWizardViewModel
             interfaceId: Long,
             repairPairing: Boolean = false,
         ) {
+            if (repairPairing) {
+                _state.update {
+                    it.copy(
+                        editingInterfaceId = interfaceId,
+                        isEditMode = true,
+                        isPairingRepairMode = true,
+                        currentStep = WizardStep.DEVICE_DISCOVERY,
+                        selectedDevice = null,
+                        showManualEntry = false,
+                    )
+                }
+            }
             viewModelScope.launch {
                 try {
                     val entity = interfaceRepository.getInterfaceById(interfaceId).first()

--- a/app/src/main/java/network/columba/app/viewmodel/RNodeWizardViewModel.kt
+++ b/app/src/main/java/network/columba/app/viewmodel/RNodeWizardViewModel.kt
@@ -1291,6 +1291,7 @@ class RNodeWizardViewModel
         }
 
         fun selectDevice(device: DiscoveredRNode) {
+            if (!isEligibleRepairDevice(device)) return
             _state.update {
                 it.copy(
                     selectedDevice = device,
@@ -1298,6 +1299,11 @@ class RNodeWizardViewModel
                     interfaceName = it.defaultInterfaceNameFor(device),
                 )
             }
+        }
+
+        private fun isEligibleRepairDevice(device: DiscoveredRNode): Boolean {
+            val state = _state.value
+            return !state.isPairingRepairMode || device.name == state.pairingRepairDeviceName
         }
 
         /**
@@ -1357,6 +1363,7 @@ class RNodeWizardViewModel
             device: DiscoveredRNode,
             onFallback: () -> Unit,
         ) {
+            if (!isEligibleRepairDevice(device)) return
             if (Build.VERSION.SDK_INT < Build.VERSION_CODES.S || companionDeviceManager == null) {
                 // Fall back to direct selection on older Android
                 onFallback()
@@ -3010,6 +3017,7 @@ class RNodeWizardViewModel
         @SuppressLint("MissingPermission")
         @Suppress("LongMethod", "CyclomaticComplexMethod")
         fun initiateBluetoothPairing(device: DiscoveredRNode) {
+            if (!isEligibleRepairDevice(device)) return
             viewModelScope.launch {
                 _state.update {
                     it.copy(

--- a/app/src/main/java/network/columba/app/viewmodel/RNodeWizardViewModel.kt
+++ b/app/src/main/java/network/columba/app/viewmodel/RNodeWizardViewModel.kt
@@ -110,6 +110,7 @@ data class RNodeWizardState(
     val isEditMode: Boolean = false,
     val isPairingRepairMode: Boolean = false,
     val pairingRepairDeviceName: String? = null,
+    val pairingRepairDeviceAddress: String? = null,
     // Transport mode - sends TNC KISS commands instead of saving interface config
     val transportMode: Boolean = false,
     val transportConfiguring: Boolean = false,
@@ -391,6 +392,13 @@ class RNodeWizardViewModel
                     val isTcp = config.connectionMode == "tcp"
                     val isBle = config.connectionMode == "ble"
                     val isUsb = config.connectionMode == "usb"
+                    val repairDeviceAddress =
+                        config.targetDeviceAddress
+                            ?: if (repairPairing && !isTcp && !isUsb) {
+                                findUniqueBondedAddress(config.targetDeviceName)
+                            } else {
+                                null
+                            }
 
                     // Determine connection type
                     val connectionType =
@@ -427,6 +435,7 @@ class RNodeWizardViewModel
                             isEditMode = true,
                             isPairingRepairMode = repairPairing,
                             pairingRepairDeviceName = config.targetDeviceName.takeIf { repairPairing },
+                            pairingRepairDeviceAddress = repairDeviceAddress.takeIf { repairPairing },
                             // Editing skips to review. Pairing repair must begin at device discovery.
                             currentStep =
                                 if (repairPairing) {
@@ -719,17 +728,18 @@ class RNodeWizardViewModel
                     state.selectedUsbDevice != null && state.selectedUsbDevice.hasPermission
             }
 
-        private fun canProceedWithBluetooth(state: RNodeWizardState): Boolean =
+        private fun canProceedWithBluetooth(state: RNodeWizardState): Boolean {
             if (state.isPairingRepairMode) {
-                !state.isPairingInProgress && state.selectedDevice?.isPaired == true
-            } else {
-                state.selectedDevice != null ||
-                    (
-                        state.showManualEntry &&
-                            state.manualDeviceName.isNotBlank() &&
-                            state.manualDeviceNameError == null
-                    )
+                val device = state.selectedDevice
+                return !state.isPairingInProgress && device?.isPaired == true && hasCurrentAndroidBond(device)
             }
+            return state.selectedDevice != null ||
+                (
+                    state.showManualEntry &&
+                        state.manualDeviceName.isNotBlank() &&
+                        state.manualDeviceNameError == null
+                )
+        }
 
         private fun applyFrequencyRegionSettings() {
             val region = _state.value.selectedFrequencyRegion ?: return
@@ -1312,14 +1322,69 @@ class RNodeWizardViewModel
                     selectedDevice = device,
                     showManualEntry = false,
                     interfaceName = it.interfaceNameAfterSelecting(device),
+                    pairingRepairDeviceAddress =
+                        if (it.isPairingRepairMode) {
+                            it.pairingRepairDeviceAddress ?: device.address
+                        } else {
+                            it.pairingRepairDeviceAddress
+                        },
                 )
             }
         }
 
         private fun isEligibleRepairDevice(device: DiscoveredRNode): Boolean {
             val state = _state.value
-            return !state.isPairingRepairMode || device.name == state.pairingRepairDeviceName
+            val expectedAddress = state.pairingRepairDeviceAddress
+            return when {
+                !state.isPairingRepairMode -> true
+                device.name != state.pairingRepairDeviceName -> false
+                expectedAddress != null -> expectedAddress.equals(device.address, ignoreCase = true)
+                else -> {
+                    val matchingAddresses =
+                        state.discoveredDevices
+                            .filter { it.name == state.pairingRepairDeviceName }
+                            .map { it.address.uppercase() }
+                            .distinct()
+                    matchingAddresses.isEmpty() || matchingAddresses == listOf(device.address.uppercase())
+                }
+            }
         }
+
+        private fun lockRepairDeviceAddress(device: DiscoveredRNode) {
+            _state.update {
+                if (it.isPairingRepairMode && it.pairingRepairDeviceAddress == null) {
+                    it.copy(pairingRepairDeviceAddress = device.address)
+                } else {
+                    it
+                }
+            }
+        }
+
+        @SuppressLint("MissingPermission")
+        private fun findUniqueBondedAddress(deviceName: String): String? =
+            try {
+                bluetoothAdapter
+                    ?.bondedDevices
+                    ?.filter { it.name == deviceName }
+                    ?.map { it.address }
+                    ?.distinct()
+                    ?.singleOrNull()
+            } catch (e: SecurityException) {
+                Log.w(TAG, "Unable to read bonded devices while loading repair identity", e)
+                null
+            }
+
+        @SuppressLint("MissingPermission")
+        private fun hasCurrentAndroidBond(device: DiscoveredRNode): Boolean =
+            try {
+                device.bluetoothDevice?.bondState == BluetoothDevice.BOND_BONDED ||
+                    bluetoothAdapter
+                        ?.bondedDevices
+                        ?.any { it.address.equals(device.address, ignoreCase = true) } == true
+            } catch (e: SecurityException) {
+                Log.w(TAG, "Unable to verify Android bond for ${device.address}", e)
+                false
+            }
 
         /**
          * Update RSSI for an already-discovered device (throttled to every 3 seconds).
@@ -1379,6 +1444,7 @@ class RNodeWizardViewModel
             onFallback: () -> Unit,
         ) {
             if (!isEligibleRepairDevice(device)) return
+            lockRepairDeviceAddress(device)
             if (Build.VERSION.SDK_INT < Build.VERSION_CODES.S || companionDeviceManager == null) {
                 // Fall back to direct selection on older Android
                 onFallback()
@@ -3041,6 +3107,7 @@ class RNodeWizardViewModel
         @Suppress("LongMethod", "CyclomaticComplexMethod")
         fun initiateBluetoothPairing(device: DiscoveredRNode) {
             if (!isEligibleRepairDevice(device)) return
+            lockRepairDeviceAddress(device)
             viewModelScope.launch {
                 _state.update {
                     it.copy(
@@ -3510,6 +3577,21 @@ class RNodeWizardViewModel
                 try {
                     val state = _state.value
 
+                    if (state.isPairingRepairMode) {
+                        val selectedDevice = state.selectedDevice
+                        if (selectedDevice == null || !hasCurrentAndroidBond(selectedDevice)) {
+                            _state.update {
+                                it.copy(
+                                    isSaving = false,
+                                    selectedDevice = selectedDevice?.copy(isPaired = false),
+                                    pairingError = "Android pairing was lost. Pair the configured RNode again.",
+                                    saveError = "Android pairing was lost before the repair could be saved.",
+                                )
+                            }
+                            return@launch
+                        }
+                    }
+
                     // Check for duplicate interface names before saving
                     var existingNames = interfaceRepository.allInterfaces.first().map { it.name }
 
@@ -3547,6 +3629,7 @@ class RNodeWizardViewModel
                     val usbDeviceId: Int?
                     val usbVendorId: Int?
                     val usbProductId: Int?
+                    val targetDeviceAddress: String?
 
                     when (state.connectionType) {
                         RNodeConnectionType.TCP_WIFI -> {
@@ -3558,6 +3641,7 @@ class RNodeWizardViewModel
                             usbDeviceId = null
                             usbVendorId = null
                             usbProductId = null
+                            targetDeviceAddress = null
                         }
                         RNodeConnectionType.USB_SERIAL -> {
                             // USB Serial mode
@@ -3568,6 +3652,7 @@ class RNodeWizardViewModel
                             usbDeviceId = state.selectedUsbDevice?.deviceId
                             usbVendorId = state.selectedUsbDevice?.vendorId
                             usbProductId = state.selectedUsbDevice?.productId
+                            targetDeviceAddress = null
                         }
                         RNodeConnectionType.BLUETOOTH -> {
                             // Bluetooth mode
@@ -3594,6 +3679,7 @@ class RNodeWizardViewModel
                             usbDeviceId = null
                             usbVendorId = null
                             usbProductId = null
+                            targetDeviceAddress = state.selectedDevice?.address?.ifBlank { null }
                         }
                     }
 
@@ -3602,6 +3688,7 @@ class RNodeWizardViewModel
                             name = state.interfaceName.trim(),
                             enabled = true,
                             targetDeviceName = deviceName,
+                            targetDeviceAddress = targetDeviceAddress,
                             connectionMode = connectionMode,
                             tcpHost = tcpHost,
                             tcpPort = tcpPort,

--- a/app/src/main/java/network/columba/app/viewmodel/RNodeWizardViewModel.kt
+++ b/app/src/main/java/network/columba/app/viewmodel/RNodeWizardViewModel.kt
@@ -399,6 +399,12 @@ class RNodeWizardViewModel
                             } else {
                                 null
                             }
+                    val shouldPreselectBluetoothDevice =
+                        when {
+                            isTcp || isUsb -> false
+                            repairPairing -> false
+                            else -> !config.targetDeviceAddress.isNullOrBlank()
+                        }
 
                     // Determine connection type
                     val connectionType =
@@ -453,7 +459,7 @@ class RNodeWizardViewModel
                             selectedUsbDevice = usbDevice,
                             // Pre-populate Bluetooth device (for Bluetooth mode)
                             selectedDevice =
-                                if (isTcp || isUsb || repairPairing) {
+                                if (!shouldPreselectBluetoothDevice) {
                                     null
                                 } else {
                                     DiscoveredRNode(
@@ -486,7 +492,7 @@ class RNodeWizardViewModel
                     }
 
                     // Start RSSI polling for BLE devices (not TCP)
-                    if (isBle && !isTcp) {
+                    if (isBle && shouldPreselectBluetoothDevice) {
                         startRssiPolling()
                     }
 
@@ -1077,11 +1083,12 @@ class RNodeWizardViewModel
 
         /**
          * Update selected device from scan results.
-         * Handles edit mode where device was loaded from config without RSSI/address.
+         * Handles edit mode where an exact device address was loaded without RSSI.
          */
         private fun updateSelectedFromScan(devices: Collection<DiscoveredRNode>): DiscoveredRNode? {
             val currentSelected = _state.value.selectedDevice ?: return null
-            return devices.find { it.name == currentSelected.name }?.also { foundDevice ->
+            if (currentSelected.address.isBlank()) return currentSelected
+            return devices.find { it.address.equals(currentSelected.address, ignoreCase = true) }?.also { foundDevice ->
                 Log.d(TAG, "Updating selected device from scan: rssi=${foundDevice.rssi}")
             } ?: currentSelected
         }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -204,6 +204,7 @@
     <string name="rnode_pairing_repair_explanation">Android’s saved pairing for %1$s is missing or was rejected by the RNode.</string>
     <string name="rnode_pairing_repair_pairing_mode">Hold USR for five seconds to enter pairing mode.</string>
     <string name="rnode_pairing_repair_select_device">Then select the RNode below and complete Android’s pairing prompt.</string>
+    <string name="rnode_pairing_repair_identity_unavailable">This interface has no saved Bluetooth identity. Open Edit, select the original RNode, and save once before using Repair.</string>
 
     <!-- Precise location permission prompt (issue #855) -->
     <string name="enable_precise_location">Enable Precise Location</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -202,7 +202,7 @@
     <string name="repair_rnode_pairing">Repair</string>
     <string name="rnode_paired_in_android">Paired in Android</string>
     <string name="rnode_pairing_repair_explanation">Android’s saved pairing for %1$s is missing or was rejected by the RNode.</string>
-    <string name="rnode_pairing_repair_heltec_v3">If this is a Heltec V3, hold USR for five seconds to enter pairing mode.</string>
+    <string name="rnode_pairing_repair_pairing_mode">Hold USR for five seconds to enter pairing mode.</string>
     <string name="rnode_pairing_repair_select_device">Then select the RNode below and complete Android’s pairing prompt.</string>
 
     <!-- Precise location permission prompt (issue #855) -->

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -198,6 +198,9 @@
     <string name="view_interface_details">View interface details</string>
     <string name="interface_actions">Interface actions</string>
     <string name="edit_interface">Edit interface</string>
+    <string name="rnode_pairing_required">Pairing required</string>
+    <string name="repair_rnode_pairing">Repair</string>
+    <string name="rnode_paired_in_android">Paired in Android</string>
 
     <!-- Precise location permission prompt (issue #855) -->
     <string name="enable_precise_location">Enable Precise Location</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -201,6 +201,9 @@
     <string name="rnode_pairing_required">Pairing required</string>
     <string name="repair_rnode_pairing">Repair</string>
     <string name="rnode_paired_in_android">Paired in Android</string>
+    <string name="rnode_pairing_repair_explanation">Android’s saved pairing for %1$s is missing or was rejected by the RNode.</string>
+    <string name="rnode_pairing_repair_heltec_v3">If this is a Heltec V3, hold USR for five seconds to enter pairing mode.</string>
+    <string name="rnode_pairing_repair_select_device">Then select the RNode below and complete Android’s pairing prompt.</string>
 
     <!-- Precise location permission prompt (issue #855) -->
     <string name="enable_precise_location">Enable Precise Location</string>

--- a/app/src/test/java/network/columba/app/repository/InterfaceRepositoryTest.kt
+++ b/app/src/test/java/network/columba/app/repository/InterfaceRepositoryTest.kt
@@ -1150,7 +1150,12 @@ class InterfaceRepositoryTest {
                     InterfaceConfig.TCPServer(name = "tcps"),
                     InterfaceConfig.UDP(name = "udp"),
                     InterfaceConfig.AndroidBLE(name = "ble"),
-                    InterfaceConfig.RNode(name = "rnode", targetDeviceName = "RNode 1234", connectionMode = "classic"),
+                    InterfaceConfig.RNode(
+                        name = "rnode",
+                        targetDeviceName = "RNode 1234",
+                        targetDeviceAddress = "AA:BB:CC:DD:EE:FF",
+                        connectionMode = "classic",
+                    ),
                 )
 
             samples.forEachIndexed { idx, source ->
@@ -1205,6 +1210,12 @@ class InterfaceRepositoryTest {
                         source::class,
                         parsed.single()::class,
                     )
+                    if (source is InterfaceConfig.RNode) {
+                        assertEquals(
+                            source.targetDeviceAddress,
+                            (parsed.single() as InterfaceConfig.RNode).targetDeviceAddress,
+                        )
+                    }
                     cancelAndIgnoreRemainingEvents()
                 }
             }

--- a/app/src/test/java/network/columba/app/ui/screens/InterfaceManagementScreenTest.kt
+++ b/app/src/test/java/network/columba/app/ui/screens/InterfaceManagementScreenTest.kt
@@ -62,9 +62,34 @@ class InterfaceManagementScreenTest {
     }
 
     @Test
-    fun `pending restart suppresses stale runtime pairing reason`() {
-        assertEquals(null, effectiveRuntimeStatusReason("pairing_required", hasPendingChanges = true))
-        assertEquals("pairing_required", effectiveRuntimeStatusReason("pairing_required", hasPendingChanges = false))
+    fun `pending restart suppresses stale runtime pairing reason only for changed interface`() {
+        assertEquals(
+            null,
+            effectiveRuntimeStatusReason(
+                statusReason = "pairing_required",
+                interfaceId = 42,
+                hasPendingChanges = true,
+                pendingInterfaceIds = setOf(42),
+            ),
+        )
+        assertEquals(
+            "pairing_required",
+            effectiveRuntimeStatusReason(
+                statusReason = "pairing_required",
+                interfaceId = 42,
+                hasPendingChanges = true,
+                pendingInterfaceIds = setOf(99),
+            ),
+        )
+        assertEquals(
+            "pairing_required",
+            effectiveRuntimeStatusReason(
+                statusReason = "pairing_required",
+                interfaceId = 42,
+                hasPendingChanges = false,
+                pendingInterfaceIds = setOf(42),
+            ),
+        )
     }
 
     // ========== formatAddressWithPort Tests ==========

--- a/app/src/test/java/network/columba/app/ui/screens/InterfaceManagementScreenTest.kt
+++ b/app/src/test/java/network/columba/app/ui/screens/InterfaceManagementScreenTest.kt
@@ -61,6 +61,12 @@ class InterfaceManagementScreenTest {
         assertTrue(repairRequested)
     }
 
+    @Test
+    fun `pending restart suppresses stale runtime pairing reason`() {
+        assertEquals(null, effectiveRuntimeStatusReason("pairing_required", hasPendingChanges = true))
+        assertEquals("pairing_required", effectiveRuntimeStatusReason("pairing_required", hasPendingChanges = false))
+    }
+
     // ========== formatAddressWithPort Tests ==========
 
     @Test

--- a/app/src/test/java/network/columba/app/ui/screens/InterfaceManagementScreenTest.kt
+++ b/app/src/test/java/network/columba/app/ui/screens/InterfaceManagementScreenTest.kt
@@ -1,11 +1,15 @@
 package network.columba.app.ui.screens
 
 import android.app.Application
+import android.bluetooth.BluetoothAdapter
+import androidx.compose.material3.MaterialTheme
 import androidx.compose.ui.test.assertIsDisplayed
 import androidx.compose.ui.test.junit4.createComposeRule
 import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.performClick
 import network.columba.app.test.RegisterComponentActivityRule
+import network.columba.app.data.database.entity.InterfaceEntity
+import network.columba.app.rns.host.manager.CurrentTransport
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertTrue
 import org.junit.Rule
@@ -25,6 +29,37 @@ class InterfaceManagementScreenTest {
     val ruleChain: RuleChain = RuleChain.outerRule(registerActivityRule).around(composeRule)
 
     val composeTestRule get() = composeRule
+
+    @Test
+    fun `RNode card exposes repair action when pairing is required`() {
+        var repairRequested = false
+        val rnode =
+            InterfaceEntity(
+                id = 42,
+                name = "RNode E517 BLE",
+                type = "RNode",
+                configJson = """{"connection_mode":"ble","target_device_name":"RNode E517"}""",
+            )
+
+        composeTestRule.setContent {
+            MaterialTheme {
+                InterfaceCard(
+                    interfaceEntity = rnode,
+                    onToggle = {},
+                    bluetoothState = BluetoothAdapter.STATE_ON,
+                    blePermissionsGranted = true,
+                    currentTransport = CurrentTransport.WIFI_LIKE,
+                    isOnline = false,
+                    statusReason = "pairing_required",
+                    onRepairPairing = { repairRequested = true },
+                )
+            }
+        }
+
+        composeTestRule.onNodeWithText("Pairing required").assertIsDisplayed()
+        composeTestRule.onNodeWithText("Repair").performClick()
+        assertTrue(repairRequested)
+    }
 
     // ========== formatAddressWithPort Tests ==========
 

--- a/app/src/test/java/network/columba/app/ui/screens/rnode/DeviceDiscoveryStepTest.kt
+++ b/app/src/test/java/network/columba/app/ui/screens/rnode/DeviceDiscoveryStepTest.kt
@@ -136,7 +136,8 @@ class DeviceDiscoveryStepTest {
 
         composeTestRule.onNodeWithText("Pairing required").assertIsDisplayed()
         composeTestRule.onNodeWithText("RNode E517", substring = true).assertIsDisplayed()
-        composeTestRule.onNodeWithText("hold USR for five seconds", substring = true).assertIsDisplayed()
+        composeTestRule.onNodeWithText("Hold USR for five seconds to enter pairing mode.").assertIsDisplayed()
+        composeTestRule.onNodeWithText("Heltec V3", substring = true).assertDoesNotExist()
         composeTestRule.onNodeWithText("Current Device").assertDoesNotExist()
     }
 

--- a/app/src/test/java/network/columba/app/ui/screens/rnode/DeviceDiscoveryStepTest.kt
+++ b/app/src/test/java/network/columba/app/ui/screens/rnode/DeviceDiscoveryStepTest.kt
@@ -142,6 +142,37 @@ class DeviceDiscoveryStepTest {
     }
 
     @Test
+    fun pairingRepair_showsOnlyConfiguredRNode() {
+        val configuredDevice =
+            pairedBleDevice.copy(
+                name = "RNode E517",
+                address = "AA:BB:CC:DD:EE:51",
+            )
+        val otherDevice =
+            pairedBleDevice.copy(
+                name = "RNode OTHER",
+                address = "AA:BB:CC:DD:EE:00",
+            )
+        val mockViewModel = mockk<RNodeWizardViewModel>()
+        every { mockViewModel.state } returns
+            MutableStateFlow(
+                RNodeWizardState(
+                    isEditMode = true,
+                    isPairingRepairMode = true,
+                    pairingRepairDeviceName = "RNode E517",
+                    discoveredDevices = listOf(otherDevice, configuredDevice),
+                ),
+            )
+
+        composeTestRule.setContent {
+            DeviceDiscoveryStep(viewModel = mockViewModel)
+        }
+
+        composeTestRule.onNodeWithText("RNode E517").assertIsDisplayed()
+        composeTestRule.onNodeWithText("RNode OTHER").assertDoesNotExist()
+    }
+
+    @Test
     fun pairingRepair_afterSuccessfulBond_hidesRecoveryInstructions() {
         val pairedDevice =
             pairedBleDevice.copy(

--- a/app/src/test/java/network/columba/app/ui/screens/rnode/DeviceDiscoveryStepTest.kt
+++ b/app/src/test/java/network/columba/app/ui/screens/rnode/DeviceDiscoveryStepTest.kt
@@ -126,6 +126,7 @@ class DeviceDiscoveryStepTest {
                     isEditMode = true,
                     isPairingRepairMode = true,
                     pairingRepairDeviceName = "RNode E517",
+                    pairingRepairDeviceAddress = "AA:BB:CC:DD:EE:51",
                     selectedDevice = null,
                 ),
             )
@@ -147,6 +148,37 @@ class DeviceDiscoveryStepTest {
     }
 
     @Test
+    fun pairingRepair_withoutSavedIdentity_failsClosed() {
+        val sameNameDevice =
+            pairedBleDevice.copy(
+                name = "RNode E517",
+                address = "AA:BB:CC:DD:EE:99",
+            )
+        val mockViewModel = mockk<RNodeWizardViewModel>()
+        every { mockViewModel.state } returns
+            MutableStateFlow(
+                RNodeWizardState(
+                    isEditMode = true,
+                    isPairingRepairMode = true,
+                    pairingRepairDeviceName = "RNode E517",
+                    discoveredDevices = listOf(sameNameDevice),
+                ),
+            )
+
+        composeTestRule.setContent {
+            DeviceDiscoveryStep(viewModel = mockViewModel)
+        }
+
+        composeTestRule
+            .onNodeWithText(
+                "This interface has no saved Bluetooth identity. " +
+                    "Open Edit, select the original RNode, and save once before using Repair.",
+            ).assertIsDisplayed()
+        composeTestRule.onNodeWithText("Hold USR for five seconds to enter pairing mode.").assertDoesNotExist()
+        composeTestRule.onNodeWithText("RNode E517").assertDoesNotExist()
+    }
+
+    @Test
     fun pairingRepair_showsOnlyConfiguredRNode() {
         val configuredDevice =
             pairedBleDevice.copy(
@@ -165,6 +197,7 @@ class DeviceDiscoveryStepTest {
                     isEditMode = true,
                     isPairingRepairMode = true,
                     pairingRepairDeviceName = "RNode E517",
+                    pairingRepairDeviceAddress = configuredDevice.address,
                     discoveredDevices = listOf(otherDevice, configuredDevice),
                 ),
             )
@@ -191,6 +224,7 @@ class DeviceDiscoveryStepTest {
                     isEditMode = true,
                     isPairingRepairMode = true,
                     pairingRepairDeviceName = "RNode E517",
+                    pairingRepairDeviceAddress = pairedDevice.address,
                     discoveredDevices = listOf(pairedDevice),
                     selectedDevice = pairedDevice,
                 ),

--- a/app/src/test/java/network/columba/app/ui/screens/rnode/DeviceDiscoveryStepTest.kt
+++ b/app/src/test/java/network/columba/app/ui/screens/rnode/DeviceDiscoveryStepTest.kt
@@ -142,6 +142,34 @@ class DeviceDiscoveryStepTest {
     }
 
     @Test
+    fun pairingRepair_afterSuccessfulBond_hidesRecoveryInstructions() {
+        val pairedDevice =
+            pairedBleDevice.copy(
+                name = "RNode E517",
+                address = "AA:BB:CC:DD:EE:51",
+            )
+        val mockViewModel = mockk<RNodeWizardViewModel>()
+        every { mockViewModel.state } returns
+            MutableStateFlow(
+                RNodeWizardState(
+                    isEditMode = true,
+                    isPairingRepairMode = true,
+                    pairingRepairDeviceName = "RNode E517",
+                    discoveredDevices = listOf(pairedDevice),
+                    selectedDevice = pairedDevice,
+                ),
+            )
+
+        composeTestRule.setContent {
+            DeviceDiscoveryStep(viewModel = mockViewModel)
+        }
+
+        composeTestRule.onNodeWithText("Pairing required").assertDoesNotExist()
+        composeTestRule.onNodeWithText("Hold USR for five seconds to enter pairing mode.").assertDoesNotExist()
+        composeTestRule.onNodeWithText("Paired in Android").assertIsDisplayed()
+    }
+
+    @Test
     fun pairedDevice_cardClick_selectsDevice() {
         // Given
         val mockViewModel = mockk<RNodeWizardViewModel>()

--- a/app/src/test/java/network/columba/app/ui/screens/rnode/DeviceDiscoveryStepTest.kt
+++ b/app/src/test/java/network/columba/app/ui/screens/rnode/DeviceDiscoveryStepTest.kt
@@ -139,6 +139,9 @@ class DeviceDiscoveryStepTest {
         composeTestRule.onNodeWithText("Hold USR for five seconds to enter pairing mode.").assertIsDisplayed()
         composeTestRule.onNodeWithText("Heltec V3", substring = true).assertDoesNotExist()
         composeTestRule.onNodeWithText("Current Device").assertDoesNotExist()
+        composeTestRule.onRoot().performTouchInput { swipeUp() }
+        composeTestRule.waitForIdle()
+        composeTestRule.onNodeWithText("Pair via USB").assertDoesNotExist()
     }
 
     @Test

--- a/app/src/test/java/network/columba/app/ui/screens/rnode/DeviceDiscoveryStepTest.kt
+++ b/app/src/test/java/network/columba/app/ui/screens/rnode/DeviceDiscoveryStepTest.kt
@@ -851,15 +851,20 @@ class DeviceDiscoveryStepTest {
     }
 
     @Test
-    fun editMode_allowsSelectingDifferentDevice() {
+    fun editMode_allowsSelectingDifferentAddressWithSameName() {
         // Given
         val mockViewModel = mockk<RNodeWizardViewModel>()
+        val sameNameOther =
+            pairedBleDevice.copy(
+                address = "AA:BB:CC:DD:EE:99",
+                isPaired = false,
+            )
         val state =
             RNodeWizardState(
                 connectionType = RNodeConnectionType.BLUETOOTH,
                 isEditMode = true,
                 selectedDevice = pairedBleDevice,
-                discoveredDevices = listOf(unpairedBleDevice, pairedBleDevice),
+                discoveredDevices = listOf(sameNameOther, pairedBleDevice),
             )
         every { mockViewModel.state } returns MutableStateFlow(state)
 
@@ -868,9 +873,8 @@ class DeviceDiscoveryStepTest {
             DeviceDiscoveryStep(viewModel = mockViewModel)
         }
 
-        // Then - other devices should be visible in the list
-        composeTestRule.onNodeWithText("RNode 1234").assertIsDisplayed()
-        // The current device (RNode 5678) should not be in the list below, only in "Current Device" section
+        // Then - the current card and explicit same-name alternative are both visible.
+        composeTestRule.onAllNodesWithText("RNode 5678").assertCountEquals(2)
     }
 
     // ========== USB Bluetooth Pairing Mode Tests ==========

--- a/app/src/test/java/network/columba/app/ui/screens/rnode/DeviceDiscoveryStepTest.kt
+++ b/app/src/test/java/network/columba/app/ui/screens/rnode/DeviceDiscoveryStepTest.kt
@@ -139,8 +139,10 @@ class DeviceDiscoveryStepTest {
         composeTestRule.onNodeWithText("Hold USR for five seconds to enter pairing mode.").assertIsDisplayed()
         composeTestRule.onNodeWithText("Heltec V3", substring = true).assertDoesNotExist()
         composeTestRule.onNodeWithText("Current Device").assertDoesNotExist()
+        composeTestRule.onNodeWithText("Connection Method").assertDoesNotExist()
         composeTestRule.onRoot().performTouchInput { swipeUp() }
         composeTestRule.waitForIdle()
+        composeTestRule.onNodeWithText("Enter device manually").assertDoesNotExist()
         composeTestRule.onNodeWithText("Pair via USB").assertDoesNotExist()
     }
 

--- a/app/src/test/java/network/columba/app/ui/screens/rnode/DeviceDiscoveryStepTest.kt
+++ b/app/src/test/java/network/columba/app/ui/screens/rnode/DeviceDiscoveryStepTest.kt
@@ -98,6 +98,26 @@ class DeviceDiscoveryStepTest {
     }
 
     @Test
+    fun pairedDevice_showsAndroidScopedBondLabel() {
+        val mockViewModel = mockk<RNodeWizardViewModel>()
+        every { mockViewModel.state } returns
+            MutableStateFlow(
+                RNodeWizardState(
+                    discoveredDevices = listOf(pairedBleDevice),
+                    isPairingInProgress = false,
+                    isAssociating = false,
+                ),
+            )
+
+        composeTestRule.setContent {
+            DeviceDiscoveryStep(viewModel = mockViewModel)
+        }
+
+        composeTestRule.onNodeWithText("Paired in Android").assertIsDisplayed()
+        composeTestRule.onNodeWithText("Paired").assertDoesNotExist()
+    }
+
+    @Test
     fun pairedDevice_cardClick_selectsDevice() {
         // Given
         val mockViewModel = mockk<RNodeWizardViewModel>()

--- a/app/src/test/java/network/columba/app/ui/screens/rnode/DeviceDiscoveryStepTest.kt
+++ b/app/src/test/java/network/columba/app/ui/screens/rnode/DeviceDiscoveryStepTest.kt
@@ -118,6 +118,29 @@ class DeviceDiscoveryStepTest {
     }
 
     @Test
+    fun pairingRepair_showsRecoveryInstructions_insteadOfCurrentDevice() {
+        val mockViewModel = mockk<RNodeWizardViewModel>()
+        every { mockViewModel.state } returns
+            MutableStateFlow(
+                RNodeWizardState(
+                    isEditMode = true,
+                    isPairingRepairMode = true,
+                    pairingRepairDeviceName = "RNode E517",
+                    selectedDevice = null,
+                ),
+            )
+
+        composeTestRule.setContent {
+            DeviceDiscoveryStep(viewModel = mockViewModel)
+        }
+
+        composeTestRule.onNodeWithText("Pairing required").assertIsDisplayed()
+        composeTestRule.onNodeWithText("RNode E517", substring = true).assertIsDisplayed()
+        composeTestRule.onNodeWithText("hold USR for five seconds", substring = true).assertIsDisplayed()
+        composeTestRule.onNodeWithText("Current Device").assertDoesNotExist()
+    }
+
+    @Test
     fun pairedDevice_cardClick_selectsDevice() {
         // Given
         val mockViewModel = mockk<RNodeWizardViewModel>()

--- a/app/src/test/java/network/columba/app/ui/screens/rnode/RNodeWizardCompletionTest.kt
+++ b/app/src/test/java/network/columba/app/ui/screens/rnode/RNodeWizardCompletionTest.kt
@@ -36,7 +36,7 @@ class RNodeWizardCompletionTest {
     @Test
     fun repairModePendingConfig_doesNotExposeOrdinaryWizard() {
         val viewModel = mockk<RNodeWizardViewModel>(relaxed = true)
-        every { viewModel.state } returns MutableStateFlow(RNodeWizardState())
+        every { viewModel.state } returns MutableStateFlow(RNodeWizardState(isPairingRepairMode = true))
 
         composeRule.setContent {
             RNodeWizardScreen(

--- a/app/src/test/java/network/columba/app/ui/screens/rnode/RNodeWizardCompletionTest.kt
+++ b/app/src/test/java/network/columba/app/ui/screens/rnode/RNodeWizardCompletionTest.kt
@@ -4,8 +4,8 @@ import android.app.Application
 import androidx.activity.OnBackPressedDispatcher
 import androidx.activity.compose.LocalOnBackPressedDispatcherOwner
 import androidx.compose.ui.test.junit4.createComposeRule
-import androidx.compose.ui.test.onNodeWithContentDescription
-import androidx.compose.ui.test.performClick
+import androidx.compose.ui.test.*
+
 import network.columba.app.test.RegisterComponentActivityRule
 import network.columba.app.viewmodel.RNodeWizardState
 import network.columba.app.viewmodel.RNodeWizardViewModel
@@ -32,6 +32,28 @@ class RNodeWizardCompletionTest {
 
     @get:Rule
     val ruleChain: RuleChain = RuleChain.outerRule(registerActivityRule).around(composeRule)
+
+    @Test
+    fun repairModePendingConfig_doesNotExposeOrdinaryWizard() {
+        val viewModel = mockk<RNodeWizardViewModel>(relaxed = true)
+        every { viewModel.state } returns MutableStateFlow(RNodeWizardState())
+
+        composeRule.setContent {
+            RNodeWizardScreen(
+                editingInterfaceId = 3L,
+                repairPairing = true,
+                onNavigateBack = {},
+                onComplete = {},
+                viewModel = viewModel,
+            )
+        }
+        composeRule.waitForIdle()
+
+        composeRule.onNodeWithText("Repair RNode Pairing").assertIsDisplayed()
+        composeRule.onNodeWithText("Select RNode Device").assertDoesNotExist()
+        composeRule.onNodeWithText("Pair via USB").assertDoesNotExist()
+        verify(exactly = 1) { viewModel.loadExistingConfig(3L, repairPairing = true) }
+    }
 
     @Test
     fun saveSuccess_isConsumedBeforeCompletionNavigation() {

--- a/app/src/test/java/network/columba/app/viewmodel/InterfaceManagementViewModelNetworkRestrictionTest.kt
+++ b/app/src/test/java/network/columba/app/viewmodel/InterfaceManagementViewModelNetworkRestrictionTest.kt
@@ -31,6 +31,7 @@ import network.columba.app.rns.api.model.InterfaceConfig
 import network.columba.app.rns.api.model.NetworkRestriction
 import network.columba.app.rns.host.manager.CurrentTransport
 import network.columba.app.service.InterfaceConfigManager
+import network.columba.app.service.PendingInterfaceChanges
 import network.columba.app.service.manager.InterfaceTransportObserver
 import org.junit.After
 import org.junit.Assert.assertEquals
@@ -66,7 +67,7 @@ class InterfaceManagementViewModelNetworkRestrictionTest {
         every { interfaceRepository.enabledInterfaces } returns flowOf(emptyList())
 
         configManager = mockk()
-        every { configManager.checkAndClearPendingChanges() } returns false
+        every { configManager.consumePendingChanges() } returns PendingInterfaceChanges()
 
         bleStatusRepository = mockk()
         every { bleStatusRepository.getConnectedPeersFlow() } returns

--- a/app/src/test/java/network/columba/app/viewmodel/InterfaceManagementViewModelStatusEventTest.kt
+++ b/app/src/test/java/network/columba/app/viewmodel/InterfaceManagementViewModelStatusEventTest.kt
@@ -15,6 +15,7 @@ import network.columba.app.rns.api.model.InterfaceConfig
 import network.columba.app.rns.api.RnsBackend
 import network.columba.app.rns.api.RnsTransportAdmin
 import network.columba.app.service.InterfaceConfigManager
+import network.columba.app.service.PendingInterfaceChanges
 import io.mockk.clearAllMocks
 import io.mockk.coEvery
 import io.mockk.every
@@ -111,7 +112,7 @@ class InterfaceManagementViewModelStatusEventTest {
             flowOf(BleConnectionsState.Success(emptyList()))
 
         // Mock InterfaceConfigManager
-        every { configManager.checkAndClearPendingChanges() } returns false
+        every { configManager.consumePendingChanges() } returns PendingInterfaceChanges()
 
         // Mock event flows for NativeReticulumProtocol (event-driven updates)
         interfaceStatusFlow = MutableSharedFlow(replay = 1, extraBufferCapacity = 1)
@@ -167,7 +168,11 @@ class InterfaceManagementViewModelStatusEventTest {
     @Test
     fun `refreshExternalPendingChanges surfaces wizard changes on Python backend`() =
         runTest {
-            every { configManager.checkAndClearPendingChanges() } returnsMany listOf(false, true)
+            every { configManager.consumePendingChanges() } returnsMany
+                listOf(
+                    PendingInterfaceChanges(),
+                    PendingInterfaceChanges(hasPendingChanges = true, interfaceIds = setOf(42)),
+                )
             every { rnsBackend.capabilities } returns
                 MutableStateFlow(
                     BackendCapabilities.UNKNOWN.copy(
@@ -189,7 +194,8 @@ class InterfaceManagementViewModelStatusEventTest {
             viewModel.refreshExternalPendingChanges()
 
             assertTrue(viewModel.state.value.hasPendingChanges)
-            verify(exactly = 2) { configManager.checkAndClearPendingChanges() }
+            assertEquals(setOf(42L), viewModel.state.value.pendingInterfaceIds)
+            verify(exactly = 2) { configManager.consumePendingChanges() }
         }
 
     @Test

--- a/app/src/test/java/network/columba/app/viewmodel/InterfaceManagementViewModelStatusEventTest.kt
+++ b/app/src/test/java/network/columba/app/viewmodel/InterfaceManagementViewModelStatusEventTest.kt
@@ -35,6 +35,7 @@ import kotlinx.coroutines.test.runTest
 import kotlinx.coroutines.test.setMain
 import org.junit.After
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
 import org.junit.Assert.assertNotNull
 import org.junit.Assert.assertTrue
 import org.junit.Before
@@ -161,6 +162,34 @@ class InterfaceManagementViewModelStatusEventTest {
 
             assertNotNull(viewModel)
             assertNotNull(viewModel.state.value)
+        }
+
+    @Test
+    fun `refreshExternalPendingChanges surfaces wizard changes on Python backend`() =
+        runTest {
+            every { configManager.checkAndClearPendingChanges() } returnsMany listOf(false, true)
+            every { rnsBackend.capabilities } returns
+                MutableStateFlow(
+                    BackendCapabilities.UNKNOWN.copy(
+                        interfaces = BackendCapabilities.InterfaceCaps(hotReloadInterfaces = false),
+                    ),
+                )
+            viewModel =
+                InterfaceManagementViewModel(
+                    interfaceRepository,
+                    configManager,
+                    bleStatusRepository,
+                    serviceProtocol,
+                    transportObserver,
+                    rnsBackend,
+                )
+            advanceUntilIdle()
+            assertFalse(viewModel.state.value.hasPendingChanges)
+
+            viewModel.refreshExternalPendingChanges()
+
+            assertTrue(viewModel.state.value.hasPendingChanges)
+            verify(exactly = 2) { configManager.checkAndClearPendingChanges() }
         }
 
     @Test

--- a/app/src/test/java/network/columba/app/viewmodel/InterfaceManagementViewModelStatusEventTest.kt
+++ b/app/src/test/java/network/columba/app/viewmodel/InterfaceManagementViewModelStatusEventTest.kt
@@ -207,6 +207,31 @@ class InterfaceManagementViewModelStatusEventTest {
         }
 
     @Test
+    fun `debug info exposes pairing required reason for an RNode`() =
+        runTest {
+            viewModel =
+                InterfaceManagementViewModel(
+                    interfaceRepository,
+                    configManager,
+                    bleStatusRepository,
+                    serviceProtocol,
+                    transportObserver,
+                    rnsBackend,
+                )
+            advanceUntilIdle()
+
+            debugInfoFlow.emit(
+                """{"interfaces":[{"name":"RNode E517 BLE","type":"RNode","online":false,"status_reason":"pairing_required"}]}""",
+            )
+            advanceUntilIdle()
+
+            assertEquals(
+                "pairing_required",
+                viewModel.state.value.transportInterfaces.single().statusReason,
+            )
+        }
+
+    @Test
     fun `replayed RNode status delta updates reconnect state without clearing siblings`() =
         runTest {
             coEvery { serviceProtocol.getInterfaceStats("Test RNode") } returns

--- a/app/src/test/java/network/columba/app/viewmodel/RNodeWizardViewModelTest.kt
+++ b/app/src/test/java/network/columba/app/viewmodel/RNodeWizardViewModelTest.kt
@@ -1673,6 +1673,9 @@ class RNodeWizardViewModelTest {
             assertEquals(WizardStep.DEVICE_DISCOVERY, repairState.currentStep)
             assertNull(repairState.selectedDevice)
 
+            viewModel.setConnectionType(RNodeConnectionType.USB_SERIAL)
+            viewModel.showManualEntry()
+            viewModel.preselectUsbDevice(1, 2, 3, "Other RNode")
             viewModel.startUsbAssistedPairing()
             runCurrent()
             assertEquals(repairState, viewModel.state.value)

--- a/app/src/test/java/network/columba/app/viewmodel/RNodeWizardViewModelTest.kt
+++ b/app/src/test/java/network/columba/app/viewmodel/RNodeWizardViewModelTest.kt
@@ -1671,6 +1671,37 @@ class RNodeWizardViewModelTest {
         }
 
     @Test
+    fun `ordinary edit legacy RNode requires explicit device selection`() =
+        runViewModelTest {
+            val interfaceId = 22L
+            val entity = InterfaceEntity(interfaceId, "Legacy RNode", "RNode", true, "{}")
+            val config =
+                InterfaceConfig.RNode(
+                    name = "Legacy RNode",
+                    targetDeviceName = "RNode SAME",
+                    connectionMode = "ble",
+                )
+            coEvery { interfaceRepository.getInterfaceById(interfaceId) } returns flowOf(entity)
+            coEvery { interfaceRepository.entityToConfig(entity) } returns config
+
+            viewModel.loadExistingConfig(interfaceId)
+            advanceUntilIdle()
+
+            assertNull(viewModel.state.value.selectedDevice)
+            val explicitlySelected =
+                DiscoveredRNode(
+                    name = "RNode SAME",
+                    address = "AA:BB:CC:DD:EE:22",
+                    type = BluetoothType.BLE,
+                    rssi = -50,
+                    isPaired = false,
+                )
+            viewModel.selectDevice(explicitlySelected)
+
+            assertEquals(explicitlySelected, viewModel.state.value.selectedDevice)
+        }
+
+    @Test
     fun `pairing repair latches before config load`() =
         runViewModelTest {
             val entities = MutableSharedFlow<InterfaceEntity?>()

--- a/app/src/test/java/network/columba/app/viewmodel/RNodeWizardViewModelTest.kt
+++ b/app/src/test/java/network/columba/app/viewmodel/RNodeWizardViewModelTest.kt
@@ -1703,8 +1703,7 @@ class RNodeWizardViewModelTest {
             advanceUntilIdle()
             assertEquals(stateBeforeUsbAttempt, viewModel.state.value)
 
-            val originalFrequency = state.frequency
-            val originalBandwidth = state.bandwidth
+            val (originalFrequency, originalBandwidth) = state.frequency to state.bandwidth
             val unpairedDevice =
                 DiscoveredRNode(
                     name = "RNode E517",

--- a/app/src/test/java/network/columba/app/viewmodel/RNodeWizardViewModelTest.kt
+++ b/app/src/test/java/network/columba/app/viewmodel/RNodeWizardViewModelTest.kt
@@ -1709,6 +1709,15 @@ class RNodeWizardViewModelTest {
                     isPaired = false,
                 )
 
+            viewModel.selectDevice(
+                unpairedDevice.copy(
+                    name = "RNode OTHER",
+                    address = "AA:BB:CC:DD:EE:00",
+                    isPaired = true,
+                ),
+            )
+            assertNull(viewModel.state.value.selectedDevice)
+
             viewModel.selectDevice(unpairedDevice)
             assertFalse(viewModel.canProceed())
             viewModel.goToNextStep()

--- a/app/src/test/java/network/columba/app/viewmodel/RNodeWizardViewModelTest.kt
+++ b/app/src/test/java/network/columba/app/viewmodel/RNodeWizardViewModelTest.kt
@@ -1633,6 +1633,7 @@ class RNodeWizardViewModelTest {
                     enabled = true,
                     connectionMode = "classic", // classic doesn't trigger RSSI polling
                     targetDeviceName = "RNode Classic123",
+                    targetDeviceAddress = "AA:BB:CC:DD:EE:11",
                     tcpHost = null,
                     tcpPort = 7633,
                     frequency = 915000000,
@@ -1655,7 +1656,17 @@ class RNodeWizardViewModelTest {
                 assertEquals(RNodeConnectionType.BLUETOOTH, state.connectionType)
                 assertNotNull(state.selectedDevice)
                 assertEquals("RNode Classic123", state.selectedDevice?.name)
+                assertEquals("AA:BB:CC:DD:EE:11", state.selectedDevice?.address)
                 assertEquals(BluetoothType.CLASSIC, state.selectedDevice?.type)
+            }
+
+            viewModel.saveConfiguration()
+            advanceUntilIdle()
+            coVerify(exactly = 1) {
+                interfaceRepository.updateInterface(
+                    interfaceId,
+                    match { it is InterfaceConfig.RNode && it.targetDeviceAddress == "AA:BB:CC:DD:EE:11" },
+                )
             }
         }
 
@@ -1705,6 +1716,7 @@ class RNodeWizardViewModelTest {
                     enabled = true,
                     connectionMode = "ble",
                     targetDeviceName = "RNode E517",
+                    targetDeviceAddress = "AA:BB:CC:DD:EE:FF",
                     tcpHost = null,
                     tcpPort = 7633,
                     frequency = 915000000,
@@ -1804,9 +1816,22 @@ class RNodeWizardViewModelTest {
                     isEditMode = true,
                     isPairingRepairMode = true,
                     pairingRepairDeviceName = configuredDevice.name,
-                    discoveredDevices = listOf(configuredDevice, otherDevice),
+                    isScanning = true,
+                    discoveredDevices = listOf(configuredDevice),
                 )
 
+            viewModel.selectDevice(configuredDevice)
+            assertNull(viewModel.state.value.selectedDevice)
+            viewModel.initiateBluetoothPairing(configuredDevice)
+            runCurrent()
+            assertNull(viewModel.state.value.pairingRepairDeviceAddress)
+
+            stateFlow.update {
+                it.copy(
+                    isScanning = false,
+                    discoveredDevices = listOf(configuredDevice, otherDevice),
+                )
+            }
             viewModel.selectDevice(configuredDevice)
             assertNull(viewModel.state.value.selectedDevice)
 
@@ -1818,7 +1843,8 @@ class RNodeWizardViewModelTest {
             assertTrue(viewModel.canProceed())
 
             currentBondState = BluetoothDevice.BOND_NONE
-            assertFalse(viewModel.canProceed())
+            viewModel.goToNextStep()
+            assertEquals(WizardStep.DEVICE_DISCOVERY, viewModel.state.value.currentStep)
             viewModel.saveConfiguration()
             advanceUntilIdle()
             assertNotNull(viewModel.state.value.saveError)
@@ -1826,6 +1852,19 @@ class RNodeWizardViewModelTest {
 
             val entity = InterfaceEntity(3L, "RNode LoRa", "RNode", true, "{}")
             coEvery { interfaceRepository.getInterfaceById(3L) } returns flowOf(entity)
+            val pendingNames = MutableSharedFlow<List<InterfaceConfig>>()
+            every { interfaceRepository.allInterfaces } returns pendingNames
+            currentBondState = BluetoothDevice.BOND_BONDED
+            stateFlow.update { it.copy(selectedDevice = configuredDevice, saveError = null) }
+            viewModel.saveConfiguration()
+            runCurrent()
+            currentBondState = BluetoothDevice.BOND_NONE
+            pendingNames.emit(emptyList())
+            advanceUntilIdle()
+            assertNotNull(viewModel.state.value.saveError)
+            coVerify(exactly = 0) { interfaceRepository.updateInterface(3L, any()) }
+
+            every { interfaceRepository.allInterfaces } returns flowOf(emptyList())
             currentBondState = BluetoothDevice.BOND_BONDED
             stateFlow.update { it.copy(selectedDevice = configuredDevice, saveError = null) }
             viewModel.saveConfiguration()

--- a/app/src/test/java/network/columba/app/viewmodel/RNodeWizardViewModelTest.kt
+++ b/app/src/test/java/network/columba/app/viewmodel/RNodeWizardViewModelTest.kt
@@ -1687,7 +1687,16 @@ class RNodeWizardViewModelTest {
             viewModel.loadExistingConfig(interfaceId)
             advanceUntilIdle()
 
+            assertEquals(WizardStep.DEVICE_DISCOVERY, viewModel.state.value.currentStep)
             assertNull(viewModel.state.value.selectedDevice)
+            viewModel.goToStep(WizardStep.REVIEW_CONFIGURE)
+            assertFalse(viewModel.canProceed())
+            viewModel.saveConfiguration()
+            advanceUntilIdle()
+            assertNotNull(viewModel.state.value.saveError)
+            coVerify(exactly = 0) { interfaceRepository.updateInterface(interfaceId, any()) }
+
+            viewModel.goToStep(WizardStep.DEVICE_DISCOVERY)
             val explicitlySelected =
                 DiscoveredRNode(
                     name = "RNode SAME",
@@ -1699,6 +1708,16 @@ class RNodeWizardViewModelTest {
             viewModel.selectDevice(explicitlySelected)
 
             assertEquals(explicitlySelected, viewModel.state.value.selectedDevice)
+            viewModel.goToNextStep()
+            assertEquals(WizardStep.REVIEW_CONFIGURE, viewModel.state.value.currentStep)
+            viewModel.saveConfiguration()
+            advanceUntilIdle()
+            coVerify(exactly = 1) {
+                interfaceRepository.updateInterface(
+                    interfaceId,
+                    match { it is InterfaceConfig.RNode && it.targetDeviceAddress == explicitlySelected.address },
+                )
+            }
         }
 
     @Test

--- a/app/src/test/java/network/columba/app/viewmodel/RNodeWizardViewModelTest.kt
+++ b/app/src/test/java/network/columba/app/viewmodel/RNodeWizardViewModelTest.kt
@@ -1698,9 +1698,10 @@ class RNodeWizardViewModelTest {
             assertEquals("RNode E517", state.pairingRepairDeviceName)
             assertNull(state.selectedDevice)
 
+            val stateBeforeUsbAttempt = viewModel.state.value
             viewModel.startUsbAssistedPairing()
             advanceUntilIdle()
-            assertNull(viewModel.state.value.usbPairingStatus)
+            assertEquals(stateBeforeUsbAttempt, viewModel.state.value)
 
             val originalFrequency = state.frequency
             val originalBandwidth = state.bandwidth

--- a/app/src/test/java/network/columba/app/viewmodel/RNodeWizardViewModelTest.kt
+++ b/app/src/test/java/network/columba/app/viewmodel/RNodeWizardViewModelTest.kt
@@ -1698,18 +1698,34 @@ class RNodeWizardViewModelTest {
             assertEquals("RNode E517", state.pairingRepairDeviceName)
             assertNull(state.selectedDevice)
 
-            viewModel.selectDevice(
+            val originalFrequency = state.frequency
+            val originalBandwidth = state.bandwidth
+            val unpairedDevice =
                 DiscoveredRNode(
                     name = "RNode E517",
                     address = "AA:BB:CC:DD:EE:FF",
                     type = BluetoothType.BLE,
                     rssi = null,
-                    isPaired = true,
-                ),
-            )
+                    isPaired = false,
+                )
+
+            viewModel.selectDevice(unpairedDevice)
+            assertFalse(viewModel.canProceed())
+            viewModel.goToNextStep()
+            assertEquals(WizardStep.DEVICE_DISCOVERY, viewModel.state.value.currentStep)
+
+            viewModel.selectDevice(unpairedDevice.copy(isPaired = true))
+            assertTrue(viewModel.canProceed())
             viewModel.goToNextStep()
 
             assertEquals(WizardStep.REVIEW_CONFIGURE, viewModel.state.value.currentStep)
+            assertTrue(viewModel.state.value.skippedRegionSelection)
+
+            viewModel.goToPreviousStep()
+
+            assertEquals(WizardStep.DEVICE_DISCOVERY, viewModel.state.value.currentStep)
+            assertEquals(originalFrequency, viewModel.state.value.frequency)
+            assertEquals(originalBandwidth, viewModel.state.value.bandwidth)
         }
 
     @Test

--- a/app/src/test/java/network/columba/app/viewmodel/RNodeWizardViewModelTest.kt
+++ b/app/src/test/java/network/columba/app/viewmodel/RNodeWizardViewModelTest.kt
@@ -1693,14 +1693,14 @@ class RNodeWizardViewModelTest {
             val entity =
                 InterfaceEntity(
                     id = interfaceId,
-                    name = "RNode E517 BLE",
+                    name = "RNode Interface",
                     type = "RNode",
                     enabled = true,
                     configJson = """{"connection_mode":"ble","target_device_name":"RNode E517"}""",
                 )
             val rnodeConfig =
                 InterfaceConfig.RNode(
-                    name = "RNode E517 BLE",
+                    name = "RNode Interface",
                     enabled = true,
                     connectionMode = "ble",
                     targetDeviceName = "RNode E517",
@@ -1727,6 +1727,7 @@ class RNodeWizardViewModelTest {
             assertNull(state.selectedDevice)
 
             val (originalFrequency, originalBandwidth) = state.frequency to state.bandwidth
+            val originalInterfaceName = state.interfaceName
             val unpairedDevice =
                 DiscoveredRNode(
                     name = "RNode E517",
@@ -1772,6 +1773,7 @@ class RNodeWizardViewModelTest {
             assertEquals(WizardStep.DEVICE_DISCOVERY, viewModel.state.value.currentStep)
             assertEquals(originalFrequency, viewModel.state.value.frequency)
             assertEquals(originalBandwidth, viewModel.state.value.bandwidth)
+            assertEquals(originalInterfaceName, viewModel.state.value.interfaceName)
         }
 
     @Test

--- a/app/src/test/java/network/columba/app/viewmodel/RNodeWizardViewModelTest.kt
+++ b/app/src/test/java/network/columba/app/viewmodel/RNodeWizardViewModelTest.kt
@@ -1698,6 +1698,10 @@ class RNodeWizardViewModelTest {
             assertEquals("RNode E517", state.pairingRepairDeviceName)
             assertNull(state.selectedDevice)
 
+            viewModel.startUsbAssistedPairing()
+            advanceUntilIdle()
+            assertNull(viewModel.state.value.usbPairingStatus)
+
             val originalFrequency = state.frequency
             val originalBandwidth = state.bandwidth
             val unpairedDevice =

--- a/app/src/test/java/network/columba/app/viewmodel/RNodeWizardViewModelTest.kt
+++ b/app/src/test/java/network/columba/app/viewmodel/RNodeWizardViewModelTest.kt
@@ -25,6 +25,7 @@ import io.mockk.slot
 import io.mockk.verify
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.flow.update
@@ -32,6 +33,7 @@ import kotlinx.coroutines.test.StandardTestDispatcher
 import kotlinx.coroutines.test.TestScope
 import kotlinx.coroutines.test.advanceUntilIdle
 import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.runCurrent
 import kotlinx.coroutines.test.runTest
 import kotlinx.coroutines.test.setMain
 import org.junit.After
@@ -1657,6 +1659,29 @@ class RNodeWizardViewModelTest {
         }
 
     @Test
+    fun `pairing repair latches before config load`() =
+        runViewModelTest {
+            val entities = MutableSharedFlow<InterfaceEntity?>()
+            coEvery { interfaceRepository.getInterfaceById(3L) } returns entities
+
+            viewModel.loadExistingConfig(3L, repairPairing = true)
+            runCurrent()
+
+            val repairState = viewModel.state.value
+            assertTrue(repairState.isEditMode)
+            assertTrue(repairState.isPairingRepairMode)
+            assertEquals(WizardStep.DEVICE_DISCOVERY, repairState.currentStep)
+            assertNull(repairState.selectedDevice)
+
+            viewModel.startUsbAssistedPairing()
+            runCurrent()
+            assertEquals(repairState, viewModel.state.value)
+
+            entities.emit(null)
+            advanceUntilIdle()
+        }
+
+    @Test
     fun `loadExistingConfig for pairing repair starts discovery without claiming current device is paired`() =
         runViewModelTest {
             advanceUntilIdle()
@@ -1697,11 +1722,6 @@ class RNodeWizardViewModelTest {
             assertEquals(WizardStep.DEVICE_DISCOVERY, state.currentStep)
             assertEquals("RNode E517", state.pairingRepairDeviceName)
             assertNull(state.selectedDevice)
-
-            val stateBeforeUsbAttempt = viewModel.state.value
-            viewModel.startUsbAssistedPairing()
-            advanceUntilIdle()
-            assertEquals(stateBeforeUsbAttempt, viewModel.state.value)
 
             val (originalFrequency, originalBandwidth) = state.frequency to state.bandwidth
             val unpairedDevice =

--- a/app/src/test/java/network/columba/app/viewmodel/RNodeWizardViewModelTest.kt
+++ b/app/src/test/java/network/columba/app/viewmodel/RNodeWizardViewModelTest.kt
@@ -1693,14 +1693,14 @@ class RNodeWizardViewModelTest {
             val entity =
                 InterfaceEntity(
                     id = interfaceId,
-                    name = "RNode Interface",
+                    name = "RNode LoRa",
                     type = "RNode",
                     enabled = true,
                     configJson = """{"connection_mode":"ble","target_device_name":"RNode E517"}""",
                 )
             val rnodeConfig =
                 InterfaceConfig.RNode(
-                    name = "RNode Interface",
+                    name = "RNode LoRa",
                     enabled = true,
                     connectionMode = "ble",
                     targetDeviceName = "RNode E517",

--- a/app/src/test/java/network/columba/app/viewmodel/RNodeWizardViewModelTest.kt
+++ b/app/src/test/java/network/columba/app/viewmodel/RNodeWizardViewModelTest.kt
@@ -1,5 +1,6 @@
 package network.columba.app.viewmodel
 
+import android.bluetooth.BluetoothDevice
 import android.content.Context
 import android.content.SharedPreferences
 import androidx.arch.core.executor.testing.InstantTaskExecutorRule
@@ -1720,7 +1721,6 @@ class RNodeWizardViewModelTest {
             advanceUntilIdle()
 
             val state = viewModel.state.value
-            assertTrue(state.isEditMode)
             assertTrue(state.isPairingRepairMode)
             assertEquals(WizardStep.DEVICE_DISCOVERY, state.currentStep)
             assertEquals("RNode E517", state.pairingRepairDeviceName)
@@ -1728,6 +1728,7 @@ class RNodeWizardViewModelTest {
 
             val (originalFrequency, originalBandwidth) = state.frequency to state.bandwidth
             val originalInterfaceName = state.interfaceName
+            val bluetoothDevice = mockk<BluetoothDevice> { every { bondState } returns BluetoothDevice.BOND_BONDED }
             val unpairedDevice =
                 DiscoveredRNode(
                     name = "RNode E517",
@@ -1735,6 +1736,7 @@ class RNodeWizardViewModelTest {
                     type = BluetoothType.BLE,
                     rssi = null,
                     isPaired = false,
+                    bluetoothDevice = bluetoothDevice,
                 )
 
             viewModel.selectDevice(
@@ -1745,7 +1747,6 @@ class RNodeWizardViewModelTest {
                 ),
             )
             assertNull(viewModel.state.value.selectedDevice)
-
             viewModel.selectDevice(unpairedDevice)
             assertFalse(viewModel.canProceed())
             viewModel.goToNextStep()
@@ -1767,13 +1768,74 @@ class RNodeWizardViewModelTest {
 
             assertEquals(WizardStep.REVIEW_CONFIGURE, viewModel.state.value.currentStep)
             assertTrue(viewModel.state.value.skippedRegionSelection)
-
             viewModel.goToPreviousStep()
 
             assertEquals(WizardStep.DEVICE_DISCOVERY, viewModel.state.value.currentStep)
             assertEquals(originalFrequency, viewModel.state.value.frequency)
             assertEquals(originalBandwidth, viewModel.state.value.bandwidth)
             assertEquals(originalInterfaceName, viewModel.state.value.interfaceName)
+        }
+
+    @Test
+    fun `pairing repair requires live bond and configured address`() =
+        runViewModelTest {
+            advanceUntilIdle()
+
+            var currentBondState = BluetoothDevice.BOND_BONDED
+            val bluetoothDevice = mockk<BluetoothDevice>()
+            every { bluetoothDevice.bondState } answers { currentBondState }
+            val configuredDevice =
+                DiscoveredRNode(
+                    name = "RNode E517",
+                    address = "AA:BB:CC:DD:EE:FF",
+                    type = BluetoothType.BLE,
+                    rssi = null,
+                    isPaired = true,
+                    bluetoothDevice = bluetoothDevice,
+                )
+            val otherDevice = configuredDevice.copy(address = "AA:BB:CC:DD:EE:00")
+            val stateField = RNodeWizardViewModel::class.java.getDeclaredField("_state")
+            stateField.isAccessible = true
+            @Suppress("UNCHECKED_CAST")
+            val stateFlow = stateField.get(viewModel) as kotlinx.coroutines.flow.MutableStateFlow<RNodeWizardState>
+            stateFlow.value =
+                RNodeWizardState(
+                    editingInterfaceId = 3L,
+                    isEditMode = true,
+                    isPairingRepairMode = true,
+                    pairingRepairDeviceName = configuredDevice.name,
+                    discoveredDevices = listOf(configuredDevice, otherDevice),
+                )
+
+            viewModel.selectDevice(configuredDevice)
+            assertNull(viewModel.state.value.selectedDevice)
+
+            stateFlow.update { it.copy(pairingRepairDeviceAddress = configuredDevice.address) }
+            viewModel.selectDevice(otherDevice)
+            assertNull(viewModel.state.value.selectedDevice)
+            viewModel.selectDevice(configuredDevice)
+            assertEquals(configuredDevice.address, viewModel.state.value.selectedDevice?.address)
+            assertTrue(viewModel.canProceed())
+
+            currentBondState = BluetoothDevice.BOND_NONE
+            assertFalse(viewModel.canProceed())
+            viewModel.saveConfiguration()
+            advanceUntilIdle()
+            assertNotNull(viewModel.state.value.saveError)
+            coVerify(exactly = 0) { interfaceRepository.updateInterface(3L, any()) }
+
+            val entity = InterfaceEntity(3L, "RNode LoRa", "RNode", true, "{}")
+            coEvery { interfaceRepository.getInterfaceById(3L) } returns flowOf(entity)
+            currentBondState = BluetoothDevice.BOND_BONDED
+            stateFlow.update { it.copy(selectedDevice = configuredDevice, saveError = null) }
+            viewModel.saveConfiguration()
+            advanceUntilIdle()
+            coVerify(exactly = 1) {
+                interfaceRepository.updateInterface(
+                    3L,
+                    match { it is InterfaceConfig.RNode && it.targetDeviceAddress == configuredDevice.address },
+                )
+            }
         }
 
     @Test

--- a/app/src/test/java/network/columba/app/viewmodel/RNodeWizardViewModelTest.kt
+++ b/app/src/test/java/network/columba/app/viewmodel/RNodeWizardViewModelTest.kt
@@ -1656,6 +1656,62 @@ class RNodeWizardViewModelTest {
         }
 
     @Test
+    fun `loadExistingConfig for pairing repair starts discovery without claiming current device is paired`() =
+        runViewModelTest {
+            advanceUntilIdle()
+
+            val interfaceId = 3L
+            val entity =
+                InterfaceEntity(
+                    id = interfaceId,
+                    name = "RNode E517 BLE",
+                    type = "RNode",
+                    enabled = true,
+                    configJson = """{"connection_mode":"ble","target_device_name":"RNode E517"}""",
+                )
+            val rnodeConfig =
+                InterfaceConfig.RNode(
+                    name = "RNode E517 BLE",
+                    enabled = true,
+                    connectionMode = "ble",
+                    targetDeviceName = "RNode E517",
+                    tcpHost = null,
+                    tcpPort = 7633,
+                    frequency = 915000000,
+                    bandwidth = 125000,
+                    txPower = 17,
+                    spreadingFactor = 8,
+                    codingRate = 5,
+                )
+
+            coEvery { interfaceRepository.getInterfaceById(interfaceId) } returns flowOf(entity)
+            coEvery { interfaceRepository.entityToConfig(entity) } returns rnodeConfig
+
+            viewModel.loadExistingConfig(interfaceId, repairPairing = true)
+            advanceUntilIdle()
+
+            val state = viewModel.state.value
+            assertTrue(state.isEditMode)
+            assertTrue(state.isPairingRepairMode)
+            assertEquals(WizardStep.DEVICE_DISCOVERY, state.currentStep)
+            assertEquals("RNode E517", state.pairingRepairDeviceName)
+            assertNull(state.selectedDevice)
+
+            viewModel.selectDevice(
+                DiscoveredRNode(
+                    name = "RNode E517",
+                    address = "AA:BB:CC:DD:EE:FF",
+                    type = BluetoothType.BLE,
+                    rssi = null,
+                    isPaired = true,
+                ),
+            )
+            viewModel.goToNextStep()
+
+            assertEquals(WizardStep.REVIEW_CONFIGURE, viewModel.state.value.currentStep)
+        }
+
+    @Test
     fun `loadExistingConfig handles interface not found`() =
         runViewModelTest {
             advanceUntilIdle()

--- a/app/src/test/java/network/columba/app/viewmodel/RNodeWizardViewModelTest.kt
+++ b/app/src/test/java/network/columba/app/viewmodel/RNodeWizardViewModelTest.kt
@@ -1829,7 +1829,7 @@ class RNodeWizardViewModelTest {
             stateFlow.update {
                 it.copy(
                     isScanning = false,
-                    discoveredDevices = listOf(configuredDevice, otherDevice),
+                    discoveredDevices = listOf(configuredDevice),
                 )
             }
             viewModel.selectDevice(configuredDevice)

--- a/app/src/test/java/network/columba/app/viewmodel/RNodeWizardViewModelTest.kt
+++ b/app/src/test/java/network/columba/app/viewmodel/RNodeWizardViewModelTest.kt
@@ -22,6 +22,7 @@ import io.mockk.every
 import io.mockk.just
 import io.mockk.mockk
 import io.mockk.slot
+import io.mockk.verify
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -113,7 +114,7 @@ class RNodeWizardViewModelTest {
         every { interfaceRepository.allInterfaces } returns flowOf(emptyList())
 
         // Mock configManager.setPendingChanges() which is called after successful save
-        every { configManager.setPendingChanges(any()) } just Runs
+        every { configManager.setPendingChanges(any(), any()) } just Runs
     }
 
     @After
@@ -2273,6 +2274,7 @@ class RNodeWizardViewModelTest {
             advanceUntilIdle()
 
             assertTrue("updateInterface should be called in edit mode", updateCalled)
+            verify(exactly = 1) { configManager.setPendingChanges(true, interfaceId) }
             viewModel.state.test {
                 val state = awaitItem()
                 assertTrue("save should succeed", state.saveSuccess)

--- a/app/src/test/java/network/columba/app/viewmodel/RNodeWizardViewModelTest.kt
+++ b/app/src/test/java/network/columba/app/viewmodel/RNodeWizardViewModelTest.kt
@@ -1715,6 +1715,16 @@ class RNodeWizardViewModelTest {
             assertEquals(WizardStep.DEVICE_DISCOVERY, viewModel.state.value.currentStep)
 
             viewModel.selectDevice(unpairedDevice.copy(isPaired = true))
+            val stateField = RNodeWizardViewModel::class.java.getDeclaredField("_state")
+            stateField.isAccessible = true
+            @Suppress("UNCHECKED_CAST")
+            val stateFlow = stateField.get(viewModel) as kotlinx.coroutines.flow.MutableStateFlow<RNodeWizardState>
+            stateFlow.update { it.copy(isPairingInProgress = true) }
+            assertFalse(viewModel.canProceed())
+            viewModel.goToNextStep()
+            assertEquals(WizardStep.DEVICE_DISCOVERY, viewModel.state.value.currentStep)
+
+            stateFlow.update { it.copy(isPairingInProgress = false) }
             assertTrue(viewModel.canProceed())
             viewModel.goToNextStep()
 

--- a/rns-api/src/main/java/network/columba/app/rns/api/model/InterfaceConfigExt.kt
+++ b/rns-api/src/main/java/network/columba/app/rns/api/model/InterfaceConfigExt.kt
@@ -45,6 +45,7 @@ fun InterfaceConfig.toJsonString(): String =
             JSONObject()
                 .apply {
                     put("target_device_name", targetDeviceName)
+                    targetDeviceAddress?.let { put("target_device_address", it) }
                     put("connection_mode", connectionMode)
                     tcpHost?.let { put("tcp_host", it) }
                     put("tcp_port", tcpPort)

--- a/rns-api/src/main/java/network/columba/app/rns/api/model/ReticulumConfig.kt
+++ b/rns-api/src/main/java/network/columba/app/rns/api/model/ReticulumConfig.kt
@@ -368,7 +368,6 @@ sealed class InterfaceConfig : Parcelable {
             parcel.writeString(name)
             parcel.writeInt(if (enabled) 1 else 0)
             parcel.writeString(targetDeviceName)
-            parcel.writeString(targetDeviceAddress)
             parcel.writeString(connectionMode)
             parcel.writeString(tcpHost)
             parcel.writeInt(tcpPort)
@@ -387,6 +386,7 @@ sealed class InterfaceConfig : Parcelable {
             parcel.writeString(passphrase)
             parcel.writeInt(if (enableFramebuffer) 1 else 0)
             parcel.writeParcelable(networkRestriction, flags)
+            parcel.writeString(targetDeviceAddress)
         }
     }
 
@@ -557,7 +557,6 @@ sealed class InterfaceConfig : Parcelable {
                             name = parcel.readString().orEmpty(),
                             enabled = parcel.readInt() != 0,
                             targetDeviceName = parcel.readString().orEmpty(),
-                            targetDeviceAddress = parcel.readString(),
                             connectionMode = parcel.readString().orEmpty(),
                             tcpHost = parcel.readString(),
                             tcpPort = parcel.readInt(),
@@ -576,6 +575,7 @@ sealed class InterfaceConfig : Parcelable {
                             passphrase = parcel.readString(),
                             enableFramebuffer = parcel.readInt() != 0,
                             networkRestriction = readNetworkRestriction(),
+                            targetDeviceAddress = if (parcel.dataAvail() > 0) parcel.readString() else null,
                         )
                     TAG_UDP ->
                         UDP(

--- a/rns-api/src/main/java/network/columba/app/rns/api/model/ReticulumConfig.kt
+++ b/rns-api/src/main/java/network/columba/app/rns/api/model/ReticulumConfig.kt
@@ -340,7 +340,8 @@ sealed class InterfaceConfig : Parcelable {
         override val name: String = "RNode LoRa",
         override val enabled: Boolean = true,
         val targetDeviceName: String = "", // Required for Bluetooth, empty for TCP/USB
-        val targetDeviceAddress: String? = null, // App-owned repair identity; not emitted to Reticulum config
+        // App-owned repair identity; intentionally omitted from Parcelable/runtime transport.
+        val targetDeviceAddress: String? = null,
         val connectionMode: String = "classic", // "classic", "ble", "tcp", or "usb"
         val tcpHost: String? = null, // IP/hostname for TCP mode
         val tcpPort: Int = 7633, // RNode TCP port (default)
@@ -386,7 +387,6 @@ sealed class InterfaceConfig : Parcelable {
             parcel.writeString(passphrase)
             parcel.writeInt(if (enableFramebuffer) 1 else 0)
             parcel.writeParcelable(networkRestriction, flags)
-            parcel.writeString(targetDeviceAddress)
         }
     }
 
@@ -575,7 +575,6 @@ sealed class InterfaceConfig : Parcelable {
                             passphrase = parcel.readString(),
                             enableFramebuffer = parcel.readInt() != 0,
                             networkRestriction = readNetworkRestriction(),
-                            targetDeviceAddress = if (parcel.dataAvail() > 0) parcel.readString() else null,
                         )
                     TAG_UDP ->
                         UDP(

--- a/rns-api/src/main/java/network/columba/app/rns/api/model/ReticulumConfig.kt
+++ b/rns-api/src/main/java/network/columba/app/rns/api/model/ReticulumConfig.kt
@@ -319,6 +319,7 @@ sealed class InterfaceConfig : Parcelable {
      * @param name User-friendly name for this interface
      * @param enabled Whether this interface should be initialized
      * @param targetDeviceName Bluetooth device name of the paired RNode (required for Bluetooth)
+     * @param targetDeviceAddress Optional stable Android Bluetooth address used only to bind repair to the configured device
      * @param connectionMode Connection mode: "classic" (SPP/RFCOMM), "ble" (GATT), "tcp" (WiFi), or "usb" (serial)
      * @param tcpHost IP address or hostname for TCP/WiFi mode (required when connectionMode="tcp")
      * @param tcpPort TCP port for WiFi mode (default: 7633, the RNode standard port)
@@ -339,6 +340,7 @@ sealed class InterfaceConfig : Parcelable {
         override val name: String = "RNode LoRa",
         override val enabled: Boolean = true,
         val targetDeviceName: String = "", // Required for Bluetooth, empty for TCP/USB
+        val targetDeviceAddress: String? = null, // App-owned repair identity; not emitted to Reticulum config
         val connectionMode: String = "classic", // "classic", "ble", "tcp", or "usb"
         val tcpHost: String? = null, // IP/hostname for TCP mode
         val tcpPort: Int = 7633, // RNode TCP port (default)
@@ -366,6 +368,7 @@ sealed class InterfaceConfig : Parcelable {
             parcel.writeString(name)
             parcel.writeInt(if (enabled) 1 else 0)
             parcel.writeString(targetDeviceName)
+            parcel.writeString(targetDeviceAddress)
             parcel.writeString(connectionMode)
             parcel.writeString(tcpHost)
             parcel.writeInt(tcpPort)
@@ -554,6 +557,7 @@ sealed class InterfaceConfig : Parcelable {
                             name = parcel.readString().orEmpty(),
                             enabled = parcel.readInt() != 0,
                             targetDeviceName = parcel.readString().orEmpty(),
+                            targetDeviceAddress = parcel.readString(),
                             connectionMode = parcel.readString().orEmpty(),
                             tcpHost = parcel.readString(),
                             tcpPort = parcel.readInt(),

--- a/rns-api/src/test/java/network/columba/app/rns/api/ParcelRoundTripTest.kt
+++ b/rns-api/src/test/java/network/columba/app/rns/api/ParcelRoundTripTest.kt
@@ -16,6 +16,7 @@ import network.columba.app.rns.api.model.NetworkStatus
 import network.columba.app.rns.api.model.NetworkRestriction
 import network.columba.app.rns.api.model.NodeType
 import network.columba.app.rns.api.model.PeerIdentityEntry
+import network.columba.app.rns.api.model.ReticulumConfig
 import org.junit.Assert.assertArrayEquals
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNotNull
@@ -239,18 +240,20 @@ class ParcelRoundTripTest {
     }
 
     @Test
-    fun `InterfaceConfig RNode round-trips with all nullables populated`() {
-        val original: InterfaceConfig = InterfaceConfig.RNode(
-            targetDeviceName = "RNode 1234",
-            targetDeviceAddress = "AA:BB:CC:DD:EE:FF",
-            usbDeviceId = 42,
-            usbVendorId = 0x1A86,
-            usbProductId = 0x7523,
-            stAlock = 1.5,
-            ltAlock = 2.0,
-        )
+    fun `InterfaceConfig RNode omits app-only address from parcel transport`() {
+        val original =
+            InterfaceConfig.RNode(
+                targetDeviceName = "RNode 1234",
+                targetDeviceAddress = "AA:BB:CC:DD:EE:FF",
+                usbDeviceId = 42,
+                usbVendorId = 0x1A86,
+                usbProductId = 0x7523,
+                stAlock = 1.5,
+                ltAlock = 2.0,
+            )
         val restored = roundTrip(original, InterfaceConfig.CREATOR)
-        assertEquals(original, restored)
+        assertEquals(original.copy(targetDeviceAddress = null), restored)
+        assertNull((restored as InterfaceConfig.RNode).targetDeviceAddress)
     }
 
     @Test
@@ -294,6 +297,28 @@ class ParcelRoundTripTest {
         } finally {
             parcel.recycle()
         }
+    }
+
+    @Test
+    fun `ReticulumConfig transport omits RNode address without corrupting following interface`() {
+        val original =
+            ReticulumConfig(
+                storagePath = "/tmp/rns",
+                enabledInterfaces =
+                    listOf(
+                        InterfaceConfig.RNode(
+                            targetDeviceName = "RNode 1234",
+                            targetDeviceAddress = "AA:BB:CC:DD:EE:FF",
+                        ),
+                        InterfaceConfig.UDP(name = "Following UDP"),
+                    ),
+            )
+
+        val restored = roundTripViaFramework(original)
+
+        assertEquals(2, restored.enabledInterfaces.size)
+        assertNull((restored.enabledInterfaces[0] as InterfaceConfig.RNode).targetDeviceAddress)
+        assertEquals("Following UDP", (restored.enabledInterfaces[1] as InterfaceConfig.UDP).name)
     }
 
     @Test

--- a/rns-api/src/test/java/network/columba/app/rns/api/ParcelRoundTripTest.kt
+++ b/rns-api/src/test/java/network/columba/app/rns/api/ParcelRoundTripTest.kt
@@ -241,6 +241,7 @@ class ParcelRoundTripTest {
     fun `InterfaceConfig RNode round-trips with all nullables populated`() {
         val original: InterfaceConfig = InterfaceConfig.RNode(
             targetDeviceName = "RNode 1234",
+            targetDeviceAddress = "AA:BB:CC:DD:EE:FF",
             usbDeviceId = 42,
             usbVendorId = 0x1A86,
             usbProductId = 0x7523,

--- a/rns-api/src/test/java/network/columba/app/rns/api/ParcelRoundTripTest.kt
+++ b/rns-api/src/test/java/network/columba/app/rns/api/ParcelRoundTripTest.kt
@@ -19,6 +19,7 @@ import network.columba.app.rns.api.model.PeerIdentityEntry
 import org.junit.Assert.assertArrayEquals
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertNull
 import org.junit.Assert.assertTrue
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -257,6 +258,42 @@ class ParcelRoundTripTest {
         val original: InterfaceConfig = InterfaceConfig.RNode()
         val restored = roundTrip(original, InterfaceConfig.CREATOR)
         assertEquals(original, restored)
+    }
+
+    @Test
+    fun `InterfaceConfig RNode decodes legacy parcel without device address`() {
+        val parcel = Parcel.obtain()
+        try {
+            parcel.writeInt(2)
+            parcel.writeString("Legacy RNode")
+            parcel.writeInt(1)
+            parcel.writeString("RNode 1234")
+            parcel.writeString("ble")
+            parcel.writeString(null)
+            parcel.writeInt(7633)
+            repeat(3) { parcel.writeInt(0) }
+            parcel.writeLong(915000000)
+            parcel.writeInt(125000)
+            parcel.writeInt(7)
+            parcel.writeInt(7)
+            parcel.writeInt(5)
+            repeat(2) { parcel.writeInt(0) }
+            parcel.writeString("access_point")
+            parcel.writeString(null)
+            parcel.writeString(null)
+            parcel.writeInt(1)
+            parcel.writeParcelable(NetworkRestriction.ANY, 0)
+            parcel.setDataPosition(0)
+
+            val restored = InterfaceConfig.CREATOR.createFromParcel(parcel) as InterfaceConfig.RNode
+
+            assertEquals("RNode 1234", restored.targetDeviceName)
+            assertEquals("ble", restored.connectionMode)
+            assertEquals(915000000, restored.frequency)
+            assertNull(restored.targetDeviceAddress)
+        } finally {
+            parcel.recycle()
+        }
     }
 
     @Test

--- a/rns-api/src/test/java/network/columba/app/rns/api/model/InterfaceConfigExtTest.kt
+++ b/rns-api/src/test/java/network/columba/app/rns/api/model/InterfaceConfigExtTest.kt
@@ -139,6 +139,7 @@ class InterfaceConfigExtTest {
                 name = "Test RNode",
                 enabled = true,
                 targetDeviceName = "RNode-BT",
+                targetDeviceAddress = "AA:BB:CC:DD:EE:FF",
                 connectionMode = "ble",
                 frequency = 868000000L,
                 bandwidth = 250000,
@@ -156,6 +157,7 @@ class InterfaceConfigExtTest {
         val json = JSONObject(config.toJsonString())
 
         assertEquals("RNode-BT", json.getString("target_device_name"))
+        assertEquals("AA:BB:CC:DD:EE:FF", json.getString("target_device_address"))
         assertEquals("ble", json.getString("connection_mode"))
         assertEquals(868000000L, json.getLong("frequency"))
         assertEquals(250000, json.getInt("bandwidth"))
@@ -189,6 +191,7 @@ class InterfaceConfigExtTest {
         assertFalse(json.has("lt_alock"))
         assertFalse(json.has("network_name"))
         assertFalse(json.has("passphrase"))
+        assertFalse(json.has("target_device_address"))
     }
 
     @Test

--- a/rns-backend-py/src/main/kotlin/network/columba/app/rns/backend/py/PythonRnsTransportAdmin.kt
+++ b/rns-backend-py/src/main/kotlin/network/columba/app/rns/backend/py/PythonRnsTransportAdmin.kt
@@ -369,8 +369,9 @@ class PythonRnsTransportAdmin(
 
     /**
      * Enumerate `RNS.Transport.interfaces` into the same per-interface shape
-     * `NativeRnsBackendImpl.getDebugInfo()` emits — `{name, type, online,
-     * parent_name, can_send, rx_bytes, tx_bytes}`. `name` is the configured
+     * `NativeRnsBackendImpl.getDebugInfo()` emits, plus the optional Python
+     * runtime status reason: `{name, type, online, parent_name, can_send,
+     * rx_bytes, tx_bytes, status_reason}`. `name` is the configured
      * interface name (`interface.name` — the RNS config `[[section]]` header),
      * matching `NativeRnsBackendImpl`'s `iface.name` and what the UI keys its
      * online-status overlay on (`InterfaceEntity.name`). Per-interface reads
@@ -409,6 +410,11 @@ class PythonRnsTransportAdmin(
                             ?.takeIf { it.toString() != "None" }
                             ?.get("name")?.toString()
                     }.getOrNull()
+                    val statusReason = runCatching {
+                        iface["status_reason"]
+                            ?.takeIf { it.toString() != "None" }
+                            ?.toString()
+                    }.getOrNull().orEmpty()
                     linkedMapOf<String, Any>(
                         "name" to uiName,
                         "type" to uiType,
@@ -417,6 +423,7 @@ class PythonRnsTransportAdmin(
                         "can_send" to (iface["OUT"]?.toJava(Boolean::class.javaObjectType) ?: false),
                         "rx_bytes" to (iface["rxb"]?.toJava(Long::class.javaObjectType) ?: 0L),
                         "tx_bytes" to (iface["txb"]?.toJava(Long::class.javaObjectType) ?: 0L),
+                        "status_reason" to statusReason,
                     )
                 }.getOrElse {
                     Log.w(TAG, "getDebugInfo: skipping an interface (attr read failed)", it)

--- a/rns-backend-py/src/main/python/columba_rnode_interface.py
+++ b/rns-backend-py/src/main/python/columba_rnode_interface.py
@@ -532,14 +532,30 @@ class ColumbaRNodeInterface(Interface):
         except Exception as e:  # noqa: BLE001
             RNS.log(f"ColumbaRNodeInterface: optional callback registration failed (non-fatal): {e}", RNS.LOG_DEBUG)
 
-        # Connect via Kotlin bridge with specified mode
-        if not self.kotlin_bridge.connect(self.target_device_name, self.connection_mode):
-            failure_reason = None
+        # Connect and consume its reason atomically. The Kotlin bridge is shared by
+        # every Python RNode interface, so a separate connect()/failure getter pair
+        # can be overwritten by another interface starting concurrently.
+        failure_reason = None
+        if hasattr(self.kotlin_bridge, "connectWithResult"):
+            connection_result = self.kotlin_bridge.connectWithResult(
+                self.target_device_name,
+                self.connection_mode,
+            )
+            connected = connection_result == "connected"
+            if not connected and connection_result != "failed":
+                failure_reason = connection_result
+        else:
+            connected = self.kotlin_bridge.connect(
+                self.target_device_name,
+                self.connection_mode,
+            )
             try:
-                if hasattr(self.kotlin_bridge, "getLastConnectionFailure"):
+                if not connected and hasattr(self.kotlin_bridge, "getLastConnectionFailure"):
                     failure_reason = self.kotlin_bridge.getLastConnectionFailure()
             except Exception as e:  # noqa: BLE001
                 RNS.log(f"Could not read RNode connection failure reason: {e}", RNS.LOG_DEBUG)
+
+        if not connected:
             self.status_reason = failure_reason
             if failure_reason == "pairing_required":
                 RNS.log(

--- a/rns-backend-py/src/main/python/columba_rnode_interface.py
+++ b/rns-backend-py/src/main/python/columba_rnode_interface.py
@@ -350,6 +350,7 @@ class ColumbaRNodeInterface(Interface):
         self._max_reconnect_attempts = 30  # Try for ~5 minutes (30 * 10s)
         self._reconnect_interval = 10.0  # Seconds between reconnection attempts
         self._long_reconnect_interval = 15 * 60  # Indefinite low-duty recovery cadence
+        self.status_reason = None
 
         # Error / status callbacks (Kotlin sets these via setOnErrorReceived /
         # setOnOnlineStatusChanged on the constructed interface — optional).
@@ -533,8 +534,23 @@ class ColumbaRNodeInterface(Interface):
 
         # Connect via Kotlin bridge with specified mode
         if not self.kotlin_bridge.connect(self.target_device_name, self.connection_mode):
-            RNS.log(f"Failed to connect to {self.target_device_name}", RNS.LOG_ERROR)
+            failure_reason = None
+            try:
+                if hasattr(self.kotlin_bridge, "getLastConnectionFailure"):
+                    failure_reason = self.kotlin_bridge.getLastConnectionFailure()
+            except Exception as e:  # noqa: BLE001
+                RNS.log(f"Could not read RNode connection failure reason: {e}", RNS.LOG_DEBUG)
+            self.status_reason = failure_reason
+            if failure_reason == "pairing_required":
+                RNS.log(
+                    f"Pairing required for {self.target_device_name}; stopping automatic reconnect until the user repairs the bond",
+                    RNS.LOG_ERROR,
+                )
+            else:
+                RNS.log(f"Failed to connect to {self.target_device_name}", RNS.LOG_ERROR)
             return False
+
+        self.status_reason = None
 
         if self._reconnect_cancelled.is_set():
             self.kotlin_bridge.disconnect()
@@ -1490,6 +1506,15 @@ class ColumbaRNodeInterface(Interface):
                     return
                 else:
                     RNS.log(f"Reconnection attempt {attempt_label} failed", RNS.LOG_WARNING)
+                    if self.status_reason == "pairing_required":
+                        with self._reconnect_lock:
+                            self._reconnecting = False
+                            self._reconnect_requested = False
+                        RNS.log(
+                            f"Automatic reconnect stopped for {self.target_device_name}: pairing required",
+                            RNS.LOG_WARNING,
+                        )
+                        return
             except Exception as e:  # noqa: BLE001
                 RNS.log(f"Reconnection attempt {attempt_label} error: {e}", RNS.LOG_ERROR)
 

--- a/rns-backend-py/src/test/python/test_columba_rnode_reconnect.py
+++ b/rns-backend-py/src/test/python/test_columba_rnode_reconnect.py
@@ -29,9 +29,11 @@ class BaseInterface:
 class ScriptedBleBridge:
     """Mock the Kotlin BLE bridge across successive transport attempts."""
 
-    def __init__(self, interface, connect_results):
+    def __init__(self, interface, connect_results, connection_failures=None):
         self.interface = interface
         self.connect_results = iter(connect_results)
+        self.connection_failures = iter(connection_failures or [])
+        self.last_connection_failure = None
         self.connect_calls = 0
         self.disconnect_calls = 0
         self.online_notifications = []
@@ -49,11 +51,15 @@ class ScriptedBleBridge:
         self.connect_calls += 1
         self.callback_registered_at_connect.append(self.connection_callback is not None)
         self.connected = next(self.connect_results)
+        self.last_connection_failure = next(self.connection_failures, None)
         if self.connected and self.connection_callback is not None:
             # Kotlin reports GATT transport readiness before Python finishes
             # RNode detection and radio configuration.
             self.connection_callback(True, device_name)
         return self.connected
+
+    def getLastConnectionFailure(self):
+        return self.last_connection_failure
 
     def setOnConnectionStateChanged(self, callback):
         self.connection_callback = callback
@@ -118,8 +124,10 @@ class RNodeReconnectTests(unittest.TestCase):
         interface._reconnect_cancelled = threading.Event()
         interface._max_reconnect_attempts = 3
         interface._reconnect_interval = 0
+        interface._long_reconnect_interval = 15 * 60
         interface.online = False
         interface.detected = False
+        interface.status_reason = None
         interface._on_online_status_changed = None
         interface.usb_bridge = None
         return interface
@@ -177,6 +185,26 @@ class RNodeReconnectTests(unittest.TestCase):
         self.assertEqual(3, bridge.connect_calls)
         self.assertEqual([0, 0, 15 * 60], waits)
         self.assertFalse(interface.online)
+        self.assertFalse(interface._reconnecting)
+
+    def test_ble_reconnect_stops_immediately_when_pairing_is_required(self):
+        interface = self.new_interface()
+        bridge = ScriptedBleBridge(
+            interface,
+            [False, False],
+            connection_failures=["pairing_required", "pairing_required"],
+        )
+        interface.kotlin_bridge = bridge
+
+        def unexpected_wait(delay):
+            self.fail(f"pairing-required failure waited {delay}s instead of stopping")
+
+        interface._wait_for_reconnect = unexpected_wait
+
+        interface._reconnection_loop()
+
+        self.assertEqual(1, bridge.connect_calls)
+        self.assertEqual("pairing_required", interface.status_reason)
         self.assertFalse(interface._reconnecting)
 
     def test_explicit_stop_cancels_reconnect_without_joining_itself(self):

--- a/rns-backend-py/src/test/python/test_columba_rnode_reconnect.py
+++ b/rns-backend-py/src/test/python/test_columba_rnode_reconnect.py
@@ -58,6 +58,11 @@ class ScriptedBleBridge:
             self.connection_callback(True, device_name)
         return self.connected
 
+    def connectWithResult(self, device_name, mode):
+        return "connected" if self.connect(device_name, mode) else (
+            self.last_connection_failure or "failed"
+        )
+
     def getLastConnectionFailure(self):
         return self.last_connection_failure
 
@@ -206,6 +211,25 @@ class RNodeReconnectTests(unittest.TestCase):
         self.assertEqual(1, bridge.connect_calls)
         self.assertEqual("pairing_required", interface.status_reason)
         self.assertFalse(interface._reconnecting)
+
+    def test_ble_reconnect_uses_failure_returned_atomically_with_connect(self):
+        interface = self.new_interface()
+        bridge = ScriptedBleBridge(
+            interface,
+            [False],
+            connection_failures=["pairing_required"],
+        )
+        bridge.getLastConnectionFailure = mock.Mock(return_value=None)
+        interface.kotlin_bridge = bridge
+        interface._wait_for_reconnect = lambda delay: self.fail(
+            f"atomic pairing-required result waited {delay}s instead of stopping"
+        )
+
+        interface._reconnection_loop()
+
+        self.assertEqual(1, bridge.connect_calls)
+        self.assertEqual("pairing_required", interface.status_reason)
+        bridge.getLastConnectionFailure.assert_not_called()
 
     def test_explicit_stop_cancels_reconnect_without_joining_itself(self):
         interface = self.new_interface()

--- a/rns-host/src/main/kotlin/network/columba/app/rns/host/rnode/KotlinRNodeBridge.kt
+++ b/rns-host/src/main/kotlin/network/columba/app/rns/host/rnode/KotlinRNodeBridge.kt
@@ -119,6 +119,7 @@ class KotlinRNodeBridge(
         private const val BLE_CONNECT_TIMEOUT_MS = 15000L
         private const val BLE_CONNECT_MAX_RETRIES = 3
         private const val BLE_RETRY_DELAY_MS = 1000L
+        private const val CONNECTION_FAILURE_PAIRING_REQUIRED = "pairing_required"
 
         /**
          * Convert GATT status code to human-readable string for debugging.
@@ -181,6 +182,12 @@ class KotlinRNodeBridge(
 
     @Volatile
     private var bleMtuCallbackReceived = false // Tracks if onMtuChanged callback fired
+
+    @Volatile
+    private var bleSetupFailed = false
+
+    @Volatile
+    private var lastConnectionFailure: String? = null
 
     @Volatile
     private var bleRssi: Int = -100 // Current RSSI (-100 = unknown)
@@ -390,6 +397,7 @@ class KotlinRNodeBridge(
         deviceName: String,
         mode: String,
     ): Boolean {
+        lastConnectionFailure = null
         val requestedMode =
             when (mode.lowercase()) {
                 "classic", "spp", "rfcomm" -> RNodeConnectionMode.CLASSIC
@@ -535,6 +543,7 @@ class KotlinRNodeBridge(
             }
 
         if (device == null) {
+            markPairingRequired(deviceName, "device is no longer bonded in Android")
             Log.e(TAG, "████ RNODE BLE FAILED ████ paired device not found: $deviceName")
             return false
         }
@@ -551,6 +560,10 @@ class KotlinRNodeBridge(
                 return true
             }
 
+            if (lastConnectionFailure == CONNECTION_FAILURE_PAIRING_REQUIRED) {
+                return false
+            }
+
             if (attempt < BLE_CONNECT_MAX_RETRIES) {
                 Log.w(TAG, "BLE connection failed, will retry...")
             }
@@ -563,15 +576,22 @@ class KotlinRNodeBridge(
     /**
      * Single attempt to connect via BLE GATT.
      */
+    @Suppress("ReturnCount")
     private fun attemptBleConnection(
         device: BluetoothDevice,
         deviceName: String,
     ): Boolean {
         return try {
+            if (device.bondState != BluetoothDevice.BOND_BONDED) {
+                markPairingRequired(deviceName, "bond was lost before GATT setup")
+                return false
+            }
+
             // Reset BLE state
             bleConnected = false
             bleServicesDiscovered = false
             bleMtuCallbackReceived = false
+            bleSetupFailed = false
             bleRxCharacteristic = null
             bleTxCharacteristic = null
 
@@ -581,12 +601,21 @@ class KotlinRNodeBridge(
 
             // Wait for connection and service discovery
             val startTime = System.currentTimeMillis()
-            while (!bleServicesDiscovered && (System.currentTimeMillis() - startTime) < BLE_CONNECT_TIMEOUT_MS) {
+            while (
+                !bleServicesDiscovered &&
+                !bleSetupFailed &&
+                (System.currentTimeMillis() - startTime) < BLE_CONNECT_TIMEOUT_MS
+            ) {
+                if (device.bondState != BluetoothDevice.BOND_BONDED) {
+                    markPairingRequired(deviceName, "bond was lost during GATT setup")
+                    cleanupBle()
+                    return false
+                }
                 Thread.sleep(100)
             }
 
             if (!bleServicesDiscovered) {
-                Log.e(TAG, "BLE connection timeout - services not discovered")
+                Log.e(TAG, "BLE setup failed or timed out before secured notifications were ready")
                 cleanupBle()
                 return false
             }
@@ -671,10 +700,15 @@ class KotlinRNodeBridge(
                 gatt.discoverServices()
             }
 
+            @Suppress("ReturnCount")
             override fun onServicesDiscovered(
                 gatt: BluetoothGatt,
                 status: Int,
             ) {
+                if (gatt !== bluetoothGatt) {
+                    Log.w(TAG, "Ignoring service discovery from a stale GATT")
+                    return
+                }
                 if (status != BluetoothGatt.GATT_SUCCESS) {
                     Log.e(TAG, "Service discovery failed: $status")
                     return
@@ -700,16 +734,53 @@ class KotlinRNodeBridge(
                     return
                 }
 
-                // Enable notifications on TX characteristic (data from RNode)
-                gatt.setCharacteristicNotification(txChar, true)
+                // The transport is not ready until the protected notification
+                // descriptor write succeeds while the device remains bonded.
+                if (!gatt.setCharacteristicNotification(txChar, true)) {
+                    Log.e(TAG, "Failed to enable local NUS notifications")
+                    bleSetupFailed = true
+                    return
+                }
                 val descriptor = txChar.getDescriptor(CCCD_UUID)
-                descriptor?.let {
-                    it.value = BluetoothGattDescriptor.ENABLE_NOTIFICATION_VALUE
-                    gatt.writeDescriptor(it)
+                if (descriptor == null) {
+                    Log.e(TAG, "NUS notification descriptor not found")
+                    bleSetupFailed = true
+                    return
+                }
+                descriptor.value = BluetoothGattDescriptor.ENABLE_NOTIFICATION_VALUE
+                if (!gatt.writeDescriptor(descriptor)) {
+                    Log.e(TAG, "Failed to start NUS notification descriptor write")
+                    bleSetupFailed = true
+                }
+            }
+
+            @Deprecated("Deprecated in API 33")
+            override fun onDescriptorWrite(
+                gatt: BluetoothGatt,
+                descriptor: BluetoothGattDescriptor,
+                status: Int,
+            ) {
+                if (gatt !== bluetoothGatt) {
+                    Log.w(TAG, "Ignoring descriptor write from a stale GATT")
+                    return
+                }
+                if (descriptor.uuid != CCCD_UUID) return
+
+                if (status == BluetoothGatt.GATT_SUCCESS && gatt.device.bondState == BluetoothDevice.BOND_BONDED) {
+                    bleServicesDiscovered = true
+                    Log.i(TAG, "BLE NUS secured notifications ready")
+                    return
                 }
 
-                bleServicesDiscovered = true
-                Log.i(TAG, "BLE NUS service ready")
+                if (
+                    status == BluetoothGatt.GATT_INSUFFICIENT_AUTHENTICATION ||
+                    status == BluetoothGatt.GATT_INSUFFICIENT_ENCRYPTION ||
+                    gatt.device.bondState != BluetoothDevice.BOND_BONDED
+                ) {
+                    markPairingRequired(gatt.device.name ?: "RNode", "secured notification setup was rejected")
+                }
+                Log.e(TAG, "NUS notification descriptor write failed: ${gattStatusToString(status)}")
+                bleSetupFailed = true
             }
 
             override fun onCharacteristicChanged(
@@ -783,7 +854,19 @@ class KotlinRNodeBridge(
         bleConnected = false
         bleServicesDiscovered = false
         bleMtuCallbackReceived = false
+        bleSetupFailed = false
     }
+
+    private fun markPairingRequired(
+        deviceName: String,
+        detail: String,
+    ) {
+        lastConnectionFailure = CONNECTION_FAILURE_PAIRING_REQUIRED
+        Log.e(TAG, "Pairing required for $deviceName: $detail")
+    }
+
+    /** Machine-readable failure from the most recent connect attempt. */
+    fun getLastConnectionFailure(): String? = lastConnectionFailure
 
     /**
      * Disconnect from the current RNode device.

--- a/rns-host/src/main/kotlin/network/columba/app/rns/host/rnode/KotlinRNodeBridge.kt
+++ b/rns-host/src/main/kotlin/network/columba/app/rns/host/rnode/KotlinRNodeBridge.kt
@@ -119,6 +119,8 @@ class KotlinRNodeBridge(
         private const val BLE_CONNECT_TIMEOUT_MS = 15000L
         private const val BLE_CONNECT_MAX_RETRIES = 3
         private const val BLE_RETRY_DELAY_MS = 1000L
+        private const val CONNECTION_RESULT_CONNECTED = "connected"
+        private const val CONNECTION_RESULT_FAILED = "failed"
         private const val CONNECTION_FAILURE_PAIRING_REQUIRED = "pairing_required"
 
         /**
@@ -392,6 +394,7 @@ class KotlinRNodeBridge(
      * @param mode Connection mode: "classic" for Bluetooth Classic, "ble" for BLE
      * @return true if connection successful, false otherwise
      */
+    @Synchronized
     @Suppress("ReturnCount")
     fun connect(
         deviceName: String,
@@ -452,6 +455,24 @@ class KotlinRNodeBridge(
             RNodeConnectionMode.BLE -> connectBle(deviceName, adapter)
         }
     }
+
+    /**
+     * Connect and return its machine-readable result as one synchronized operation.
+     *
+     * The bridge is shared by every Python RNode interface. Returning the result
+     * atomically prevents another interface from clearing or replacing the failure
+     * reason between a boolean connect result and a follow-up getter call.
+     */
+    @Synchronized
+    fun connectWithResult(
+        deviceName: String,
+        mode: String,
+    ): String =
+        if (connect(deviceName, mode)) {
+            CONNECTION_RESULT_CONNECTED
+        } else {
+            lastConnectionFailure ?: CONNECTION_RESULT_FAILED
+        }
 
     /**
      * Connect via Bluetooth Classic (SPP/RFCOMM).

--- a/rns-host/src/test/kotlin/network/columba/app/rns/host/rnode/KotlinRNodeBridgeOnlineStatusTest.kt
+++ b/rns-host/src/test/kotlin/network/columba/app/rns/host/rnode/KotlinRNodeBridgeOnlineStatusTest.kt
@@ -1,11 +1,15 @@
 package network.columba.app.rns.host.rnode
 
 import android.bluetooth.BluetoothAdapter
+import android.bluetooth.BluetoothDevice
+import android.bluetooth.BluetoothGatt
 import android.bluetooth.BluetoothManager
 import android.content.Context
 import io.mockk.clearAllMocks
 import io.mockk.every
+import io.mockk.just
 import io.mockk.mockk
+import io.mockk.Runs
 import io.mockk.verify
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.isActive
@@ -53,7 +57,34 @@ class KotlinRNodeBridgeOnlineStatusTest {
         val bridge = KotlinRNodeBridge(mockContext)
 
         assertFalse(bridge.connect("RNode 1234", "ble"))
+        assertEquals("pairing_required", bridge.getLastConnectionFailure())
 
+        verify(exactly = 0) { mockBluetoothAdapter.bluetoothLeScanner }
+    }
+
+    @Test
+    fun `runtime BLE connect rejects a bond lost during GATT setup`() {
+        val device = mockk<BluetoothDevice>()
+        val gatt = mockk<BluetoothGatt>()
+        every { device.name } returns "RNode E517"
+        every { device.address } returns "9C:13:9E:A0:80:11"
+        every { device.bondState } returnsMany
+            listOf(
+                BluetoothDevice.BOND_BONDED,
+                BluetoothDevice.BOND_NONE,
+            )
+        every { device.connectGatt(mockContext, false, any(), BluetoothDevice.TRANSPORT_LE) } returns gatt
+        every { gatt.disconnect() } just Runs
+        every { gatt.close() } just Runs
+        every { mockBluetoothAdapter.bondedDevices } returns setOf(device)
+        val bridge = KotlinRNodeBridge(mockContext)
+
+        assertFalse(bridge.connect("RNode E517", "ble"))
+        assertEquals("pairing_required", bridge.getLastConnectionFailure())
+
+        verify(exactly = 1) {
+            device.connectGatt(mockContext, false, any(), BluetoothDevice.TRANSPORT_LE)
+        }
         verify(exactly = 0) { mockBluetoothAdapter.bluetoothLeScanner }
     }
 

--- a/rns-host/src/test/kotlin/network/columba/app/rns/host/rnode/KotlinRNodeBridgeOnlineStatusTest.kt
+++ b/rns-host/src/test/kotlin/network/columba/app/rns/host/rnode/KotlinRNodeBridgeOnlineStatusTest.kt
@@ -63,6 +63,14 @@ class KotlinRNodeBridgeOnlineStatusTest {
     }
 
     @Test
+    fun `atomic connect result carries pairing required reason`() {
+        every { mockBluetoothAdapter.bondedDevices } returns emptySet()
+        val bridge = KotlinRNodeBridge(mockContext)
+
+        assertEquals("pairing_required", bridge.connectWithResult("RNode 1234", "ble"))
+    }
+
+    @Test
     fun `runtime BLE connect rejects a bond lost during GATT setup`() {
         val device = mockk<BluetoothDevice>()
         val gatt = mockk<BluetoothGatt>()


### PR DESCRIPTION
## Summary

- detect missing, unresolved, or rejected Android BLE bonds before reporting RNode setup success
- propagate a typed `pairing_required` reason through the Kotlin bridge, Python RNode interface, and transport status payload
- stop automatic reconnect attempts when user pairing action is required
- show Pairing required with a guided Repair flow that preserves the configured interface and existing LoRa settings
- observe Android pairing completion, require a completed bond before repair can advance, and keep pairing failures retryable
- keep Back navigation inside the bond-only repair flow so preserved LoRa settings cannot be edited accidentally
- fail closed while repair configuration loads, expose only the persisted RNode target, and block manual, USB, or connection-mode retargeting
- revalidate the live Android bond at Continue and immediately before persistence; bind repair to app-database Bluetooth address metadata that is omitted from runtime config and IPC
- fail closed for legacy interfaces without a recoverable address; ordinary Edit requires explicit device selection and cannot Update until identity is recorded
- preserve the exact interface ID, saved interface name, and LoRa profile across every repair success path
- refresh externally written pending changes when returning to Network Interfaces so Python-backend updates expose Apply & Restart
- suppress pre-update runtime pairing diagnostics while a restart is pending

## Issue relationship

Partially addresses the Android BLE recovery layer described in #905.

The stale-bond failure may explain one cause of the broader symptoms in #686 and #1021, but those reports require reporter retesting. This PR intentionally does not claim to close them.

This does not address the online RX/TX and SNR behavior in #961, sustained-traffic disconnects in #748, or Classic Bluetooth behavior in #887.

## Verification

- Kotlin RNode bridge online/failure-state regression suite
- Python RNode reconnect suite: 12 tests passed
- complete affected RNode wizard, Device Discovery, Interface Management, and status-event test classes
- ktlint, detekt, Android lint, Kotlin-backend compile, and no-Sentry Python-backend APK assembly
- physical Samsung SM-G998U1 and Heltec V3 validation with app data preserved:
  - reproduced stale Android bond failure after `HCI_ERR_KEY_MISSING`
  - existing configured interface displayed Pairing required instead of generic Offline
  - Repair opened explicit pairing recovery rather than ordinary edit/review
  - successful second pairing attempt dismissed recovery guidance
  - Update returned to Network Interfaces with Apply & Restart visible
  - after process restart, RNode E517 displayed Online without a stale pairing warning

## Risk and rollback

The runtime now stops reconnecting when the bridge identifies a pairing-required state because retries cannot repair missing bond keys. Other connection failures retain their existing retry behavior. The repair flow updates the existing interface rather than deleting it, and no database migration is included. Rollback is a normal code revert.
