### PR TITLE
fix(ui): keep the long-message reaction overlay on screen

### DIFF
--- a/app/src/main/java/network/columba/app/ui/components/OverlayLayoutDimensions.kt
+++ b/app/src/main/java/network/columba/app/ui/components/OverlayLayoutDimensions.kt
@@ -1,15 +1,33 @@
 package network.columba.app.ui.components
 
 import kotlin.math.max
+import kotlin.math.min
+
+/**
+ * Maximum height (in physical pixels) of the message snapshot captured for the
+ * reaction mode overlay. GPUs on supported devices cap hardware textures well
+ * below this, so capturing a full-height bitmap of a very tall bubble can
+ * silently fail (blank snapshot). Recording at most this many pixels keeps the
+ * capture within the safe texture size on every supported device.
+ */
+const val OVERLAY_MAX_CAPTURE_HEIGHT_PX = 4096
+
+/**
+ * Minimum scale applied to the message preview in the pinned (overflow) layout.
+ * The preview is shrunk to fit the space between the bars until shrinking it
+ * further would make the text illegible; below this floor the preview is capped
+ * and scrolls internally instead.
+ */
+const val OVERLAY_MIN_PREVIEW_SCALE = 0.35f
 
 /**
  * Layout dimensions for the reaction mode overlay.
- * Contains all the measurements needed to calculate proper scaling and positioning.
+ * Contains all the measurements needed to calculate proper positioning.
  *
  * @property screenHeight The total screen height in pixels
  * @property emojiBarHeight Height of the emoji bar in pixels (typically ~56dp)
  * @property emojiBarGap Gap between emoji bar and message in pixels (typically ~76dp)
- * @property actionButtonsHeight Height of action buttons in pixels (typically ~56dp)
+ * @property actionButtonsHeight Height of the action buttons in pixels (typically ~56dp)
  * @property actionButtonsGap Gap between message and action buttons in pixels (typically ~12dp)
  * @property topPadding Padding for status bar etc. in pixels (typically ~48dp)
  * @property bottomPadding Padding for navigation bar etc. in pixels (typically ~48dp)
@@ -25,34 +43,132 @@ data class OverlayLayoutDimensions(
 )
 
 /**
- * Calculates the scale factor for a message in the reaction mode overlay.
+ * Resolved on-screen layout for the reaction mode overlay.
  *
- * When a message is very large (e.g., a long text or large image), the context menu
- * (emoji bar above and action buttons below) may be pushed off screen. This function
- * calculates how much to scale down the message so that everything fits on screen.
+ * All values are in physical pixels. [messageFinalY] is the top of the message's
+ * visible area, [messageContainerHeight] is the height of that area, and
+ * [bitmapHeight] is the height of the message snapshot bitmap as captured.
+ * [previewScale] scales the snapshot so the whole preview is visible: it is 1f
+ * for messages that fit, and for the pinned (overflow) layout it shrinks the
+ * preview to the space between the bars down to [OVERLAY_MIN_PREVIEW_SCALE].
+ * When [messageScrollable] is true the scaled preview still exceeds the
+ * viewport, which then scrolls to reveal the rest.
  *
- * @param messageHeight The original height of the message in pixels
- * @param dimensions Layout dimensions for the overlay
- * @param minScale Minimum scale factor (default 0.3 to keep content readable)
- * @return Scale factor between minScale and 1.0
+ * The layout guarantees the emoji bar and the action buttons are always fully
+ * on screen, and the message preview is never blank or pushed off screen.
+ *
+ * @property messageFinalY Top (Y) of the message's visible area
+ * @property messageContainerHeight Visible height of the message area
+ * @property bitmapHeight Height of the message snapshot bitmap as captured
+ * @property emojiBarY Top (Y) of the emoji bar
+ * @property actionButtonsY Top (Y) of the action buttons
+ * @property isOverflow True when the pinned (top/bottom) layout is in use
+ * @property messageScrollable True when the scaled preview is taller than the viewport
+ * @property previewScale Scale factor applied to the snapshot preview (1f = full size)
  */
