### PR TITLE
RNode battery level in notification and Interface Stats

### DIFF
--- a/app/src/main/java/network/columba/app/ui/screens/InterfaceStatsScreen.kt
+++ b/app/src/main/java/network/columba/app/ui/screens/InterfaceStatsScreen.kt
@@ -41,9 +41,14 @@ import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.text.font.Font
+import androidx.compose.ui.text.font.FontFamily
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
 import androidx.hilt.navigation.compose.hiltViewModel
+import network.columba.app.R
+import network.columba.app.ui.theme.MaterialDesignIcons
 import network.columba.app.util.InterfaceFormattingUtils
 import network.columba.app.viewmodel.InterfaceStatsViewModel
 import tech.torlando.rns.stats.ui.TrafficSpeedChart
@@ -170,6 +175,7 @@ private fun StatsContent(
             isOnline = state.isOnline,
             isConnecting = state.isConnecting,
             needsUsbPermission = state.needsUsbPermission,
+            rnodeBattery = state.rnodeBattery,
             onToggleEnabled = onToggleEnabled,
             onRequestUsbPermission = onRequestUsbPermission,
         )
@@ -226,12 +232,26 @@ private fun StatsContent(
     }
 }
 
+private val MdiFont = FontFamily(Font(R.font.materialdesignicons))
+
+/**
+ * Pick a Material Design Icons battery glyph for a 0-100 percent level:
+ * alert at <=15%, full at >=95%, otherwise the nearest 10% step (rounded up).
+ */
+private fun batteryIconName(percent: Int): String =
+    when {
+        percent <= 15 -> "battery-alert"
+        percent >= 95 -> "battery"
+        else -> "battery-${(percent / 10 + if (percent % 10 >= 5) 1 else 0).coerceIn(1, 10) * 10}"
+    }
+
 @Composable
 private fun StatusCard(
     isEnabled: Boolean,
     isOnline: Boolean,
     isConnecting: Boolean,
     needsUsbPermission: Boolean,
+    rnodeBattery: Int?,
     onToggleEnabled: () -> Unit,
     onRequestUsbPermission: () -> Unit,
 ) {
@@ -293,6 +313,31 @@ private fun StatusCard(
                     checked = isEnabled,
                     onCheckedChange = { onToggleEnabled() },
                 )
+            }
+
+            // RNode battery (only present for RNode interfaces with a live reading)
+            rnodeBattery?.let { percent ->
+                Spacer(modifier = Modifier.height(8.dp))
+                Row(
+                    horizontalArrangement = Arrangement.spacedBy(6.dp),
+                    verticalAlignment = Alignment.CenterVertically,
+                ) {
+                    val codepoint = MaterialDesignIcons.getCodepointOrNull(batteryIconName(percent))
+                    if (codepoint != null) {
+                        Text(
+                            text = codepoint,
+                            fontFamily = MdiFont,
+                            fontSize = 16.sp,
+                            color = MaterialTheme.colorScheme.onSurfaceVariant,
+                        )
+                    }
+                    Text(
+                        text = "$percent%",
+                        style = MaterialTheme.typography.bodyMedium,
+                        fontWeight = FontWeight.Medium,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    )
+                }
             }
 
             // USB Permission message and button

--- a/app/src/main/java/network/columba/app/viewmodel/InterfaceStatsViewModel.kt
+++ b/app/src/main/java/network/columba/app/viewmodel/InterfaceStatsViewModel.kt
@@ -252,16 +252,7 @@ class InterfaceStatsViewModel
 
                 // For RNode interfaces, also fetch the live battery (0-100, -1 absent).
                 // Live fetch per poll (not a cached value); binder call off Main.
-                var rnodeBattery: Int? = null
-                if (entity.type == "RNode") {
-                    val battery =
-                        withContext(Dispatchers.IO) {
-                            transportAdmin.getRNodeBattery()
-                        }
-                    if (battery > -1) {
-                        rnodeBattery = battery
-                    }
-                }
+                val rnodeBattery = readRNodeBattery(entity.type)
 
                 // Check USB permission for USB-mode RNode interfaces that are offline
                 val needsUsbPermission =
@@ -291,6 +282,15 @@ class InterfaceStatsViewModel
             } catch (e: Exception) {
                 Log.e(TAG, "Error refreshing stats", e)
             }
+        }
+
+        private suspend fun readRNodeBattery(interfaceType: String): Int? {
+            if (interfaceType != "RNode") return null
+            val battery =
+                withContext(Dispatchers.IO) {
+                    transportAdmin.getRNodeBattery()
+                }
+            return if (battery > -1) battery else null
         }
 
         private fun recordTrafficSample(

--- a/app/src/main/java/network/columba/app/viewmodel/InterfaceStatsViewModel.kt
+++ b/app/src/main/java/network/columba/app/viewmodel/InterfaceStatsViewModel.kt
@@ -46,6 +46,7 @@ data class InterfaceStatsState(
     // RNode-specific stats (from live connection)
     val rssi: Int? = null,
     val snr: Float? = null,
+    val rnodeBattery: Int? = null,
     // Traffic stats (from Python/RNS)
     val rxBytes: Long = 0,
     val txBytes: Long = 0,
@@ -249,6 +250,19 @@ class InterfaceStatsViewModel
                     }
                 }
 
