### PR TITLE
fix(rnode): recover cleanly after Bluetooth adapter cycle

### DIFF
--- a/rns-backend-py/src/main/python/columba_rnode_interface.py
+++ b/rns-backend-py/src/main/python/columba_rnode_interface.py
@@ -520,6 +520,25 @@ class ColumbaRNodeInterface(Interface):
         except Exception as e:  # noqa: BLE001
             RNS.log(f"Bridge contention check failed (continuing): {e}", RNS.LOG_DEBUG)
 
+        # Stop the previous generation's poller before creating a replacement
+        # transport. Otherwise it can consume and drop bytes from the fresh
+        # Kotlin bridge owner before the post-connect cleanup below runs.
+        if self._read_thread is not None and self._read_thread.is_alive():
+            RNS.log(
+                f"ColumbaRNodeInterface[{self.name}]: stopping stale BLE/Classic "
+                "read thread before reconnect transport",
+                RNS.LOG_INFO,
+            )
+            self._running.clear()
+            self._read_thread.join(timeout=2.0)
+            if self._read_thread.is_alive():
+                RNS.log(
+                    f"ColumbaRNodeInterface[{self.name}]: stale read thread did not stop "
+                    "within timeout — aborting start to prevent race",
+                    RNS.LOG_ERROR,
+                )
+                return False
+
         RNS.log(f"Connecting to RNode '{self.target_device_name}' via {mode_str}...", RNS.LOG_INFO)
 
         # Install observers before connect(). Kotlin can synchronously report
@@ -572,29 +591,6 @@ class ColumbaRNodeInterface(Interface):
             self.kotlin_bridge.disconnect()
             return False
 
-
-        # Stop any stale read thread before starting a new one.
-        # _on_connection_state_changed(False) does NOT clear _running, so an
-        # existing thread from the previous connection is still looping. Without
-        # this guard, both the old and the new thread poll the same
-        # KotlinRNodeBridge.readBuffer concurrently, stealing bytes from each
-        # other and corrupting every KISS frame. _start_usb() already applies
-        # this pattern (lines ~594-600) — mirror it here.
-        if self._read_thread is not None and self._read_thread.is_alive():
-            RNS.log(
-                f"ColumbaRNodeInterface[{self.name}]: stopping stale BLE/Classic "
-                "read thread before reconnect start",
-                RNS.LOG_INFO,
-            )
-            self._running.clear()
-            self._read_thread.join(timeout=2.0)
-            if self._read_thread.is_alive():
-                RNS.log(
-                    f"ColumbaRNodeInterface[{self.name}]: stale read thread did not stop "
-                    "within timeout — aborting start to prevent race",
-                    RNS.LOG_ERROR,
-                )
-                return False
 
         # A prior connection's protocol responses must not validate this
         # transport. Require fresh detection, firmware, and radio readback.

--- a/rns-backend-py/src/main/python/columba_rnode_interface.py
+++ b/rns-backend-py/src/main/python/columba_rnode_interface.py
@@ -1502,6 +1502,15 @@ class ColumbaRNodeInterface(Interface):
                 RNS.LOG_INFO,
             )
 
+            # A disconnect observed during a failed attempt is already accounted
+            # for by the retry this loop is about to perform. Do not let that
+            # request poison a later successful attempt and force an unnecessary
+            # idempotent reconnect against stale GATT state. A disconnect during
+            # this new attempt sets the flag again and is consumed below before
+            # successful ownership teardown.
+            with self._reconnect_lock:
+                self._reconnect_requested = False
+
             try:
                 if self.start():
                     with self._reconnect_lock:

--- a/rns-backend-py/src/test/python/test_columba_rnode_reconnect.py
+++ b/rns-backend-py/src/test/python/test_columba_rnode_reconnect.py
@@ -388,6 +388,30 @@ class RNodeReconnectTests(unittest.TestCase):
         self.assertTrue(interface.online)
         self.assertFalse(interface._reconnecting)
 
+    def test_disconnect_during_failed_attempt_does_not_poison_next_success(self):
+        interface = self.new_interface()
+        interface.kotlin_bridge = ScriptedBleBridge(interface, [True])
+        attempts = 0
+
+        def start():
+            nonlocal attempts
+            attempts += 1
+            if attempts == 1:
+                # Reproduce a GATT drop while RNode configuration is still
+                # finishing. The attempt fails, then the next attempt succeeds.
+                interface._on_connection_state_changed(False, "Test RNode")
+                return False
+            interface._set_online(True)
+            return True
+
+        interface.start = start
+        interface._reconnection_loop()
+
+        self.assertEqual(2, attempts)
+        self.assertTrue(interface.online)
+        self.assertFalse(interface._reconnecting)
+        self.assertFalse(interface._reconnect_requested)
+
     def test_start_attempts_are_single_flight(self):
         interface = self.new_interface()
         first_entered = threading.Event()

--- a/rns-backend-py/src/test/python/test_columba_rnode_reconnect.py
+++ b/rns-backend-py/src/test/python/test_columba_rnode_reconnect.py
@@ -137,6 +137,36 @@ class RNodeReconnectTests(unittest.TestCase):
         interface.usb_bridge = None
         return interface
 
+    def test_stale_reader_is_joined_before_replacement_transport_connects(self):
+        interface = self.new_interface()
+        bridge = ScriptedBleBridge(interface, [False])
+        interface.kotlin_bridge = bridge
+        interface._running.set()
+        events = []
+
+        class StaleReader:
+            alive = True
+
+            def is_alive(self):
+                return self.alive
+
+            def join(self, timeout):
+                events.append(("join", timeout, interface._running.is_set()))
+                self.alive = False
+
+        interface._read_thread = StaleReader()
+        original_connect = bridge.connect
+
+        def connect_after_join(device_name, mode):
+            events.append(("connect", interface._read_thread.is_alive()))
+            return original_connect(device_name, mode)
+
+        bridge.connect = connect_after_join
+
+        self.assertFalse(interface._start_once())
+        self.assertEqual([("join", 2.0, False), ("connect", False)], events)
+        self.assertEqual(1, bridge.connect_calls)
+
     def test_ble_reconnect_survives_transport_and_configuration_failures(self):
         interface = self.new_interface()
         bridge = ScriptedBleBridge(interface, [False, True, True])

--- a/rns-host/src/main/kotlin/network/columba/app/rns/host/rnode/KotlinRNodeBridge.kt
+++ b/rns-host/src/main/kotlin/network/columba/app/rns/host/rnode/KotlinRNodeBridge.kt
@@ -201,7 +201,8 @@ class KotlinRNodeBridge(
         }
     }
 
-    // Current connection mode
+    // Current connection mode and transport generation ownership.
+    private val transportOwnerLock = Any()
     private var connectionMode: RNodeConnectionMode? = null
 
     // Bluetooth Classic connection state
