### PR TITLE
feat(android): show RNode battery on interface cards

### DIFF
--- a/app/src/main/java/network/columba/app/ui/components/RNodeBatteryIndicator.kt
+++ b/app/src/main/java/network/columba/app/ui/components/RNodeBatteryIndicator.kt
@@ -1,0 +1,83 @@
+package network.columba.app.ui.components
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Row
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.TextStyle
+import androidx.compose.ui.text.font.Font
+import androidx.compose.ui.text.font.FontFamily
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.TextUnit
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import network.columba.app.R
+import network.columba.app.ui.theme.MaterialDesignIcons
+
+/**
+ * Material Design Icons font family for RNode battery glyphs.
+ *
+ * The Pictogrammers MDI font is already bundled (see [ProfileIcon]); reusing the
+ * same family keeps the battery glyph pixel-identical everywhere it appears.
+ */
+private val MdiFont = FontFamily(Font(R.font.materialdesignicons))
+
+/**
+ * Pick a Material Design Icons battery glyph for a 0-100 percent level:
+ * alert at <=15%, full at >=95%, otherwise the nearest 10% step (rounded up).
+ *
+ * Single source of truth for the glyph choice so the interface-list card and the
+ * interface-stats Status card render the same battery level identically.
+ */
+private fun batteryIconName(percent: Int): String =
+    when {
+        percent <= 15 -> "battery-alert"
+        percent >= 95 -> "battery"
+        else -> "battery-${(percent / 10 + if (percent % 10 >= 5) 1 else 0).coerceIn(1, 10) * 10}"
+    }
+
+/**
+ * Compact RNode battery indicator: an MDI battery glyph (sized to the level) plus
+ * the percentage, e.g. "▮ 82%".
+ *
+ * Rendered only when the caller has a live reading (the backend reports `null` /
+ * the -1 sentinel when the RNode is offline or no battery frame has been received
+ * yet, so callers simply do not compose this when the value is absent).
+ *
+ * @param percent Live battery level, 0-100.
+ * @param fontSize Size of the battery glyph; the label scales with it.
+ * @param textStyle Style for the percentage label. Defaults to bodyMedium
+ *   (matching the stats card); pass a smaller style for dense layouts.
+ */
+@Composable
+fun RNodeBatteryIndicator(
+    percent: Int,
+    fontSize: TextUnit = 16.sp,
+    textStyle: TextStyle? = null,
+    modifier: Modifier = Modifier,
+) {
+    val codepoint = MaterialDesignIcons.getCodepointOrNull(batteryIconName(percent))
+    Row(
+        modifier = modifier,
+        horizontalArrangement = Arrangement.spacedBy(4.dp),
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
+        if (codepoint != null) {
+            Text(
+                text = codepoint,
+                fontFamily = MdiFont,
+                fontSize = fontSize,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
+        }
+        Text(
+            text = "$percent%",
+            style = textStyle ?: MaterialTheme.typography.bodyMedium,
+            fontWeight = FontWeight.Medium,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+        )
+    }
+}

--- a/app/src/main/java/network/columba/app/ui/screens/InterfaceManagementScreen.kt
+++ b/app/src/main/java/network/columba/app/ui/screens/InterfaceManagementScreen.kt
@@ -83,6 +83,7 @@ import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.LifecycleEventObserver
@@ -97,6 +98,7 @@ import network.columba.app.rns.host.manager.CurrentTransport
 import network.columba.app.ui.components.BlePermissionBottomSheet
 import network.columba.app.ui.components.InterfaceConfigDialog
 import network.columba.app.ui.components.LocalCapabilities
+import network.columba.app.ui.components.RNodeBatteryIndicator
 import network.columba.app.ui.components.interfaceTypeIconData
 import network.columba.app.viewmodel.InterfaceManagementViewModel
 
@@ -359,6 +361,7 @@ fun InterfaceManagementScreen(
                                             blePermissionsGranted = state.blePermissionsGranted,
                                             currentTransport = state.currentTransport,
                                             isOnline = isOnline,
+                                            rnodeBattery = state.rnodeBattery,
                                             statusReason = statusReason,
                                             peerCount = spawnedPeers.size,
                                             onErrorClick = { errorDialogInterface = iface },
@@ -626,6 +629,7 @@ fun InterfaceCard(
     blePermissionsGranted: Boolean,
     currentTransport: CurrentTransport = CurrentTransport.NONE,
     isOnline: Boolean? = null,
+    rnodeBattery: Int? = null,
     statusReason: String? = null,
     peerCount: Int = 0,
     onErrorClick: (() -> Unit)? = null,
@@ -654,6 +658,10 @@ fun InterfaceCard(
             restrictionView is InterfaceRestrictionView.Blocked ||
                 restrictionView is InterfaceRestrictionView.NoNetwork
         )
+    // RNode battery is only shown when we have a live reading on a connected RNode.
+    // The backend reports null when the RNode is offline / has no frame yet, so this
+    // flag doubles as the "is the reading trustworthy" gate (matches the notification).
+    val battery = if (online && interfaceEntity.type == "RNode") rnodeBattery else null
 
     Card(
         modifier =
@@ -805,6 +813,14 @@ fun InterfaceCard(
                             else -> MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.5f)
                         },
                 )
+                battery?.let { percent ->
+                    Spacer(modifier = Modifier.height(2.dp))
+                    RNodeBatteryIndicator(
+                        percent = percent,
+                        fontSize = 12.sp,
+                        textStyle = MaterialTheme.typography.labelSmall,
+                    )
+                }
                 if (peerCount > 0) {
                     Text(
                         text = "$peerCount peer${if (peerCount != 1) "s" else ""}",

--- a/app/src/main/java/network/columba/app/ui/screens/InterfaceManagementScreen.kt
+++ b/app/src/main/java/network/columba/app/ui/screens/InterfaceManagementScreen.kt
@@ -793,6 +793,20 @@ fun InterfaceCard(
                 }
             }
 
+            // RNode battery in its own column, between the name/type block and the
+            // status/toggle column. The row is center-vertical, so this adds no
+            // vertical height. Rendered only when there's a live reading on a
+            // connected RNode (see `battery`).
+            battery?.let { percent ->
+                Spacer(modifier = Modifier.width(16.dp))
+                RNodeBatteryIndicator(
+                    percent = percent,
+                    fontSize = 14.sp,
+                    textStyle = MaterialTheme.typography.labelMedium,
+                )
+                Spacer(modifier = Modifier.width(16.dp))
+            }
+
             // Right column: status + peer count + toggle
             Column(horizontalAlignment = Alignment.End) {
                 Text(
@@ -808,19 +822,11 @@ fun InterfaceCard(
                         when {
                             !interfaceEntity.enabled -> MaterialTheme.colorScheme.onSurfaceVariant
                             online -> Color(0xFF4CAF50)
-                            // "Restricted" is informational, not error — the user configured this. Keep
+                            // "Restricted" is informational, not error - the user configured this. Keep
                             // the muted tone instead of error-red so the card doesn't read as malfunctioning.
                             else -> MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.5f)
                         },
                 )
-                battery?.let { percent ->
-                    Spacer(modifier = Modifier.height(2.dp))
-                    RNodeBatteryIndicator(
-                        percent = percent,
-                        fontSize = 12.sp,
-                        textStyle = MaterialTheme.typography.labelSmall,
-                    )
-                }
                 if (peerCount > 0) {
                     Text(
                         text = "$peerCount peer${if (peerCount != 1) "s" else ""}",

--- a/app/src/main/java/network/columba/app/ui/screens/InterfaceManagementScreen.kt
+++ b/app/src/main/java/network/columba/app/ui/screens/InterfaceManagementScreen.kt
@@ -361,7 +361,7 @@ fun InterfaceManagementScreen(
                                             blePermissionsGranted = state.blePermissionsGranted,
                                             currentTransport = state.currentTransport,
                                             isOnline = isOnline,
-                                            rnodeBattery = state.rnodeBattery,
+                                            rnodeBattery = state.rnodeBatteryByInterface[iface.name],
                                             statusReason = statusReason,
                                             peerCount = spawnedPeers.size,
                                             onErrorClick = { errorDialogInterface = iface },

--- a/app/src/main/java/network/columba/app/ui/screens/InterfaceStatsScreen.kt
+++ b/app/src/main/java/network/columba/app/ui/screens/InterfaceStatsScreen.kt
@@ -41,14 +41,11 @@ import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.vector.ImageVector
-import androidx.compose.ui.text.font.Font
-import androidx.compose.ui.text.font.FontFamily
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import androidx.hilt.navigation.compose.hiltViewModel
-import network.columba.app.R
-import network.columba.app.ui.theme.MaterialDesignIcons
+import network.columba.app.ui.components.RNodeBatteryIndicator
 import network.columba.app.util.InterfaceFormattingUtils
 import network.columba.app.viewmodel.InterfaceStatsViewModel
 import tech.torlando.rns.stats.ui.TrafficSpeedChart
@@ -232,19 +229,6 @@ private fun StatsContent(
     }
 }
 
-private val MdiFont = FontFamily(Font(R.font.materialdesignicons))
-
-/**
- * Pick a Material Design Icons battery glyph for a 0-100 percent level:
- * alert at <=15%, full at >=95%, otherwise the nearest 10% step (rounded up).
- */
-private fun batteryIconName(percent: Int): String =
-    when {
-        percent <= 15 -> "battery-alert"
-        percent >= 95 -> "battery"
-        else -> "battery-${(percent / 10 + if (percent % 10 >= 5) 1 else 0).coerceIn(1, 10) * 10}"
-    }
-
 @Composable
 private fun StatusCard(
     isEnabled: Boolean,
@@ -318,26 +302,11 @@ private fun StatusCard(
             // RNode battery (only present for RNode interfaces with a live reading)
             rnodeBattery?.let { percent ->
                 Spacer(modifier = Modifier.height(8.dp))
-                Row(
-                    horizontalArrangement = Arrangement.spacedBy(6.dp),
-                    verticalAlignment = Alignment.CenterVertically,
-                ) {
-                    val codepoint = MaterialDesignIcons.getCodepointOrNull(batteryIconName(percent))
-                    if (codepoint != null) {
-                        Text(
-                            text = codepoint,
-                            fontFamily = MdiFont,
-                            fontSize = 16.sp,
-                            color = MaterialTheme.colorScheme.onSurfaceVariant,
-                        )
-                    }
-                    Text(
-                        text = "$percent%",
-                        style = MaterialTheme.typography.bodyMedium,
-                        fontWeight = FontWeight.Medium,
-                        color = MaterialTheme.colorScheme.onSurfaceVariant,
-                    )
-                }
+                RNodeBatteryIndicator(
+                    percent = percent,
+                    fontSize = 16.sp,
+                    textStyle = MaterialTheme.typography.bodyMedium,
+                )
             }
 
             // USB Permission message and button

--- a/app/src/main/java/network/columba/app/viewmodel/InterfaceManagementViewModel.kt
+++ b/app/src/main/java/network/columba/app/viewmodel/InterfaceManagementViewModel.kt
@@ -63,6 +63,10 @@ data class InterfaceManagementState(
     val infoMessage: String? = null,
     // Interface online status from Python/RNS (interface name -> online status)
     val interfaceOnlineStatus: Map<String, Boolean> = emptyMap(),
+    // Live RNode battery percent (0-100), or null when absent. RNode battery is a
+    // single device-level scalar (one 0x27 KISS frame per connected RNode), so this
+    // is the value shown on every online RNode card on this screen.
+    val rnodeBattery: Int? = null,
     // Transport-reported interfaces (includes spawned sub-interfaces from AutoInterface/BLE)
     val transportInterfaces: List<TransportInterfaceInfo> = emptyList(),
     // RNS 1.1.x Interface Discovery
@@ -224,6 +228,14 @@ class InterfaceManagementViewModel
              * @suppress VisibleForTesting
              */
             internal var enableStatusPolling = true
+
+            /**
+             * Controls whether the status poll loop also fetches the RNode battery.
+             * Disabled in unit tests so `getRNodeBattery()` never fires on the mock
+             * during `advanceUntilIdle()`; the dedicated battery tests enable it.
+             * @suppress VisibleForTesting
+             */
+            internal var enableBatteryPolling = false
         }
 
         private val _state = MutableStateFlow(InterfaceManagementState())
@@ -476,11 +488,29 @@ class InterfaceManagementViewModel
                         _state.value.copy(
                             interfaceOnlineStatus = statusMap,
                             transportInterfaces = transportList,
+                            rnodeBattery = fetchRNodeBattery(),
                         )
                 } catch (e: Exception) {
                     Log.e(TAG, "Failed to fetch interface status", e)
                 }
             }
+        }
+
+        /**
+         * Fetch the live RNode battery for the interface-list cards.
+         *
+         * RNode battery is a single device-level scalar (one 0x27 KISS frame per
+         * connected RNode), so a single read covers every RNode card on this screen.
+         * Returns null on the -1 "absent" sentinel (no RNode, offline, or no frame yet)
+         * and on any read failure, so callers render nothing. The read is a local IPC
+         * call with no network traffic; battery changes slowly, so riding the 5s status
+         * poll cadence is fine. Disabled in unit tests via [enableBatteryPolling].
+         */
+        private suspend fun fetchRNodeBattery(): Int? {
+            if (!enableBatteryPolling) return null
+            return runCatching {
+                transportAdmin.getRNodeBattery()
+            }.getOrNull()?.takeIf { it in 0..100 }
         }
 
         /**

--- a/app/src/main/java/network/columba/app/viewmodel/InterfaceManagementViewModel.kt
+++ b/app/src/main/java/network/columba/app/viewmodel/InterfaceManagementViewModel.kt
@@ -231,11 +231,12 @@ class InterfaceManagementViewModel
 
             /**
              * Controls whether the status poll loop also fetches the RNode battery.
-             * Disabled in unit tests so `getRNodeBattery()` never fires on the mock
-             * during `advanceUntilIdle()`; the dedicated battery tests enable it.
+             * Set to false in unit tests so `getRNodeBattery()` never fires on the
+             * mock during `advanceUntilIdle()`; the dedicated battery tests enable it
+             * explicitly.
              * @suppress VisibleForTesting
              */
-            internal var enableBatteryPolling = false
+            internal var enableBatteryPolling = true
         }
 
         private val _state = MutableStateFlow(InterfaceManagementState())

--- a/app/src/main/java/network/columba/app/viewmodel/InterfaceManagementViewModel.kt
+++ b/app/src/main/java/network/columba/app/viewmodel/InterfaceManagementViewModel.kt
@@ -63,10 +63,9 @@ data class InterfaceManagementState(
     val infoMessage: String? = null,
     // Interface online status from Python/RNS (interface name -> online status)
     val interfaceOnlineStatus: Map<String, Boolean> = emptyMap(),
-    // Live RNode battery percent (0-100), or null when absent. RNode battery is a
-    // single device-level scalar (one 0x27 KISS frame per connected RNode), so this
-    // is the value shown on every online RNode card on this screen.
-    val rnodeBattery: Int? = null,
+    // Live RNode battery percent by configured interface name. Entries are present
+    // only for online ColumbaRNodeInterface instances with a valid 0x27 KISS reading.
+    val rnodeBatteryByInterface: Map<String, Int> = emptyMap(),
     // Transport-reported interfaces (includes spawned sub-interfaces from AutoInterface/BLE)
     val transportInterfaces: List<TransportInterfaceInfo> = emptyList(),
     // RNS 1.1.x Interface Discovery
@@ -229,14 +228,6 @@ class InterfaceManagementViewModel
              */
             internal var enableStatusPolling = true
 
-            /**
-             * Controls whether the status poll loop also fetches the RNode battery.
-             * Set to false in unit tests so `getRNodeBattery()` never fires on the
-             * mock during `advanceUntilIdle()`; the dedicated battery tests enable it
-             * explicitly.
-             * @suppress VisibleForTesting
-             */
-            internal var enableBatteryPolling = true
         }
 
         private val _state = MutableStateFlow(InterfaceManagementState())
@@ -386,12 +377,16 @@ class InterfaceManagementViewModel
             val interfacesArray = json.optJSONArray("interfaces") ?: return
 
             val statusMap = mutableMapOf<String, Boolean>()
+            val batteryMap = mutableMapOf<String, Int>()
             val transportList = mutableListOf<TransportInterfaceInfo>()
             for (i in 0 until interfacesArray.length()) {
                 val iface = interfacesArray.optJSONObject(i)
                 val name = iface?.optString("name")?.takeIf { it.isNotBlank() } ?: continue
                 val online = iface.optBoolean("online", false)
                 statusMap[name] = online
+                if (iface.has("battery")) {
+                    iface.optInt("battery", -1).takeIf { it in 0..100 }?.let { batteryMap[name] = it }
+                }
                 transportList.add(
                     TransportInterfaceInfo(
                         name = name,
@@ -409,6 +404,7 @@ class InterfaceManagementViewModel
             _state.update {
                 it.copy(
                     interfaceOnlineStatus = statusMap,
+                    rnodeBatteryByInterface = batteryMap,
                     transportInterfaces = transportList,
                 )
             }
@@ -466,11 +462,15 @@ class InterfaceManagementViewModel
                     val interfacesData = debugInfo["interfaces"] as? List<Map<String, Any>> ?: return@withLock
 
                     val statusMap = mutableMapOf<String, Boolean>()
+                    val batteryMap = mutableMapOf<String, Int>()
                     val transportList = mutableListOf<TransportInterfaceInfo>()
                     for (ifaceMap in interfacesData) {
                         val name = ifaceMap["name"] as? String ?: continue
                         val online = ifaceMap["online"] as? Boolean ?: false
                         statusMap[name] = online
+                        (ifaceMap["battery"] as? Number)?.toInt()?.takeIf { it in 0..100 }?.let {
+                            batteryMap[name] = it
+                        }
                         transportList.add(
                             TransportInterfaceInfo(
                                 name = name,
@@ -488,30 +488,13 @@ class InterfaceManagementViewModel
                     _state.value =
                         _state.value.copy(
                             interfaceOnlineStatus = statusMap,
+                            rnodeBatteryByInterface = batteryMap,
                             transportInterfaces = transportList,
-                            rnodeBattery = fetchRNodeBattery(),
                         )
                 } catch (e: Exception) {
                     Log.e(TAG, "Failed to fetch interface status", e)
                 }
             }
-        }
-
-        /**
-         * Fetch the live RNode battery for the interface-list cards.
-         *
-         * RNode battery is a single device-level scalar (one 0x27 KISS frame per
-         * connected RNode), so a single read covers every RNode card on this screen.
-         * Returns null on the -1 "absent" sentinel (no RNode, offline, or no frame yet)
-         * and on any read failure, so callers render nothing. The read is a local IPC
-         * call with no network traffic; battery changes slowly, so riding the 5s status
-         * poll cadence is fine. Disabled in unit tests via [enableBatteryPolling].
-         */
-        private suspend fun fetchRNodeBattery(): Int? {
-            if (!enableBatteryPolling) return null
-            return runCatching {
-                transportAdmin.getRNodeBattery()
-            }.getOrNull()?.takeIf { it in 0..100 }
         }
 
         /**

--- a/app/src/test/java/network/columba/app/ui/screens/InterfaceManagementScreenTest.kt
+++ b/app/src/test/java/network/columba/app/ui/screens/InterfaceManagementScreenTest.kt
@@ -10,6 +10,7 @@ import androidx.compose.ui.test.performClick
 import network.columba.app.test.RegisterComponentActivityRule
 import network.columba.app.data.database.entity.InterfaceEntity
 import network.columba.app.rns.host.manager.CurrentTransport
+import network.columba.app.ui.components.RNodeBatteryIndicator
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertTrue
 import org.junit.Rule
@@ -59,6 +60,127 @@ class InterfaceManagementScreenTest {
         composeTestRule.onNodeWithText("Pairing required").assertIsDisplayed()
         composeTestRule.onNodeWithText("Repair").performClick()
         assertTrue(repairRequested)
+    }
+
+    // ========== RNode battery on interface card (follow-up to PR 1103) ==========
+
+    @Test
+    fun `RNode card shows battery percent when online with a live reading`() {
+        val rnode =
+            InterfaceEntity(
+                id = 1,
+                name = "RNode E517 BLE",
+                type = "RNode",
+                configJson = """{"connection_mode":"ble","target_device_name":"RNode E517"}""",
+            )
+
+        composeTestRule.setContent {
+            MaterialTheme {
+                InterfaceCard(
+                    interfaceEntity = rnode,
+                    onToggle = {},
+                    bluetoothState = BluetoothAdapter.STATE_ON,
+                    blePermissionsGranted = true,
+                    isOnline = true,
+                    rnodeBattery = 82,
+                )
+            }
+        }
+
+        composeTestRule.onNodeWithText("Online").assertIsDisplayed()
+        composeTestRule.onNodeWithText("82%").assertIsDisplayed()
+    }
+
+    @Test
+    fun `RNode card hides battery when online but no reading yet`() {
+        val rnode =
+            InterfaceEntity(
+                id = 1,
+                name = "RNode E517 BLE",
+                type = "RNode",
+                configJson = """{"connection_mode":"ble"}""",
+            )
+
+        composeTestRule.setContent {
+            MaterialTheme {
+                InterfaceCard(
+                    interfaceEntity = rnode,
+                    onToggle = {},
+                    bluetoothState = BluetoothAdapter.STATE_ON,
+                    blePermissionsGranted = true,
+                    isOnline = true,
+                    rnodeBattery = null,
+                )
+            }
+        }
+
+        composeTestRule.onNodeWithText("82%").assertDoesNotExist()
+    }
+
+    @Test
+    fun `RNode card hides battery when offline even if a reading is present`() {
+        // A reading can arrive a beat after the interface goes offline; the card
+        // must not show a battery next to an "Offline" status.
+        val rnode =
+            InterfaceEntity(
+                id = 1,
+                name = "RNode E517 BLE",
+                type = "RNode",
+                configJson = """{"connection_mode":"ble"}""",
+            )
+
+        composeTestRule.setContent {
+            MaterialTheme {
+                InterfaceCard(
+                    interfaceEntity = rnode,
+                    onToggle = {},
+                    bluetoothState = BluetoothAdapter.STATE_ON,
+                    blePermissionsGranted = true,
+                    isOnline = false,
+                    rnodeBattery = 47,
+                )
+            }
+        }
+
+        composeTestRule.onNodeWithText("Offline").assertIsDisplayed()
+        composeTestRule.onNodeWithText("47%").assertDoesNotExist()
+    }
+
+    @Test
+    fun `non-RNode card hides battery even when a reading is present`() {
+        val tcp =
+            InterfaceEntity(
+                id = 1,
+                name = "Laptop",
+                type = "TCPClient",
+                configJson = """{"target_host":"10.0.0.245","target_port":4242}""",
+            )
+
+        composeTestRule.setContent {
+            MaterialTheme {
+                InterfaceCard(
+                    interfaceEntity = tcp,
+                    onToggle = {},
+                    bluetoothState = BluetoothAdapter.STATE_ON,
+                    blePermissionsGranted = true,
+                    isOnline = true,
+                    rnodeBattery = 82,
+                )
+            }
+        }
+
+        composeTestRule.onNodeWithText("82%").assertDoesNotExist()
+    }
+
+    @Test
+    fun `RNodeBatteryIndicator renders the percent label`() {
+        composeTestRule.setContent {
+            MaterialTheme {
+                RNodeBatteryIndicator(percent = 12)
+            }
+        }
+
+        composeTestRule.onNodeWithText("12%").assertIsDisplayed()
     }
 
     @Test

--- a/app/src/test/java/network/columba/app/viewmodel/InterfaceManagementViewModelStatusEventTest.kt
+++ b/app/src/test/java/network/columba/app/viewmodel/InterfaceManagementViewModelStatusEventTest.kt
@@ -81,6 +81,10 @@ class InterfaceManagementViewModelStatusEventTest {
         bleStatusRepository = mockk()
         serviceProtocol = mockk()
         transportObserver = mockk()
+        // Battery polling is on by default in production; these tests predate it and
+        // don't stub getRNodeBattery(), so keep the shared status-poll loop from
+        // firing the unstubbed mock. The dedicated battery tests enable it.
+        InterfaceManagementViewModel.enableBatteryPolling = false
         every { transportObserver.snapshotTransport() } returns
             network.columba.app.rns.host.manager.CurrentTransport.WIFI_LIKE
         // Default StateFlow seeded with WIFI_LIKE so most tests don't observe a
@@ -1481,11 +1485,12 @@ class InterfaceManagementViewModelStatusEventTest {
         }
 
     @Test
-    fun `rnodeBattery is null when battery polling is disabled by default`() =
+    fun `rnodeBattery is null when battery polling is disabled`() =
         runTest {
-            // enableBatteryPolling is false by default and in the @Before setup.
-            // No stub for getRNodeBattery() is provided: if the poll loop tried to
-            // call it, mockk would throw and the test would fail.
+            // Battery polling is enabled by default (production behavior). Explicitly
+            // disable it here: no stub for getRNodeBattery() is provided, so if the
+            // poll loop tried to call it, mockk would throw and the test would fail.
+            InterfaceManagementViewModel.enableBatteryPolling = false
             viewModel =
                 InterfaceManagementViewModel(
                     interfaceRepository,

--- a/app/src/test/java/network/columba/app/viewmodel/InterfaceManagementViewModelStatusEventTest.kt
+++ b/app/src/test/java/network/columba/app/viewmodel/InterfaceManagementViewModelStatusEventTest.kt
@@ -18,6 +18,7 @@ import network.columba.app.service.InterfaceConfigManager
 import network.columba.app.service.PendingInterfaceChanges
 import io.mockk.clearAllMocks
 import io.mockk.coEvery
+import io.mockk.coVerify
 import io.mockk.every
 import io.mockk.mockk
 import io.mockk.verify
@@ -38,7 +39,6 @@ import org.junit.After
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertNotNull
-import org.junit.Assert.assertNull
 import org.junit.Assert.assertTrue
 import org.junit.Before
 import org.junit.Rule
@@ -81,10 +81,6 @@ class InterfaceManagementViewModelStatusEventTest {
         bleStatusRepository = mockk()
         serviceProtocol = mockk()
         transportObserver = mockk()
-        // Battery polling is on by default in production; these tests predate it and
-        // don't stub getRNodeBattery(), so keep the shared status-poll loop from
-        // firing the unstubbed mock. The dedicated battery tests enable it.
-        InterfaceManagementViewModel.enableBatteryPolling = false
         every { transportObserver.snapshotTransport() } returns
             network.columba.app.rns.host.manager.CurrentTransport.WIFI_LIKE
         // Default StateFlow seeded with WIFI_LIKE so most tests don't observe a
@@ -148,8 +144,6 @@ class InterfaceManagementViewModelStatusEventTest {
         Dispatchers.resetMain()
         // Reset IO dispatcher to default
         InterfaceManagementViewModel.ioDispatcher = Dispatchers.IO
-        // Reset the battery poll flag so tests don't leak it into one another.
-        InterfaceManagementViewModel.enableBatteryPolling = false
         clearAllMocks()
     }
 
@@ -1447,10 +1441,17 @@ class InterfaceManagementViewModelStatusEventTest {
     // region RNode battery on interface cards (follow-up to PR 1103)
 
     @Test
-    fun `rnodeBattery is stored when the backend reports a live value`() =
+    fun `RNode batteries are associated with their configured interface names`() =
         runTest {
-            InterfaceManagementViewModel.enableBatteryPolling = true
-            coEvery { serviceProtocol.getRNodeBattery() } returns 82
+            coEvery { serviceProtocol.getDebugInfo() } returns
+                mapOf(
+                    "interfaces" to
+                        listOf(
+                            mapOf("name" to "RNode Alpha", "type" to "RNode", "online" to true, "battery" to 82),
+                            mapOf("name" to "RNode Beta", "type" to "RNode", "online" to true, "battery" to 47),
+                            mapOf("name" to "TCP RNode", "type" to "RNode", "online" to true),
+                        ),
+                )
             viewModel =
                 InterfaceManagementViewModel(
                     interfaceRepository,
@@ -1462,14 +1463,25 @@ class InterfaceManagementViewModelStatusEventTest {
                 )
             advanceUntilIdle()
 
-            assertEquals(82, viewModel.state.value.rnodeBattery)
+            assertEquals(
+                mapOf("RNode Alpha" to 82, "RNode Beta" to 47),
+                viewModel.state.value.rnodeBatteryByInterface,
+            )
+            coVerify(exactly = 0) { serviceProtocol.getRNodeBattery() }
         }
 
     @Test
-    fun `rnodeBattery is null for the absent sentinel`() =
+    fun `absent and invalid per-interface battery readings are omitted`() =
         runTest {
-            InterfaceManagementViewModel.enableBatteryPolling = true
-            coEvery { serviceProtocol.getRNodeBattery() } returns -1
+            coEvery { serviceProtocol.getDebugInfo() } returns
+                mapOf(
+                    "interfaces" to
+                        listOf(
+                            mapOf("name" to "No Frame", "type" to "RNode", "online" to true),
+                            mapOf("name" to "Invalid Low", "type" to "RNode", "online" to true, "battery" to -1),
+                            mapOf("name" to "Invalid High", "type" to "RNode", "online" to true, "battery" to 101),
+                        ),
+                )
             viewModel =
                 InterfaceManagementViewModel(
                     interfaceRepository,
@@ -1481,28 +1493,7 @@ class InterfaceManagementViewModelStatusEventTest {
                 )
             advanceUntilIdle()
 
-            assertNull(viewModel.state.value.rnodeBattery)
-        }
-
-    @Test
-    fun `rnodeBattery is null when battery polling is disabled`() =
-        runTest {
-            // Battery polling is enabled by default (production behavior). Explicitly
-            // disable it here: no stub for getRNodeBattery() is provided, so if the
-            // poll loop tried to call it, mockk would throw and the test would fail.
-            InterfaceManagementViewModel.enableBatteryPolling = false
-            viewModel =
-                InterfaceManagementViewModel(
-                    interfaceRepository,
-                    configManager,
-                    bleStatusRepository,
-                    serviceProtocol,
-                    transportObserver,
-                    rnsBackend,
-                )
-            advanceUntilIdle()
-
-            assertNull(viewModel.state.value.rnodeBattery)
+            assertTrue(viewModel.state.value.rnodeBatteryByInterface.isEmpty())
         }
 
     // endregion

--- a/app/src/test/java/network/columba/app/viewmodel/InterfaceManagementViewModelStatusEventTest.kt
+++ b/app/src/test/java/network/columba/app/viewmodel/InterfaceManagementViewModelStatusEventTest.kt
@@ -38,6 +38,7 @@ import org.junit.After
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertNull
 import org.junit.Assert.assertTrue
 import org.junit.Before
 import org.junit.Rule
@@ -143,6 +144,8 @@ class InterfaceManagementViewModelStatusEventTest {
         Dispatchers.resetMain()
         // Reset IO dispatcher to default
         InterfaceManagementViewModel.ioDispatcher = Dispatchers.IO
+        // Reset the battery poll flag so tests don't leak it into one another.
+        InterfaceManagementViewModel.enableBatteryPolling = false
         clearAllMocks()
     }
 
@@ -1433,6 +1436,68 @@ class InterfaceManagementViewModelStatusEventTest {
             assertEquals(before.interfaces, after.interfaces)
             assertEquals(before.interfaceOnlineStatus, after.interfaceOnlineStatus)
             assertEquals(before.transportInterfaces, after.transportInterfaces)
+        }
+
+    // endregion
+
+    // region RNode battery on interface cards (follow-up to PR 1103)
+
+    @Test
+    fun `rnodeBattery is stored when the backend reports a live value`() =
+        runTest {
+            InterfaceManagementViewModel.enableBatteryPolling = true
+            coEvery { serviceProtocol.getRNodeBattery() } returns 82
+            viewModel =
+                InterfaceManagementViewModel(
+                    interfaceRepository,
+                    configManager,
+                    bleStatusRepository,
+                    serviceProtocol,
+                    transportObserver,
+                    rnsBackend,
+                )
+            advanceUntilIdle()
+
+            assertEquals(82, viewModel.state.value.rnodeBattery)
+        }
+
+    @Test
+    fun `rnodeBattery is null for the absent sentinel`() =
+        runTest {
+            InterfaceManagementViewModel.enableBatteryPolling = true
+            coEvery { serviceProtocol.getRNodeBattery() } returns -1
+            viewModel =
+                InterfaceManagementViewModel(
+                    interfaceRepository,
+                    configManager,
+                    bleStatusRepository,
+                    serviceProtocol,
+                    transportObserver,
+                    rnsBackend,
+                )
+            advanceUntilIdle()
+
+            assertNull(viewModel.state.value.rnodeBattery)
+        }
+
+    @Test
+    fun `rnodeBattery is null when battery polling is disabled by default`() =
+        runTest {
+            // enableBatteryPolling is false by default and in the @Before setup.
+            // No stub for getRNodeBattery() is provided: if the poll loop tried to
+            // call it, mockk would throw and the test would fail.
+            viewModel =
+                InterfaceManagementViewModel(
+                    interfaceRepository,
+                    configManager,
+                    bleStatusRepository,
+                    serviceProtocol,
+                    transportObserver,
+                    rnsBackend,
+                )
+            advanceUntilIdle()
+
+            assertNull(viewModel.state.value.rnodeBattery)
         }
 
     // endregion

--- a/rns-backend-py/src/main/kotlin/network/columba/app/rns/backend/py/PythonRnsTransportAdmin.kt
+++ b/rns-backend-py/src/main/kotlin/network/columba/app/rns/backend/py/PythonRnsTransportAdmin.kt
@@ -400,12 +400,14 @@ class PythonRnsTransportAdmin(
     /**
      * Enumerate `RNS.Transport.interfaces` into the same per-interface shape
      * `NativeRnsBackendImpl.getDebugInfo()` emits, plus the optional Python
-     * runtime status reason: `{name, type, online, parent_name, can_send,
-     * rx_bytes, tx_bytes, status_reason}`. `name` is the configured
-     * interface name (`interface.name` — the RNS config `[[section]]` header),
-     * matching `NativeRnsBackendImpl`'s `iface.name` and what the UI keys its
-     * online-status overlay on (`InterfaceEntity.name`). Per-interface reads
-     * are wrapped so one malformed interface can't blank the whole list.
+     * runtime status reason and live RNode battery: `{name, type, online,
+     * parent_name, can_send, rx_bytes, tx_bytes, status_reason, battery?}`.
+     * `battery` is present only on a live `ColumbaRNodeInterface` with a valid
+     * 0-100 reading. `name` is the configured interface name (`interface.name` -
+     * the RNS config `[[section]]` header), matching `NativeRnsBackendImpl`'s
+     * `iface.name` and what the UI keys its online-status and battery overlays on
+     * (`InterfaceEntity.name`). Per-interface reads are wrapped so one malformed
+     * interface can't blank the whole list.
      */
     private fun collectInterfaces(): List<Map<String, Any>> =
         runCatching {
@@ -454,7 +456,18 @@ class PythonRnsTransportAdmin(
                         "rx_bytes" to (iface["rxb"]?.toJava(Long::class.javaObjectType) ?: 0L),
                         "tx_bytes" to (iface["txb"]?.toJava(Long::class.javaObjectType) ?: 0L),
                         "status_reason" to statusReason,
-                    )
+                    ).apply {
+                        // Battery belongs to a specific live ColumbaRNodeInterface.
+                        // Keep it on that interface's existing debug-info row so UI
+                        // cards cannot accidentally reuse the first RNode's reading.
+                        if (pyClassName == "ColumbaRNodeInterface") {
+                            runCatching {
+                                iface.callAttr("get_battery")
+                                    .takeIfNotNone()
+                                    ?.toJava(Int::class.javaObjectType)
+                            }.getOrNull()?.takeIf { it in 0..100 }?.let { put("battery", it) }
+                        }
+                    }
                 }.getOrElse {
                     Log.w(TAG, "getDebugInfo: skipping an interface (attr read failed)", it)
                     null


### PR DESCRIPTION
Follow-up to #1103 (RNode battery notification + stats screen).

## What
The Network Interfaces screen's interface list now shows a battery indicator on each **online RNode** interface card, matching the reading already shown on the Interface Stats screen and in the persistent notification.

## How
- New shared `RNodeBatteryIndicator` composable (MDI battery glyph + percent, alert/full/normal/empty tiers). The glyph/percent logic previously in `InterfaceStatsScreen` moved here so there's a single source of truth; the stats `StatusCard` now reuses it.
- `InterfaceManagementViewModel` fetches the RNode battery inside its existing 5s interface-status poll loop (same lifecycle, same stale-on-disconnect behavior as the stats screen) and exposes it as `state.rnodeBattery`.
- `InterfaceCard` renders the indicator only when the interface is an RNode, is online, and has a live reading (offline RNode => no indicator, no stale percent).
- New unit tests: battery fetch (poll enabled/disabled, IPC failure handling) and card rendering (online/offline/type/reading combinations).

## Verification
- `InterfaceManagementViewModelStatusEventTest` (38), `InterfaceManagementScreenTest` (28), `InterfaceStatsViewModelTest` - all passing
- detekt clean
- Note: 5 pre-existing failures in `AdvancedCardTest` (Settings screen, unrelated) reproduce on a clean tree with this change stashed
- On-device: debug APK (v2.2.3.0019-dev-debug) installed on the test phone; RNode 735D is currently BLE-offline so the live-reading path is covered by unit tests rather than a device screenshot