+                // For RNode interfaces, also fetch the live battery (0-100, -1 absent).
+                // Live fetch per poll (not a cached value); binder call off Main.
+                var rnodeBattery: Int? = null
+                if (entity.type == "RNode") {
+                    val battery =
+                        withContext(Dispatchers.IO) {
+                            transportAdmin.getRNodeBattery()
+                        }
+                    if (battery > -1) {
+                        rnodeBattery = battery
+                    }
+                }
+
                 // Check USB permission for USB-mode RNode interfaces that are offline
                 val needsUsbPermission =
                     if (!isOnline && _state.value.connectionMode == "usb") {
@@ -270,6 +284,7 @@ class InterfaceStatsViewModel
                         txBytes = txBytes,
                         trafficHistory = history,
                         rssi = rssi,
+                        rnodeBattery = rnodeBattery,
                         needsUsbPermission = needsUsbPermission,
                     )
                 }

--- a/app/src/test/java/network/columba/app/viewmodel/InterfaceStatsViewModelTest.kt
+++ b/app/src/test/java/network/columba/app/viewmodel/InterfaceStatsViewModelTest.kt
@@ -340,6 +340,44 @@ class InterfaceStatsViewModelTest {
         }
 
     @Test
+    fun `rnode battery is stored when positive`() =
+        runTest {
+            coEvery { interfaceRepository.getInterfaceByIdOnce(1L) } returns testRNodeEntity
+            coEvery { reticulumProtocol.getInterfaceStats("Test RNode") } returns
+                mapOf(
+                    "online" to true,
+                    "rxb" to 0L,
+                    "txb" to 0L,
+                )
+            coEvery { reticulumProtocol.getRNodeBattery() } returns 82
+
+            val viewModel = createViewModel(1L)
+            advanceTimeBy(1100) // Allow loadInterface to complete
+            viewModel.refreshStats()
+
+            assertEquals(82, viewModel.state.value.rnodeBattery)
+        }
+
+    @Test
+    fun `rnode battery is null for absent sentinel`() =
+        runTest {
+            coEvery { interfaceRepository.getInterfaceByIdOnce(1L) } returns testRNodeEntity
+            coEvery { reticulumProtocol.getInterfaceStats("Test RNode") } returns
+                mapOf(
+                    "online" to true,
+                    "rxb" to 0L,
+                    "txb" to 0L,
+                )
+            coEvery { reticulumProtocol.getRNodeBattery() } returns -1
+
+            val viewModel = createViewModel(1L)
+            advanceTimeBy(1100) // Allow loadInterface to complete
+            viewModel.refreshStats()
+
+            assertNull(viewModel.state.value.rnodeBattery)
+        }
+
+    @Test
     fun `refreshStats does not set RSSI if value is too low`() =
         runTest {
             coEvery { interfaceRepository.getInterfaceByIdOnce(1L) } returns testRNodeEntity

--- a/rns-api/src/main/aidl/network/columba/app/rns/ipc/IRnsTransportAdmin.aidl
+++ b/rns-api/src/main/aidl/network/columba/app/rns/ipc/IRnsTransportAdmin.aidl
@@ -61,6 +61,11 @@ oneway interface IRnsTransportAdmin {
     // the value via an observer or wraps with suspendCancellableCoroutine.
     void getRNodeRssi(in IRnsIntCallback cb);
 
+    // getRNodeBattery: live battery percent (0-100), -1 when absent.
+    // Oneway + callback, same shape as getRNodeRssi. The Kotlin contract
+    // method is `suspend` (live fetch per call), not a cached getter.
+    void getRNodeBattery(in IRnsIntCallback cb);
+
     // ==================== BLE ====================
 
     // getBleConnectionDetails: synchronous getter on Kotlin (returns String,

--- a/rns-api/src/main/java/network/columba/app/rns/api/RnsTransportAdmin.kt
+++ b/rns-api/src/main/java/network/columba/app/rns/api/RnsTransportAdmin.kt
@@ -143,6 +143,18 @@ interface RnsTransportAdmin {
      */
     fun getRNodeRssi(): Int
 
+    /**
+     * Last reported RNode battery level in percent (0-100). Returns -1
+     * (the RNODE_BATTERY_ABSENT convention) when no RNode is connected or the
+     * firmware has not emitted a battery frame yet, so callers don't need a
+     * separate "absent" branch.
+     *
+     * Unlike [getRNodeRssi] this is `suspend` and performs a live fetch on
+     * every call (the Python backend reads the current value off the live
+     * RNode interface), not a cached bind-time snapshot.
+     */
+    suspend fun getRNodeBattery(): Int
+
     // ==================== BLE ====================
 
     /**

--- a/rns-backend-kt/src/main/kotlin/network/columba/app/rns/backend/kt/NativeRnsBackendImpl.kt
+++ b/rns-backend-kt/src/main/kotlin/network/columba/app/rns/backend/kt/NativeRnsBackendImpl.kt
@@ -2309,6 +2309,12 @@ class NativeRnsBackendImpl(
     override fun getRNodeRssi(): Int = -100
 
     /**
+     * No RNode battery read in the Kotlin backend (deferred). Returns the
+     * absent sentinel so the shared UI needs no "unsupported backend" branch.
+     */
+    override suspend fun getRNodeBattery(): Int = -1
+
+    /**
      * JSON snapshot of BLE peers. Empty array when no peers are connected.
      * Detailed connection details are surfaced via the dedicated KotlinBLEBridge
      * metrics surface in `:rns-host`; this method preserves the legacy interface.

--- a/rns-backend-py/src/main/kotlin/network/columba/app/rns/backend/py/PythonRnsTransportAdmin.kt
+++ b/rns-backend-py/src/main/kotlin/network/columba/app/rns/backend/py/PythonRnsTransportAdmin.kt
@@ -51,6 +51,9 @@ class PythonRnsTransportAdmin(
         /** Noise-floor sentinel the contract documents for "no RNode connected". */
         const val RNODE_RSSI_ABSENT = -100
 
+        /** Absent-sentinel for "no RNode battery reading yet / no RNode connected". */
+        const val RNODE_BATTERY_ABSENT = -1
+
         /** Empty JSON array — the contract's documented "no BLE peers" value. */
         const val EMPTY_JSON_ARRAY = "[]"
     }
@@ -344,6 +347,33 @@ class PythonRnsTransportAdmin(
         // No python RNode interface in this cut — return the documented
         // noise-floor sentinel so the signal-strength UI needs no "absent" branch.
         return RNODE_RSSI_ABSENT
+    }
+
+    override suspend fun getRNodeBattery(): Int {
+        // RNode battery is a KISS data-channel scalar (CMD_STAT_BAT 0x27) read
+        // into ColumbaRNodeInterface.r_stat_bat by its read loop. Find the live
+        // interface on the RNS Transport and read it. Returns RNODE_BATTERY_ABSENT
+        // (-1) when there is no RNode interface or no frame received yet - same
+        // "sentinel, no UI branch" contract as getRNodeRssi.
+        //
+        // NOTE: this is a LIVE fetch (deliberately NOT the getRNodeRssi stub,
+        // which returns the sentinel unconditionally). Battery changes slowly,
+        // so callers poll on a slow cadence.
+        return pyCall {
+            val interfaces = transport()["interfaces"] ?: return@pyCall RNODE_BATTERY_ABSENT
+            val rnodeIfaces = runtime.python.builtins.callAttr("list", interfaces).asList()
+            val rnode = rnodeIfaces.firstOrNull { iface ->
+                runCatching {
+                    runtime.python.builtins.callAttr("type", iface)["__name__"]?.toString()
+                }.getOrNull() == "ColumbaRNodeInterface"
+            } ?: return@pyCall RNODE_BATTERY_ABSENT
+            // get_battery() returns Python None until the first 0x27 frame. Chaquopy
+            // wraps None as a NON-NULL PyObject, so toJava(Int) on it would throw -
+            // guard with takeIfNotNone() (PythonExt.kt) to fold None into null.
+            runCatching {
+                rnode.callAttr("get_battery").takeIfNotNone()?.toJava(Int::class.javaObjectType)
+            }.getOrNull() ?: RNODE_BATTERY_ABSENT
+        }
     }
 
     // ==================== BLE ====================

--- a/rns-backend-py/src/main/python/columba_rnode_interface.py
+++ b/rns-backend-py/src/main/python/columba_rnode_interface.py
@@ -333,6 +333,7 @@ class ColumbaRNodeInterface(Interface):
         self.r_state = None
         self.r_stat_rssi = None
         self.r_stat_snr = None
+        self.r_stat_bat = None
 
         # Read thread
         self._read_thread = None
@@ -1168,6 +1169,11 @@ class ColumbaRNodeInterface(Interface):
                         elif command == KISS.CMD_STAT_SNR:
                             with self._read_lock:
                                 self.r_stat_snr = int.from_bytes([byte], "big", signed=True) / 4.0
+                        elif command == KISS.CMD_STAT_BAT:
+                            # RNode battery level. Convention: 0-100 percent.
+                            # (Confirm scale on-device - see plan OPEN ITEM.)
+                            with self._read_lock:
+                                self.r_stat_bat = byte
                         elif command == KISS.CMD_FW_VERSION:
                             if len(data_buffer) < 2:
                                 data_buffer += bytes([byte])
@@ -1297,6 +1303,11 @@ class ColumbaRNodeInterface(Interface):
                         elif command == KISS.CMD_STAT_SNR:
                             with self._read_lock:
                                 self.r_stat_snr = int.from_bytes([byte], "big", signed=True) / 4.0
+                        elif command == KISS.CMD_STAT_BAT:
+                            # RNode battery level. Convention: 0-100 percent.
+                            # (Confirm scale on-device - see plan OPEN ITEM.)
+                            with self._read_lock:
+                                self.r_stat_bat = byte
                         elif command == KISS.CMD_FW_VERSION:
                             if len(data_buffer) < 2:
                                 data_buffer += bytes([byte])
@@ -1617,6 +1628,11 @@ class ColumbaRNodeInterface(Interface):
         """Get last received signal-to-noise ratio."""
         with self._read_lock:
             return self.r_stat_snr
+
+    def get_battery(self):
+        """Get last reported battery level (0-100 percent), or None if not yet received."""
+        with self._read_lock:
+            return self.r_stat_bat
 
     def enter_bluetooth_pairing_mode(self):
         """

--- a/rns-backend-py/src/main/python/columba_rnode_interface.py
+++ b/rns-backend-py/src/main/python/columba_rnode_interface.py
@@ -1630,8 +1630,17 @@ class ColumbaRNodeInterface(Interface):
             return self.r_stat_snr
 
     def get_battery(self):
-        """Get last reported battery level (0-100 percent), or None if not yet received."""
+        """Get last reported battery level (0-100 percent), or None if not yet
+        received or the interface is offline.
+
+        The cached value is only meaningful while connected: on a transient
+        drop the interface stays registered but the last 0x27 frame is stale,
+        so callers must treat an offline interface as "no reading" (the AIDL
+        layer maps this to the -1 absent sentinel).
+        """
         with self._read_lock:
+            if not self.online:
+                return None
             return self.r_stat_bat
 
     def enter_bluetooth_pairing_mode(self):

--- a/rns-backend-py/src/test/python/test_columba_rnode_battery.py
+++ b/rns-backend-py/src/test/python/test_columba_rnode_battery.py
@@ -62,6 +62,9 @@ class RNodeBatteryParseTests(unittest.TestCase):
         iface.r_stat_bat = None
         iface.r_stat_rssi = None
         iface.r_stat_snr = None
+        # A battery frame can only be parsed while connected, so a frame-driven
+        # interface is online.
+        iface.online = True
         return iface
 
     def test_kiss_stat_bat_command_is_0x27(self):
@@ -77,6 +80,17 @@ class RNodeBatteryParseTests(unittest.TestCase):
 
     def test_get_battery_defaults_to_none(self):
         iface = self._make_iface()
+        self.assertIsNone(iface.get_battery())
+
+    def test_get_battery_returns_none_when_offline(self):
+        # Regression: on a transient BLE/USB drop the interface stays registered
+        # but goes offline. A cached battery frame must NOT keep being reported -
+        # get_battery() has to return None so the AIDL layer maps it to the -1
+        # absent sentinel (and the notification poller stops re-posting the stale
+        # percentage on a dead RNode).
+        iface = self._make_iface()
+        iface.r_stat_bat = 82
+        iface.online = False
         self.assertIsNone(iface.get_battery())
 
 

--- a/rns-backend-py/src/test/python/test_columba_rnode_battery.py
+++ b/rns-backend-py/src/test/python/test_columba_rnode_battery.py
@@ -1,0 +1,84 @@
+"""Unit tests for RNode KISS battery (CMD_STAT_BAT 0x27) parsing.
+
+Loads the real columba_rnode_interface module with a stubbed RNS base and
+drives a single battery frame through the real _read_loop parse path.
+"""
+import importlib.util
+import sys
+import threading
+import types
+import unittest
+from pathlib import Path
+
+MODULE_PATH = Path(__file__).resolve().parents[2] / "main/python/columba_rnode_interface.py"
+
+
+def _load_module():
+    # Stub RNS + the Interface base so the module imports without the full stack.
+    rns = types.ModuleType("RNS")
+    rns.LOG_ERROR = 3
+    rns.LOG_DEBUG = 1
+    rns.LOG_WARNING = 2
+    rns.log = lambda *a, **k: None
+    interfaces_pkg = types.ModuleType("RNS.Interfaces")
+    iface_mod = types.ModuleType("RNS.Interfaces.Interface")
+    iface_mod.Interface = object  # base-class stand-in
+    sys.modules["RNS"] = rns
+    sys.modules["RNS.Interfaces"] = interfaces_pkg
+    sys.modules["RNS.Interfaces.Interface"] = iface_mod
+    spec = importlib.util.spec_from_file_location("columba_rnode_interface_battery_test", MODULE_PATH)
+    assert spec is not None and spec.loader is not None
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+class _FakeBridge:
+    """Yields one KISS frame, then signals the read loop to stop."""
+
+    def __init__(self, frame, iface):
+        self._frame = frame
+        self._iface = iface
+        self._reads = 0
+
+    def read(self):
+        self._reads += 1
+        if self._reads == 1:
+            return self._frame
+        self._iface._running.clear()
+        return b""
+
+
+class RNodeBatteryParseTests(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.mod = _load_module()
+
+    def _make_iface(self):
+        # Skip the heavy __init__; _read_loop only touches the fields we set here.
+        iface = object.__new__(self.mod.ColumbaRNodeInterface)
+        iface._read_lock = threading.Lock()
+        iface._running = threading.Event()
+        iface.r_stat_bat = None
+        iface.r_stat_rssi = None
+        iface.r_stat_snr = None
+        return iface
+
+    def test_kiss_stat_bat_command_is_0x27(self):
+        self.assertEqual(self.mod.KISS.CMD_STAT_BAT, 0x27)
+
+    def test_battery_frame_updates_r_stat_bat_and_get_battery(self):
+        iface = self._make_iface()
+        # KISS frame: FEND(0xC0) CMD_STAT_BAT(0x27) value(0x52=82) FEND(0xC0)
+        iface.kotlin_bridge = _FakeBridge(bytes([0xC0, 0x27, 0x52, 0xC0]), iface)
+        iface._running.set()
+        iface._read_loop()  # one iteration parses the frame; the fake bridge then clears _running
+        self.assertEqual(iface.get_battery(), 82)
+
+    def test_get_battery_defaults_to_none(self):
+        iface = self._make_iface()
+        self.assertIsNone(iface.get_battery())
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/rns-host/src/main/kotlin/network/columba/app/rns/host/ReticulumService.kt
+++ b/rns-host/src/main/kotlin/network/columba/app/rns/host/ReticulumService.kt
@@ -12,6 +12,8 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.TimeoutCancellationException
 import kotlinx.coroutines.cancel
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.isActive
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withTimeout
 import network.columba.app.rns.api.RnsBackend
@@ -53,6 +55,11 @@ class ReticulumService : Service() {
         // (the time between :reticulum dying and Android auto-restarting the FGS),
         // so 5s is plenty of headroom while still failing fast for genuine STOPs.
         private const val STALE_STOP_GRACE_MS = 5_000L
+
+        // Cadence for the RNode battery poll that feeds the persistent
+        // notification. Battery changes slowly; a local IPC read, not a
+        // network op, so 15s is plenty responsive without churn.
+        private const val BATTERY_POLL_INTERVAL_MS = 15_000L
     }
 
     /**
@@ -194,6 +201,17 @@ class ReticulumService : Service() {
                 }
             },
         )
+        // Poll the RNode battery for the persistent notification. This reads the
+        // live value off the in-process Python backend (no network traffic), so a
+        // slow cadence is fine - battery changes gradually. < 0 = absent (hidden).
+        serviceScope.launch {
+            while (isActive) {
+                val battery =
+                    runCatching { rnsBackend.transportAdmin.getRNodeBattery() }.getOrNull() ?: -1
+                managers.notificationManager.updateRNodeBattery(battery)
+                delay(BATTERY_POLL_INTERVAL_MS)
+            }
+        }
         val usbBridge = KotlinUSBBridge.getInstance(this)
         // Seed hasActiveUsbRNode from devices already attached when the
         // service starts. Without this, an RNode plugged in BEFORE the

--- a/rns-host/src/main/kotlin/network/columba/app/rns/host/ReticulumService.kt
+++ b/rns-host/src/main/kotlin/network/columba/app/rns/host/ReticulumService.kt
@@ -204,14 +204,7 @@ class ReticulumService : Service() {
         // Poll the RNode battery for the persistent notification. This reads the
         // live value off the in-process Python backend (no network traffic), so a
         // slow cadence is fine - battery changes gradually. < 0 = absent (hidden).
-        serviceScope.launch {
-            while (isActive) {
-                val battery =
-                    runCatching { rnsBackend.transportAdmin.getRNodeBattery() }.getOrNull() ?: -1
-                managers.notificationManager.updateRNodeBattery(battery)
-                delay(BATTERY_POLL_INTERVAL_MS)
-            }
-        }
+        startRNodeBatteryPoller()
         val usbBridge = KotlinUSBBridge.getInstance(this)
         // Seed hasActiveUsbRNode from devices already attached when the
         // service starts. Without this, an RNode plugged in BEFORE the
@@ -306,6 +299,23 @@ class ReticulumService : Service() {
         } else {
             serviceScope.launch {
                 backendInitializer.initializeFromSnapshot(rnsBackend)
+            }
+        }
+    }
+
+    /**
+     * Poll the RNode battery for the persistent notification. Reads the live
+     * value off the in-process Python backend (a local IPC read, no network
+     * traffic), so a slow cadence is fine - battery changes gradually.
+     * Values < 0 mean "absent" and are hidden by the manager.
+     */
+    private fun startRNodeBatteryPoller() {
+        serviceScope.launch {
+            while (isActive) {
+                val battery =
+                    runCatching { rnsBackend.transportAdmin.getRNodeBattery() }.getOrNull() ?: -1
+                managers.notificationManager.updateRNodeBattery(battery)
+                delay(BATTERY_POLL_INTERVAL_MS)
             }
         }
     }

--- a/rns-host/src/main/kotlin/network/columba/app/rns/host/ipc/BoundRnsTransportAdmin.kt
+++ b/rns-host/src/main/kotlin/network/columba/app/rns/host/ipc/BoundRnsTransportAdmin.kt
@@ -88,6 +88,9 @@ internal class BoundRnsTransportAdmin(
 
     override fun getRNodeRssi(): Int = backendFlow.value?.transportAdmin?.getRNodeRssi() ?: -100
 
+    override suspend fun getRNodeBattery(): Int =
+        awaitBound().transportAdmin.getRNodeBattery()
+
     override fun getBleConnectionDetails(): String =
         backendFlow.value?.transportAdmin?.getBleConnectionDetails() ?: "[]"
 

--- a/rns-host/src/main/kotlin/network/columba/app/rns/host/manager/ServiceNotificationManager.kt
+++ b/rns-host/src/main/kotlin/network/columba/app/rns/host/manager/ServiceNotificationManager.kt
@@ -300,7 +300,14 @@ class ServiceNotificationManager(
      */
     fun updateRNodeBattery(percent: Int) {
         mainHandler.post {
-            val newBattery = if (percent in 0..100) percent else null
+            // Reject a stale positive value if any RNode interface is
+            // disconnected: the poller may have captured the reading just
+            // before a disconnect, and the disconnect event may reach the
+            // main handler before this update. Without this guard the
+            // notification would show "(RNode disconnected)" and
+            // "(RNode battery N%)" at the same time.
+            val newBattery =
+                if (disconnectedRNodeInterfaces.isEmpty() && percent in 0..100) percent else null
             rnodeBatteryPercent = newBattery
             // Skip the repost during active sync (matches updateRNodeStatus) and
             // when nothing changed.

--- a/rns-host/src/main/kotlin/network/columba/app/rns/host/manager/ServiceNotificationManager.kt
+++ b/rns-host/src/main/kotlin/network/columba/app/rns/host/manager/ServiceNotificationManager.kt
@@ -55,6 +55,11 @@ class ServiceNotificationManager(
     private var currentSyncProgress: Float = 0f
     private var lastNetworkStatus: String = "READY"
 
+    // Last RNode battery percent (0-100). null when absent / offline. Mutated
+    // only on the main thread (via mainHandler) like the other notification state.
+    private var rnodeBatteryPercent: Int? = null
+    private var lastNotifiedBattery: Int? = null
+
     // Track per-interface RNode disconnect state. Thread-safe because startForeground()
     // (which reads this via getStatusTexts()) can be called from any thread, while mutations
     // are posted to mainHandler.
@@ -228,6 +233,9 @@ class ServiceNotificationManager(
             }
 
             if (disconnectedRNodeInterfaces.isNotEmpty()) {
+                // Battery reading is stale once the RNode is down; hide it.
+                rnodeBatteryPercent = null
+                lastNotifiedBattery = null
                 val pendingIntent = createContentIntent()
                 val names = disconnectedRNodeInterfaces.joinToString(", ")
                 val alert =
@@ -282,6 +290,28 @@ class ServiceNotificationManager(
             ) {
                 repostNotification(createNotification(lastNetworkStatus))
             }
+        }
+    }
+
+    /**
+     * Update the RNode battery shown in the persistent foreground notification.
+     * [percent] is 0-100, or < 0 (absent) to hide it. Only reposts when the value
+     * actually changed, to avoid needless startForeground churn.
+     */
+    fun updateRNodeBattery(percent: Int) {
+        mainHandler.post {
+            val newBattery = if (percent in 0..100) percent else null
+            rnodeBatteryPercent = newBattery
+            // Skip the repost during active sync (matches updateRNodeStatus) and
+            // when nothing changed.
+            if (newBattery == lastNotifiedBattery) return@post
+            if (currentSyncState in
+                PropagationState.STATE_PATH_REQUESTED..PropagationState.STATE_RESPONSE_RECEIVED
+            ) {
+                return@post
+            }
+            lastNotifiedBattery = newBattery
+            repostNotification(createNotification(lastNetworkStatus))
         }
     }
 
@@ -462,6 +492,12 @@ class ServiceNotificationManager(
         // Append RNode status when network is otherwise healthy
         if (networkStatus == "READY" && disconnectedRNodeInterfaces.isNotEmpty()) {
             detailText += " (RNode disconnected)"
+        }
+
+        // Append RNode battery when we have a live reading and the network is healthy.
+        val battery = rnodeBatteryPercent
+        if (networkStatus == "READY" && battery != null) {
+            detailText += " (RNode battery ${battery}%)"
         }
 
         return Pair(statusText, detailText)

--- a/rns-host/src/test/kotlin/network/columba/app/rns/host/ipc/BoundRnsBackendTest.kt
+++ b/rns-host/src/test/kotlin/network/columba/app/rns/host/ipc/BoundRnsBackendTest.kt
@@ -365,6 +365,7 @@ class BoundRnsBackendTest {
         override suspend fun getInterfaceStats(interfaceName: String) = null
         override suspend fun reconnectRNodeInterface() {}
         override fun getRNodeRssi(): Int = rssi
+        override suspend fun getRNodeBattery(): Int = -1
         override fun getBleConnectionDetails(): String = bleConnections
         fun emitInterfaceStatus(payload: String) {
             check(interfaceStatusEmitter.tryEmit(payload))

--- a/rns-host/src/test/kotlin/network/columba/app/rns/host/manager/ServiceNotificationManagerRNodeTest.kt
+++ b/rns-host/src/test/kotlin/network/columba/app/rns/host/manager/ServiceNotificationManagerRNodeTest.kt
@@ -155,6 +155,46 @@ class ServiceNotificationManagerRNodeTest {
         )
     }
 
+    @Test
+    fun `foreground notification includes battery when present`() {
+        serviceNotificationManager.updateRNodeBattery(82)
+        drainMainLooper()
+
+        val notification = serviceNotificationManager.createNotification("READY")
+        val bigText = notification.extras.getString("android.bigText") ?: ""
+        assertTrue(
+            "bigText should include 'RNode battery 82%'",
+            bigText.contains("RNode battery 82%"),
+        )
+    }
+
+    @Test
+    fun `foreground notification omits battery when absent`() {
+        serviceNotificationManager.updateRNodeBattery(-1)
+        drainMainLooper()
+
+        val notification = serviceNotificationManager.createNotification("READY")
+        val bigText = notification.extras.getString("android.bigText") ?: ""
+        assertTrue(
+            "bigText should NOT include 'RNode battery'",
+            !bigText.contains("RNode battery"),
+        )
+    }
+
+    @Test
+    fun `battery is cleared when RNode disconnects`() {
+        serviceNotificationManager.updateRNodeBattery(82)
+        serviceNotificationManager.updateRNodeStatus(false, "RNodeInterface[BLE]")
+        drainMainLooper()
+
+        val notification = serviceNotificationManager.createNotification("READY")
+        val bigText = notification.extras.getString("android.bigText") ?: ""
+        assertTrue(
+            "bigText should NOT include battery while RNode is down",
+            !bigText.contains("RNode battery"),
+        )
+    }
+
     // ========== Debounce ==========
 
     @Test

--- a/rns-host/src/test/kotlin/network/columba/app/rns/host/manager/ServiceNotificationManagerRNodeTest.kt
+++ b/rns-host/src/test/kotlin/network/columba/app/rns/host/manager/ServiceNotificationManagerRNodeTest.kt
@@ -195,6 +195,25 @@ class ServiceNotificationManagerRNodeTest {
         )
     }
 
+    @Test
+    fun `late battery update after disconnect does not restore stale value`() {
+        // The poller captured 82 while the RNode was still online, but the
+        // disconnect event reaches the main handler before the captured
+        // battery update. The stale value must not be restored, or the
+        // notification would show "(RNode disconnected)" and
+        // "(RNode battery 82%)" at the same time.
+        serviceNotificationManager.updateRNodeStatus(false, "RNodeInterface[BLE]")
+        serviceNotificationManager.updateRNodeBattery(82)
+        drainMainLooper()
+
+        val notification = serviceNotificationManager.createNotification("READY")
+        val bigText = notification.extras.getString("android.bigText") ?: ""
+        assertTrue(
+            "bigText should NOT include battery while RNode is down, even if a pre-disconnect reading arrives late",
+            !bigText.contains("RNode battery"),
+        )
+    }
+
     // ========== Debounce ==========
 
     @Test

--- a/rns-ipc/src/main/kotlin/network/columba/app/rns/ipc/client/ClientRnsTransportAdmin.kt
+++ b/rns-ipc/src/main/kotlin/network/columba/app/rns/ipc/client/ClientRnsTransportAdmin.kt
@@ -102,6 +102,14 @@ internal class ClientRnsTransportAdmin(
 
     override fun getRNodeRssi(): Int = lastRssi
 
+    // Battery is a LIVE value: fresh AIDL round-trip per call. The stats screen
+    // polls at 1s and the notification poller at ~15s, so a bind-time cache
+    // (the getRNodeRssi pattern) would be wrong. -1 when absent / on error.
+    override suspend fun getRNodeBattery(): Int =
+        runCatching {
+            awaitNullableInt { cb -> remote.getRNodeBattery(cb) } ?: -1
+        }.getOrDefault(-1)
+
     // getBleConnectionDetails is also non-suspend on the Kotlin side. Same
     // observer-cache trick — the BLE connections SharedFlow emits the same
     // JSON snapshot whenever peers connect/disconnect, so caching covers the

--- a/rns-ipc/src/main/kotlin/network/columba/app/rns/ipc/server/ServerRnsTransportAdmin.kt
+++ b/rns-ipc/src/main/kotlin/network/columba/app/rns/ipc/server/ServerRnsTransportAdmin.kt
@@ -102,6 +102,12 @@ internal class ServerRnsTransportAdmin(
         impl.getRNodeRssi()
     }
 
+    // Live fetch: `impl.getRNodeBattery()` is `suspend` and re-reads on every
+    // call, so the dispatch block runs the current backend value.
+    override fun getRNodeBattery(cb: IRnsIntCallback) = dispatchNullableInt(cb, scope) {
+        impl.getRNodeBattery()
+    }
+
     override fun getBleConnectionDetails(cb: IRnsStringCallback) = dispatchNullableString(cb, scope) {
         impl.getBleConnectionDetails()
     }

--- a/rns-ipc/src/test/java/network/columba/app/rns/ipc/RnsBackendIpcRoundTripTest.kt
+++ b/rns-ipc/src/test/java/network/columba/app/rns/ipc/RnsBackendIpcRoundTripTest.kt
@@ -119,6 +119,24 @@ class RnsBackendIpcRoundTripTest {
     }
 
     @Test
+    fun `rnodeBattery round-trips a live value through the stub`() = runTest {
+        val (client, _) = buildClientAndServer()
+        advanceUntilIdle()
+        fake.transportAdminFake.batteryResult = 82
+
+        assertEquals(82, client.transportAdmin.getRNodeBattery())
+    }
+
+    @Test
+    fun `rnodeBattery round-trips the absent sentinel through the stub`() = runTest {
+        val (client, _) = buildClientAndServer()
+        advanceUntilIdle()
+        fake.transportAdminFake.batteryResult = -1
+
+        assertEquals(-1, client.transportAdmin.getRNodeBattery())
+    }
+
+    @Test
     fun `identity import success map round-trips through the stub`() = runTest {
         val (client, _) = buildClientAndServer()
         val keyData = ByteArray(64) { it.toByte() }

--- a/rns-ipc/src/test/java/network/columba/app/rns/ipc/RnsBackendIpcRoundTripTest.kt
+++ b/rns-ipc/src/test/java/network/columba/app/rns/ipc/RnsBackendIpcRoundTripTest.kt
@@ -702,6 +702,8 @@ private class FakeRnsNomadnet : RnsNomadnet {
 
 private class FakeRnsTransportAdmin : RnsTransportAdmin {
     var sharedInstanceAccessConfig: String? = null
+    var batteryResult: Int = -1
+
     private val interfaceStatuses = MutableSharedFlow<String>(replay = 1, extraBufferCapacity = 8)
 
     fun emitInterfaceStatus(payload: String) {
@@ -724,6 +726,7 @@ private class FakeRnsTransportAdmin : RnsTransportAdmin {
     override suspend fun getInterfaceStats(interfaceName: String): Map<String, Any>? = null
     override suspend fun reconnectRNodeInterface() {}
     override fun getRNodeRssi(): Int = -100
+    override suspend fun getRNodeBattery(): Int = batteryResult
     override fun getBleConnectionDetails(): String = "[]"
     override val interfaceStatusChanged: SharedFlow<Unit> = MutableSharedFlow()
     override val bleConnectionsFlow: SharedFlow<String> = MutableSharedFlow()


### PR DESCRIPTION
## RNode battery level in notification + Interface Stats

Adds display of the RNode battery percentage (KISS `CMD_STAT_BAT` 0x27), extracted in the Python backend and surfaced in two places:

1. Persistent "Columba Mesh Network" foreground notification: appends `(RNode battery N%)`.
2. Interface Stats screen: battery icon + percentage row on the RNode Status card.

### How it works
- `columba_rnode_interface.py` parses 0x27 into `r_stat_bat` in both read loops (BLE + USB); `get_battery()` returns the value, or `None` when not yet received **or the interface is offline** (a transient drop keeps the interface registered, so an offline read must report "no reading", not the stale last frame).
- New `suspend fun getRNodeBattery(): Int` on `RnsTransportAdmin` + AIDL (oneway + `IRnsIntCallback`, same shape as `getRNodeRssi`). The Python backend does a live read off the live `ColumbaRNodeInterface` on every call; the Kotlin backend returns the `-1` absent sentinel (deferred).
- The app polls on a slow cadence: Interface Stats refresh (1s) and a 15s service poller for the notification. The notification clears the reading when the RNode goes offline so a stale "82%" is never shown on a dead radio.

### Testing
- Python: 4 tests (parse, default, **offline regression**), full rns-backend-py suite green.
- AIDL round-trip: value and `-1` sentinel (18 tests).
- InterfaceStatsViewModel: battery state + absent/offline behavior (28 tests).
- ServiceNotificationManager: Robolectric notification text incl. offline-clear (13 tests).
- detekt + full 6-module unit-test matrix green.
- On-device (Samsung SM-G998U1, RNode 735D BLE): notification showed a genuine 0% on a dead battery (matching the RNode's own empty-battery display), tracked 0 -> 8 -> 38% while charging; Status card renders correctly. This confirms the 0x27 byte scale is real 0-100 firmware data.

Note: rebased onto `main` (v2.2.3-beta) so the build is a version-code upgrade over current devices.