@@ -531,10 +532,34 @@ class KotlinRNodeBridge(
     /**
      * Connect via Bluetooth Classic (SPP/RFCOMM).
      */
+    internal fun replaceClassicSocketOwner(socket: BluetoothSocket) {
+        synchronized(transportOwnerLock) {
+            bluetoothSocket = socket
+            classicReadSocket = null
+            readBuffer.clear()
+        }
+    }
+
+    internal fun publishClassicRead(
+        ownerSocket: BluetoothSocket,
+        data: ByteArray,
+    ): Boolean =
+        synchronized(transportOwnerLock) {
+            if (!isCurrentClassicReader(ownerSocket)) {
+                false
+            } else {
+                for (byte in data) {
+                    readBuffer.offer(byte)
+                }
+                true
+            }
+        }
+
     private fun connectClassic(
         deviceName: String,
         adapter: BluetoothAdapter,
     ): Boolean {
+        var ownedSocket: BluetoothSocket? = null
         // Find the device by name in bonded devices
         val device: BluetoothDevice? =
             try {
@@ -552,9 +577,14 @@ class KotlinRNodeBridge(
         return try {
             Log.i(TAG, "Connecting to $deviceName (${device.address}) via Bluetooth Classic...")
 
-            // Create RFCOMM socket
-            val socket = device.createRfcommSocketToServiceRecord(SPP_UUID)
-            bluetoothSocket = socket
+            // Create and publish RFCOMM socket atomically against adapter invalidation.
+            val socket =
+                synchronized(transportOwnerLock) {
+                    device.createRfcommSocketToServiceRecord(SPP_UUID).also {
+                        replaceClassicSocketOwner(it)
+                    }
+                }
+            ownedSocket = socket
 
             // Cancel discovery to speed up connection
             try {
@@ -566,29 +596,44 @@ class KotlinRNodeBridge(
             // Connect (blocking call)
             socket.connect()
 
-            // Setup streams
+            // Setup streams, then publish readiness only if this socket still owns the attempt.
             val connectedInputStream = BufferedInputStream(socket.inputStream, STREAM_BUFFER_SIZE)
-            inputStream = connectedInputStream
-            outputStream = BufferedOutputStream(socket.outputStream, STREAM_BUFFER_SIZE)
-            connectedDeviceName = deviceName
-            connectionMode = RNodeConnectionMode.CLASSIC
-            isConnected.set(true)
+            val connectedOutputStream = BufferedOutputStream(socket.outputStream, STREAM_BUFFER_SIZE)
+            val admitted =
+                synchronized(transportOwnerLock) {
+                    if (bluetoothSocket !== socket) {
+                        false
+                    } else {
+                        inputStream = connectedInputStream
+                        outputStream = connectedOutputStream
+                        connectedDeviceName = deviceName
+                        connectionMode = RNodeConnectionMode.CLASSIC
+                        isConnected.set(true)
+                        classicReadSocket = socket
+                        true
+                    }
+                }
+            if (!admitted) {
+                connectedInputStream.close()
+                connectedOutputStream.close()
+                socket.close()
+                return false
+            }
 
             Log.i(TAG, "Connected to $deviceName via Bluetooth Classic")
 
-            notifyConnectionStateChanged(true, deviceName, "classic connect")
-
-            // Start a reader owned by this exact socket generation.
+            // Start a reader owned by this exact socket generation before notifying Python.
             startClassicReadThread(socket, connectedInputStream)
+            notifyConnectionStateChanged(true, deviceName, "classic connect")
 
             true
         } catch (e: IOException) {
             Log.e(TAG, "Failed to connect to $deviceName via Classic", e)
-            cleanupClassic()
+            ownedSocket?.let { cleanupClassic(it) }
             false
         } catch (e: SecurityException) {
             Log.e(TAG, "Missing Bluetooth permission", e)
-            cleanupClassic()
+            ownedSocket?.let { cleanupClassic(it) }
             false
         }
     }
@@ -648,59 +693,107 @@ class KotlinRNodeBridge(
     /**
      * Single attempt to connect via BLE GATT.
      */
+    private fun resetBleAttemptStateLocked() {
+        bleConnected = false
+        bleServicesDiscovered = false
+        bleMtuCallbackReceived = false
+        bleSetupFailed = false
+        bleRxCharacteristic = null
+        bleTxCharacteristic = null
+        bleMtu = 20
+        bleRssi = -100
+        readBuffer.clear()
+    }
+
+    internal fun replaceBleGattOwner(gatt: BluetoothGatt) {
+        synchronized(transportOwnerLock) {
+            resetBleAttemptStateLocked()
+            bluetoothGatt = gatt
+        }
+    }
+
+    private fun createBleGatt(device: BluetoothDevice): BluetoothGatt =
+        synchronized(transportOwnerLock) {
+            device.connectGatt(context, false, gattCallback, BluetoothDevice.TRANSPORT_LE).also {
+                replaceBleGattOwner(it)
+            }
+        }
+
+    private fun isCurrentGatt(gatt: BluetoothGatt): Boolean =
+        synchronized(transportOwnerLock) { gatt === bluetoothGatt }
+
+    private fun isBleAttemptActive(gatt: BluetoothGatt): Boolean =
+        synchronized(transportOwnerLock) {
+            gatt === bluetoothGatt && !bleServicesDiscovered && !bleSetupFailed
+        }
+
+    private fun mutateCurrentGatt(
+        gatt: BluetoothGatt,
+        mutation: () -> Unit,
+    ): Boolean =
+        synchronized(transportOwnerLock) {
+            if (gatt !== bluetoothGatt) {
+                false
+            } else {
+                mutation()
+                true
+            }
+        }
+
     @Suppress("ReturnCount")
     private fun attemptBleConnection(
         device: BluetoothDevice,
         deviceName: String,
     ): Boolean {
+        var ownedGatt: BluetoothGatt? = null
         return try {
             if (device.bondState != BluetoothDevice.BOND_BONDED) {
                 markPairingRequired(deviceName, "bond was lost before GATT setup")
                 return false
             }
 
-            // Reset BLE state
-            bleConnected = false
-            bleServicesDiscovered = false
-            bleMtuCallbackReceived = false
-            bleSetupFailed = false
-            bleRxCharacteristic = null
-            bleTxCharacteristic = null
-
-            // Connect GATT
+            // Connect GATT and publish the new owner atomically with attempt-state reset.
             Log.d(TAG, "Connecting GATT to ${device.address}...")
-            bluetoothGatt = device.connectGatt(context, false, gattCallback, BluetoothDevice.TRANSPORT_LE)
+            val attemptGatt = createBleGatt(device)
+            ownedGatt = attemptGatt
 
             // Wait for connection and service discovery
             val startTime = System.currentTimeMillis()
             while (
-                !bleServicesDiscovered &&
-                !bleSetupFailed &&
+                isBleAttemptActive(attemptGatt) &&
                 (System.currentTimeMillis() - startTime) < BLE_CONNECT_TIMEOUT_MS
             ) {
                 if (device.bondState != BluetoothDevice.BOND_BONDED) {
-                    markPairingRequired(deviceName, "bond was lost during GATT setup")
-                    cleanupBle()
+                    mutateCurrentGatt(attemptGatt) {
+                        markPairingRequired(deviceName, "bond was lost during GATT setup")
+                    }
+                    cleanupBle(attemptGatt)
                     return false
                 }
                 Thread.sleep(100)
             }
 
-            if (!bleServicesDiscovered) {
+            if (!isCurrentGatt(attemptGatt) || !bleServicesDiscovered) {
                 Log.e(TAG, "BLE setup failed or timed out before secured notifications were ready")
-                cleanupBle()
+                cleanupBle(attemptGatt)
                 return false
             }
 
             if (bleRxCharacteristic == null || bleTxCharacteristic == null) {
                 Log.e(TAG, "Nordic UART Service characteristics not found")
-                cleanupBle()
+                cleanupBle(attemptGatt)
                 return false
             }
 
-            connectedDeviceName = deviceName
-            connectionMode = RNodeConnectionMode.BLE
-            isConnected.set(true)
+            if (
+                !mutateCurrentGatt(attemptGatt) {
+                    connectedDeviceName = deviceName
+                    connectionMode = RNodeConnectionMode.BLE
+                    isConnected.set(true)
+                }
+            ) {
+                return false
+            }
 
             Log.d(TAG, "████ RNODE BLE SUCCESS ████ deviceName=$deviceName MTU=$bleMtu")
 
@@ -709,7 +802,7 @@ class KotlinRNodeBridge(
             true
         } catch (e: Exception) {
             Log.e(TAG, "Failed to connect to $deviceName via BLE", e)
-            cleanupBle()
+            ownedGatt?.let { cleanupBle(it) }
             false
         }
     }
@@ -725,32 +818,48 @@ class KotlinRNodeBridge(
                 status: Int,
                 newState: Int,
             ) {
-                if (gatt !== bluetoothGatt) {
-                    Log.w(TAG, "Ignoring connection-state callback from a stale GATT")
-                    return
-                }
                 when (newState) {
                     BluetoothProfile.STATE_CONNECTED -> {
+                        val admitted =
+                            mutateCurrentGatt(gatt) {
+                                bleConnected = true
+                                bleMtuCallbackReceived = false
+                            }
+                        if (!admitted) {
+                            Log.w(TAG, "Ignoring connection-state callback from a stale GATT")
+                            return
+                        }
                         Log.i(TAG, "BLE connected, requesting MTU...")
-                        bleConnected = true
-                        bleMtuCallbackReceived = false
                         // Request higher MTU for better throughput
                         gatt.requestMtu(512)
                         // Timeout: if onMtuChanged doesn't fire within 2 seconds,
                         // proceed with service discovery anyway to prevent hang
                         scope.launch {
                             delay(2000)
-                            if (gatt === bluetoothGatt && !bleMtuCallbackReceived && bleConnected) {
+                            var shouldDiscover = false
+                            mutateCurrentGatt(gatt) {
+                                shouldDiscover = !bleMtuCallbackReceived && bleConnected
+                            }
+                            if (shouldDiscover) {
                                 Log.w(TAG, "MTU callback timeout, proceeding with service discovery")
                                 gatt.discoverServices()
                             }
                         }
                     }
                     BluetoothProfile.STATE_DISCONNECTED -> {
+                        var shouldDisconnect = false
+                        val admitted =
+                            mutateCurrentGatt(gatt) {
+                                bleConnected = false
+                                shouldDisconnect = isConnected.get() && connectionMode == RNodeConnectionMode.BLE
+                            }
+                        if (!admitted) {
+                            Log.w(TAG, "Ignoring connection-state callback from a stale GATT")
+                            return
+                        }
                         Log.i(TAG, "BLE disconnected (status=${gattStatusToString(status)})")
-                        bleConnected = false
-                        if (isConnected.get() && connectionMode == RNodeConnectionMode.BLE) {
-                            handleDisconnect()
+                        if (shouldDisconnect) {
+                            handleDisconnect(expectedBleGatt = gatt)
                         }
                     }
                 }
@@ -761,18 +870,24 @@ class KotlinRNodeBridge(
                 mtu: Int,
                 status: Int,
             ) {
-                if (gatt !== bluetoothGatt) {
+                val admitted =
+                    mutateCurrentGatt(gatt) {
+                        bleMtuCallbackReceived = true
+                        if (status == BluetoothGatt.GATT_SUCCESS) {
+                            bleMtu = mtu
+                        }
+                    }
+                if (!admitted) {
                     Log.w(TAG, "Ignoring MTU callback from a stale GATT")
                     return
                 }
-                bleMtuCallbackReceived = true
                 if (status == BluetoothGatt.GATT_SUCCESS) {
-                    bleMtu = mtu
                     Log.d(TAG, "BLE MTU changed to $mtu")
                 } else {
                     Log.w(TAG, "MTU change failed with status $status, using default MTU")
                 }
-                // Discover services after MTU negotiation
+                // Discover services after MTU negotiation. If ownership changed
+                // after admission, any resulting callback is rejected.
                 gatt.discoverServices()
             }
 
@@ -781,7 +896,7 @@ class KotlinRNodeBridge(
                 gatt: BluetoothGatt,
                 status: Int,
             ) {
-                if (gatt !== bluetoothGatt) {
+                if (!isCurrentGatt(gatt)) {
                     Log.w(TAG, "Ignoring service discovery from a stale GATT")
                     return
                 }
@@ -799,14 +914,21 @@ class KotlinRNodeBridge(
                     return
                 }
 
-                // Get characteristics
+                // Get characteristics, then publish them only if this GATT still owns the attempt.
                 val rxChar = nusService.getCharacteristic(NUS_RX_CHAR_UUID)
                 val txChar = nusService.getCharacteristic(NUS_TX_CHAR_UUID)
-                bleRxCharacteristic = rxChar
-                bleTxCharacteristic = txChar
 
                 if (rxChar == null || txChar == null) {
                     Log.e(TAG, "NUS characteristics not found")
+                    return
+                }
+                if (
+                    !mutateCurrentGatt(gatt) {
+                        bleRxCharacteristic = rxChar
+                        bleTxCharacteristic = txChar
+                    }
+                ) {
+                    Log.w(TAG, "Ignoring service discovery completed by a stale GATT")
                     return
                 }
 
@@ -814,19 +936,19 @@ class KotlinRNodeBridge(
                 // descriptor write succeeds while the device remains bonded.
                 if (!gatt.setCharacteristicNotification(txChar, true)) {
                     Log.e(TAG, "Failed to enable local NUS notifications")
-                    bleSetupFailed = true
+                    mutateCurrentGatt(gatt) { bleSetupFailed = true }
                     return
                 }
                 val descriptor = txChar.getDescriptor(CCCD_UUID)
                 if (descriptor == null) {
                     Log.e(TAG, "NUS notification descriptor not found")
-                    bleSetupFailed = true
+                    mutateCurrentGatt(gatt) { bleSetupFailed = true }
                     return
                 }
                 descriptor.value = BluetoothGattDescriptor.ENABLE_NOTIFICATION_VALUE
                 if (!gatt.writeDescriptor(descriptor)) {
                     Log.e(TAG, "Failed to start NUS notification descriptor write")
-                    bleSetupFailed = true
+                    mutateCurrentGatt(gatt) { bleSetupFailed = true }
                 }
             }
 
@@ -836,48 +958,58 @@ class KotlinRNodeBridge(
                 descriptor: BluetoothGattDescriptor,
                 status: Int,
             ) {
-                if (gatt !== bluetoothGatt) {
+                if (descriptor.uuid != CCCD_UUID) return
+
+                val bonded = gatt.device.bondState == BluetoothDevice.BOND_BONDED
+                if (status == BluetoothGatt.GATT_SUCCESS && bonded) {
+                    if (mutateCurrentGatt(gatt) { bleServicesDiscovered = true }) {
+                        Log.i(TAG, "BLE NUS secured notifications ready")
+                    } else {
+                        Log.w(TAG, "Ignoring descriptor write completed by a stale GATT")
+                    }
+                    return
+                }
+
+                val pairingRequired =
+                    status == BluetoothGatt.GATT_INSUFFICIENT_AUTHENTICATION ||
+                        status == BluetoothGatt.GATT_INSUFFICIENT_ENCRYPTION ||
+                        !bonded
+                val admitted =
+                    mutateCurrentGatt(gatt) {
+                        if (pairingRequired) {
+                            markPairingRequired(
+                                gatt.device.name ?: "RNode",
+                                "secured notification setup was rejected",
+                            )
+                        }
+                        bleSetupFailed = true
+                    }
+                if (!admitted) {
                     Log.w(TAG, "Ignoring descriptor write from a stale GATT")
                     return
                 }
-                if (descriptor.uuid != CCCD_UUID) return
-
-                if (status == BluetoothGatt.GATT_SUCCESS && gatt.device.bondState == BluetoothDevice.BOND_BONDED) {
-                    bleServicesDiscovered = true
-                    Log.i(TAG, "BLE NUS secured notifications ready")
-                    return
-                }
-
-                if (
-                    status == BluetoothGatt.GATT_INSUFFICIENT_AUTHENTICATION ||
-                    status == BluetoothGatt.GATT_INSUFFICIENT_ENCRYPTION ||
-                    gatt.device.bondState != BluetoothDevice.BOND_BONDED
-                ) {
-                    markPairingRequired(gatt.device.name ?: "RNode", "secured notification setup was rejected")
-                }
                 Log.e(TAG, "NUS notification descriptor write failed: ${gattStatusToString(status)}")
-                bleSetupFailed = true
             }
 
             override fun onCharacteristicChanged(
                 gatt: BluetoothGatt,
                 characteristic: BluetoothGattCharacteristic,
             ) {
-                if (gatt !== bluetoothGatt) {
-                    Log.w(TAG, "Ignoring characteristic change from a stale GATT")
-                    return
-                }
-                if (characteristic.uuid == NUS_TX_CHAR_UUID) {
-                    val data = characteristic.value
-                    if (data != null && data.isNotEmpty()) {
-                        Log.v(TAG, "BLE received ${data.size} bytes")
+                if (characteristic.uuid != NUS_TX_CHAR_UUID) return
+                val data = characteristic.value
+                if (data == null || data.isEmpty()) return
 
-                        // Add to read buffer
+                if (
+                    !mutateCurrentGatt(gatt) {
                         for (byte in data) {
                             readBuffer.offer(byte)
                         }
                     }
+                ) {
+                    Log.w(TAG, "Ignoring characteristic change from a stale GATT")
+                    return
                 }
+                Log.v(TAG, "BLE received ${data.size} bytes")
             }
 
             @Deprecated("Deprecated in API 33")
@@ -886,22 +1018,22 @@ class KotlinRNodeBridge(
                 characteristic: BluetoothGattCharacteristic,
                 status: Int,
             ) {
-                if (gatt !== bluetoothGatt) {
+                val admitted =
+                    mutateCurrentGatt(gatt) {
+                        // Signal write completion to the exact current GATT write.
+                        synchronized(bleWriteLock) {
+                            val currentLatch = bleWriteLatch
+                            if (currentLatch != null) {
+                                bleWriteStatus.set(status)
+                                currentLatch.countDown()
+                            } else {
+                                Log.w(TAG, "Ignoring stale BLE write callback (no latch)")
+                            }
+                        }
+                    }
+                if (!admitted) {
                     Log.w(TAG, "Ignoring characteristic write from a stale GATT")
                     return
-                }
-                // Signal write completion to waiting thread
-                // Use write ID to prevent race condition where delayed callback
-                // corrupts status for a different write operation
-                synchronized(bleWriteLock) {
-                    val currentLatch = bleWriteLatch
-                    if (currentLatch != null) {
-                        bleWriteStatus.set(status)
-                        currentLatch.countDown()
-                    } else {
-                        // Stale callback - latch was already cleared (write timed out or completed)
-                        Log.w(TAG, "Ignoring stale BLE write callback (no latch)")
-                    }
                 }
                 if (status != BluetoothGatt.GATT_SUCCESS) {
                     Log.e(TAG, "BLE write failed: $status")
@@ -913,12 +1045,17 @@ class KotlinRNodeBridge(
                 rssi: Int,
                 status: Int,
             ) {
-                if (gatt !== bluetoothGatt) {
+                val admitted =
+                    mutateCurrentGatt(gatt) {
+                        if (status == BluetoothGatt.GATT_SUCCESS) {
+                            bleRssi = rssi
+                        }
+                    }
+                if (!admitted) {
                     Log.w(TAG, "Ignoring RSSI callback from a stale GATT")
                     return
                 }
                 if (status == BluetoothGatt.GATT_SUCCESS) {
-                    bleRssi = rssi
                     Log.v(TAG, "BLE RSSI: $rssi dBm")
                 } else {
                     Log.w(TAG, "Failed to read RSSI: status=$status")
@@ -929,20 +1066,65 @@ class KotlinRNodeBridge(
     /**
      * Clean up BLE resources.
      */
-    private fun cleanupBle() {
+    private fun closeBleGatt(gatt: BluetoothGatt?) {
         try {
-            bluetoothGatt?.disconnect()
-            bluetoothGatt?.close()
+            gatt?.disconnect()
+            gatt?.close()
         } catch (e: Exception) {
             Log.w(TAG, "Error closing BLE GATT", e)
         }
-        bluetoothGatt = null
-        bleRxCharacteristic = null
-        bleTxCharacteristic = null
-        bleConnected = false
-        bleServicesDiscovered = false
-        bleMtuCallbackReceived = false
-        bleSetupFailed = false
+    }
+
+    private fun closeClassicResources(
+        resources: Triple<BufferedInputStream?, BufferedOutputStream?, BluetoothSocket?>,
+    ) {
+        try {
+            resources.first?.close()
+        } catch (e: IOException) {
+            Log.w(TAG, "Error closing input stream", e)
+        }
+        try {
+            resources.second?.close()
+        } catch (e: IOException) {
+            Log.w(TAG, "Error closing output stream", e)
+        }
+        try {
+            resources.third?.close()
+        } catch (e: IOException) {
+            Log.w(TAG, "Error closing socket", e)
+        }
+    }
+
+    private fun cleanupAllTransports() {
+        val detached =
+            synchronized(transportOwnerLock) {
+                val classicResources = Triple(inputStream, outputStream, bluetoothSocket)
+                val gatt = bluetoothGatt
+                inputStream = null
+                outputStream = null
+                bluetoothSocket = null
+                classicReadSocket = null
+                bluetoothGatt = null
+                resetBleAttemptStateLocked()
+                classicResources to gatt
+            }
+        closeClassicResources(detached.first)
+        closeBleGatt(detached.second)
+    }
+
+    private fun cleanupBle(expectedGatt: BluetoothGatt? = null) {
+        val gattToClose =
+            synchronized(transportOwnerLock) {
+                if (expectedGatt != null && bluetoothGatt !== expectedGatt) {
+                    return
+                }
+                val currentGatt = bluetoothGatt
+                bluetoothGatt = null
+                resetBleAttemptStateLocked()
+                readBuffer.clear()
+                currentGatt
+            }
+        closeBleGatt(gattToClose)
     }
 
     private fun markPairingRequired(
@@ -960,29 +1142,44 @@ class KotlinRNodeBridge(
      * Disconnect from the current RNode device.
      */
     fun disconnect() {
-        if (!isConnected.get()) {
-            Log.d(TAG, "Not connected")
+        var deviceName: String? = null
+        var mode: RNodeConnectionMode? = null
+        var bleOwner: BluetoothGatt? = null
+        var classicOwner: BluetoothSocket? = null
+        val wasOnline =
+            synchronized(transportOwnerLock) {
+                if (!isConnected.getAndSet(false)) {
+                    false
+                } else {
+                    deviceName = connectedDeviceName
+                    mode = connectionMode
+                    bleOwner = bluetoothGatt
+                    classicOwner = bluetoothSocket
+                    true
+                }
+            }
+        if (!wasOnline) {
+            Log.d(TAG, "Not online; cleaning any provisional Bluetooth transports")
+            cleanupAllTransports()
             return
         }
 
-        val deviceName = connectedDeviceName
-        val mode = connectionMode
         Log.i(TAG, "Disconnecting from $deviceName (mode=$mode)...")
-
-        isConnected.set(false)
-
         when (mode) {
-            RNodeConnectionMode.CLASSIC -> cleanupClassic()
-            RNodeConnectionMode.BLE -> cleanupBle()
+            RNodeConnectionMode.CLASSIC -> classicOwner?.let { cleanupClassic(it) }
+            RNodeConnectionMode.BLE -> bleOwner?.let { cleanupBle(it) }
             null -> {
-                cleanupClassic()
-                cleanupBle()
+                cleanupAllTransports()
             }
         }
 
-        connectionMode = null
-        connectedDeviceName = null
-        readBuffer.clear()
+        synchronized(transportOwnerLock) {
+            if (!isConnected.get() && bluetoothGatt == null && bluetoothSocket == null) {
+                connectionMode = null
+                connectedDeviceName = null
+                readBuffer.clear()
+            }
+        }
 
         Log.i(TAG, "Disconnected from $deviceName")
     }
@@ -1331,17 +1528,19 @@ class KotlinRNodeBridge(
     /**
      * Start the background read thread for Bluetooth Classic.
      */
-    private fun isCurrentClassicTransport(ownerSocket: BluetoothSocket): Boolean =
-        bluetoothSocket === ownerSocket && connectionMode == RNodeConnectionMode.CLASSIC
-
     private fun isCurrentClassicReader(ownerSocket: BluetoothSocket): Boolean =
-        isConnected.get() && isCurrentClassicTransport(ownerSocket) && classicReadSocket === ownerSocket
+        synchronized(transportOwnerLock) {
+            isConnected.get() &&
+                bluetoothSocket === ownerSocket &&
+                connectionMode == RNodeConnectionMode.CLASSIC &&
+                classicReadSocket === ownerSocket
+        }
 
     private fun startClassicReadThread(
         ownerSocket: BluetoothSocket,
         ownerInputStream: BufferedInputStream,
     ) {
-        classicReadSocket = ownerSocket
+        if (!isCurrentClassicReader(ownerSocket)) return
 
         scope.launch {
             val buffer = ByteArray(READ_BUFFER_SIZE)
@@ -1356,13 +1555,8 @@ class KotlinRNodeBridge(
                         if (available > 0) {
                             val bytesRead = ownerInputStream.read(buffer, 0, minOf(available, buffer.size))
                             if (bytesRead > 0) {
-                                if (!isCurrentClassicReader(ownerSocket)) break
+                                if (!publishClassicRead(ownerSocket, buffer.copyOf(bytesRead))) break
                                 Log.v(TAG, "Classic received $bytesRead bytes")
-
-                                // Add to buffer only while this socket still owns it.
-                                for (i in 0 until bytesRead) {
-                                    readBuffer.offer(buffer[i])
-                                }
                             } else if (bytesRead == -1) {
                                 // End of stream - connection closed
                                 Log.i(TAG, "End of stream - connection closed by remote")
@@ -1387,37 +1581,68 @@ class KotlinRNodeBridge(
     }
 
     internal fun handleClassicReaderFinished(ownerSocket: BluetoothSocket) {
-        val ownsCurrentReader = classicReadSocket === ownerSocket
+        val ownsCurrentReader =
+            synchronized(transportOwnerLock) {
+                if (classicReadSocket !== ownerSocket) {
+                    false
+                } else {
+                    classicReadSocket = null
+                    true
+                }
+            }
         if (ownsCurrentReader) {
-            classicReadSocket = null
-        }
-        if (ownsCurrentReader && isConnected.get() && isCurrentClassicTransport(ownerSocket)) {
-            handleDisconnect()
+            handleDisconnect(expectedClassicSocket = ownerSocket)
         }
     }
 
     /**
-     * Handle unexpected disconnection.
+     * Handle unexpected disconnection from an optional exact transport owner.
      */
-    private fun handleDisconnect() {
-        if (isConnected.getAndSet(false)) {
-            val deviceName = connectedDeviceName
-            val mode = connectionMode
-            Log.w(TAG, "Connection lost to $deviceName (mode=$mode)")
-
-            when (mode) {
-                RNodeConnectionMode.CLASSIC -> cleanupClassic()
-                RNodeConnectionMode.BLE -> cleanupBle()
-                null -> {}
+    private fun handleDisconnect(
+        expectedBleGatt: BluetoothGatt? = null,
+        expectedClassicSocket: BluetoothSocket? = null,
+    ) {
+        var deviceName: String? = null
+        var mode: RNodeConnectionMode? = null
+        var bleOwner: BluetoothGatt? = null
+        var classicOwner: BluetoothSocket? = null
+        val admitted =
+            synchronized(transportOwnerLock) {
+                val bleMatches = expectedBleGatt == null || bluetoothGatt === expectedBleGatt
+                val classicMatches = expectedClassicSocket == null || bluetoothSocket === expectedClassicSocket
+                if (!bleMatches || !classicMatches || !isConnected.getAndSet(false)) {
+                    false
+                } else {
+                    deviceName = connectedDeviceName
+                    mode = connectionMode
+                    bleOwner = bluetoothGatt
+                    classicOwner = bluetoothSocket
+                    true
+                }
             }
+        if (!admitted) return
 
-            connectionMode = null
-            connectedDeviceName = null
-            readBuffer.clear()
+        Log.w(TAG, "Connection lost to $deviceName (mode=$mode)")
+        when (mode) {
+            RNodeConnectionMode.CLASSIC -> classicOwner?.let { cleanupClassic(it) }
+            RNodeConnectionMode.BLE -> bleOwner?.let { cleanupBle(it) }
+            null -> {}
+        }
 
-            // Notify python interface so it can flip self.online = False,
-            // notify the kotlin notification listener (ServiceNotificationManager
-            // posts the heads-up alert), and kick off the reconnection loop.
+        val shouldNotify =
+            synchronized(transportOwnerLock) {
+                if (!isConnected.get()) {
+                    connectionMode = null
+                    connectedDeviceName = null
+                    readBuffer.clear()
+                    true
+                } else {
+                    false
+                }
+            }
+        if (shouldNotify) {
+            // Notify python only if a replacement did not become online while
+            // the detached owner's resources were closing.
             notifyConnectionStateChanged(false, deviceName, "disconnect")
         }
     }
@@ -1433,37 +1658,28 @@ class KotlinRNodeBridge(
             // is still in flight, before connectionMode/isConnected are committed.
             // Close those provisional resources so stale callbacks cannot revive
             // the old transport after Bluetooth is enabled again.
-            cleanupClassic()
-            cleanupBle()
-            readBuffer.clear()
+            cleanupAllTransports()
         }
     }
 
     /**
      * Clean up Bluetooth Classic resources.
      */
-    private fun cleanupClassic() {
-        try {
-            inputStream?.close()
-        } catch (e: IOException) {
-            Log.w(TAG, "Error closing input stream", e)
-        }
-
-        try {
-            outputStream?.close()
-        } catch (e: IOException) {
-            Log.w(TAG, "Error closing output stream", e)
-        }
-
-        try {
-            bluetoothSocket?.close()
-        } catch (e: IOException) {
-            Log.w(TAG, "Error closing socket", e)
-        }
-
-        inputStream = null
-        outputStream = null
-        bluetoothSocket = null
+    private fun cleanupClassic(expectedSocket: BluetoothSocket? = null) {
+        val resources =
+            synchronized(transportOwnerLock) {
+                if (expectedSocket != null && bluetoothSocket !== expectedSocket) {
+                    return
+                }
+                val detached = Triple(inputStream, outputStream, bluetoothSocket)
+                inputStream = null
+                outputStream = null
+                bluetoothSocket = null
+                classicReadSocket = null
+                readBuffer.clear()
+                detached
+            }
+        closeClassicResources(resources)
     }
 
     /**

--- a/rns-host/src/main/kotlin/network/columba/app/rns/host/rnode/KotlinRNodeBridge.kt
+++ b/rns-host/src/main/kotlin/network/columba/app/rns/host/rnode/KotlinRNodeBridge.kt
@@ -82,6 +82,13 @@ interface RNodeOnlineStatusListener {
     )
 }
 
+internal fun interface RNodeConnectionStateNotifier {
+    fun notify(
+        connected: Boolean,
+        deviceName: String?,
+    )
+}
+
 /**
  * Kotlin RNode Bridge for Bluetooth communication.
  *
@@ -198,11 +205,13 @@ class KotlinRNodeBridge(
     private var connectionMode: RNodeConnectionMode? = null
 
     // Bluetooth Classic connection state
+    @Volatile
     private var bluetoothSocket: BluetoothSocket? = null
     private var inputStream: BufferedInputStream? = null
     private var outputStream: BufferedOutputStream? = null
 
     // BLE connection state
+    @Volatile
     private var bluetoothGatt: BluetoothGatt? = null
     private var bleRxCharacteristic: BluetoothGattCharacteristic? = null
     private var bleTxCharacteristic: BluetoothGattCharacteristic? = null
@@ -231,7 +240,9 @@ class KotlinRNodeBridge(
 
     // Thread-safe state flags
     private val isConnected = AtomicBoolean(false)
-    private val isReading = AtomicBoolean(false)
+
+    @Volatile
+    private var classicReadSocket: BluetoothSocket? = null
 
     // Read buffer for non-blocking reads
     private val readBuffer = ConcurrentLinkedQueue<Byte>()
@@ -251,15 +262,11 @@ class KotlinRNodeBridge(
     private val onlineStatusListeners = mutableListOf<RNodeOnlineStatusListener>()
 
     // Python-side connection-state callback. Single slot (not a list) because
-    // the consumer is ColumbaRNodeInterface._on_connection_state_changed —
-    // there's one Python interface per bridge instance at a time. PyObject
-    // (Chaquopy) instead of a Kotlin SAM because Chaquopy doesn't auto-
-    // adapt a Python bound method to a Kotlin functional interface
-    // ("Cannot convert method object to ..." at runtime). PyObject +
-    // callAttr("__call__", ...) is the working pattern used throughout
-    // KotlinBLEBridge for the same situation.
+    // the consumer is ColumbaRNodeInterface._on_connection_state_changed.
+    // Keep PyObject adaptation at this boundary while the transport lifecycle
+    // uses a testable Kotlin notifier.
     @Volatile
-    private var connectionStateListener: PyObject? = null
+    internal var connectionStateNotifier: RNodeConnectionStateNotifier? = null
 
     /**
      * Register a Kotlin listener for RNode error events.
@@ -349,7 +356,22 @@ class KotlinRNodeBridge(
      *   `def _on_connection_state_changed(self, connected: bool, device_name: str | None)`
      */
     fun setOnConnectionStateChanged(callback: PyObject) {
-        connectionStateListener = callback
+        connectionStateNotifier =
+            RNodeConnectionStateNotifier { connected, deviceName ->
+                callback.callAttr("__call__", connected, deviceName)
+            }
+    }
+
+    private fun notifyConnectionStateChanged(
+        connected: Boolean,
+        deviceName: String?,
+        transition: String,
+    ) {
+        try {
+            connectionStateNotifier?.notify(connected, deviceName)
+        } catch (e: Exception) {
+            Log.w(TAG, "Error in connection state listener ($transition)", e)
+        }
     }
 
     /**
@@ -545,7 +567,8 @@ class KotlinRNodeBridge(
             socket.connect()
 
             // Setup streams
-            inputStream = BufferedInputStream(socket.inputStream, STREAM_BUFFER_SIZE)
+            val connectedInputStream = BufferedInputStream(socket.inputStream, STREAM_BUFFER_SIZE)
+            inputStream = connectedInputStream
             outputStream = BufferedOutputStream(socket.outputStream, STREAM_BUFFER_SIZE)
             connectedDeviceName = deviceName
             connectionMode = RNodeConnectionMode.CLASSIC
@@ -553,14 +576,10 @@ class KotlinRNodeBridge(
 
             Log.i(TAG, "Connected to $deviceName via Bluetooth Classic")
 
-            try {
-                connectionStateListener?.callAttr("__call__", true, deviceName)
-            } catch (e: Exception) {
-                Log.w(TAG, "Error in connection state listener (classic connect)", e)
-            }
+            notifyConnectionStateChanged(true, deviceName, "classic connect")
 
-            // Start read thread
-            startClassicReadThread()
+            // Start a reader owned by this exact socket generation.
+            startClassicReadThread(socket, connectedInputStream)
 
             true
         } catch (e: IOException) {
@@ -685,11 +704,7 @@ class KotlinRNodeBridge(
 
             Log.d(TAG, "████ RNODE BLE SUCCESS ████ deviceName=$deviceName MTU=$bleMtu")
 
-            try {
-                connectionStateListener?.callAttr("__call__", true, deviceName)
-            } catch (e: Exception) {
-                Log.w(TAG, "Error in connection state listener (BLE connect)", e)
-            }
+            notifyConnectionStateChanged(true, deviceName, "BLE connect")
 
             true
         } catch (e: Exception) {
@@ -710,6 +725,10 @@ class KotlinRNodeBridge(
                 status: Int,
                 newState: Int,
             ) {
+                if (gatt !== bluetoothGatt) {
+                    Log.w(TAG, "Ignoring connection-state callback from a stale GATT")
+                    return
+                }
                 when (newState) {
                     BluetoothProfile.STATE_CONNECTED -> {
                         Log.i(TAG, "BLE connected, requesting MTU...")
@@ -721,7 +740,7 @@ class KotlinRNodeBridge(
                         // proceed with service discovery anyway to prevent hang
                         scope.launch {
                             delay(2000)
-                            if (!bleMtuCallbackReceived && bleConnected) {
+                            if (gatt === bluetoothGatt && !bleMtuCallbackReceived && bleConnected) {
                                 Log.w(TAG, "MTU callback timeout, proceeding with service discovery")
                                 gatt.discoverServices()
                             }
@@ -742,6 +761,10 @@ class KotlinRNodeBridge(
                 mtu: Int,
                 status: Int,
             ) {
+                if (gatt !== bluetoothGatt) {
+                    Log.w(TAG, "Ignoring MTU callback from a stale GATT")
+                    return
+                }
                 bleMtuCallbackReceived = true
                 if (status == BluetoothGatt.GATT_SUCCESS) {
                     bleMtu = mtu
@@ -840,6 +863,10 @@ class KotlinRNodeBridge(
                 gatt: BluetoothGatt,
                 characteristic: BluetoothGattCharacteristic,
             ) {
+                if (gatt !== bluetoothGatt) {
+                    Log.w(TAG, "Ignoring characteristic change from a stale GATT")
+                    return
+                }
                 if (characteristic.uuid == NUS_TX_CHAR_UUID) {
                     val data = characteristic.value
                     if (data != null && data.isNotEmpty()) {
@@ -859,6 +886,10 @@ class KotlinRNodeBridge(
                 characteristic: BluetoothGattCharacteristic,
                 status: Int,
             ) {
+                if (gatt !== bluetoothGatt) {
+                    Log.w(TAG, "Ignoring characteristic write from a stale GATT")
+                    return
+                }
                 // Signal write completion to waiting thread
                 // Use write ID to prevent race condition where delayed callback
                 // corrupts status for a different write operation
@@ -882,6 +913,10 @@ class KotlinRNodeBridge(
                 rssi: Int,
                 status: Int,
             ) {
+                if (gatt !== bluetoothGatt) {
+                    Log.w(TAG, "Ignoring RSSI callback from a stale GATT")
+                    return
+                }
                 if (status == BluetoothGatt.GATT_SUCCESS) {
                     bleRssi = rssi
                     Log.v(TAG, "BLE RSSI: $rssi dBm")
@@ -1296,10 +1331,17 @@ class KotlinRNodeBridge(
     /**
      * Start the background read thread for Bluetooth Classic.
      */
-    private fun startClassicReadThread() {
-        if (isReading.getAndSet(true)) {
-            return // Already reading
-        }
+    private fun isCurrentClassicTransport(ownerSocket: BluetoothSocket): Boolean =
+        bluetoothSocket === ownerSocket && connectionMode == RNodeConnectionMode.CLASSIC
+
+    private fun isCurrentClassicReader(ownerSocket: BluetoothSocket): Boolean =
+        isConnected.get() && isCurrentClassicTransport(ownerSocket) && classicReadSocket === ownerSocket
+
+    private fun startClassicReadThread(
+        ownerSocket: BluetoothSocket,
+        ownerInputStream: BufferedInputStream,
+    ) {
+        classicReadSocket = ownerSocket
 
         scope.launch {
             val buffer = ByteArray(READ_BUFFER_SIZE)
@@ -1307,18 +1349,17 @@ class KotlinRNodeBridge(
             Log.d(TAG, "Classic read thread started")
 
             try {
-                while (isConnected.get() && connectionMode == RNodeConnectionMode.CLASSIC) {
-                    val stream = inputStream ?: break
-
+                while (isCurrentClassicReader(ownerSocket)) {
                     try {
                         // Check if data is available (non-blocking check)
-                        val available = stream.available()
+                        val available = ownerInputStream.available()
                         if (available > 0) {
-                            val bytesRead = stream.read(buffer, 0, minOf(available, buffer.size))
+                            val bytesRead = ownerInputStream.read(buffer, 0, minOf(available, buffer.size))
                             if (bytesRead > 0) {
+                                if (!isCurrentClassicReader(ownerSocket)) break
                                 Log.v(TAG, "Classic received $bytesRead bytes")
 
-                                // Add to buffer
+                                // Add to buffer only while this socket still owns it.
                                 for (i in 0 until bytesRead) {
                                     readBuffer.offer(buffer[i])
                                 }
@@ -1332,20 +1373,26 @@ class KotlinRNodeBridge(
                             delay(10)
                         }
                     } catch (e: IOException) {
-                        if (isConnected.get()) {
+                        if (bluetoothSocket === ownerSocket && isConnected.get()) {
                             Log.e(TAG, "Classic read error", e)
                         }
                         break
                     }
                 }
             } finally {
-                isReading.set(false)
                 Log.d(TAG, "Classic read thread stopped")
-
-                if (isConnected.get() && connectionMode == RNodeConnectionMode.CLASSIC) {
-                    handleDisconnect()
-                }
+                handleClassicReaderFinished(ownerSocket)
             }
+        }
+    }
+
+    internal fun handleClassicReaderFinished(ownerSocket: BluetoothSocket) {
+        val ownsCurrentReader = classicReadSocket === ownerSocket
+        if (ownsCurrentReader) {
+            classicReadSocket = null
+        }
+        if (ownsCurrentReader && isConnected.get() && isCurrentClassicTransport(ownerSocket)) {
+            handleDisconnect()
         }
     }
 
@@ -1371,11 +1418,7 @@ class KotlinRNodeBridge(
             // Notify python interface so it can flip self.online = False,
             // notify the kotlin notification listener (ServiceNotificationManager
             // posts the heads-up alert), and kick off the reconnection loop.
-            try {
-                connectionStateListener?.callAttr("__call__", false, deviceName)
-            } catch (e: Exception) {
-                Log.w(TAG, "Error in connection state listener (disconnect)", e)
-            }
+            notifyConnectionStateChanged(false, deviceName, "disconnect")
         }
     }
 

--- a/rns-host/src/main/kotlin/network/columba/app/rns/host/rnode/KotlinRNodeBridge.kt
+++ b/rns-host/src/main/kotlin/network/columba/app/rns/host/rnode/KotlinRNodeBridge.kt
@@ -11,7 +11,10 @@ import android.bluetooth.BluetoothGattDescriptor
 import android.bluetooth.BluetoothManager
 import android.bluetooth.BluetoothProfile
 import android.bluetooth.BluetoothSocket
+import android.content.BroadcastReceiver
 import android.content.Context
+import android.content.Intent
+import android.content.IntentFilter
 import android.util.Log
 import com.chaquo.python.PyObject
 import kotlinx.coroutines.CoroutineScope
@@ -161,6 +164,35 @@ class KotlinRNodeBridge(
     private val scope = CoroutineScope(Dispatchers.IO + SupervisorJob())
     private val bluetoothManager = context.getSystemService(Context.BLUETOOTH_SERVICE) as BluetoothManager
     private val bluetoothAdapter: BluetoothAdapter? = bluetoothManager.adapter
+
+    private val bluetoothStateReceiver =
+        object : BroadcastReceiver() {
+            override fun onReceive(
+                context: Context?,
+                intent: Intent?,
+            ) {
+                if (intent?.action != BluetoothAdapter.ACTION_STATE_CHANGED) return
+                val state =
+                    intent.getIntExtra(
+                        BluetoothAdapter.EXTRA_STATE,
+                        BluetoothAdapter.STATE_OFF,
+                    )
+                handleBluetoothAdapterStateChanged(state)
+            }
+        }
+    private var isBluetoothStateReceiverRegistered = false
+
+    init {
+        try {
+            context.registerReceiver(
+                bluetoothStateReceiver,
+                IntentFilter(BluetoothAdapter.ACTION_STATE_CHANGED),
+            )
+            isBluetoothStateReceiverRegistered = true
+        } catch (e: Exception) {
+            Log.e(TAG, "Failed to register Bluetooth adapter state receiver", e)
+        }
+    }
 
     // Current connection mode
     private var connectionMode: RNodeConnectionMode? = null
@@ -1347,6 +1379,23 @@ class KotlinRNodeBridge(
         }
     }
 
+    internal fun handleBluetoothAdapterStateChanged(state: Int) {
+        if (state != BluetoothAdapter.STATE_TURNING_OFF && state != BluetoothAdapter.STATE_OFF) return
+
+        Log.i(TAG, "Bluetooth adapter is turning off; invalidating RNode connection")
+        if (isConnected.get()) {
+            handleDisconnect()
+        } else {
+            // Adapter state can change while connectGatt() or RFCOMM connect()
+            // is still in flight, before connectionMode/isConnected are committed.
+            // Close those provisional resources so stale callbacks cannot revive
+            // the old transport after Bluetooth is enabled again.
+            cleanupClassic()
+            cleanupBle()
+            readBuffer.clear()
+        }
+    }
+
     /**
      * Clean up Bluetooth Classic resources.
      */
@@ -1379,6 +1428,14 @@ class KotlinRNodeBridge(
      */
     fun shutdown() {
         disconnect()
+        if (isBluetoothStateReceiverRegistered) {
+            try {
+                context.unregisterReceiver(bluetoothStateReceiver)
+            } catch (e: Exception) {
+                Log.w(TAG, "Error unregistering Bluetooth adapter state receiver", e)
+            }
+            isBluetoothStateReceiverRegistered = false
+        }
         scope.cancel()
     }
 }

--- a/rns-host/src/main/kotlin/network/columba/app/rns/host/rnode/KotlinRNodeBridge.kt
+++ b/rns-host/src/main/kotlin/network/columba/app/rns/host/rnode/KotlinRNodeBridge.kt
@@ -363,15 +363,32 @@ class KotlinRNodeBridge(
             }
     }
 
-    private fun notifyConnectionStateChanged(
+    internal fun notifyConnectionStateChanged(
         connected: Boolean,
         deviceName: String?,
         transition: String,
+        expectedBleGatt: BluetoothGatt? = null,
+        expectedClassicSocket: BluetoothSocket? = null,
     ) {
-        try {
-            connectionStateNotifier?.notify(connected, deviceName)
-        } catch (e: Exception) {
-            Log.w(TAG, "Error in connection state listener ($transition)", e)
+        synchronized(transportOwnerLock) {
+            val ownerMatches =
+                when {
+                    expectedBleGatt != null -> bluetoothGatt === expectedBleGatt
+                    expectedClassicSocket != null -> bluetoothSocket === expectedClassicSocket
+                    else -> true
+                }
+            val stateMatches = if (connected) isConnected.get() && ownerMatches else !isConnected.get()
+            if (!stateMatches) {
+                Log.w(TAG, "Suppressing stale connection state notification ($transition, connected=$connected)")
+                return
+            }
+            try {
+                // Keep owner transitions serialized until the foreign callback returns.
+                // The current Python callback never waits for a bridge operation.
+                connectionStateNotifier?.notify(connected, deviceName)
+            } catch (e: Exception) {
+                Log.w(TAG, "Error in connection state listener ($transition)", e)
+            }
         }
     }
 
@@ -624,7 +641,12 @@ class KotlinRNodeBridge(
 
             // Start a reader owned by this exact socket generation before notifying Python.
             startClassicReadThread(socket, connectedInputStream)
-            notifyConnectionStateChanged(true, deviceName, "classic connect")
+            notifyConnectionStateChanged(
+                true,
+                deviceName,
+                "classic connect",
+                expectedClassicSocket = socket,
+            )
 
             true
         } catch (e: IOException) {
@@ -797,7 +819,12 @@ class KotlinRNodeBridge(
 
             Log.d(TAG, "████ RNODE BLE SUCCESS ████ deviceName=$deviceName MTU=$bleMtu")
 
-            notifyConnectionStateChanged(true, deviceName, "BLE connect")
+            notifyConnectionStateChanged(
+                true,
+                deviceName,
+                "BLE connect",
+                expectedBleGatt = attemptGatt,
+            )
 
             true
         } catch (e: Exception) {
@@ -1468,30 +1495,38 @@ class KotlinRNodeBridge(
      *
      * @return Available bytes, or empty array if no data
      */
-    fun read(): ByteArray {
-        if (readBuffer.isEmpty()) {
-            return ByteArray(0)
-        }
+    fun read(): ByteArray =
+        synchronized(transportOwnerLock) {
+            if (readBuffer.isEmpty()) {
+                return@synchronized ByteArray(0)
+            }
 
-        val data = mutableListOf<Byte>()
-        while (true) {
-            val byte = readBuffer.poll() ?: break
-            data.add(byte)
-        }
+            val data = mutableListOf<Byte>()
+            while (true) {
+                val byte = readBuffer.poll() ?: break
+                data.add(byte)
+            }
 
-        if (data.isNotEmpty()) {
-            Log.v(TAG, "Read ${data.size} bytes from buffer")
-        }
+            if (data.isNotEmpty()) {
+                Log.v(TAG, "Read ${data.size} bytes from buffer")
+            }
 
-        return data.toByteArray()
-    }
+            data.toByteArray()
+        }
 
     /**
      * Get number of bytes available in the read buffer.
      *
      * @return Number of buffered bytes
      */
-    fun available(): Int = readBuffer.size
+    fun available(): Int = synchronized(transportOwnerLock) { readBuffer.size }
+
+    private fun currentTransportOwnerLocked(): Any? =
+        when (connectionMode) {
+            RNodeConnectionMode.CLASSIC -> bluetoothSocket
+            RNodeConnectionMode.BLE -> bluetoothGatt
+            null -> null
+        }
 
     /**
      * Blocking read with timeout.
@@ -1505,7 +1540,8 @@ class KotlinRNodeBridge(
         maxBytes: Int,
         timeoutMs: Long,
     ): ByteArray {
-        if (!isConnected.get()) {
+        val owner = synchronized(transportOwnerLock) { currentTransportOwnerLocked() }
+        if (!isConnected.get() || owner == null) {
             return ByteArray(0)
         }
 
@@ -1513,7 +1549,17 @@ class KotlinRNodeBridge(
         val data = mutableListOf<Byte>()
 
         while (data.size < maxBytes && (System.currentTimeMillis() - startTime) < timeoutMs) {
-            val byte = readBuffer.poll()
+            var ownerIsCurrent = true
+            val byte =
+                synchronized(transportOwnerLock) {
+                    if (currentTransportOwnerLocked() !== owner) {
+                        ownerIsCurrent = false
+                        null
+                    } else {
+                        readBuffer.poll()
+                    }
+                }
+            if (!ownerIsCurrent) break
             if (byte != null) {
                 data.add(byte)
             } else {

--- a/rns-host/src/main/kotlin/network/columba/app/rns/host/rnode/KotlinRNodeBridge.kt
+++ b/rns-host/src/main/kotlin/network/columba/app/rns/host/rnode/KotlinRNodeBridge.kt
@@ -1696,49 +1696,40 @@ class KotlinRNodeBridge(
         expectedBleGatt: BluetoothGatt? = null,
         expectedClassicSocket: BluetoothSocket? = null,
     ) {
-        var deviceName: String? = null
-        var mode: RNodeConnectionMode? = null
-        var bleOwner: BluetoothGatt? = null
-        var classicOwner: BluetoothSocket? = null
-        val admitted =
+        val detached =
             synchronized(transportOwnerLock) {
                 val bleMatches = expectedBleGatt == null || bluetoothGatt === expectedBleGatt
                 val classicMatches = expectedClassicSocket == null || bluetoothSocket === expectedClassicSocket
                 if (!bleMatches || !classicMatches || !isConnected.getAndSet(false)) {
-                    false
+                    null
                 } else {
-                    deviceName = connectedDeviceName
-                    mode = connectionMode
-                    bleOwner = bluetoothGatt
-                    classicOwner = bluetoothSocket
-                    true
-                }
-            }
-        if (!admitted) return
-
-        Log.w(TAG, "Connection lost to $deviceName (mode=$mode)")
-        when (mode) {
-            RNodeConnectionMode.CLASSIC -> classicOwner?.let { cleanupClassic(it) }
-            RNodeConnectionMode.BLE -> bleOwner?.let { cleanupBle(it) }
-            null -> {}
-        }
-
-        val shouldNotify =
-            synchronized(transportOwnerLock) {
-                if (!isConnected.get()) {
+                    val transports =
+                        DetachedTransports(
+                            wasOnline = true,
+                            deviceName = connectedDeviceName,
+                            classicResources = Triple(inputStream, outputStream, bluetoothSocket),
+                            gatt = bluetoothGatt,
+                        )
+                    inputStream = null
+                    outputStream = null
+                    bluetoothSocket = null
+                    classicReadSocket = null
+                    bluetoothGatt = null
                     connectionMode = null
                     connectedDeviceName = null
+                    resetBleAttemptStateLocked()
                     readBuffer.clear()
-                    true
-                } else {
-                    false
+                    transports
                 }
-            }
-        if (shouldNotify) {
-            // Notify python only if a replacement did not become online while
-            // the detached owner's resources were closing.
-            notifyConnectionStateChanged(false, deviceName, "disconnect")
-        }
+            } ?: return
+
+        Log.w(TAG, "Connection lost to ${detached.deviceName}")
+        closeClassicResources(detached.classicResources)
+        closeBleGatt(detached.gatt)
+
+        // Notify Python only if a replacement did not become online while the
+        // detached owner's resources were closing.
+        notifyConnectionStateChanged(false, detached.deviceName, "disconnect")
     }
 
     internal fun handleBluetoothAdapterStateChanged(state: Int) {

--- a/rns-host/src/main/kotlin/network/columba/app/rns/host/rnode/KotlinRNodeBridge.kt
+++ b/rns-host/src/main/kotlin/network/columba/app/rns/host/rnode/KotlinRNodeBridge.kt
@@ -168,7 +168,7 @@ class KotlinRNodeBridge(
             }
     }
 
-    private val scope = CoroutineScope(Dispatchers.IO + SupervisorJob())
+    internal var scope = CoroutineScope(Dispatchers.IO + SupervisorJob())
     private val bluetoothManager = context.getSystemService(Context.BLUETOOTH_SERVICE) as BluetoothManager
     private val bluetoothAdapter: BluetoothAdapter? = bluetoothManager.adapter
 

--- a/rns-host/src/main/kotlin/network/columba/app/rns/host/rnode/KotlinRNodeBridge.kt
+++ b/rns-host/src/main/kotlin/network/columba/app/rns/host/rnode/KotlinRNodeBridge.kt
@@ -1321,24 +1321,44 @@ class KotlinRNodeBridge(
     /**
      * Write data via Bluetooth Classic.
      */
-    private suspend fun writeClassic(data: ByteArray): Int =
-        try {
+    private data class ClassicWriteOwner(
+        val socket: BluetoothSocket,
+        val stream: BufferedOutputStream,
+    )
+
+    private fun currentClassicWriteOwner(): ClassicWriteOwner? =
+        synchronized(transportOwnerLock) {
+            if (!isConnected.get() || connectionMode != RNodeConnectionMode.CLASSIC) {
+                return@synchronized null
+            }
+            val socket = bluetoothSocket
+            val stream = outputStream
+            if (socket != null && stream != null) {
+                ClassicWriteOwner(socket, stream)
+            } else {
+                null
+            }
+        }
+
+    private suspend fun writeClassic(data: ByteArray): Int {
+        val owner =
+            currentClassicWriteOwner() ?: run {
+                Log.e(TAG, "Classic write owner is unavailable")
+                return -1
+            }
+        return try {
             withContext(Dispatchers.IO) {
-                outputStream?.let { stream ->
-                    stream.write(data)
-                    stream.flush()
-                    Log.v(TAG, "Wrote ${data.size} bytes (Classic)")
-                    data.size
-                } ?: run {
-                    Log.e(TAG, "Output stream is null")
-                    -1
-                }
+                owner.stream.write(data)
+                owner.stream.flush()
+                Log.v(TAG, "Wrote ${data.size} bytes (Classic)")
+                data.size
             }
         } catch (e: IOException) {
             Log.e(TAG, "Classic write failed", e)
-            handleDisconnect()
+            handleDisconnect(expectedClassicSocket = owner.socket)
             -1
         }
+    }
 
     /**
      * Write data via BLE.
@@ -1415,24 +1435,31 @@ class KotlinRNodeBridge(
     /**
      * Synchronous write via Bluetooth Classic.
      */
-    private fun writeSyncClassic(data: ByteArray): Int =
-        synchronized(this) {
-            try {
-                outputStream?.let { stream ->
-                    stream.write(data)
-                    stream.flush()
+    private fun writeSyncClassic(data: ByteArray): Int {
+        val owner =
+            currentClassicWriteOwner() ?: run {
+                Log.e(TAG, "Classic write owner is unavailable")
+                return -1
+            }
+        var writeFailed = false
+        val result =
+            synchronized(this) {
+                try {
+                    owner.stream.write(data)
+                    owner.stream.flush()
                     Log.v(TAG, "Wrote ${data.size} bytes (Classic sync)")
                     data.size
-                } ?: run {
-                    Log.e(TAG, "Output stream is null")
+                } catch (e: IOException) {
+                    Log.e(TAG, "Classic write failed", e)
+                    writeFailed = true
                     -1
                 }
-            } catch (e: IOException) {
-                Log.e(TAG, "Classic write failed", e)
-                scope.launch { handleDisconnect() }
-                -1
             }
+        if (writeFailed) {
+            handleDisconnect(expectedClassicSocket = owner.socket)
         }
+        return result
+    }
 
     /**
      * Synchronous write via BLE.

--- a/rns-host/src/main/kotlin/network/columba/app/rns/host/rnode/KotlinRNodeBridge.kt
+++ b/rns-host/src/main/kotlin/network/columba/app/rns/host/rnode/KotlinRNodeBridge.kt
@@ -203,6 +203,9 @@ class KotlinRNodeBridge(
 
     // Current connection mode and transport generation ownership.
     private val transportOwnerLock = Any()
+    private var transportAdmissionEpoch = 0L
+    private var adapterAdmissionBlocked = false
+    private var bridgeShutdown = false
     private var connectionMode: RNodeConnectionMode? = null
 
     // Bluetooth Classic connection state
@@ -522,9 +525,21 @@ class KotlinRNodeBridge(
             return false
         }
 
+        val admissionEpoch =
+            synchronized(transportOwnerLock) {
+                if (adapterAdmissionBlocked || bridgeShutdown) {
+                    null
+                } else {
+                    transportAdmissionEpoch
+                }
+            } ?: run {
+                Log.e(TAG, "Bluetooth transport admission is unavailable")
+                return false
+            }
+
         return when (requestedMode) {
-            RNodeConnectionMode.CLASSIC -> connectClassic(deviceName, adapter)
-            RNodeConnectionMode.BLE -> connectBle(deviceName, adapter)
+            RNodeConnectionMode.CLASSIC -> connectClassic(deviceName, adapter, admissionEpoch)
+            RNodeConnectionMode.BLE -> connectBle(deviceName, adapter, admissionEpoch)
         }
     }
 
@@ -549,6 +564,9 @@ class KotlinRNodeBridge(
     /**
      * Connect via Bluetooth Classic (SPP/RFCOMM).
      */
+    private fun isTransportAdmissionCurrentLocked(epoch: Long): Boolean =
+        epoch == transportAdmissionEpoch && !adapterAdmissionBlocked && !bridgeShutdown
+
     internal fun replaceClassicSocketOwner(socket: BluetoothSocket) {
         synchronized(transportOwnerLock) {
             bluetoothSocket = socket
@@ -572,9 +590,11 @@ class KotlinRNodeBridge(
             }
         }
 
+    @Suppress("ReturnCount")
     private fun connectClassic(
         deviceName: String,
         adapter: BluetoothAdapter,
+        admissionEpoch: Long,
     ): Boolean {
         var ownedSocket: BluetoothSocket? = null
         // Find the device by name in bonded devices
@@ -597,6 +617,9 @@ class KotlinRNodeBridge(
             // Create and publish RFCOMM socket atomically against adapter invalidation.
             val socket =
                 synchronized(transportOwnerLock) {
+                    if (!isTransportAdmissionCurrentLocked(admissionEpoch)) {
+                        return false
+                    }
                     device.createRfcommSocketToServiceRecord(SPP_UUID).also {
                         replaceClassicSocketOwner(it)
                     }
@@ -618,7 +641,7 @@ class KotlinRNodeBridge(
             val connectedOutputStream = BufferedOutputStream(socket.outputStream, STREAM_BUFFER_SIZE)
             val admitted =
                 synchronized(transportOwnerLock) {
-                    if (bluetoothSocket !== socket) {
+                    if (bluetoothSocket !== socket || !isTransportAdmissionCurrentLocked(admissionEpoch)) {
                         false
                     } else {
                         inputStream = connectedInputStream
@@ -668,6 +691,7 @@ class KotlinRNodeBridge(
     private fun connectBle(
         deviceName: String,
         adapter: BluetoothAdapter,
+        admissionEpoch: Long,
     ): Boolean {
         Log.d(TAG, "████ RNODE BLE CONNECT ████ deviceName=$deviceName")
 
@@ -694,7 +718,7 @@ class KotlinRNodeBridge(
                 Thread.sleep(BLE_RETRY_DELAY_MS)
             }
 
-            val success = attemptBleConnection(device, deviceName)
+            val success = attemptBleConnection(device, deviceName, admissionEpoch)
             if (success) {
                 return true
             }
@@ -734,8 +758,14 @@ class KotlinRNodeBridge(
         }
     }
 
-    private fun createBleGatt(device: BluetoothDevice): BluetoothGatt =
+    private fun createBleGatt(
+        device: BluetoothDevice,
+        admissionEpoch: Long,
+    ): BluetoothGatt? =
         synchronized(transportOwnerLock) {
+            if (!isTransportAdmissionCurrentLocked(admissionEpoch)) {
+                return@synchronized null
+            }
             device.connectGatt(context, false, gattCallback, BluetoothDevice.TRANSPORT_LE).also {
                 replaceBleGattOwner(it)
             }
@@ -766,6 +796,7 @@ class KotlinRNodeBridge(
     private fun attemptBleConnection(
         device: BluetoothDevice,
         deviceName: String,
+        admissionEpoch: Long,
     ): Boolean {
         var ownedGatt: BluetoothGatt? = null
         return try {
@@ -776,7 +807,7 @@ class KotlinRNodeBridge(
 
             // Connect GATT and publish the new owner atomically with attempt-state reset.
             Log.d(TAG, "Connecting GATT to ${device.address}...")
-            val attemptGatt = createBleGatt(device)
+            val attemptGatt = createBleGatt(device, admissionEpoch) ?: return false
             ownedGatt = attemptGatt
 
             // Wait for connection and service discovery
@@ -807,13 +838,18 @@ class KotlinRNodeBridge(
                 return false
             }
 
-            if (
-                !mutateCurrentGatt(attemptGatt) {
-                    connectedDeviceName = deviceName
-                    connectionMode = RNodeConnectionMode.BLE
-                    isConnected.set(true)
+            val admitted =
+                synchronized(transportOwnerLock) {
+                    if (bluetoothGatt !== attemptGatt || !isTransportAdmissionCurrentLocked(admissionEpoch)) {
+                        false
+                    } else {
+                        connectedDeviceName = deviceName
+                        connectionMode = RNodeConnectionMode.BLE
+                        isConnected.set(true)
+                        true
+                    }
                 }
-            ) {
+            if (!admitted) {
                 return false
             }
 
@@ -1122,9 +1158,24 @@ class KotlinRNodeBridge(
         }
     }
 
-    private fun cleanupAllTransports() {
+    private data class DetachedTransports(
+        val wasOnline: Boolean,
+        val deviceName: String?,
+        val classicResources: Triple<BufferedInputStream?, BufferedOutputStream?, BluetoothSocket?>,
+        val gatt: BluetoothGatt?,
+    )
+
+    private fun invalidateAllTransports(
+        blockAdapterAdmission: Boolean = false,
+        shutdownBridge: Boolean = false,
+    ): DetachedTransports {
         val detached =
             synchronized(transportOwnerLock) {
+                transportAdmissionEpoch++
+                if (blockAdapterAdmission) adapterAdmissionBlocked = true
+                if (shutdownBridge) bridgeShutdown = true
+                val wasOnline = isConnected.getAndSet(false)
+                val deviceName = connectedDeviceName
                 val classicResources = Triple(inputStream, outputStream, bluetoothSocket)
                 val gatt = bluetoothGatt
                 inputStream = null
@@ -1132,11 +1183,15 @@ class KotlinRNodeBridge(
                 bluetoothSocket = null
                 classicReadSocket = null
                 bluetoothGatt = null
+                connectionMode = null
+                connectedDeviceName = null
                 resetBleAttemptStateLocked()
-                classicResources to gatt
+                readBuffer.clear()
+                DetachedTransports(wasOnline, deviceName, classicResources, gatt)
             }
-        closeClassicResources(detached.first)
-        closeBleGatt(detached.second)
+        closeClassicResources(detached.classicResources)
+        closeBleGatt(detached.gatt)
+        return detached
     }
 
     private fun cleanupBle(expectedGatt: BluetoothGatt? = null) {
@@ -1169,46 +1224,12 @@ class KotlinRNodeBridge(
      * Disconnect from the current RNode device.
      */
     fun disconnect() {
-        var deviceName: String? = null
-        var mode: RNodeConnectionMode? = null
-        var bleOwner: BluetoothGatt? = null
-        var classicOwner: BluetoothSocket? = null
-        val wasOnline =
-            synchronized(transportOwnerLock) {
-                if (!isConnected.getAndSet(false)) {
-                    false
-                } else {
-                    deviceName = connectedDeviceName
-                    mode = connectionMode
-                    bleOwner = bluetoothGatt
-                    classicOwner = bluetoothSocket
-                    true
-                }
-            }
-        if (!wasOnline) {
-            Log.d(TAG, "Not online; cleaning any provisional Bluetooth transports")
-            cleanupAllTransports()
-            return
+        val detached = invalidateAllTransports()
+        if (detached.wasOnline) {
+            Log.i(TAG, "Disconnected from ${detached.deviceName}")
+        } else {
+            Log.d(TAG, "Cleaned provisional Bluetooth transports")
         }
-
-        Log.i(TAG, "Disconnecting from $deviceName (mode=$mode)...")
-        when (mode) {
-            RNodeConnectionMode.CLASSIC -> classicOwner?.let { cleanupClassic(it) }
-            RNodeConnectionMode.BLE -> bleOwner?.let { cleanupBle(it) }
-            null -> {
-                cleanupAllTransports()
-            }
-        }
-
-        synchronized(transportOwnerLock) {
-            if (!isConnected.get() && bluetoothGatt == null && bluetoothSocket == null) {
-                connectionMode = null
-                connectedDeviceName = null
-                readBuffer.clear()
-            }
-        }
-
-        Log.i(TAG, "Disconnected from $deviceName")
     }
 
     /**
@@ -1694,17 +1715,18 @@ class KotlinRNodeBridge(
     }
 
     internal fun handleBluetoothAdapterStateChanged(state: Int) {
+        if (state == BluetoothAdapter.STATE_ON) {
+            synchronized(transportOwnerLock) {
+                if (!bridgeShutdown) adapterAdmissionBlocked = false
+            }
+            return
+        }
         if (state != BluetoothAdapter.STATE_TURNING_OFF && state != BluetoothAdapter.STATE_OFF) return
 
         Log.i(TAG, "Bluetooth adapter is turning off; invalidating RNode connection")
-        if (isConnected.get()) {
-            handleDisconnect()
-        } else {
-            // Adapter state can change while connectGatt() or RFCOMM connect()
-            // is still in flight, before connectionMode/isConnected are committed.
-            // Close those provisional resources so stale callbacks cannot revive
-            // the old transport after Bluetooth is enabled again.
-            cleanupAllTransports()
+        val detached = invalidateAllTransports(blockAdapterAdmission = true)
+        if (detached.wasOnline) {
+            notifyConnectionStateChanged(false, detached.deviceName, "adapter shutdown")
         }
     }
 
@@ -1732,7 +1754,7 @@ class KotlinRNodeBridge(
      * Shutdown the bridge and release resources.
      */
     fun shutdown() {
-        disconnect()
+        invalidateAllTransports(shutdownBridge = true)
         if (isBluetoothStateReceiverRegistered) {
             try {
                 context.unregisterReceiver(bluetoothStateReceiver)

--- a/rns-host/src/test/kotlin/network/columba/app/rns/host/rnode/KotlinRNodeBridgeOnlineStatusTest.kt
+++ b/rns-host/src/test/kotlin/network/columba/app/rns/host/rnode/KotlinRNodeBridgeOnlineStatusTest.kt
@@ -308,6 +308,71 @@ class KotlinRNodeBridgeOnlineStatusTest {
     }
 
     @Test
+    fun `disconnect before delayed connect notification suppresses stale Online`() {
+        val oldGatt = mockk<BluetoothGatt>()
+        every { oldGatt.disconnect() } just Runs
+        every { oldGatt.close() } just Runs
+        val bridge = KotlinRNodeBridge(mockContext)
+        bridge.replaceBleGattOwner(oldGatt)
+        setBridgeField(bridge, "connectionMode", RNodeConnectionMode.BLE)
+        setBridgeField(bridge, "connectedDeviceName", "RNode E517")
+        setBridgeBoolean(bridge, "bleConnected", true)
+        setBridgeConnected(bridge, true)
+        val states = mutableListOf<Boolean>()
+        bridge.connectionStateNotifier =
+            RNodeConnectionStateNotifier { connected, _ -> states += connected }
+
+        bridge.handleBluetoothAdapterStateChanged(BluetoothAdapter.STATE_OFF)
+        bridge.notifyConnectionStateChanged(
+            true,
+            "RNode E517",
+            "delayed BLE connect",
+            expectedBleGatt = oldGatt,
+        )
+
+        assertEquals(listOf(false), states)
+    }
+
+    @Test
+    fun `replacement Online precedes and suppresses delayed Offline notification`() {
+        val freshGatt = mockk<BluetoothGatt>()
+        val bridge = KotlinRNodeBridge(mockContext)
+        val states = mutableListOf<Boolean>()
+        bridge.connectionStateNotifier =
+            RNodeConnectionStateNotifier { connected, _ -> states += connected }
+        val ownerLock = bridgeField(bridge, "transportOwnerLock")
+        val notificationStarted = CountDownLatch(1)
+        val notificationFinished = CountDownLatch(1)
+        val delayedOffline =
+            Thread {
+                notificationStarted.countDown()
+                bridge.notifyConnectionStateChanged(false, "Old RNode", "delayed disconnect")
+                notificationFinished.countDown()
+            }
+
+        synchronized(ownerLock) {
+            delayedOffline.start()
+            assertTrue(notificationStarted.await(1, TimeUnit.SECONDS))
+            bridge.replaceBleGattOwner(freshGatt)
+            setBridgeField(bridge, "connectionMode", RNodeConnectionMode.BLE)
+            setBridgeField(bridge, "connectedDeviceName", "RNode E517")
+            setBridgeBoolean(bridge, "bleConnected", true)
+            setBridgeConnected(bridge, true)
+            bridge.notifyConnectionStateChanged(
+                true,
+                "RNode E517",
+                "replacement BLE connect",
+                expectedBleGatt = freshGatt,
+            )
+            assertFalse(notificationFinished.await(50, TimeUnit.MILLISECONDS))
+        }
+        assertTrue(notificationFinished.await(1, TimeUnit.SECONDS))
+        delayedOffline.join()
+
+        assertEquals(listOf(true), states)
+    }
+
+    @Test
     fun `shutdown unregisters adapter state receiver`() {
         val receiver = io.mockk.slot<BroadcastReceiver>()
         every {

--- a/rns-host/src/test/kotlin/network/columba/app/rns/host/rnode/KotlinRNodeBridgeOnlineStatusTest.kt
+++ b/rns-host/src/test/kotlin/network/columba/app/rns/host/rnode/KotlinRNodeBridgeOnlineStatusTest.kt
@@ -12,11 +12,14 @@ import android.content.BroadcastReceiver
 import android.content.Context
 import android.content.Intent
 import android.content.IntentFilter
+import android.util.Log
 import io.mockk.clearAllMocks
 import io.mockk.every
 import io.mockk.just
 import io.mockk.mockk
+import io.mockk.mockkStatic
 import io.mockk.Runs
+import io.mockk.unmockkStatic
 import io.mockk.verify
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.ExperimentalCoroutinesApi
@@ -535,12 +538,15 @@ class KotlinRNodeBridgeOnlineStatusTest {
     fun `unexpected BLE disconnect closes detached GATT without touching replacement`() {
         val oldGatt = mockk<BluetoothGatt>()
         val freshGatt = mockk<BluetoothGatt>()
-        val closeStarted = CountDownLatch(1)
-        val releaseClose = CountDownLatch(1)
-        every { oldGatt.disconnect() } answers {
-            closeStarted.countDown()
-            assertTrue(releaseClose.await(1, TimeUnit.SECONDS))
+        val logStarted = CountDownLatch(1)
+        val releaseLog = CountDownLatch(1)
+        mockkStatic(Log::class)
+        every { Log.w(any<String>(), match<String> { it.startsWith("Connection lost to") }) } answers {
+            logStarted.countDown()
+            assertTrue(releaseLog.await(1, TimeUnit.SECONDS))
+            0
         }
+        every { oldGatt.disconnect() } just Runs
         every { oldGatt.close() } just Runs
         every { freshGatt.disconnect() } just Runs
         every { freshGatt.close() } just Runs
@@ -554,14 +560,14 @@ class KotlinRNodeBridgeOnlineStatusTest {
 
         val disconnect = Thread { invokeHandleDisconnect(bridge, expectedBleGatt = oldGatt) }
         disconnect.start()
-        assertTrue(closeStarted.await(1, TimeUnit.SECONDS))
+        assertTrue(logStarted.await(1, TimeUnit.SECONDS))
 
         bridge.replaceBleGattOwner(freshGatt)
         setBridgeField(bridge, "connectionMode", RNodeConnectionMode.BLE)
         setBridgeField(bridge, "connectedDeviceName", "Fresh RNode")
         setBridgeBoolean(bridge, "bleConnected", true)
         setBridgeConnected(bridge, true)
-        releaseClose.countDown()
+        releaseLog.countDown()
         disconnect.join()
 
         assertTrue(bridge.isConnected())
@@ -582,12 +588,15 @@ class KotlinRNodeBridgeOnlineStatusTest {
         val freshSocket = mockk<BluetoothSocket>()
         val freshInput = mockk<BufferedInputStream>()
         val freshOutput = mockk<BufferedOutputStream>()
-        val closeStarted = CountDownLatch(1)
-        val releaseClose = CountDownLatch(1)
-        every { oldInput.close() } answers {
-            closeStarted.countDown()
-            assertTrue(releaseClose.await(1, TimeUnit.SECONDS))
+        val logStarted = CountDownLatch(1)
+        val releaseLog = CountDownLatch(1)
+        mockkStatic(Log::class)
+        every { Log.w(any<String>(), match<String> { it.startsWith("Connection lost to") }) } answers {
+            logStarted.countDown()
+            assertTrue(releaseLog.await(1, TimeUnit.SECONDS))
+            0
         }
+        every { oldInput.close() } just Runs
         every { oldOutput.close() } just Runs
         every { oldSocket.close() } just Runs
         every { freshInput.close() } just Runs
@@ -606,7 +615,7 @@ class KotlinRNodeBridgeOnlineStatusTest {
 
         val disconnect = Thread { invokeHandleDisconnect(bridge, expectedClassicSocket = oldSocket) }
         disconnect.start()
-        assertTrue(closeStarted.await(1, TimeUnit.SECONDS))
+        assertTrue(logStarted.await(1, TimeUnit.SECONDS))
 
         setBridgeField(bridge, "bluetoothSocket", freshSocket)
         setBridgeField(bridge, "inputStream", freshInput)
@@ -614,7 +623,7 @@ class KotlinRNodeBridgeOnlineStatusTest {
         setBridgeField(bridge, "connectionMode", RNodeConnectionMode.CLASSIC)
         setBridgeField(bridge, "connectedDeviceName", "Fresh RNode")
         setBridgeConnected(bridge, true)
-        releaseClose.countDown()
+        releaseLog.countDown()
         disconnect.join()
 
         assertTrue(bridge.isConnected())
@@ -714,6 +723,7 @@ class KotlinRNodeBridgeOnlineStatusTest {
 
     @After
     fun tearDown() {
+        unmockkStatic(Log::class)
         clearAllMocks()
     }
 

--- a/rns-host/src/test/kotlin/network/columba/app/rns/host/rnode/KotlinRNodeBridgeOnlineStatusTest.kt
+++ b/rns-host/src/test/kotlin/network/columba/app/rns/host/rnode/KotlinRNodeBridgeOnlineStatusTest.kt
@@ -32,6 +32,7 @@ import java.util.concurrent.CountDownLatch
 import java.util.concurrent.TimeUnit
 import java.util.concurrent.atomic.AtomicBoolean
 import java.util.concurrent.atomic.AtomicInteger
+import java.util.UUID
 
 /**
  * Unit tests for KotlinRNodeBridge online status listener functionality.
@@ -175,56 +176,52 @@ class KotlinRNodeBridgeOnlineStatusTest {
     }
 
     @Test
-    fun `stale GATT callbacks cannot disconnect fresh BLE owner`() {
+    fun `callback waiting behind owner replacement cannot mutate fresh BLE owner`() {
         val oldGatt = mockk<BluetoothGatt>()
         val freshGatt = mockk<BluetoothGatt>()
         every { oldGatt.discoverServices() } returns true
         val bridge = KotlinRNodeBridge(mockContext)
-        KotlinRNodeBridge::class.java.getDeclaredField("bluetoothGatt").apply {
-            isAccessible = true
-            set(bridge, freshGatt)
-        }
-        KotlinRNodeBridge::class.java.getDeclaredField("bleConnected").apply {
-            isAccessible = true
-            setBoolean(bridge, true)
-        }
-        KotlinRNodeBridge::class.java.getDeclaredField("bleMtuCallbackReceived").apply {
-            isAccessible = true
-            setBoolean(bridge, false)
-        }
-        KotlinRNodeBridge::class.java.getDeclaredField("connectionMode").apply {
-            isAccessible = true
-            set(bridge, RNodeConnectionMode.BLE)
-        }
-        KotlinRNodeBridge::class.java.getDeclaredField("connectedDeviceName").apply {
-            isAccessible = true
-            set(bridge, "RNode E517")
-        }
-        KotlinRNodeBridge::class.java.getDeclaredField("isConnected").apply {
-            isAccessible = true
-            (get(bridge) as AtomicBoolean).set(true)
-        }
+        bridge.replaceBleGattOwner(oldGatt)
+        setBridgeBoolean(bridge, "bleConnected", true)
+        setBridgeBoolean(bridge, "bleMtuCallbackReceived", false)
+        setBridgeField(bridge, "connectionMode", RNodeConnectionMode.BLE)
+        setBridgeField(bridge, "connectedDeviceName", "RNode E517")
+        setBridgeConnected(bridge, true)
         val connectionStates = mutableListOf<Boolean>()
         bridge.connectionStateNotifier =
             RNodeConnectionStateNotifier { connected, _ -> connectionStates += connected }
         val pendingWrite = CountDownLatch(1)
-        KotlinRNodeBridge::class.java.getDeclaredField("bleWriteLatch").apply {
-            isAccessible = true
-            set(bridge, pendingWrite)
-        }
+        setBridgeField(bridge, "bleWriteLatch", pendingWrite)
         val staleCharacteristic = mockk<BluetoothGattCharacteristic>()
-        val callback =
-            KotlinRNodeBridge::class.java.getDeclaredField("gattCallback").let { field ->
-                field.isAccessible = true
-                field.get(bridge) as BluetoothGattCallback
+        every { staleCharacteristic.uuid } returns
+            UUID.fromString("6e400003-b5a3-f393-e0a9-e50e24dcca9e")
+        every { staleCharacteristic.value } returns byteArrayOf(0x2A)
+        val callback = bridgeField(bridge, "gattCallback") as BluetoothGattCallback
+
+        val ownerLock = bridgeField(bridge, "transportOwnerLock")
+        val callbackStarted = CountDownLatch(1)
+        val callbackFinished = CountDownLatch(1)
+        val callbackThread =
+            Thread {
+                callbackStarted.countDown()
+                callback.onMtuChanged(oldGatt, 247, BluetoothGatt.GATT_SUCCESS)
+                callbackFinished.countDown()
             }
+        synchronized(ownerLock) {
+            callbackThread.start()
+            assertTrue(callbackStarted.await(1, TimeUnit.SECONDS))
+            bridge.replaceBleGattOwner(freshGatt)
+            setBridgeBoolean(bridge, "bleConnected", true)
+            assertFalse(callbackFinished.await(50, TimeUnit.MILLISECONDS))
+        }
+        assertTrue(callbackFinished.await(1, TimeUnit.SECONDS))
+        callbackThread.join()
 
         callback.onConnectionStateChange(
             oldGatt,
             BluetoothGatt.GATT_SUCCESS,
             BluetoothProfile.STATE_DISCONNECTED,
         )
-        callback.onMtuChanged(oldGatt, 247, BluetoothGatt.GATT_SUCCESS)
         callback.onCharacteristicChanged(oldGatt, staleCharacteristic)
         callback.onCharacteristicWrite(
             oldGatt,
@@ -238,29 +235,23 @@ class KotlinRNodeBridgeOnlineStatusTest {
         assertEquals(1L, pendingWrite.count)
         assertEquals(0, bridge.available())
         assertEquals(-100, bridge.getRssi())
-        KotlinRNodeBridge::class.java.getDeclaredField("bleMtuCallbackReceived").apply {
-            isAccessible = true
-            assertFalse(getBoolean(bridge))
-        }
+        assertFalse(bridgeField(bridge, "bleMtuCallbackReceived") as Boolean)
         verify(exactly = 0) { freshGatt.disconnect() }
         verify(exactly = 0) { freshGatt.close() }
         verify(exactly = 0) { oldGatt.discoverServices() }
     }
 
     @Test
-    fun `stale Classic reader cannot disconnect fresh socket owner`() {
+    fun `post-read publication waiting behind replacement cannot contaminate fresh Classic owner`() {
         val oldSocket = mockk<BluetoothSocket>()
         val freshSocket = mockk<BluetoothSocket>()
         every { freshSocket.isConnected } returns true
         every { freshSocket.close() } just Runs
         val bridge = KotlinRNodeBridge(mockContext)
-        KotlinRNodeBridge::class.java.getDeclaredField("bluetoothSocket").apply {
-            isAccessible = true
-            set(bridge, freshSocket)
-        }
+        bridge.replaceClassicSocketOwner(oldSocket)
         KotlinRNodeBridge::class.java.getDeclaredField("classicReadSocket").apply {
             isAccessible = true
-            set(bridge, freshSocket)
+            set(bridge, oldSocket)
         }
         KotlinRNodeBridge::class.java.getDeclaredField("connectionMode").apply {
             isAccessible = true
@@ -277,6 +268,31 @@ class KotlinRNodeBridgeOnlineStatusTest {
         val connectionStates = mutableListOf<Boolean>()
         bridge.connectionStateNotifier =
             RNodeConnectionStateNotifier { connected, _ -> connectionStates += connected }
+
+        val ownerLock = bridgeField(bridge, "transportOwnerLock")
+        val publicationStarted = CountDownLatch(1)
+        val publicationFinished = CountDownLatch(1)
+        val publicationAccepted = AtomicBoolean(true)
+        val publicationThread =
+            Thread {
+                publicationStarted.countDown()
+                publicationAccepted.set(bridge.publishClassicRead(oldSocket, byteArrayOf(0x2A)))
+                publicationFinished.countDown()
+            }
+        synchronized(ownerLock) {
+            publicationThread.start()
+            assertTrue(publicationStarted.await(1, TimeUnit.SECONDS))
+            bridge.replaceClassicSocketOwner(freshSocket)
+            assertFalse(publicationFinished.await(50, TimeUnit.MILLISECONDS))
+        }
+        assertTrue(publicationFinished.await(1, TimeUnit.SECONDS))
+        publicationThread.join()
+        assertFalse(publicationAccepted.get())
+        assertEquals(0, bridge.available())
+        KotlinRNodeBridge::class.java.getDeclaredField("classicReadSocket").apply {
+            isAccessible = true
+            set(bridge, freshSocket)
+        }
 
         bridge.handleClassicReaderFinished(oldSocket)
 
@@ -312,6 +328,44 @@ class KotlinRNodeBridgeOnlineStatusTest {
     @After
     fun tearDown() {
         clearAllMocks()
+    }
+
+    private fun setBridgeField(
+        bridge: KotlinRNodeBridge,
+        name: String,
+        value: Any?,
+    ) {
+        KotlinRNodeBridge::class.java.getDeclaredField(name).apply {
+            isAccessible = true
+            set(bridge, value)
+        }
+    }
+
+    private fun setBridgeBoolean(
+        bridge: KotlinRNodeBridge,
+        name: String,
+        value: Boolean,
+    ) {
+        KotlinRNodeBridge::class.java.getDeclaredField(name).apply {
+            isAccessible = true
+            setBoolean(bridge, value)
+        }
+    }
+
+    private fun bridgeField(
+        bridge: KotlinRNodeBridge,
+        name: String,
+    ): Any =
+        KotlinRNodeBridge::class.java.getDeclaredField(name).let { field ->
+            field.isAccessible = true
+            requireNotNull(field.get(bridge))
+        }
+
+    private fun setBridgeConnected(
+        bridge: KotlinRNodeBridge,
+        connected: Boolean,
+    ) {
+        (bridgeField(bridge, "isConnected") as AtomicBoolean).set(connected)
     }
 
     // ========== RNodeOnlineStatusListener Tests ==========

--- a/rns-host/src/test/kotlin/network/columba/app/rns/host/rnode/KotlinRNodeBridgeOnlineStatusTest.kt
+++ b/rns-host/src/test/kotlin/network/columba/app/rns/host/rnode/KotlinRNodeBridgeOnlineStatusTest.kt
@@ -176,6 +176,94 @@ class KotlinRNodeBridgeOnlineStatusTest {
     }
 
     @Test
+    fun `adapter admission remains blocked until Bluetooth is on`() {
+        val device = mockk<BluetoothDevice>()
+        val gatt = mockk<BluetoothGatt>()
+        every { device.name } returns "RNode E517"
+        every { device.address } returns "9C:13:9E:A0:80:11"
+        every { device.bondState } returnsMany
+            listOf(
+                BluetoothDevice.BOND_BONDED,
+                BluetoothDevice.BOND_NONE,
+            )
+        every { device.connectGatt(mockContext, false, any(), BluetoothDevice.TRANSPORT_LE) } returns gatt
+        every { gatt.disconnect() } just Runs
+        every { gatt.close() } just Runs
+        every { mockBluetoothAdapter.bondedDevices } returns setOf(device)
+        val bridge = KotlinRNodeBridge(mockContext)
+
+        bridge.handleBluetoothAdapterStateChanged(BluetoothAdapter.STATE_TURNING_OFF)
+        assertFalse(bridge.connect("RNode E517", "ble"))
+        verify(exactly = 0) {
+            device.connectGatt(mockContext, false, any(), BluetoothDevice.TRANSPORT_LE)
+        }
+
+        bridge.handleBluetoothAdapterStateChanged(BluetoothAdapter.STATE_ON)
+        assertFalse(bridge.connect("RNode E517", "ble"))
+        verify(exactly = 1) {
+            device.connectGatt(mockContext, false, any(), BluetoothDevice.TRANSPORT_LE)
+        }
+    }
+
+    @Test
+    fun `shutdown permanently rejects new transport admission`() {
+        val device = mockk<BluetoothDevice>()
+        every { device.name } returns "RNode E517"
+        every { mockBluetoothAdapter.bondedDevices } returns setOf(device)
+        val bridge = KotlinRNodeBridge(mockContext)
+
+        bridge.shutdown()
+
+        assertFalse(bridge.connect("RNode E517", "ble"))
+        verify(exactly = 0) {
+            device.connectGatt(mockContext, false, any(), BluetoothDevice.TRANSPORT_LE)
+        }
+    }
+
+    @Test
+    fun `adapter invalidation atomically clears connection admitted while callback waits`() {
+        val admittedGatt = mockk<BluetoothGatt>()
+        every { admittedGatt.disconnect() } just Runs
+        every { admittedGatt.close() } just Runs
+        val bridge = KotlinRNodeBridge(mockContext)
+        val states = mutableListOf<Boolean>()
+        bridge.connectionStateNotifier =
+            RNodeConnectionStateNotifier { connected, _ -> states += connected }
+        val ownerLock = bridgeField(bridge, "transportOwnerLock")
+        val invalidationStarted = CountDownLatch(1)
+        val invalidation =
+            Thread {
+                invalidationStarted.countDown()
+                bridge.handleBluetoothAdapterStateChanged(BluetoothAdapter.STATE_TURNING_OFF)
+            }
+
+        synchronized(ownerLock) {
+            invalidation.start()
+            assertTrue(invalidationStarted.await(1, TimeUnit.SECONDS))
+            val deadline = System.nanoTime() + TimeUnit.SECONDS.toNanos(1)
+            while (invalidation.state != Thread.State.BLOCKED && System.nanoTime() < deadline) {
+                Thread.yield()
+            }
+            assertEquals(Thread.State.BLOCKED, invalidation.state)
+            bridge.replaceBleGattOwner(admittedGatt)
+            setBridgeField(bridge, "connectionMode", RNodeConnectionMode.BLE)
+            setBridgeField(bridge, "connectedDeviceName", "RNode E517")
+            setBridgeBoolean(bridge, "bleConnected", true)
+            setBridgeConnected(bridge, true)
+        }
+        invalidation.join()
+
+        assertFalse(bridge.isConnected())
+        assertNull(nullableBridgeField(bridge, "bluetoothGatt"))
+        assertNull(nullableBridgeField(bridge, "connectionMode"))
+        assertNull(nullableBridgeField(bridge, "connectedDeviceName"))
+        assertFalse(bridgeBoolean(bridge, "bleConnected"))
+        assertEquals(listOf(false), states)
+        verify(exactly = 1) { admittedGatt.disconnect() }
+        verify(exactly = 1) { admittedGatt.close() }
+    }
+
+    @Test
     fun `callback waiting behind owner replacement cannot mutate fresh BLE owner`() {
         val oldGatt = mockk<BluetoothGatt>()
         val freshGatt = mockk<BluetoothGatt>()
@@ -424,6 +512,24 @@ class KotlinRNodeBridgeOnlineStatusTest {
         KotlinRNodeBridge::class.java.getDeclaredField(name).let { field ->
             field.isAccessible = true
             requireNotNull(field.get(bridge))
+        }
+
+    private fun nullableBridgeField(
+        bridge: KotlinRNodeBridge,
+        name: String,
+    ): Any? =
+        KotlinRNodeBridge::class.java.getDeclaredField(name).let { field ->
+            field.isAccessible = true
+            field.get(bridge)
+        }
+
+    private fun bridgeBoolean(
+        bridge: KotlinRNodeBridge,
+        name: String,
+    ): Boolean =
+        KotlinRNodeBridge::class.java.getDeclaredField(name).let { field ->
+            field.isAccessible = true
+            field.getBoolean(bridge)
         }
 
     private fun setBridgeConnected(

--- a/rns-host/src/test/kotlin/network/columba/app/rns/host/rnode/KotlinRNodeBridgeOnlineStatusTest.kt
+++ b/rns-host/src/test/kotlin/network/columba/app/rns/host/rnode/KotlinRNodeBridgeOnlineStatusTest.kt
@@ -19,8 +19,13 @@ import io.mockk.mockk
 import io.mockk.Runs
 import io.mockk.verify
 import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.cancel
 import kotlinx.coroutines.isActive
 import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.TestScope
+import kotlinx.coroutines.test.runCurrent
 import org.junit.After
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
@@ -30,7 +35,9 @@ import org.junit.Assert.assertTrue
 import org.junit.Before
 import org.junit.Test
 import java.io.BufferedOutputStream
+import java.io.ByteArrayOutputStream
 import java.io.IOException
+import java.io.InputStream
 import java.util.concurrent.CountDownLatch
 import java.util.concurrent.TimeUnit
 import java.util.concurrent.atomic.AtomicBoolean
@@ -406,10 +413,66 @@ class KotlinRNodeBridgeOnlineStatusTest {
     }
 
     @Test
-    fun `stale sync Classic write failure cannot disconnect replacement owner`() {
-        assertStaleClassicWriteFailureCannotDisconnectReplacement { bridge, data ->
-            bridge.writeSync(data)
+    @OptIn(ExperimentalCoroutinesApi::class)
+    fun `stale sync Classic cleanup queued before replacement cannot disconnect new connection`() {
+        val oldSocket = mockk<BluetoothSocket>()
+        val oldStream = mockk<BufferedOutputStream>()
+        every { oldSocket.close() } just Runs
+        every { oldStream.close() } just Runs
+        every { oldStream.write(any<ByteArray>()) } throws IOException("old socket closed")
+        val bridge = KotlinRNodeBridge(mockContext)
+        bridge.scope.cancel()
+        val testScope = TestScope(StandardTestDispatcher())
+        bridge.scope = testScope
+        bridge.replaceClassicSocketOwner(oldSocket)
+        setBridgeField(bridge, "outputStream", oldStream)
+        setBridgeField(bridge, "connectionMode", RNodeConnectionMode.CLASSIC)
+        setBridgeField(bridge, "connectedDeviceName", "Old RNode")
+        setBridgeConnected(bridge, true)
+
+        assertEquals(-1, bridge.writeSync(byteArrayOf(0x2A)))
+        bridge.disconnect()
+
+        val freshDevice = mockk<BluetoothDevice>()
+        val freshSocket = mockk<BluetoothSocket>()
+        val freshInput = mockk<InputStream>()
+        val readerRelease = CountDownLatch(1)
+        every { freshDevice.name } returns "Fresh RNode"
+        every { freshDevice.address } returns "9C:13:9E:A0:80:12"
+        every { freshDevice.createRfcommSocketToServiceRecord(any()) } returns freshSocket
+        every { mockBluetoothAdapter.bondedDevices } returns setOf(freshDevice)
+        every { mockBluetoothAdapter.cancelDiscovery() } returns true
+        every { freshSocket.connect() } just Runs
+        every { freshSocket.inputStream } returns freshInput
+        every { freshSocket.outputStream } returns ByteArrayOutputStream()
+        every { freshSocket.isConnected } returns true
+        every { freshSocket.close() } answers { readerRelease.countDown() }
+        every { freshInput.available() } returns 0
+        every { freshInput.read(any<ByteArray>(), any(), any()) } answers {
+            readerRelease.await()
+            -1
         }
+        every { freshInput.close() } answers { readerRelease.countDown() }
+        val states = mutableListOf<Boolean>()
+        bridge.connectionStateNotifier =
+            RNodeConnectionStateNotifier { connected, _ -> states += connected }
+
+        assertTrue(bridge.connect("Fresh RNode", "classic"))
+        testScope.runCurrent()
+
+        assertTrue(
+            "fresh connection lost: atomic=${(bridgeField(bridge, "isConnected") as AtomicBoolean).get()} " +
+                "mode=${nullableBridgeField(bridge, "connectionMode")} " +
+                "ownerMatches=${nullableBridgeField(bridge, "bluetoothSocket") === freshSocket} " +
+                "socketConnected=${freshSocket.isConnected}",
+            bridge.isConnected(),
+        )
+        assertTrue(nullableBridgeField(bridge, "bluetoothSocket") === freshSocket)
+        assertEquals("Fresh RNode", nullableBridgeField(bridge, "connectedDeviceName"))
+        assertEquals(listOf(true), states)
+        verify(exactly = 0) { freshSocket.close() }
+
+        bridge.disconnect()
     }
 
     private fun assertStaleClassicWriteFailureCannotDisconnectReplacement(

--- a/rns-host/src/test/kotlin/network/columba/app/rns/host/rnode/KotlinRNodeBridgeOnlineStatusTest.kt
+++ b/rns-host/src/test/kotlin/network/columba/app/rns/host/rnode/KotlinRNodeBridgeOnlineStatusTest.kt
@@ -3,7 +3,11 @@ package network.columba.app.rns.host.rnode
 import android.bluetooth.BluetoothAdapter
 import android.bluetooth.BluetoothDevice
 import android.bluetooth.BluetoothGatt
+import android.bluetooth.BluetoothGattCallback
+import android.bluetooth.BluetoothGattCharacteristic
 import android.bluetooth.BluetoothManager
+import android.bluetooth.BluetoothProfile
+import android.bluetooth.BluetoothSocket
 import android.content.BroadcastReceiver
 import android.content.Context
 import android.content.Intent
@@ -130,6 +134,11 @@ class KotlinRNodeBridgeOnlineStatusTest {
             isAccessible = true
             (get(bridge) as AtomicBoolean).set(true)
         }
+        val connectionStates = mutableListOf<Pair<Boolean, String?>>()
+        bridge.connectionStateNotifier =
+            RNodeConnectionStateNotifier { connected, deviceName ->
+                connectionStates += connected to deviceName
+            }
         val adapterOffIntent = mockk<Intent>()
         every { adapterOffIntent.action } returns BluetoothAdapter.ACTION_STATE_CHANGED
         every {
@@ -142,6 +151,7 @@ class KotlinRNodeBridgeOnlineStatusTest {
         receiver.captured.onReceive(mockContext, adapterOffIntent)
 
         assertFalse(bridge.isConnected())
+        assertEquals(listOf(false to "RNode E517"), connectionStates)
         verify(exactly = 1) { gatt.disconnect() }
         verify(exactly = 1) { gatt.close() }
     }
@@ -162,6 +172,141 @@ class KotlinRNodeBridgeOnlineStatusTest {
         assertFalse(bridge.isConnected())
         verify(exactly = 1) { gatt.disconnect() }
         verify(exactly = 1) { gatt.close() }
+    }
+
+    @Test
+    fun `stale GATT callbacks cannot disconnect fresh BLE owner`() {
+        val oldGatt = mockk<BluetoothGatt>()
+        val freshGatt = mockk<BluetoothGatt>()
+        every { oldGatt.discoverServices() } returns true
+        val bridge = KotlinRNodeBridge(mockContext)
+        KotlinRNodeBridge::class.java.getDeclaredField("bluetoothGatt").apply {
+            isAccessible = true
+            set(bridge, freshGatt)
+        }
+        KotlinRNodeBridge::class.java.getDeclaredField("bleConnected").apply {
+            isAccessible = true
+            setBoolean(bridge, true)
+        }
+        KotlinRNodeBridge::class.java.getDeclaredField("bleMtuCallbackReceived").apply {
+            isAccessible = true
+            setBoolean(bridge, false)
+        }
+        KotlinRNodeBridge::class.java.getDeclaredField("connectionMode").apply {
+            isAccessible = true
+            set(bridge, RNodeConnectionMode.BLE)
+        }
+        KotlinRNodeBridge::class.java.getDeclaredField("connectedDeviceName").apply {
+            isAccessible = true
+            set(bridge, "RNode E517")
+        }
+        KotlinRNodeBridge::class.java.getDeclaredField("isConnected").apply {
+            isAccessible = true
+            (get(bridge) as AtomicBoolean).set(true)
+        }
+        val connectionStates = mutableListOf<Boolean>()
+        bridge.connectionStateNotifier =
+            RNodeConnectionStateNotifier { connected, _ -> connectionStates += connected }
+        val pendingWrite = CountDownLatch(1)
+        KotlinRNodeBridge::class.java.getDeclaredField("bleWriteLatch").apply {
+            isAccessible = true
+            set(bridge, pendingWrite)
+        }
+        val staleCharacteristic = mockk<BluetoothGattCharacteristic>()
+        val callback =
+            KotlinRNodeBridge::class.java.getDeclaredField("gattCallback").let { field ->
+                field.isAccessible = true
+                field.get(bridge) as BluetoothGattCallback
+            }
+
+        callback.onConnectionStateChange(
+            oldGatt,
+            BluetoothGatt.GATT_SUCCESS,
+            BluetoothProfile.STATE_DISCONNECTED,
+        )
+        callback.onMtuChanged(oldGatt, 247, BluetoothGatt.GATT_SUCCESS)
+        callback.onCharacteristicChanged(oldGatt, staleCharacteristic)
+        callback.onCharacteristicWrite(
+            oldGatt,
+            staleCharacteristic,
+            BluetoothGatt.GATT_SUCCESS,
+        )
+        callback.onReadRemoteRssi(oldGatt, -42, BluetoothGatt.GATT_SUCCESS)
+
+        assertTrue(bridge.isConnected())
+        assertTrue(connectionStates.isEmpty())
+        assertEquals(1L, pendingWrite.count)
+        assertEquals(0, bridge.available())
+        assertEquals(-100, bridge.getRssi())
+        KotlinRNodeBridge::class.java.getDeclaredField("bleMtuCallbackReceived").apply {
+            isAccessible = true
+            assertFalse(getBoolean(bridge))
+        }
+        verify(exactly = 0) { freshGatt.disconnect() }
+        verify(exactly = 0) { freshGatt.close() }
+        verify(exactly = 0) { oldGatt.discoverServices() }
+    }
+
+    @Test
+    fun `stale Classic reader cannot disconnect fresh socket owner`() {
+        val oldSocket = mockk<BluetoothSocket>()
+        val freshSocket = mockk<BluetoothSocket>()
+        every { freshSocket.isConnected } returns true
+        every { freshSocket.close() } just Runs
+        val bridge = KotlinRNodeBridge(mockContext)
+        KotlinRNodeBridge::class.java.getDeclaredField("bluetoothSocket").apply {
+            isAccessible = true
+            set(bridge, freshSocket)
+        }
+        KotlinRNodeBridge::class.java.getDeclaredField("classicReadSocket").apply {
+            isAccessible = true
+            set(bridge, freshSocket)
+        }
+        KotlinRNodeBridge::class.java.getDeclaredField("connectionMode").apply {
+            isAccessible = true
+            set(bridge, RNodeConnectionMode.CLASSIC)
+        }
+        KotlinRNodeBridge::class.java.getDeclaredField("connectedDeviceName").apply {
+            isAccessible = true
+            set(bridge, "RNode Classic")
+        }
+        KotlinRNodeBridge::class.java.getDeclaredField("isConnected").apply {
+            isAccessible = true
+            (get(bridge) as AtomicBoolean).set(true)
+        }
+        val connectionStates = mutableListOf<Boolean>()
+        bridge.connectionStateNotifier =
+            RNodeConnectionStateNotifier { connected, _ -> connectionStates += connected }
+
+        bridge.handleClassicReaderFinished(oldSocket)
+
+        assertTrue(bridge.isConnected())
+        assertTrue(connectionStates.isEmpty())
+        verify(exactly = 0) { freshSocket.close() }
+
+        bridge.handleClassicReaderFinished(freshSocket)
+
+        assertFalse(bridge.isConnected())
+        assertEquals(listOf(false), connectionStates)
+        verify(exactly = 1) { freshSocket.close() }
+    }
+
+    @Test
+    fun `shutdown unregisters adapter state receiver`() {
+        val receiver = io.mockk.slot<BroadcastReceiver>()
+        every {
+            mockContext.registerReceiver(capture(receiver), any<IntentFilter>())
+        } returns null
+        every { mockContext.unregisterReceiver(any()) } just Runs
+        val bridge = KotlinRNodeBridge(mockContext)
+
+        bridge.shutdown()
+
+        KotlinRNodeBridge::class.java.getDeclaredField("isBluetoothStateReceiverRegistered").apply {
+            isAccessible = true
+            assertFalse(getBoolean(bridge))
+        }
+        verify(exactly = 1) { mockContext.unregisterReceiver(receiver.captured) }
     }
 
     @After

--- a/rns-host/src/test/kotlin/network/columba/app/rns/host/rnode/KotlinRNodeBridgeOnlineStatusTest.kt
+++ b/rns-host/src/test/kotlin/network/columba/app/rns/host/rnode/KotlinRNodeBridgeOnlineStatusTest.kt
@@ -34,6 +34,7 @@ import org.junit.Assert.assertNull
 import org.junit.Assert.assertTrue
 import org.junit.Before
 import org.junit.Test
+import java.io.BufferedInputStream
 import java.io.BufferedOutputStream
 import java.io.ByteArrayOutputStream
 import java.io.IOException
@@ -531,6 +532,104 @@ class KotlinRNodeBridgeOnlineStatusTest {
     }
 
     @Test
+    fun `unexpected BLE disconnect closes detached GATT without touching replacement`() {
+        val oldGatt = mockk<BluetoothGatt>()
+        val freshGatt = mockk<BluetoothGatt>()
+        val closeStarted = CountDownLatch(1)
+        val releaseClose = CountDownLatch(1)
+        every { oldGatt.disconnect() } answers {
+            closeStarted.countDown()
+            assertTrue(releaseClose.await(1, TimeUnit.SECONDS))
+        }
+        every { oldGatt.close() } just Runs
+        every { freshGatt.disconnect() } just Runs
+        every { freshGatt.close() } just Runs
+        val bridge = KotlinRNodeBridge(mockContext)
+        bridge.replaceBleGattOwner(oldGatt)
+        setBridgeField(bridge, "connectionMode", RNodeConnectionMode.BLE)
+        setBridgeField(bridge, "connectedDeviceName", "Old RNode")
+        setBridgeConnected(bridge, true)
+        val states = mutableListOf<Boolean>()
+        bridge.connectionStateNotifier = RNodeConnectionStateNotifier { connected, _ -> states += connected }
+
+        val disconnect = Thread { invokeHandleDisconnect(bridge, expectedBleGatt = oldGatt) }
+        disconnect.start()
+        assertTrue(closeStarted.await(1, TimeUnit.SECONDS))
+
+        bridge.replaceBleGattOwner(freshGatt)
+        setBridgeField(bridge, "connectionMode", RNodeConnectionMode.BLE)
+        setBridgeField(bridge, "connectedDeviceName", "Fresh RNode")
+        setBridgeBoolean(bridge, "bleConnected", true)
+        setBridgeConnected(bridge, true)
+        releaseClose.countDown()
+        disconnect.join()
+
+        assertTrue(bridge.isConnected())
+        assertTrue(nullableBridgeField(bridge, "bluetoothGatt") === freshGatt)
+        assertEquals("Fresh RNode", nullableBridgeField(bridge, "connectedDeviceName"))
+        assertTrue(states.isEmpty())
+        verify(exactly = 1) { oldGatt.disconnect() }
+        verify(exactly = 1) { oldGatt.close() }
+        verify(exactly = 0) { freshGatt.disconnect() }
+        verify(exactly = 0) { freshGatt.close() }
+    }
+
+    @Test
+    fun `unexpected Classic disconnect closes detached resources without touching replacement`() {
+        val oldSocket = mockk<BluetoothSocket>()
+        val oldInput = mockk<BufferedInputStream>()
+        val oldOutput = mockk<BufferedOutputStream>()
+        val freshSocket = mockk<BluetoothSocket>()
+        val freshInput = mockk<BufferedInputStream>()
+        val freshOutput = mockk<BufferedOutputStream>()
+        val closeStarted = CountDownLatch(1)
+        val releaseClose = CountDownLatch(1)
+        every { oldInput.close() } answers {
+            closeStarted.countDown()
+            assertTrue(releaseClose.await(1, TimeUnit.SECONDS))
+        }
+        every { oldOutput.close() } just Runs
+        every { oldSocket.close() } just Runs
+        every { freshInput.close() } just Runs
+        every { freshOutput.close() } just Runs
+        every { freshSocket.isConnected } returns true
+        every { freshSocket.close() } just Runs
+        val bridge = KotlinRNodeBridge(mockContext)
+        setBridgeField(bridge, "bluetoothSocket", oldSocket)
+        setBridgeField(bridge, "inputStream", oldInput)
+        setBridgeField(bridge, "outputStream", oldOutput)
+        setBridgeField(bridge, "connectionMode", RNodeConnectionMode.CLASSIC)
+        setBridgeField(bridge, "connectedDeviceName", "Old RNode")
+        setBridgeConnected(bridge, true)
+        val states = mutableListOf<Boolean>()
+        bridge.connectionStateNotifier = RNodeConnectionStateNotifier { connected, _ -> states += connected }
+
+        val disconnect = Thread { invokeHandleDisconnect(bridge, expectedClassicSocket = oldSocket) }
+        disconnect.start()
+        assertTrue(closeStarted.await(1, TimeUnit.SECONDS))
+
+        setBridgeField(bridge, "bluetoothSocket", freshSocket)
+        setBridgeField(bridge, "inputStream", freshInput)
+        setBridgeField(bridge, "outputStream", freshOutput)
+        setBridgeField(bridge, "connectionMode", RNodeConnectionMode.CLASSIC)
+        setBridgeField(bridge, "connectedDeviceName", "Fresh RNode")
+        setBridgeConnected(bridge, true)
+        releaseClose.countDown()
+        disconnect.join()
+
+        assertTrue(bridge.isConnected())
+        assertTrue(nullableBridgeField(bridge, "bluetoothSocket") === freshSocket)
+        assertEquals("Fresh RNode", nullableBridgeField(bridge, "connectedDeviceName"))
+        assertTrue(states.isEmpty())
+        verify(exactly = 1) { oldInput.close() }
+        verify(exactly = 1) { oldOutput.close() }
+        verify(exactly = 1) { oldSocket.close() }
+        verify(exactly = 0) { freshInput.close() }
+        verify(exactly = 0) { freshOutput.close() }
+        verify(exactly = 0) { freshSocket.close() }
+    }
+
+    @Test
     fun `disconnect before delayed connect notification suppresses stale Online`() {
         val oldGatt = mockk<BluetoothGatt>()
         every { oldGatt.disconnect() } just Runs
@@ -616,6 +715,20 @@ class KotlinRNodeBridgeOnlineStatusTest {
     @After
     fun tearDown() {
         clearAllMocks()
+    }
+
+    private fun invokeHandleDisconnect(
+        bridge: KotlinRNodeBridge,
+        expectedBleGatt: BluetoothGatt? = null,
+        expectedClassicSocket: BluetoothSocket? = null,
+    ) {
+        KotlinRNodeBridge::class.java
+            .getDeclaredMethod(
+                "handleDisconnect",
+                BluetoothGatt::class.java,
+                BluetoothSocket::class.java,
+            ).apply { isAccessible = true }
+            .invoke(bridge, expectedBleGatt, expectedClassicSocket)
     }
 
     private fun setBridgeField(

--- a/rns-host/src/test/kotlin/network/columba/app/rns/host/rnode/KotlinRNodeBridgeOnlineStatusTest.kt
+++ b/rns-host/src/test/kotlin/network/columba/app/rns/host/rnode/KotlinRNodeBridgeOnlineStatusTest.kt
@@ -4,7 +4,10 @@ import android.bluetooth.BluetoothAdapter
 import android.bluetooth.BluetoothDevice
 import android.bluetooth.BluetoothGatt
 import android.bluetooth.BluetoothManager
+import android.content.BroadcastReceiver
 import android.content.Context
+import android.content.Intent
+import android.content.IntentFilter
 import io.mockk.clearAllMocks
 import io.mockk.every
 import io.mockk.just
@@ -94,6 +97,71 @@ class KotlinRNodeBridgeOnlineStatusTest {
             device.connectGatt(mockContext, false, any(), BluetoothDevice.TRANSPORT_LE)
         }
         verify(exactly = 0) { mockBluetoothAdapter.bluetoothLeScanner }
+    }
+
+    @Test
+    fun `adapter turning off invalidates connected BLE GATT`() {
+        val receiver = io.mockk.slot<BroadcastReceiver>()
+        every {
+            mockContext.registerReceiver(capture(receiver), any<IntentFilter>())
+        } returns null
+        val gatt = mockk<BluetoothGatt>()
+        every { gatt.disconnect() } just Runs
+        every { gatt.close() } just Runs
+        val bridge = KotlinRNodeBridge(mockContext)
+
+        KotlinRNodeBridge::class.java.getDeclaredField("bluetoothGatt").apply {
+            isAccessible = true
+            set(bridge, gatt)
+        }
+        KotlinRNodeBridge::class.java.getDeclaredField("bleConnected").apply {
+            isAccessible = true
+            setBoolean(bridge, true)
+        }
+        KotlinRNodeBridge::class.java.getDeclaredField("connectionMode").apply {
+            isAccessible = true
+            set(bridge, RNodeConnectionMode.BLE)
+        }
+        KotlinRNodeBridge::class.java.getDeclaredField("connectedDeviceName").apply {
+            isAccessible = true
+            set(bridge, "RNode E517")
+        }
+        KotlinRNodeBridge::class.java.getDeclaredField("isConnected").apply {
+            isAccessible = true
+            (get(bridge) as AtomicBoolean).set(true)
+        }
+        val adapterOffIntent = mockk<Intent>()
+        every { adapterOffIntent.action } returns BluetoothAdapter.ACTION_STATE_CHANGED
+        every {
+            adapterOffIntent.getIntExtra(
+                BluetoothAdapter.EXTRA_STATE,
+                BluetoothAdapter.STATE_OFF,
+            )
+        } returns BluetoothAdapter.STATE_TURNING_OFF
+
+        receiver.captured.onReceive(mockContext, adapterOffIntent)
+
+        assertFalse(bridge.isConnected())
+        verify(exactly = 1) { gatt.disconnect() }
+        verify(exactly = 1) { gatt.close() }
+    }
+
+    @Test
+    fun `adapter turning off closes in flight BLE GATT`() {
+        val gatt = mockk<BluetoothGatt>()
+        every { gatt.disconnect() } just Runs
+        every { gatt.close() } just Runs
+        val bridge = KotlinRNodeBridge(mockContext)
+        KotlinRNodeBridge::class.java.getDeclaredField("bluetoothGatt").apply {
+            isAccessible = true
+            set(bridge, gatt)
+        }
+
+        bridge.handleBluetoothAdapterStateChanged(BluetoothAdapter.STATE_OFF)
+
+        assertFalse(bridge.isConnected())
+        verify(exactly = 1) { gatt.disconnect() }
+        verify(exactly = 1) { gatt.close() }
     }
 
     @After

--- a/rns-host/src/test/kotlin/network/columba/app/rns/host/rnode/KotlinRNodeBridgeOnlineStatusTest.kt
+++ b/rns-host/src/test/kotlin/network/columba/app/rns/host/rnode/KotlinRNodeBridgeOnlineStatusTest.kt
@@ -20,6 +20,7 @@ import io.mockk.Runs
 import io.mockk.verify
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.isActive
+import kotlinx.coroutines.runBlocking
 import org.junit.After
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
@@ -28,6 +29,8 @@ import org.junit.Assert.assertNull
 import org.junit.Assert.assertTrue
 import org.junit.Before
 import org.junit.Test
+import java.io.BufferedOutputStream
+import java.io.IOException
 import java.util.concurrent.CountDownLatch
 import java.util.concurrent.TimeUnit
 import java.util.concurrent.atomic.AtomicBoolean
@@ -393,6 +396,75 @@ class KotlinRNodeBridgeOnlineStatusTest {
         assertFalse(bridge.isConnected())
         assertEquals(listOf(false), connectionStates)
         verify(exactly = 1) { freshSocket.close() }
+    }
+
+    @Test
+    fun `stale suspend Classic write failure cannot disconnect replacement owner`() {
+        assertStaleClassicWriteFailureCannotDisconnectReplacement { bridge, data ->
+            runBlocking { bridge.write(data) }
+        }
+    }
+
+    @Test
+    fun `stale sync Classic write failure cannot disconnect replacement owner`() {
+        assertStaleClassicWriteFailureCannotDisconnectReplacement { bridge, data ->
+            bridge.writeSync(data)
+        }
+    }
+
+    private fun assertStaleClassicWriteFailureCannotDisconnectReplacement(
+        write: (KotlinRNodeBridge, ByteArray) -> Int,
+    ) {
+        val oldSocket = mockk<BluetoothSocket>()
+        val freshSocket = mockk<BluetoothSocket>()
+        val oldStream = mockk<BufferedOutputStream>()
+        val freshStream = mockk<BufferedOutputStream>()
+        every { oldSocket.close() } just Runs
+        every { freshSocket.isConnected } returns true
+        every { freshSocket.close() } just Runs
+        every { oldStream.close() } just Runs
+        every { freshStream.close() } just Runs
+        val writeStarted = CountDownLatch(1)
+        val releaseWrite = CountDownLatch(1)
+        every { oldStream.write(any<ByteArray>()) } answers {
+            writeStarted.countDown()
+            assertTrue(releaseWrite.await(1, TimeUnit.SECONDS))
+            throw IOException("old socket closed")
+        }
+        val bridge = KotlinRNodeBridge(mockContext)
+        bridge.replaceClassicSocketOwner(oldSocket)
+        setBridgeField(bridge, "outputStream", oldStream)
+        setBridgeField(bridge, "connectionMode", RNodeConnectionMode.CLASSIC)
+        setBridgeField(bridge, "connectedDeviceName", "Old RNode")
+        setBridgeConnected(bridge, true)
+        val states = mutableListOf<Boolean>()
+        bridge.connectionStateNotifier =
+            RNodeConnectionStateNotifier { connected, _ -> states += connected }
+        val result = AtomicInteger(Int.MIN_VALUE)
+        val writer =
+            Thread {
+                result.set(write(bridge, byteArrayOf(0x2A)))
+            }
+        writer.start()
+        assertTrue(writeStarted.await(1, TimeUnit.SECONDS))
+
+        bridge.disconnect()
+        bridge.replaceClassicSocketOwner(freshSocket)
+        setBridgeField(bridge, "outputStream", freshStream)
+        setBridgeField(bridge, "connectionMode", RNodeConnectionMode.CLASSIC)
+        setBridgeField(bridge, "connectedDeviceName", "Fresh RNode")
+        setBridgeConnected(bridge, true)
+        releaseWrite.countDown()
+        writer.join()
+
+        assertEquals(-1, result.get())
+        assertTrue(bridge.isConnected())
+        assertTrue(nullableBridgeField(bridge, "bluetoothSocket") === freshSocket)
+        assertEquals("Fresh RNode", nullableBridgeField(bridge, "connectedDeviceName"))
+        assertTrue(states.isEmpty())
+        verify(exactly = 1) { oldSocket.close() }
+        verify(exactly = 0) { freshSocket.close() }
+        verify(exactly = 0) { freshStream.close() }
     }
 
     @Test


### PR DESCRIPTION
## Summary

Addresses #905.

- invalidate RNode bridge state as soon as Android Bluetooth begins shutting down
- atomically fence BLE GATT and Classic socket ownership, transport admission, reads, writes, cleanup, and connection-state notifications
- prevent stale reconnect requests, callbacks, readers, writers, and cleanup from mutating or disconnecting a replacement transport
- stop the previous Python polling generation before creating a replacement Kotlin transport
- restore a genuinely usable RNode connection after Bluetooth returns while preserving exact saved-device identity and live-bond validation

## Regression coverage

- failed reconnect attempt cannot poison a later successful attempt
- stale Python poller is joined before replacement transport creation
- stale BLE callbacks and Classic readers cannot affect replacement owners
- adapter shutdown, explicit disconnect, and bridge shutdown atomically invalidate transport admission
- stale Online and Offline notifications cannot invert replacement state
- blocked Classic suspend and synchronous writes attribute failure to the exact captured socket owner
- queued legacy synchronous cleanup is drained after production-path replacement admission and cannot disconnect the new owner

## Verification

Exact head: `77000e12f90e4bf0ec94cc22eb788a1af752a7cb`

- independent exact-head concurrency review: APPROVED
- focused RNode bridge tests: 30 passed
- complete `rns-host` Python-backend unit suite: passed
- complete `rns-host` Kotlin-backend unit suite: passed
- Python reconnect suite: 21 passed
- ktlint, Detekt, CPD, and Android lint: passed
- `assembleNoSentryPythonBackendDebug`: passed
- canonical Gradle matrix: 543 tasks, 80 executed, 463 up-to-date
- `git diff --check`: passed

## Physical validation

Validated in place on a Samsung S21 Ultra with app data preserved and a Heltec V3/E517 RNode:

1. Android Bluetooth OFF immediately transitioned the RNode interface Offline.
2. Android Bluetooth ON created a fresh secured BLE/NUS transport with MTU 517.
3. RNode detection and protocol configuration completed before the interface returned Online.
4. Columba and the physical E517 display agreed on recovered connection state.
5. Bidirectional traffic succeeded after recovery.
6. The app remained running without a fatal exception.

## Risk and rollback

The change is limited to RNode Bluetooth lifecycle ownership and its regressions. Rollback is a normal revert of this PR. No database or shared AIDL/Parcelable schema changes are included.