-fun calculateMessageScaleForOverlay(
+data class OverlayLayout(
+    val messageFinalY: Float,
+    val messageContainerHeight: Float,
+    val bitmapHeight: Float,
+    val emojiBarY: Float,
+    val actionButtonsY: Float,
+    val isOverflow: Boolean,
+    val messageScrollable: Boolean,
+    val previewScale: Float = 1f,
+) {
+    /** Height of the message preview after [previewScale] is applied. */
+    val scaledPreviewHeight: Float
+        get() = bitmapHeight * previewScale
+
+    /**
+     * True when the message, the emoji bar, and the action buttons are all
+     * within the screen bounds.
+     */
+    fun fitsOnScreen(dimensions: OverlayLayoutDimensions): Boolean {
+        return emojiBarY >= 0f &&
+            emojiBarY + dimensions.emojiBarHeight <= dimensions.screenHeight &&
+            actionButtonsY >= 0f &&
+            actionButtonsY + dimensions.actionButtonsHeight <= dimensions.screenHeight &&
+            messageFinalY >= 0f &&
+            messageFinalY + messageContainerHeight <= dimensions.screenHeight
+    }
+}
+
+/**
+ * Resolves the on-screen layout for the reaction mode overlay.
+ *
+ * Messages that fit are centered at full size, with the emoji bar above and the
+ * action buttons below. A message that does not fit pins the bars to the top
+ * and bottom safe areas and shrinks the preview to the space between them, down
+ * to [OVERLAY_MIN_PREVIEW_SCALE]. Only when the preview at that floor is still
+ * taller than the space between the bars does it get capped and scroll
+ * internally. The preview is therefore always visible and at a legible size for
+ * the range of messages realistic on a phone (the capture is separately capped
+ * at [OVERLAY_MAX_CAPTURE_HEIGHT_PX]).
+ *
+ * @param messageHeight The height of the message snapshot bitmap in pixels
+ * @param dimensions Layout dimensions for the overlay
+ */
+fun calculateOverlayLayout(
     messageHeight: Int,
     dimensions: OverlayLayoutDimensions,
-    minScale: Float = 0.3f,
-): Float {
-    if (messageHeight <= 0) return 1f
-
-    val availableHeight = dimensions.screenHeight - dimensions.topPadding - dimensions.bottomPadding
-    val uiElementsHeight =
-        dimensions.emojiBarHeight + dimensions.emojiBarGap +
-            dimensions.actionButtonsGap + dimensions.actionButtonsHeight
-    val totalHeightNeeded = uiElementsHeight + messageHeight
-
-    return if (totalHeightNeeded > availableHeight) {
-        val maxMessageHeight = max(0f, availableHeight - uiElementsHeight)
-        (maxMessageHeight / messageHeight).coerceIn(minScale, 1f)
-    } else {
-        1f
+): OverlayLayout {
+    if (messageHeight <= 0) {
+        // Degenerate zero-size snapshot: keep the centered layout; nothing to cap.
+        val y = dimensions.screenHeight / 2f
+        return OverlayLayout(
+            messageFinalY = y,
+            messageContainerHeight = 0f,
+            bitmapHeight = 0f,
+            emojiBarY = (y - dimensions.emojiBarGap).coerceAtLeast(0f),
+            actionButtonsY = (y + dimensions.actionButtonsGap).coerceAtMost(dimensions.screenHeight),
+            isOverflow = false,
+            messageScrollable = false,
+            previewScale = 1f,
+        )
     }
+
+    // Centered placement: message in the middle, bars adjacent.
+    val centerY = dimensions.screenHeight / 2f - messageHeight / 2f
+    val centeredEmojiY = centerY - dimensions.emojiBarGap
+    val centeredButtonsY = centerY + messageHeight + dimensions.actionButtonsGap
+    val fitsCentered =
+        centeredEmojiY >= dimensions.topPadding &&
+            centeredButtonsY + dimensions.actionButtonsHeight <=
+                dimensions.screenHeight - dimensions.bottomPadding
+    if (fitsCentered) {
+        return OverlayLayout(
+            messageFinalY = centerY,
+            messageContainerHeight = messageHeight.toFloat(),
+            bitmapHeight = messageHeight.toFloat(),
+            emojiBarY = centeredEmojiY,
+            actionButtonsY = centeredButtonsY,
+            isOverflow = false,
+            messageScrollable = false,
+            previewScale = 1f,
+        )
+    }
+
+    // Pinned overflow layout: bars fixed to the safe-area edges, the preview
+    // shrunk to fit the space between them (down to the minimum legible scale).
+    val emojiY = dimensions.topPadding
+    val buttonsY = dimensions.screenHeight - dimensions.bottomPadding - dimensions.actionButtonsHeight
+    val messageTop = emojiY + dimensions.emojiBarHeight + dimensions.actionButtonsGap
+    val messageBottom = buttonsY - dimensions.actionButtonsGap
+    val viewportHeight = max(0f, messageBottom - messageTop)
+    val fitScale =
+        if (viewportHeight > 0f) min(1f, viewportHeight / messageHeight.toFloat())
+        else OVERLAY_MIN_PREVIEW_SCALE
+    val scale = max(OVERLAY_MIN_PREVIEW_SCALE, fitScale)
+    val scaledHeight = messageHeight.toFloat() * scale
+    return OverlayLayout(
+        messageFinalY = messageTop,
+        messageContainerHeight = viewportHeight,
+        bitmapHeight = messageHeight.toFloat(),
+        emojiBarY = emojiY,
+        actionButtonsY = buttonsY,
+        isOverflow = true,
+        messageScrollable = scaledHeight > viewportHeight,
+        previewScale = scale,
+    )
 }

--- a/app/src/main/java/network/columba/app/ui/components/OverlayLayoutDimensions.kt
+++ b/app/src/main/java/network/columba/app/ui/components/OverlayLayoutDimensions.kt
@@ -151,14 +151,47 @@ fun calculateOverlayLayout(
 
     // Pinned overflow layout: bars fixed to the safe-area edges, the preview
     // shrunk to fit the space between them (down to the minimum legible scale).
-    val emojiY = dimensions.topPadding
-    val buttonsY = dimensions.screenHeight - dimensions.bottomPadding - dimensions.actionButtonsHeight
-    val messageTop = emojiY + dimensions.emojiBarHeight + dimensions.actionButtonsGap
-    val messageBottom = buttonsY - dimensions.actionButtonsGap
-    val viewportHeight = max(0f, messageBottom - messageTop)
-    val fitScale =
-        if (viewportHeight > 0f) min(1f, viewportHeight / messageHeight.toFloat())
-        else OVERLAY_MIN_PREVIEW_SCALE
+    var emojiY = dimensions.topPadding
+    var buttonsY = dimensions.screenHeight - dimensions.bottomPadding - dimensions.actionButtonsHeight
+    var gap = dimensions.actionButtonsGap
+    var messageTop = emojiY + dimensions.emojiBarHeight + gap
+    var messageBottom = buttonsY - gap
+    var viewportHeight = max(0f, messageBottom - messageTop)
+
+    if (viewportHeight <= 0f) {
+        // Compact window: the fixed safe-area paddings and gaps consume all the
+        // vertical space, which would collapse the preview to zero height (blank)
+        // and eventually make the two bars overlap. Compress the paddings and the
+        // inter-bar gap to zero and re-pin the bars to the raw screen edges so the
+        // preview is left a positive viewport whenever the window is tall enough
+        // to hold both bars at all.
+        emojiY = 0f
+        buttonsY = dimensions.screenHeight - dimensions.actionButtonsHeight
+        gap = 0f
+        messageTop = emojiY + dimensions.emojiBarHeight
+        messageBottom = buttonsY
+        viewportHeight = max(0f, messageBottom - messageTop)
+    }
+
+    if (viewportHeight <= 0f) {
+        // Truly degenerate: the window is shorter than both bars stacked, so no
+        // real preview viewport exists. Give the message the full space between
+        // the bars (it scrolls internally) so the preview is never blank, and pin
+        // the bars to the top and bottom edges as on-screen as physically possible.
+        val fullHeight = max(1f, dimensions.screenHeight - dimensions.emojiBarHeight - dimensions.actionButtonsHeight)
+        return OverlayLayout(
+            messageFinalY = 0f,
+            messageContainerHeight = fullHeight,
+            bitmapHeight = messageHeight.toFloat(),
+            emojiBarY = 0f,
+            actionButtonsY = max(0f, dimensions.screenHeight - dimensions.actionButtonsHeight),
+            isOverflow = true,
+            messageScrollable = true,
+            previewScale = OVERLAY_MIN_PREVIEW_SCALE,
+        )
+    }
+
+    val fitScale = min(1f, viewportHeight / messageHeight.toFloat())
     val scale = max(OVERLAY_MIN_PREVIEW_SCALE, fitScale)
     val scaledHeight = messageHeight.toFloat() * scale
     return OverlayLayout(

--- a/app/src/main/java/network/columba/app/ui/components/OverlayLayoutDimensions.kt
+++ b/app/src/main/java/network/columba/app/ui/components/OverlayLayoutDimensions.kt
@@ -166,42 +166,36 @@ fun calculateOverlayLayout(
         // preview is left a positive viewport whenever the window is tall enough
         // to hold both bars at all.
         emojiY = 0f
-        buttonsY = dimensions.screenHeight - dimensions.actionButtonsHeight
+        buttonsY = max(0f, dimensions.screenHeight - dimensions.actionButtonsHeight)
         gap = 0f
         messageTop = emojiY + dimensions.emojiBarHeight
         messageBottom = buttonsY
         viewportHeight = max(0f, messageBottom - messageTop)
     }
 
+    var messageFinalY = messageTop
+    var messageContainerHeight = viewportHeight
     if (viewportHeight <= 0f) {
         // Truly degenerate: the window is shorter than both bars stacked, so no
         // real preview viewport exists. Give the message the full space between
         // the bars (it scrolls internally) so the preview is never blank, and pin
         // the bars to the top and bottom edges as on-screen as physically possible.
-        val fullHeight = max(1f, dimensions.screenHeight - dimensions.emojiBarHeight - dimensions.actionButtonsHeight)
-        return OverlayLayout(
-            messageFinalY = 0f,
-            messageContainerHeight = fullHeight,
-            bitmapHeight = messageHeight.toFloat(),
-            emojiBarY = 0f,
-            actionButtonsY = max(0f, dimensions.screenHeight - dimensions.actionButtonsHeight),
-            isOverflow = true,
-            messageScrollable = true,
-            previewScale = OVERLAY_MIN_PREVIEW_SCALE,
-        )
+        messageFinalY = 0f
+        messageContainerHeight =
+            max(1f, dimensions.screenHeight - dimensions.emojiBarHeight - dimensions.actionButtonsHeight)
     }
 
     val fitScale = min(1f, viewportHeight / messageHeight.toFloat())
     val scale = max(OVERLAY_MIN_PREVIEW_SCALE, fitScale)
     val scaledHeight = messageHeight.toFloat() * scale
     return OverlayLayout(
-        messageFinalY = messageTop,
-        messageContainerHeight = viewportHeight,
+        messageFinalY = messageFinalY,
+        messageContainerHeight = messageContainerHeight,
         bitmapHeight = messageHeight.toFloat(),
         emojiBarY = emojiY,
         actionButtonsY = buttonsY,
         isOverflow = true,
-        messageScrollable = scaledHeight > viewportHeight,
+        messageScrollable = scaledHeight > messageContainerHeight,
         previewScale = scale,
     )
 }

--- a/app/src/main/java/network/columba/app/ui/components/OverlayLayoutDimensions.kt
+++ b/app/src/main/java/network/columba/app/ui/components/OverlayLayoutDimensions.kt
@@ -180,15 +180,16 @@ fun calculateOverlayLayout(
         // (screenHeight < emojiBarHeight + actionButtonsHeight), so no positive
         // preview viewport can exist between them. This function only positions
         // the bars (their heights are fixed by the composables), and the guarantee
-        // is that both stay fully on screen. Keeping both 56dp bars fully on screen
-        // requires emojiY >= 0 and emojiY <= screenHeight - 336, which only
-        // coexists when the window is at least 336px (112dp) tall. Below that the
-        // two bars are forced to overlap by exactly (336 - screenHeight)px - no
-        // position keeps both fixed-height bars on screen without intersecting.
-        // The composable draws the action buttons after the emoji bar, so the
-        // primary actions (reply/copy/delete) deliberately win the overlap instead
-        // of the quick reactions. The preview still gets the full (clamped) space
-        // and scrolls internally, so it is never blank.
+        // is that both stay fully on screen. For the real bars (64dp reaction +
+        // 56dp action = 360px at 3x) keeping both fully on screen requires
+        // emojiY >= 0 and emojiY <= screenHeight - 360, which only coexists when
+        // the window is at least 360px (120dp) tall. Below that the two bars are
+        // forced to overlap by exactly (360 - screenHeight)px - no position keeps
+        // both fixed-height bars on screen without intersecting. The composable
+        // draws the action buttons after the emoji bar, so the primary actions
+        // (reply/copy/delete) deliberately win the overlap instead of the quick
+        // reactions. The preview still gets the full (clamped) space and scrolls
+        // internally, so it is never blank.
         messageFinalY = 0f
         messageContainerHeight =
             max(1f, dimensions.screenHeight - dimensions.emojiBarHeight - dimensions.actionButtonsHeight)

--- a/app/src/main/java/network/columba/app/ui/components/OverlayLayoutDimensions.kt
+++ b/app/src/main/java/network/columba/app/ui/components/OverlayLayoutDimensions.kt
@@ -176,10 +176,19 @@ fun calculateOverlayLayout(
     var messageFinalY = messageTop
     var messageContainerHeight = viewportHeight
     if (viewportHeight <= 0f) {
-        // Truly degenerate: the window is shorter than both bars stacked, so no
-        // real preview viewport exists. Give the message the full space between
-        // the bars (it scrolls internally) so the preview is never blank, and pin
-        // the bars to the top and bottom edges as on-screen as physically possible.
+        // Truly degenerate: the window is shorter than both bars stacked
+        // (screenHeight < emojiBarHeight + actionButtonsHeight), so no positive
+        // preview viewport can exist between them. This function only positions
+        // the bars (their heights are fixed by the composables), and the guarantee
+        // is that both stay fully on screen. Keeping both 56dp bars fully on screen
+        // requires emojiY >= 0 and emojiY <= screenHeight - 336, which only
+        // coexists when the window is at least 336px (112dp) tall. Below that the
+        // two bars are forced to overlap by exactly (336 - screenHeight)px - no
+        // position keeps both fixed-height bars on screen without intersecting.
+        // The composable draws the action buttons after the emoji bar, so the
+        // primary actions (reply/copy/delete) deliberately win the overlap instead
+        // of the quick reactions. The preview still gets the full (clamped) space
+        // and scrolls internally, so it is never blank.
         messageFinalY = 0f
         messageContainerHeight =
             max(1f, dimensions.screenHeight - dimensions.emojiBarHeight - dimensions.actionButtonsHeight)

--- a/app/src/main/java/network/columba/app/ui/components/OverlayLayoutDimensions.kt
+++ b/app/src/main/java/network/columba/app/ui/components/OverlayLayoutDimensions.kt
@@ -25,9 +25,11 @@ const val OVERLAY_MIN_PREVIEW_SCALE = 0.35f
  * Contains all the measurements needed to calculate proper positioning.
  *
  * @property screenHeight The total screen height in pixels
- * @property emojiBarHeight Height of the emoji bar in pixels (typically ~56dp)
+ * @property emojiBarHeight Height of the emoji bar in pixels (64dp for
+ * InlineReactionBar: 48dp buttons + 8dp vertical padding)
  * @property emojiBarGap Gap between emoji bar and message in pixels (typically ~76dp)
- * @property actionButtonsHeight Height of the action buttons in pixels (typically ~56dp)
+ * @property actionButtonsHeight Height of the action buttons in pixels (56dp for
+ * MessageActionButtons: 48dp icon buttons + 4dp vertical padding)
  * @property actionButtonsGap Gap between message and action buttons in pixels (typically ~12dp)
  * @property topPadding Padding for status bar etc. in pixels (typically ~48dp)
  * @property bottomPadding Padding for navigation bar etc. in pixels (typically ~48dp)

--- a/app/src/main/java/network/columba/app/ui/components/ReactionComponents.kt
+++ b/app/src/main/java/network/columba/app/ui/components/ReactionComponents.kt
@@ -15,6 +15,7 @@ import androidx.compose.foundation.clickable
 import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.BoxWithConstraints
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxSize
@@ -56,7 +57,6 @@ import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.draw.alpha
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.asAndroidBitmap
@@ -812,6 +812,12 @@ fun ReactionModeOverlay(
     messageY: Float = 0f,
     messageWidth: Int = 0,
     messageHeight: Int = 0,
+    /**
+     * The message's text content, used as a never-blank fallback when the
+     * snapshot bitmap is missing or invalid (COLUMBA-20). When null or blank
+     * the fallback is omitted and only the bars render.
+     */
+    messageContent: String? = null,
     onReactionSelected: (String) -> Unit,
     onShowFullPicker: () -> Unit,
     onReply: () -> Unit,
@@ -830,53 +836,20 @@ fun ReactionModeOverlay(
     var isDismissing by remember { mutableStateOf(false) }
     val scope = rememberCoroutineScope()
     val density = androidx.compose.ui.platform.LocalDensity.current
+
+    // Fallback height for the (rare) case where the overlay is measured in an
+    // unbounded/zero-height parent: use the full window height.
     val configuration = androidx.compose.ui.platform.LocalConfiguration.current
+    val fallbackHeightPx = with(density) { configuration.screenHeightDp.dp.toPx() }
 
-    // Calculate screen dimensions and UI element sizes in pixels
-    val layoutDimensions =
-        OverlayLayoutDimensions(
-            screenHeight = with(density) { configuration.screenHeightDp.dp.toPx() },
-            emojiBarHeight = with(density) { 56.dp.toPx() },
-            emojiBarGap = with(density) { 76.dp.toPx() },
-            actionButtonsHeight = with(density) { 56.dp.toPx() },
-            actionButtonsGap = with(density) { 12.dp.toPx() },
-            topPadding = with(density) { 48.dp.toPx() },
-            bottomPadding = with(density) { 48.dp.toPx() },
-        )
-
-    // Calculate scale factor for large messages to ensure they fit on screen
-    val messageScale =
-        calculateMessageScaleForOverlay(
-            messageHeight = messageHeight,
-            dimensions = layoutDimensions,
-        )
-
-    // Scaled message dimensions
-    val scaledMessageHeight = (messageHeight * messageScale).toInt()
-    val scaledMessageWidth = (messageWidth * messageScale).toInt()
-
-    // Calculate target position (center of screen vertically) using scaled height
-    val targetY = (layoutDimensions.screenHeight / 2) - (scaledMessageHeight / 2)
-
-    // Signal-style positioning: align based on message side, not message position
-    // Left-aligned messages (received): UI elements at left margin
-    // Right-aligned messages (sent): UI elements at right margin
-
-    // Animated offset for message position
+    // Animated offset for message position (animates from its in-chat position to
+    // the resolved layout position, and back on dismiss)
     val animatedOffsetY = remember { Animatable(messageY) }
 
-    // Trigger animations on mount
+    // Become visible on mount. The position animation is driven from inside the
+    // BoxWithConstraints below, where the resolved layout is known.
     LaunchedEffect(Unit) {
         visible = true
-        // Animate message to center
-        animatedOffsetY.animateTo(
-            targetValue = targetY,
-            animationSpec =
-                spring(
-                    dampingRatio = Spring.DampingRatioMediumBouncy,
-                    stiffness = Spring.StiffnessLow,
-                ),
-        )
     }
 
     // Function to handle dismiss with reverse animation
@@ -970,7 +943,7 @@ fun ReactionModeOverlay(
                 animationSpec = tween(durationMillis = 150, easing = LinearOutSlowInEasing),
             ),
     ) {
-        Box(
+        BoxWithConstraints(
             modifier =
                 modifier
                     .fillMaxSize()
@@ -980,6 +953,43 @@ fun ReactionModeOverlay(
                         onClick = handleDismiss,
                     ),
         ) {
+            // Resolve the on-screen layout against the *measured* container size.
+            // That can be smaller than the window height (system bar insets,
+            // non-full-screen embedding, tests); laying out against it is what
+            // keeps the context menu on screen in every case. Small messages are
+            // centered with the bars adjacent; very long messages pin the bars to
+            // the top/bottom safe areas and cap + scroll the message.
+            val measuredHeightPx = constraints.maxHeight.toFloat()
+            val screenHeightPx =
+                if (measuredHeightPx.isFinite() && measuredHeightPx > 0f) measuredHeightPx
+                else fallbackHeightPx
+            val layout =
+                calculateOverlayLayout(
+                    messageHeight = messageHeight,
+                    dimensions =
+                        OverlayLayoutDimensions(
+                            screenHeight = screenHeightPx,
+                            emojiBarHeight = with(density) { 56.dp.toPx() },
+                            emojiBarGap = with(density) { 76.dp.toPx() },
+                            actionButtonsHeight = with(density) { 56.dp.toPx() },
+                            actionButtonsGap = with(density) { 12.dp.toPx() },
+                            topPadding = with(density) { 48.dp.toPx() },
+                            bottomPadding = with(density) { 48.dp.toPx() },
+                        ),
+                )
+
+            // Animate the message from its in-chat position to the resolved one.
+            LaunchedEffect(layout.messageFinalY) {
+                animatedOffsetY.animateTo(
+                    targetValue = layout.messageFinalY,
+                    animationSpec =
+                        spring(
+                            dampingRatio = Spring.DampingRatioMediumBouncy,
+                            stiffness = Spring.StiffnessLow,
+                        ),
+                )
+            }
+
             // Dimmed scrim background
             Box(
                 modifier =
@@ -988,8 +998,53 @@ fun ReactionModeOverlay(
                         .background(Color.Black.copy(alpha = 0.5f)),
             )
 
-            // Message snapshot with animation
-            // Guard against recycled/invalid underlying bitmap (COLUMBA-20)
+            // The emoji bar and action buttons are positioned at the resolved
+            // on-screen layout coordinates. They render unconditionally (even when
+            // the message snapshot is missing or recycled, COLUMBA-20) so the
+            // context menu is never lost, and calculateOverlayLayout guarantees
+            // they are fully on screen. For messages that fit, the bars sit
+            // adjacent to the message (which springs into place); for very long
+            // messages the bars are pinned to the top/bottom safe areas.
+            Box(
+                modifier =
+                    Modifier
+                        .fillMaxWidth()
+                        .offset { IntOffset(0, layout.emojiBarY.toInt()) },
+            ) {
+                InlineReactionBar(
+                    onReactionSelected = wrappedOnReactionSelected,
+                    onShowFullPicker = wrappedOnShowFullPicker,
+                    modifier =
+                        Modifier
+                            .align(if (isFromMe) Alignment.TopEnd else Alignment.TopStart)
+                            .padding(horizontal = 16.dp),
+                )
+            }
+
+            Box(
+                modifier =
+                    Modifier
+                        .fillMaxWidth()
+                        .offset { IntOffset(0, layout.actionButtonsY.toInt()) },
+            ) {
+                MessageActionButtons(
+                    onReply = wrappedOnReply,
+                    onCopy = wrappedOnCopy,
+                    onSelectText = wrappedOnSelectText,
+                    onViewDetails = wrappedOnViewDetails,
+                    onRetry = wrappedOnRetry,
+                    onDelete = wrappedOnDelete,
+                    modifier =
+                        Modifier
+                            .align(if (isFromMe) Alignment.TopEnd else Alignment.TopStart)
+                            .padding(horizontal = 16.dp),
+                )
+            }
+
+            // Message preview with animation.
+            // Guard against recycled/invalid underlying bitmap (COLUMBA-20): when
+            // the snapshot is missing we fall back to the message's text so the
+            // preview area is never blank between the bars.
             val validBitmap =
                 messageBitmap?.let { bitmap ->
                     try {
@@ -999,87 +1054,73 @@ fun ReactionModeOverlay(
                         null
                     }
                 }
-            validBitmap?.let { bitmap ->
-                // Use scaled dimensions for large messages
-                val displayWidthDp = with(density) { scaledMessageWidth.toDp() }
-                val displayHeightDp = with(density) { scaledMessageHeight.toDp() }
-
-                // Calculate X offset to keep message aligned (adjust for width change due to scaling)
-                val scaledMessageX =
-                    if (isFromMe) {
-                        // For sent messages (right-aligned), adjust X to keep right edge aligned
-                        messageX + (messageWidth - scaledMessageWidth)
-                    } else {
-                        // For received messages (left-aligned), keep X the same
-                        messageX
-                    }
-
-                // Message snapshot - keep at full opacity during animation
-                Image(
-                    bitmap = bitmap,
-                    contentDescription = "Selected message",
-                    modifier =
-                        Modifier
-                            .size(width = displayWidthDp, height = displayHeightDp)
-                            .offset {
-                                IntOffset(scaledMessageX.toInt(), animatedOffsetY.value.toInt())
-                            }.alpha(1f) // Don't fade out with AnimatedVisibility
-                            .clip(
-                                RoundedCornerShape(
-                                    topStart = 20.dp,
-                                    topEnd = 20.dp,
-                                    bottomStart = if (isFromMe) 20.dp else 4.dp,
-                                    bottomEnd = if (isFromMe) 4.dp else 20.dp,
-                                ),
-                            ),
+            val displayWidthDp = with(density) { messageWidth.toDp() }
+            val containerHeightDp = with(density) { layout.messageContainerHeight.toDp() }
+            // The snapshot is scaled so the whole preview fits the space between
+            // the bars (down to the minimum legible scale). The scaled size is
+            // computed from the *bitmap* dimensions times the layout scale so
+            // the preview keeps the bubble's aspect ratio.
+            val previewWidthDp = displayWidthDp * layout.previewScale
+            val previewHeightDp =
+                with(density) { (layout.bitmapHeight * layout.previewScale).toDp() }
+            val bubbleShape =
+                RoundedCornerShape(
+                    topStart = 20.dp,
+                    topEnd = 20.dp,
+                    bottomStart = if (isFromMe) 20.dp else 4.dp,
+                    bottomEnd = if (isFromMe) 4.dp else 20.dp,
                 )
-
-                // Emoji bar above message
-                Box(
-                    modifier =
+            val viewportModifier =
+                Modifier
+                    .offset {
+                        IntOffset(messageX.toInt(), animatedOffsetY.value.toInt())
+                    }
+                    .width(displayWidthDp)
+                    .height(containerHeightDp)
+                    .clip(bubbleShape)
+            if (validBitmap != null) {
+                val bitmap = validBitmap
+                // The preview keeps full opacity during the enter/exit
+                // animation. When it is scrollable (scaled preview still
+                // taller than the viewport) the scroll modifier is
+                // outermost so the scroll range equals the overflow; the
+                // surrounding viewport clips the corners. When the preview
+                // fits, no scroll is attached.
+                val previewModifier =
+                    if (layout.messageScrollable) {
                         Modifier
-                            .fillMaxWidth()
-                            .offset {
-                                IntOffset(
-                                    x = 0,
-                                    y = (animatedOffsetY.value - with(density) { 76.dp.toPx() }).toInt(),
-                                )
-                            },
-                ) {
-                    InlineReactionBar(
-                        onReactionSelected = wrappedOnReactionSelected,
-                        onShowFullPicker = wrappedOnShowFullPicker,
-                        modifier =
-                            Modifier
-                                .align(if (isFromMe) Alignment.TopEnd else Alignment.TopStart)
-                                .padding(horizontal = 16.dp),
+                            .verticalScroll(rememberScrollState())
+                            .width(previewWidthDp)
+                            .height(previewHeightDp)
+                            .align(if (isFromMe) Alignment.TopEnd else Alignment.TopStart)
+                    } else {
+                        Modifier
+                            .width(previewWidthDp)
+                            .height(previewHeightDp)
+                            .align(if (isFromMe) Alignment.TopEnd else Alignment.TopStart)
+                    }
+                Box(viewportModifier) {
+                    Image(
+                        bitmap = bitmap,
+                        contentDescription = "Selected message",
+                        modifier = previewModifier,
                     )
                 }
-
-                // Action buttons below message (using scaled height)
-                Box(
-                    modifier =
-                        Modifier
-                            .fillMaxWidth()
-                            .offset {
-                                IntOffset(
-                                    x = 0,
-                                    y = (animatedOffsetY.value + scaledMessageHeight + with(density) { 12.dp.toPx() }).toInt(),
-                                )
-                            },
-                ) {
-                    MessageActionButtons(
-                        onReply = wrappedOnReply,
-                        onCopy = wrappedOnCopy,
-                        onSelectText = wrappedOnSelectText,
-                        onViewDetails = wrappedOnViewDetails,
-                        onRetry = wrappedOnRetry,
-                        onDelete = wrappedOnDelete,
-                        modifier =
-                            Modifier
-                                .align(if (isFromMe) Alignment.TopEnd else Alignment.TopStart)
-                                .padding(horizontal = 16.dp),
-                    )
+            } else {
+                // Never-blank fallback: render the message text itself,
+                // scrollable within the same viewport, so a failed or
+                // missing snapshot never leaves a blank area.
+                val fallbackText = messageContent?.takeIf { it.isNotBlank() }
+                if (fallbackText != null) {
+                    Box(viewportModifier) {
+                        SelectableMessageText(
+                            text = fallbackText,
+                            modifier =
+                                Modifier
+                                    .fillMaxSize()
+                                    .padding(horizontal = 16.dp, vertical = 10.dp),
+                        )
+                    }
                 }
             }
         }

--- a/app/src/main/java/network/columba/app/ui/components/ReactionComponents.kt
+++ b/app/src/main/java/network/columba/app/ui/components/ReactionComponents.kt
@@ -969,7 +969,13 @@ fun ReactionModeOverlay(
                     dimensions =
                         OverlayLayoutDimensions(
                             screenHeight = screenHeightPx,
-                            emojiBarHeight = with(density) { 56.dp.toPx() },
+                            // InlineReactionBar renders at 64dp (48dp emoji buttons +
+                            // 8dp top + 8dp bottom Row padding); MessageActionButtons
+                            // renders at 56dp (48dp icon buttons + 4dp top + 4dp bottom).
+                            // The reservations must match the true rendered heights or
+                            // the pinned layout under-reserves the reaction bar and the
+                            // message preview / action bar overlap its lower 8dp.
+                            emojiBarHeight = with(density) { 64.dp.toPx() },
                             emojiBarGap = with(density) { 76.dp.toPx() },
                             actionButtonsHeight = with(density) { 56.dp.toPx() },
                             actionButtonsGap = with(density) { 12.dp.toPx() },

--- a/app/src/main/java/network/columba/app/ui/screens/MessagingScreen.kt
+++ b/app/src/main/java/network/columba/app/ui/screens/MessagingScreen.kt
@@ -175,6 +175,7 @@ import androidx.paging.compose.collectAsLazyPagingItems
 import androidx.paging.compose.itemKey
 import coil.compose.AsyncImage
 import coil.request.ImageRequest
+import kotlin.math.min
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.firstOrNull
@@ -187,6 +188,7 @@ import network.columba.app.rns.api.BackendCapabilities.Support
 import network.columba.app.rns.api.model.Direction
 import network.columba.app.rns.api.model.TransferProgressUpdate
 import network.columba.app.ui.components.AttachmentPanel
+import network.columba.app.ui.components.OVERLAY_MAX_CAPTURE_HEIGHT_PX
 import network.columba.app.ui.components.VoiceMessageBubble
 import network.columba.app.ui.components.VoiceDraftPreview
 import network.columba.app.ui.components.VoiceRecordingControls
@@ -1703,6 +1705,7 @@ fun MessagingScreen(
                     messageY = state.messageY,
                     messageWidth = state.messageWidth,
                     messageHeight = state.messageHeight,
+                    messageContent = selectableMessageContent,
                     onReactionSelected = { emoji ->
                         viewModel.sendReaction(state.messageId, emoji)
                     },
@@ -2166,12 +2169,19 @@ fun MessageBubble(
                         .widthIn(max = 280.dp)
                         .drawWithCache {
                             val width = this.size.width.toInt()
-                            val height = this.size.height.toInt()
+                            // Cap the recorded snapshot at the GPU-safe height (see the
+                            // text bubble path). A full-height capture of a very tall
+                            // bubble can exceed the hardware texture limit and fail.
+                            val captureHeight =
+                                min(
+                                    this.size.height.toInt(),
+                                    OVERLAY_MAX_CAPTURE_HEIGHT_PX,
+                                )
                             onDrawWithContent {
                                 graphicsLayer.record(
                                     size =
                                         androidx.compose.ui.unit
-                                            .IntSize(width, height),
+                                            .IntSize(width, captureHeight),
                                 ) {
                                     this@onDrawWithContent.drawContent()
                                 }
@@ -2189,7 +2199,9 @@ fun MessageBubble(
                                 hapticFeedback.performHapticFeedback(HapticFeedbackType.LongPress)
                                 scope.launch {
                                     val bitmap = graphicsLayer.toImageBitmap()
-                                    onLongPress(message.id, isFromMe, message.status == "failed", bitmap, bubbleX, bubbleY, bubbleWidth, bubbleHeight)
+                                    val capturedHeight =
+                                        min(bubbleHeight, OVERLAY_MAX_CAPTURE_HEIGHT_PX)
+                                    onLongPress(message.id, isFromMe, message.status == "failed", bitmap, bubbleX, bubbleY, bubbleWidth, capturedHeight)
                                 }
                             },
                             indication = null,
@@ -2284,12 +2296,19 @@ fun MessageBubble(
                             .widthIn(max = 300.dp)
                             .drawWithCache {
                                 val width = this.size.width.toInt()
-                                val height = this.size.height.toInt()
+                                // Cap the recorded snapshot at the GPU-safe height. A full-height
+                                // capture of a very tall bubble can exceed the hardware texture
+                                // limit and fail silently, leaving the reaction overlay blank.
+                                val captureHeight =
+                                    min(
+                                        this.size.height.toInt(),
+                                        OVERLAY_MAX_CAPTURE_HEIGHT_PX,
+                                    )
                                 onDrawWithContent {
                                     graphicsLayer.record(
                                         size =
                                             androidx.compose.ui.unit
-                                                .IntSize(width, height),
+                                                .IntSize(width, captureHeight),
                                     ) {
                                         this@onDrawWithContent.drawContent()
                                     }
@@ -2307,7 +2326,9 @@ fun MessageBubble(
                                     hapticFeedback.performHapticFeedback(HapticFeedbackType.LongPress)
                                     scope.launch {
                                         val bitmap = graphicsLayer.toImageBitmap()
-                                        onLongPress(message.id, isFromMe, message.status == "failed", bitmap, bubbleX, bubbleY, bubbleWidth, bubbleHeight)
+                                        val capturedHeight =
+                                            min(bubbleHeight, OVERLAY_MAX_CAPTURE_HEIGHT_PX)
+                                        onLongPress(message.id, isFromMe, message.status == "failed", bitmap, bubbleX, bubbleY, bubbleWidth, capturedHeight)
                                     }
                                 },
                                 // Disable ripple - we use scale animation instead

--- a/app/src/test/java/network/columba/app/ui/components/ReactionComponentsTest.kt
+++ b/app/src/test/java/network/columba/app/ui/components/ReactionComponentsTest.kt
@@ -614,10 +614,13 @@ class ReactionComponentsTest {
     // ========== calculateOverlayLayout TESTS (off-screen context menu on very long messages) ==========
 
     // Realistic modern phone: 480dp x 1040dp at 3x density = 1440 x 3120 px.
+    // emojiBarHeight must match the rendered InlineReactionBar (64dp: 48dp buttons
+    // + 8dp vertical padding); actionButtonsHeight matches MessageActionButtons
+    // (56dp: 48dp icon buttons + 4dp vertical padding).
     private val phoneDimensions =
         OverlayLayoutDimensions(
             screenHeight = 3120f, // 1040dp
-            emojiBarHeight = 168f, // 56dp
+            emojiBarHeight = 192f, // 64dp
             emojiBarGap = 228f, // 76dp
             actionButtonsHeight = 168f, // 56dp
             actionButtonsGap = 36f, // 12dp
@@ -650,13 +653,13 @@ class ReactionComponentsTest {
         assertEquals(144f, layout.emojiBarY, 0.5f)
         assertEquals(3120f - 144f - 168f, layout.actionButtonsY, 0.5f)
         // The preview is scaled down so the whole thing fits between the bars.
-        // viewport = (3120 - 144 - 144) - 168 - 168 - 2 * 36 = 2424; 2424 / 4000 = 0.606.
-        val viewport = 2424f
+        // viewport = (3120 - 144 - 144) - 192 - 168 - 2 * 36 = 2400; 2400 / 4000 = 0.6.
+        val viewport = 2400f
         assertTrue("Long message should be scaled to fit, not scrolled", !layout.messageScrollable)
-        assertEquals(2424f / 4000f, layout.previewScale, 0.005f)
-        assertEquals(4000f * (2424f / 4000f), layout.scaledPreviewHeight, 1.0f)
+        assertEquals(2400f / 4000f, layout.previewScale, 0.005f)
+        assertEquals(4000f * (2400f / 4000f), layout.scaledPreviewHeight, 1.0f)
         // The scaled preview must sit inside the viewport between the bars.
-        assertTrue("Message top must be just below the emoji bar", layout.messageFinalY >= layout.emojiBarY + 168f)
+        assertTrue("Message top must be just below the emoji bar", layout.messageFinalY >= layout.emojiBarY + 192f)
         assertTrue("Scaled preview must fit inside the viewport", layout.scaledPreviewHeight <= viewport + 0.5f)
         assertTrue("Action buttons must end at or above the bottom edge", layout.actionButtonsY + 168f <= 3120f)
         assertTrue("Emoji bar must start at or below the top edge", layout.emojiBarY >= 0f)
@@ -668,17 +671,17 @@ class ReactionComponentsTest {
         assertFalse("Uncapped message should not be scrollable", small.messageScrollable)
         assertEquals(1f, small.previewScale, 0.001f)
 
-        // 4000px scales to fit (0.604 > 0.35 floor) - no scroll needed.
+        // 4000px scales to fit (0.6 > 0.35 floor) - no scroll needed.
         val scaledToFit = calculateOverlayLayout(4000, phoneDimensions)
         assertFalse("Message that fits after scaling should not be scrollable", scaledToFit.messageScrollable)
 
-        // 6000px: fit scale 2424/6000 = 0.404 -> still above the floor, fits.
+        // 6000px: fit scale 2400/6000 = 0.4 -> still above the floor, fits.
         val nearFloor = calculateOverlayLayout(6000, phoneDimensions)
-        assertEquals(2424f / 6000f, nearFloor.previewScale, 0.005f)
+        assertEquals(2400f / 6000f, nearFloor.previewScale, 0.005f)
         assertFalse(nearFloor.messageScrollable)
 
-        // 9000px: fit scale 2424/9000 = 0.269 -> clamped to the 0.35 floor, so the
-        // scaled preview (3150px) still overflows the 2424px viewport and scrolls.
+        // 9000px: fit scale 2400/9000 = 0.267 -> clamped to the 0.35 floor, so the
+        // scaled preview (3150px) still overflows the 2400px viewport and scrolls.
         val capped = calculateOverlayLayout(9000, phoneDimensions)
         assertEquals(OVERLAY_MIN_PREVIEW_SCALE, capped.previewScale, 0.0001f)
         assertTrue("Message at the scale floor should be scrollable", capped.messageScrollable)
@@ -698,8 +701,9 @@ class ReactionComponentsTest {
 
     @Test
     fun `overlay layout fits a message that is large but fits centered`() {
-        // available = 2824, UI elements = 600 -> max centered message = 2224px
-        val layout = calculateOverlayLayout(2224, phoneDimensions)
+        // available = 3120 - 144 - 144 = 2832; UI elements = 192 + 228 + 36 + 168 = 624
+        // -> max centered message = 2832 - 624 = 2208px
+        val layout = calculateOverlayLayout(2208, phoneDimensions)
 
         assertFalse("Message that exactly fits centered should not overflow", layout.isOverflow)
         assertTrue(layout.fitsOnScreen(phoneDimensions))
@@ -727,9 +731,9 @@ class ReactionComponentsTest {
         val compact =
             OverlayLayoutDimensions(
                 screenHeight = 696f, // 232dp
-                emojiBarHeight = 168f, // 56dp
+                emojiBarHeight = 192f, // 64dp (InlineReactionBar)
                 emojiBarGap = 228f, // 76dp
-                actionButtonsHeight = 168f, // 56dp
+                actionButtonsHeight = 168f, // 56dp (MessageActionButtons)
                 actionButtonsGap = 36f, // 12dp
                 topPadding = 144f, // 48dp
                 bottomPadding = 144f, // 48dp
@@ -750,14 +754,15 @@ class ReactionComponentsTest {
 
     @Test
     fun `overlay layout keeps a non-blank preview when the window is shorter than both bars`() {
-        // Degenerate: 300px is shorter than the two 168px bars stacked, so no
-        // real viewport exists even after compressing the paddings. The preview
-        // must still be non-blank (full space between bars, scrollable) and the
-        // bars must remain as on-screen as physically possible.
+        // Degenerate: 300px is shorter than the two bars stacked (192px reaction
+        // + 168px action = 360px), so no real viewport exists even after compressing
+        // the paddings. The preview must still be non-blank (full space between
+        // bars, scrollable) and the bars must remain as on-screen as physically
+        // possible.
         val tiny =
             OverlayLayoutDimensions(
                 screenHeight = 300f,
-                emojiBarHeight = 168f,
+                emojiBarHeight = 192f,
                 emojiBarGap = 228f,
                 actionButtonsHeight = 168f,
                 actionButtonsGap = 36f,
@@ -771,24 +776,25 @@ class ReactionComponentsTest {
         assertTrue("Preview must never be blank", layout.messageContainerHeight > 0f)
         assertTrue(layout.messageScrollable)
         assertTrue("Emoji bar must start at or below the top edge", layout.emojiBarY >= 0f)
-        assertTrue("Emoji bar must end at or above the bottom edge", layout.emojiBarY + 168f <= 300f)
+        assertTrue("Emoji bar must end at or above the bottom edge", layout.emojiBarY + 192f <= 300f)
         assertTrue("Action buttons must start at or below the top edge", layout.actionButtonsY >= 0f)
         assertTrue("Action buttons must end at or above the bottom edge", layout.actionButtonsY + 168f <= 300f)
 
         // Both bars are pinned fully on screen (emoji to the top edge, action to
-        // the bottom edge). In a window shorter than the two 168px bars stacked,
-        // the bars MUST overlap: keeping both fully on screen requires emojiY in
-        // [0, h - 336], which only exists when h >= 336px. The overlap is therefore
-        // forced to exactly (336 - h)px here (336 - 300 = 36px) - no position keeps
-        // both fixed-height bars on screen without intersecting. The composable
-        // draws the action buttons last, so the primary actions win that overlap.
+        // the bottom edge). In a window shorter than the two bars stacked
+        // (192 + 168 = 360px), the bars MUST overlap: keeping both fully on
+        // screen requires emojiY in [0, h - 360], which only exists when
+        // h >= 360px. The overlap is therefore forced to exactly
+        // (360 - h)px here (360 - 300 = 60px) - no position keeps both
+        // fixed-height bars on screen without intersecting. The composable draws
+        // the action buttons last, so the primary actions win that overlap.
         // Pin the exact positions and the forced overlap so this stays an
         // intentional contract rather than an accidental collision.
         assertEquals(0f, layout.emojiBarY, 0.5f)
         assertEquals(300f - 168f, layout.actionButtonsY, 0.5f)
-        val forcedOverlap = (layout.emojiBarY + 168f) - layout.actionButtonsY
-        assertEquals("Overlap is forced to exactly 336 - h px", 336f - 300f, forcedOverlap, 0.5f)
-        assertTrue("Action buttons must be drawn on top in the overlap", layout.actionButtonsY < layout.emojiBarY + 168f)
+        val forcedOverlap = (layout.emojiBarY + 192f) - layout.actionButtonsY
+        assertEquals("Overlap is forced to exactly 360 - h px", 360f - 300f, forcedOverlap, 0.5f)
+        assertTrue("Action buttons must be drawn on top in the overlap", layout.actionButtonsY < layout.emojiBarY + 192f)
     }
 
     // ========== ReactionModeOverlay on-screen context menu TESTS ==========

--- a/app/src/test/java/network/columba/app/ui/components/ReactionComponentsTest.kt
+++ b/app/src/test/java/network/columba/app/ui/components/ReactionComponentsTest.kt
@@ -774,6 +774,21 @@ class ReactionComponentsTest {
         assertTrue("Emoji bar must end at or above the bottom edge", layout.emojiBarY + 168f <= 300f)
         assertTrue("Action buttons must start at or below the top edge", layout.actionButtonsY >= 0f)
         assertTrue("Action buttons must end at or above the bottom edge", layout.actionButtonsY + 168f <= 300f)
+
+        // Both bars are pinned fully on screen (emoji to the top edge, action to
+        // the bottom edge). In a window shorter than the two 168px bars stacked,
+        // the bars MUST overlap: keeping both fully on screen requires emojiY in
+        // [0, h - 336], which only exists when h >= 336px. The overlap is therefore
+        // forced to exactly (336 - h)px here (336 - 300 = 36px) - no position keeps
+        // both fixed-height bars on screen without intersecting. The composable
+        // draws the action buttons last, so the primary actions win that overlap.
+        // Pin the exact positions and the forced overlap so this stays an
+        // intentional contract rather than an accidental collision.
+        assertEquals(0f, layout.emojiBarY, 0.5f)
+        assertEquals(300f - 168f, layout.actionButtonsY, 0.5f)
+        val forcedOverlap = (layout.emojiBarY + 168f) - layout.actionButtonsY
+        assertEquals("Overlap is forced to exactly 336 - h px", 336f - 300f, forcedOverlap, 0.5f)
+        assertTrue("Action buttons must be drawn on top in the overlap", layout.actionButtonsY < layout.emojiBarY + 168f)
     }
 
     // ========== ReactionModeOverlay on-screen context menu TESTS ==========

--- a/app/src/test/java/network/columba/app/ui/components/ReactionComponentsTest.kt
+++ b/app/src/test/java/network/columba/app/ui/components/ReactionComponentsTest.kt
@@ -717,6 +717,65 @@ class ReactionComponentsTest {
         assertTrue(negative.fitsOnScreen(phoneDimensions))
     }
 
+    @Test
+    fun `overlay layout keeps a positive preview in a compact window`() {
+        // Greptile regression: at 232dp (696px @3x) the fixed paddings, bars, and
+        // gaps consume all the vertical space, collapsing the pinned preview
+        // viewport to zero. The compact branch must re-pin the bars to the raw
+        // screen edges and leave the message a positive, scrollable viewport so
+        // the preview is never blank.
+        val compact =
+            OverlayLayoutDimensions(
+                screenHeight = 696f, // 232dp
+                emojiBarHeight = 168f, // 56dp
+                emojiBarGap = 228f, // 76dp
+                actionButtonsHeight = 168f, // 56dp
+                actionButtonsGap = 36f, // 12dp
+                topPadding = 144f, // 48dp
+                bottomPadding = 144f, // 48dp
+            )
+
+        val layout = calculateOverlayLayout(2000, compact)
+
+        assertTrue("Compact window should use the overflow layout", layout.isOverflow)
+        assertTrue("Bars must stay fully on screen in a compact window", layout.fitsOnScreen(compact))
+        // Bars re-pinned to the raw screen edges (safe-area paddings compressed).
+        assertEquals(0f, layout.emojiBarY, 0.5f)
+        assertEquals(696f - 168f, layout.actionButtonsY, 0.5f)
+        // Positive preview viewport between the bars, and it scrolls.
+        assertTrue("Compact window must leave a positive preview viewport", layout.messageContainerHeight > 0f)
+        assertTrue(layout.messageScrollable)
+        assertEquals(2000f * layout.previewScale, layout.scaledPreviewHeight, 0.5f)
+    }
+
+    @Test
+    fun `overlay layout keeps a non-blank preview when the window is shorter than both bars`() {
+        // Degenerate: 300px is shorter than the two 168px bars stacked, so no
+        // real viewport exists even after compressing the paddings. The preview
+        // must still be non-blank (full space between bars, scrollable) and the
+        // bars must remain as on-screen as physically possible.
+        val tiny =
+            OverlayLayoutDimensions(
+                screenHeight = 300f,
+                emojiBarHeight = 168f,
+                emojiBarGap = 228f,
+                actionButtonsHeight = 168f,
+                actionButtonsGap = 36f,
+                topPadding = 144f,
+                bottomPadding = 144f,
+            )
+
+        val layout = calculateOverlayLayout(2000, tiny)
+
+        assertTrue("Degenerate window should use the overflow layout", layout.isOverflow)
+        assertTrue("Preview must never be blank", layout.messageContainerHeight > 0f)
+        assertTrue(layout.messageScrollable)
+        assertTrue("Emoji bar must start at or below the top edge", layout.emojiBarY >= 0f)
+        assertTrue("Emoji bar must end at or above the bottom edge", layout.emojiBarY + 168f <= 300f)
+        assertTrue("Action buttons must start at or below the top edge", layout.actionButtonsY >= 0f)
+        assertTrue("Action buttons must end at or above the bottom edge", layout.actionButtonsY + 168f <= 300f)
+    }
+
     // ========== ReactionModeOverlay on-screen context menu TESTS ==========
 
     // A message taller than the test screen: long-pressing it must still show the

--- a/app/src/test/java/network/columba/app/ui/components/ReactionComponentsTest.kt
+++ b/app/src/test/java/network/columba/app/ui/components/ReactionComponentsTest.kt
@@ -2,14 +2,17 @@ package network.columba.app.ui.components
 
 import android.app.Application
 import androidx.compose.material3.MaterialTheme
+import androidx.compose.ui.graphics.asImageBitmap
 import androidx.compose.ui.test.assertIsDisplayed
 import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.isRoot
 import androidx.compose.ui.test.onNodeWithContentDescription
 import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.performClick
 import network.columba.app.test.RegisterComponentActivityRule
 import network.columba.app.ui.model.ReactionUi
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
 import org.junit.Ignore
 import org.junit.Rule
@@ -20,7 +23,14 @@ import org.robolectric.RobolectricTestRunner
 import org.robolectric.annotation.Config
 
 @RunWith(RobolectricTestRunner::class)
-@Config(sdk = [34], application = Application::class)
+@Config(
+    sdk = [34],
+    application = Application::class,
+    // Real modern phone (480dp x 1040dp at xxxhdpi = 1440 x 3120 px). The default
+    // Robolectric screen (320dp wide) is narrower than the ~384dp reaction bars, which
+    // clips them horizontally and defeats the on-screen bounds assertions below.
+    qualifiers = "w480dp-h1040dp-xxxhdpi",
+)
 class ReactionComponentsTest {
     private val registerActivityRule = RegisterComponentActivityRule()
     private val composeRule = createComposeRule()
@@ -601,118 +611,287 @@ class ReactionComponentsTest {
         composeTestRule.onNodeWithText("non-existent").assertDoesNotExist()
     }
 
-    // ========== calculateMessageScaleForOverlay TESTS ==========
+    // ========== calculateOverlayLayout TESTS (off-screen context menu on very long messages) ==========
 
-    // Common UI dimensions for tests (in pixels, simulating a typical phone at 3x density)
-    private val testDimensions =
+    // Realistic modern phone: 480dp x 1040dp at 3x density = 1440 x 3120 px.
+    private val phoneDimensions =
         OverlayLayoutDimensions(
-            screenHeight = 2400f, // ~800dp at 3x density
-            emojiBarHeight = 168f, // 56dp at 3x density
-            emojiBarGap = 228f, // 76dp at 3x density
-            actionButtonsHeight = 168f, // 56dp at 3x density
-            actionButtonsGap = 36f, // 12dp at 3x density
-            topPadding = 144f, // 48dp at 3x density
-            bottomPadding = 144f, // 48dp at 3x density
+            screenHeight = 3120f, // 1040dp
+            emojiBarHeight = 168f, // 56dp
+            emojiBarGap = 228f, // 76dp
+            actionButtonsHeight = 168f, // 56dp
+            actionButtonsGap = 36f, // 12dp
+            topPadding = 144f, // 48dp
+            bottomPadding = 144f, // 48dp
         )
 
     @Test
-    fun `calculateMessageScaleForOverlay returns 1f for small message that fits on screen`() {
-        val scale =
-            calculateMessageScaleForOverlay(
-                messageHeight = 300, // Small message
-                dimensions = testDimensions,
-            )
+    fun `overlay layout keeps a small message centered with bars adjacent`() {
+        val layout = calculateOverlayLayout(100, phoneDimensions)
 
-        assertEquals(1f, scale, 0.001f)
+        // Small message: centered, emoji bar 76dp above it, buttons 12dp below.
+        assertFalse("Small message should not use the pinned overflow layout", layout.isOverflow)
+        assertTrue(layout.fitsOnScreen(phoneDimensions))
+        assertEquals(1560f - 50f, layout.messageFinalY, 0.5f)
+        assertEquals(100f, layout.messageContainerHeight, 0.5f)
+        assertEquals(layout.messageFinalY - 228f, layout.emojiBarY, 0.5f)
+        assertEquals(layout.messageFinalY + 100f + 36f, layout.actionButtonsY, 0.5f)
+        assertFalse("Uncapped message should not need to scroll", layout.messageScrollable)
     }
 
     @Test
-    fun `calculateMessageScaleForOverlay returns scale less than 1 for large message`() {
-        // Available height = 2400 - 144 - 144 = 2112
-        // UI elements = 168 + 228 + 36 + 168 = 600
-        // Max message height = 2112 - 600 = 1512
-        // For a 2000px message, scale should be 1512/2000 = 0.756
-        val scale =
-            calculateMessageScaleForOverlay(
-                messageHeight = 2000, // Large message
-                dimensions = testDimensions,
-            )
+    fun `overlay layout pins bars and scales the preview to fit for a long message`() {
+        // A very long text bubble, taller than the space between the bars.
+        val layout = calculateOverlayLayout(4000, phoneDimensions)
 
-        assertTrue("Scale should be less than 1 for large message", scale < 1f)
-        assertTrue("Scale should be greater than minScale", scale >= 0.3f)
-        assertEquals(0.756f, scale, 0.01f)
+        assertTrue("Extremely long message should use the pinned overflow layout", layout.isOverflow)
+        assertTrue("Emoji bar and action buttons must both be fully on screen", layout.fitsOnScreen(phoneDimensions))
+        // Pinned to the safe-area edges.
+        assertEquals(144f, layout.emojiBarY, 0.5f)
+        assertEquals(3120f - 144f - 168f, layout.actionButtonsY, 0.5f)
+        // The preview is scaled down so the whole thing fits between the bars.
+        // viewport = (3120 - 144 - 144) - 168 - 168 - 2 * 36 = 2424; 2424 / 4000 = 0.606.
+        val viewport = 2424f
+        assertTrue("Long message should be scaled to fit, not scrolled", !layout.messageScrollable)
+        assertEquals(2424f / 4000f, layout.previewScale, 0.005f)
+        assertEquals(4000f * (2424f / 4000f), layout.scaledPreviewHeight, 1.0f)
+        // The scaled preview must sit inside the viewport between the bars.
+        assertTrue("Message top must be just below the emoji bar", layout.messageFinalY >= layout.emojiBarY + 168f)
+        assertTrue("Scaled preview must fit inside the viewport", layout.scaledPreviewHeight <= viewport + 0.5f)
+        assertTrue("Action buttons must end at or above the bottom edge", layout.actionButtonsY + 168f <= 3120f)
+        assertTrue("Emoji bar must start at or below the top edge", layout.emojiBarY >= 0f)
     }
 
     @Test
-    fun `calculateMessageScaleForOverlay respects minimum scale for very large message`() {
-        val scale =
-            calculateMessageScaleForOverlay(
-                messageHeight = 10000, // Very large message
-                dimensions = testDimensions,
-            )
+    fun `overlay layout message is scrollable only when the scaled preview still overflows`() {
+        val small = calculateOverlayLayout(100, phoneDimensions)
+        assertFalse("Uncapped message should not be scrollable", small.messageScrollable)
+        assertEquals(1f, small.previewScale, 0.001f)
 
-        assertEquals("Scale should be clamped to minScale", 0.3f, scale, 0.001f)
+        // 4000px scales to fit (0.604 > 0.35 floor) - no scroll needed.
+        val scaledToFit = calculateOverlayLayout(4000, phoneDimensions)
+        assertFalse("Message that fits after scaling should not be scrollable", scaledToFit.messageScrollable)
+
+        // 6000px: fit scale 2424/6000 = 0.404 -> still above the floor, fits.
+        val nearFloor = calculateOverlayLayout(6000, phoneDimensions)
+        assertEquals(2424f / 6000f, nearFloor.previewScale, 0.005f)
+        assertFalse(nearFloor.messageScrollable)
+
+        // 9000px: fit scale 2424/9000 = 0.269 -> clamped to the 0.35 floor, so the
+        // scaled preview (3150px) still overflows the 2424px viewport and scrolls.
+        val capped = calculateOverlayLayout(9000, phoneDimensions)
+        assertEquals(OVERLAY_MIN_PREVIEW_SCALE, capped.previewScale, 0.0001f)
+        assertTrue("Message at the scale floor should be scrollable", capped.messageScrollable)
+        assertTrue(capped.scaledPreviewHeight > capped.messageContainerHeight)
     }
 
     @Test
-    fun `calculateMessageScaleForOverlay returns 1f for zero height message`() {
-        val scale =
-            calculateMessageScaleForOverlay(
-                messageHeight = 0,
-                dimensions = testDimensions,
-            )
-
-        assertEquals(1f, scale, 0.001f)
+    fun `overlay layout never scales below the minimum legible scale`() {
+        // Even for a message absurdly taller than any capture cap allows, the
+        // scale never drops below the legibility floor.
+        val layout = calculateOverlayLayout(100_000, phoneDimensions)
+        assertTrue(layout.isOverflow)
+        assertEquals(OVERLAY_MIN_PREVIEW_SCALE, layout.previewScale, 0.0001f)
+        assertTrue(layout.messageScrollable)
+        assertTrue(layout.fitsOnScreen(phoneDimensions))
     }
 
     @Test
-    fun `calculateMessageScaleForOverlay returns 1f for negative height message`() {
-        val scale =
-            calculateMessageScaleForOverlay(
-                messageHeight = -100,
-                dimensions = testDimensions,
-            )
+    fun `overlay layout fits a message that is large but fits centered`() {
+        // available = 2824, UI elements = 600 -> max centered message = 2224px
+        val layout = calculateOverlayLayout(2224, phoneDimensions)
 
-        assertEquals(1f, scale, 0.001f)
+        assertFalse("Message that exactly fits centered should not overflow", layout.isOverflow)
+        assertTrue(layout.fitsOnScreen(phoneDimensions))
+        assertFalse(layout.messageScrollable)
     }
 
     @Test
-    fun `calculateMessageScaleForOverlay with custom minScale`() {
-        val customMinScale = 0.5f
-        val scale =
-            calculateMessageScaleForOverlay(
-                messageHeight = 10000, // Very large message
-                dimensions = testDimensions,
-                minScale = customMinScale,
-            )
+    fun `overlay layout treats zero and negative message heights as non-overflow`() {
+        val zero = calculateOverlayLayout(0, phoneDimensions)
+        assertFalse(zero.isOverflow)
+        assertTrue(zero.fitsOnScreen(phoneDimensions))
 
-        assertEquals("Scale should be clamped to custom minScale", customMinScale, scale, 0.001f)
+        val negative = calculateOverlayLayout(-50, phoneDimensions)
+        assertFalse(negative.isOverflow)
+        assertTrue(negative.fitsOnScreen(phoneDimensions))
+    }
+
+    // ========== ReactionModeOverlay on-screen context menu TESTS ==========
+
+    // A message taller than the test screen: long-pressing it must still show the
+    // emoji bar and action buttons fully on screen (the reported bug: the context
+    // menu went off screen for extremely long messages).
+    private val oversizedMessageHeight = 100_000
+
+    /**
+     * Asserts the full context menu (emoji bar + every action button) is laid out
+     * completely within the screen. Bounds-based (not assertIsDisplayed) so it
+     * catches bars that exist in the tree but are offset off screen - the exact
+     * symptom of the reported bug. The screen rectangle is read from the root
+     * node's bounds so the check is independent of the test screen's density.
+     */
+    private fun assertContextMenuOnScreen() {
+        val screen =
+            composeTestRule
+                .onNode(isRoot())
+                .fetchSemanticsNode()
+                .boundsInRoot
+
+        // Emoji bar: the first quick reaction must be fully on screen.
+        val emojiBounds =
+            composeTestRule
+                .onNodeWithText("\uD83D\uDC4D")
+                .fetchSemanticsNode()
+                .boundsInRoot
+        assertTrue("Emoji bar must start at or below top (screen=$screen): $emojiBounds", emojiBounds.top >= screen.top)
+        assertTrue("Emoji bar must end at or above bottom (screen=$screen): $emojiBounds", emojiBounds.bottom <= screen.bottom)
+
+        // Every action button must be fully on screen.
+        for (label in listOf("Reply", "Copy", "Select text", "Details", "Delete")) {
+            val bounds =
+                composeTestRule
+                    .onNodeWithContentDescription(label)
+                    .fetchSemanticsNode()
+                    .boundsInRoot
+            assertTrue("$label must start at or below top (screen=$screen): $bounds", bounds.top >= screen.top)
+            assertTrue("$label must end at or above bottom (screen=$screen): $bounds", bounds.bottom <= screen.bottom)
+        }
     }
 
     @Test
-    fun `calculateMessageScaleForOverlay with message exactly at boundary`() {
-        // Available height = 2400 - 144 - 144 = 2112
-        // UI elements = 168 + 228 + 36 + 168 = 600
-        // Max message height = 2112 - 600 = 1512
-        val scale =
-            calculateMessageScaleForOverlay(
-                messageHeight = 1512, // Exactly fits
-                dimensions = testDimensions,
-            )
+    fun `reaction overlay keeps the context menu on screen for an extremely long message`() {
+        // Realistic long-press path: the bubble snapshot bitmap is captured.
+        val androidBitmap = android.graphics.Bitmap.createBitmap(300, 2000, android.graphics.Bitmap.Config.ARGB_8888)
+        androidBitmap.eraseColor(0xFF112233.toInt())
+        val messageBitmap = androidBitmap.asImageBitmap()
 
-        assertEquals("Message that exactly fits should have scale 1", 1f, scale, 0.001f)
+        composeTestRule.setContent {
+            MaterialTheme {
+                ReactionModeOverlay(
+                    messageId = "test-message",
+                    isFromMe = true,
+                    isFailed = false,
+                    messageBitmap = messageBitmap,
+                    messageX = 100f,
+                    messageY = 400f,
+                    messageWidth = 300,
+                    messageHeight = oversizedMessageHeight,
+                    onReactionSelected = {},
+                    onShowFullPicker = {},
+                    onReply = {},
+                    onCopy = {},
+                    onSelectText = {},
+                    onViewDetails = {},
+                    onDelete = {},
+                    onDismiss = {},
+                )
+            }
+        }
+
+        assertContextMenuOnScreen()
     }
 
     @Test
-    fun `calculateMessageScaleForOverlay with small screen`() {
-        val smallScreenDimensions = testDimensions.copy(screenHeight = 1200f)
-        val scale =
-            calculateMessageScaleForOverlay(
-                messageHeight = 800,
-                dimensions = smallScreenDimensions,
-            )
+    fun `reaction overlay keeps the context menu on screen when the snapshot bitmap is missing`() {
+        // COLUMBA-20 guard: a recycled/invalid bitmap must not make the whole
+        // context menu disappear.
+        composeTestRule.setContent {
+            MaterialTheme {
+                ReactionModeOverlay(
+                    messageId = "test-message",
+                    isFromMe = false,
+                    isFailed = false,
+                    messageBitmap = null,
+                    messageX = 100f,
+                    messageY = 400f,
+                    messageWidth = 300,
+                    messageHeight = oversizedMessageHeight,
+                    onReactionSelected = {},
+                    onShowFullPicker = {},
+                    onReply = {},
+                    onCopy = {},
+                    onSelectText = {},
+                    onViewDetails = {},
+                    onDelete = {},
+                    onDismiss = {},
+                )
+            }
+        }
 
-        assertTrue("Scale should be less than 1 on small screen", scale < 1f)
-        assertTrue("Scale should be greater than minScale", scale >= 0.3f)
+        assertContextMenuOnScreen()
+    }
+
+    @Test
+    fun `reaction overlay keeps the context menu on screen for a small message`() {
+        val androidBitmap = android.graphics.Bitmap.createBitmap(300, 120, android.graphics.Bitmap.Config.ARGB_8888)
+        androidBitmap.eraseColor(0xFF112233.toInt())
+        val messageBitmap = androidBitmap.asImageBitmap()
+
+        composeTestRule.setContent {
+            MaterialTheme {
+                ReactionModeOverlay(
+                    messageId = "test-message",
+                    isFromMe = true,
+                    isFailed = false,
+                    messageBitmap = messageBitmap,
+                    messageX = 100f,
+                    messageY = 400f,
+                    messageWidth = 300,
+                    messageHeight = 120,
+                    onReactionSelected = {},
+                    onShowFullPicker = {},
+                    onReply = {},
+                    onCopy = {},
+                    onSelectText = {},
+                    onViewDetails = {},
+                    onDelete = {},
+                    onDismiss = {},
+                )
+            }
+        }
+
+        assertContextMenuOnScreen()
+    }
+
+    @Test
+    fun `reaction overlay falls back to message text when the snapshot bitmap is missing`() {
+        // COLUMBA-20 / never-blank: when the snapshot is null the overlay must
+        // still show the message content (truncated) in the preview area instead
+        // of leaving a blank space between the bars.
+        val body = "The quick brown fox jumps over the lazy dog. " + "Repeated content to make the message tall and non-blank. "
+        composeTestRule.setContent {
+            MaterialTheme {
+                ReactionModeOverlay(
+                    messageId = "test-message",
+                    isFromMe = false,
+                    isFailed = false,
+                    messageBitmap = null,
+                    messageX = 100f,
+                    messageY = 400f,
+                    messageWidth = 300,
+                    messageHeight = oversizedMessageHeight,
+                    messageContent = body.repeat(40).trim(),
+                    onReactionSelected = {},
+                    onShowFullPicker = {},
+                    onReply = {},
+                    onCopy = {},
+                    onSelectText = {},
+                    onViewDetails = {},
+                    onDelete = {},
+                    onDismiss = {},
+                )
+            }
+        }
+
+        // The fallback text is composed into the tree (the node holds the whole
+        // repeated string, so match on the prefix). A tall scrollable text node
+        // trips the visible-fraction check, so assertExists proves the fallback
+        // path rendered content rather than leaving the area blank.
+        composeTestRule
+            .onNodeWithText("The quick brown fox jumps over the lazy dog.", substring = true)
+            .assertExists()
+        // The context menu is still fully on screen.
+        assertContextMenuOnScreen()
     }
 }


### PR DESCRIPTION
## Summary

Very tall message snapshots could push the reaction mode overlay's emoji bar and action buttons off screen, or capture as a blank bitmap when exceeding GPU texture limits.

## Changes

- Cap the captured message snapshot at `OVERLAY_MAX_CAPTURE_HEIGHT_PX` (4096px), within the safe texture size on every supported device.
- Replace the single scale factor with a resolved `OverlayLayout`:
  - fitting messages stay centered at full size
  - overflow messages pin the bars to the top and bottom safe areas and shrink the preview to the space between them down to `OVERLAY_MIN_PREVIEW_SCALE` (0.35)
  - the capped preview scrolls internally when it still overflows
- `OverlayLayout.fitsOnScreen()` guarantees the bars and message preview are always fully on screen.

## Verification

- `ReactionComponentsTest`: 45 tests, 0 failures (5 skipped)
- `ktlintCheck`: passed
- `git diff --check`: clean
- Manual E2E on emulator (1080x2400): long-press on a very tall message shows the pinned top reaction bar and bottom action menu, preview visible and scrollable.