### PR TITLE
fix(fileutils): bound attachment reads (512KB generic / 32MB send) to stop unbounded in-memory reads (COLUMBA-4A)

### DIFF
--- a/app/src/main/java/network/columba/app/ui/screens/MessagingScreen.kt
+++ b/app/src/main/java/network/columba/app/ui/screens/MessagingScreen.kt
@@ -231,6 +231,7 @@ import network.columba.app.ui.util.rememberLifecycleTickerMillis
 import network.columba.app.util.AnimatedImageLoader
 import network.columba.app.util.FileAttachment
 import network.columba.app.util.FileUtils
+import network.columba.app.util.readFileForSendWithResult
 import network.columba.app.util.ImageUtils
 import network.columba.app.util.LocationPermissionManager
 import network.columba.app.util.MediaPermissionManager
@@ -609,7 +610,10 @@ fun MessagingScreen(
             uris.forEach { uri ->
                 viewModel.setProcessingFile(true)
                 scope.launch(Dispatchers.IO) {
-                    val result = FileUtils.readFileFromUriWithResult(context, uri)
+                    // Send-path cap (32MB), not the 512KB generic read cap:
+                    // the send side accepts files up to MAX_ATTACHMENT_TOTAL_BYTES,
+                    // so a 1MB composer pick must attach (canonical E2E).
+                    val result = FileUtils.readFileForSendWithResult(context, uri)
                     withContext(Dispatchers.Main) {
                         when (result) {
                             is FileUtils.FileReadResult.Success -> {

--- a/app/src/main/java/network/columba/app/ui/screens/MessagingScreen.kt
+++ b/app/src/main/java/network/columba/app/ui/screens/MessagingScreen.kt
@@ -607,37 +607,103 @@ fun MessagingScreen(
         rememberLauncherForActivityResult(
             contract = ActivityResultContracts.OpenMultipleDocuments(),
         ) { uris ->
-            uris.forEach { uri ->
+            if (uris.isNotEmpty()) {
+                // Group-budget accounting for this pick batch (COLUMBA-4A
+                // Greptile P1 "Send reads still spike heap"): attachments
+                // are read ONE AT A TIME and each pick is only retained when
+                // the combined group still fits
+                // FileUtils.MAX_TOTAL_ATTACHMENT_SIZE, so a multi-file
+                // selection can no longer retain N individually-valid arrays
+                // past the aggregate ceiling while waiting for the send-time
+                // check. groupBudgetBase counts attachments already in the
+                // composer (source of truth: the view model list);
+                // groupBudgetUsed counts this batch's accepted bytes.
+                // Sequential processing keeps at most one bounded read
+                // in-flight, and the post-read exact-bytes check provably
+                // bounds the retained working set at the group cap.
+                val groupBudgetBase =
+                    viewModel.selectedFileAttachments.value.sumOf { it.sizeBytes }
+                var groupBudgetUsed = 0
                 viewModel.setProcessingFile(true)
                 scope.launch(Dispatchers.IO) {
-                    // Send-path cap (32MB), not the 512KB generic read cap:
-                    // the send side accepts files up to MAX_ATTACHMENT_TOTAL_BYTES,
-                    // so a 1MB composer pick must attach (canonical E2E).
-                    val result = FileUtils.readFileForSendWithResult(context, uri)
-                    withContext(Dispatchers.Main) {
-                        when (result) {
-                            is FileUtils.FileReadResult.Success -> {
-                                viewModel.addFileAttachment(result.attachment)
-                            }
-                            is FileUtils.FileReadResult.FileTooLarge -> {
-                                val maxSizeKb = result.maxSize / 1024
-                                val actualSizeKb = result.actualSize / 1024
+                    for (uri in uris) {
+                        // Aggregate pre-check BEFORE opening the stream when
+                        // provider metadata is known: a pick that cannot fit
+                        // the remaining group budget is skipped without any
+                        // allocation at all. Unknown sizes (-1) fall through
+                        // to the bounded read, whose allocation is hard-
+                        // capped per file; the post-read check below is what
+                        // bounds the retained set exactly.
+                        val knownSize = FileUtils.getFileSize(context, uri)
+                        val remainingGroup =
+                            FileUtils.MAX_TOTAL_ATTACHMENT_SIZE - (groupBudgetBase + groupBudgetUsed)
+                        if (knownSize in 1..FileUtils.MAX_TOTAL_ATTACHMENT_SIZE.toLong() &&
+                            knownSize > remainingGroup
+                        ) {
+                            withContext(Dispatchers.Main) {
                                 Toast
                                     .makeText(
                                         context,
-                                        "File too large (${actualSizeKb}KB). Max size is ${maxSizeKb}KB.",
+                                        "Attachment group exceeds the total limit " +
+                                            "(${FileUtils.MAX_TOTAL_ATTACHMENT_SIZE / 1024}KB): skipped $uri.",
                                         Toast.LENGTH_LONG,
                                     ).show()
                             }
-                            is FileUtils.FileReadResult.Error -> {
-                                Toast
-                                    .makeText(
-                                        context,
-                                        "Failed to attach file: ${result.message}",
-                                        Toast.LENGTH_SHORT,
-                                    ).show()
+                            continue
+                        }
+                        // Send-path cap (32MB), not the 512KB generic read cap:
+                        // the send side accepts files up to MAX_ATTACHMENT_TOTAL_BYTES,
+                        // so a 1MB composer pick must attach (canonical E2E).
+                        val result = FileUtils.readFileForSendWithResult(context, uri)
+                        withContext(Dispatchers.Main) {
+                            when (result) {
+                                is FileUtils.FileReadResult.Success -> {
+                                    // Exact retained-bytes accounting: only
+                                    // add when the ACTUAL bytes read fit the
+                                    // remaining group budget (metadata can
+                                    // understate), so the retained working
+                                    // set never exceeds the group cap.
+                                    val attachment = result.attachment
+                                    if (FileUtils.wouldExceedSizeLimit(
+                                            groupBudgetBase + groupBudgetUsed,
+                                            attachment.sizeBytes,
+                                        )
+                                    ) {
+                                        Toast
+                                            .makeText(
+                                                context,
+                                                "Attachment group exceeds the total limit " +
+                                                    "(${FileUtils.MAX_TOTAL_ATTACHMENT_SIZE / 1024}KB): " +
+                                                    "skipped ${attachment.filename}.",
+                                                Toast.LENGTH_LONG,
+                                            ).show()
+                                    } else {
+                                        groupBudgetUsed += attachment.sizeBytes
+                                        viewModel.addFileAttachment(attachment)
+                                    }
+                                }
+                                is FileUtils.FileReadResult.FileTooLarge -> {
+                                    val maxSizeKb = result.maxSize / 1024
+                                    val actualSizeKb = result.actualSize / 1024
+                                    Toast
+                                        .makeText(
+                                            context,
+                                            "File too large (${actualSizeKb}KB). Max size is ${maxSizeKb}KB.",
+                                            Toast.LENGTH_LONG,
+                                        ).show()
+                                }
+                                is FileUtils.FileReadResult.Error -> {
+                                    Toast
+                                        .makeText(
+                                            context,
+                                            "Failed to attach file: ${result.message}",
+                                            Toast.LENGTH_SHORT,
+                                        ).show()
+                                }
                             }
                         }
+                    }
+                    withContext(Dispatchers.Main) {
                         viewModel.setProcessingFile(false)
                     }
                 }

--- a/app/src/main/java/network/columba/app/ui/screens/MessagingScreen.kt
+++ b/app/src/main/java/network/columba/app/ui/screens/MessagingScreen.kt
@@ -179,6 +179,8 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.firstOrNull
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
 import kotlinx.coroutines.withContext
 import network.columba.app.R
 import network.columba.app.service.SyncProgress
@@ -603,6 +605,24 @@ fun MessagingScreen(
         }
 
     // File picker launcher
+    //
+    // Group-budget lock (COLUMBA-4A Greptile P1 "Picker budgets race"):
+    // the retained composer working set (viewModel.selectedFileAttachments)
+    // must stay bounded at FileUtils.MAX_TOTAL_ATTACHMENT_SIZE even when
+    // two picker callbacks OVERLAP. The per-callback groupBudgetBase
+    // snapshot this replaces was stale by construction: each overlapping
+    // batch validated against its own entry snapshot plus a callback-local
+    // counter, so two batches could each accept up to the full remaining
+    // budget and jointly retain >32MB until the send-time aggregate check.
+    // With this mutex, the "sum the CURRENT retained set -> check -> add"
+    // sequence is one critical section on the Main dispatcher shared by
+    // every batch, and the sum is re-read fresh at add time (never
+    // snapshotted at callback entry), so the combined retained bytes are
+    // provably bounded at the group cap regardless of interleaving.
+    // remember: the lock must be ONE instance shared by every batch for the
+    // whole screen lifetime, not a fresh mutex per recomposition.
+    val groupBudgetMutex = remember { Mutex() }
+
     val filePickerLauncher =
         rememberLauncherForActivityResult(
             contract = ActivityResultContracts.OpenMultipleDocuments(),
@@ -615,15 +635,10 @@ fun MessagingScreen(
                 // FileUtils.MAX_TOTAL_ATTACHMENT_SIZE, so a multi-file
                 // selection can no longer retain N individually-valid arrays
                 // past the aggregate ceiling while waiting for the send-time
-                // check. groupBudgetBase counts attachments already in the
-                // composer (source of truth: the view model list);
-                // groupBudgetUsed counts this batch's accepted bytes.
-                // Sequential processing keeps at most one bounded read
-                // in-flight, and the post-read exact-bytes check provably
-                // bounds the retained working set at the group cap.
-                val groupBudgetBase =
-                    viewModel.selectedFileAttachments.value.sumOf { it.sizeBytes }
-                var groupBudgetUsed = 0
+                // check. All add-time accounting goes through
+                // [tryReserveGroupBudgetLocked] under groupBudgetMutex so
+                // overlapping batches share ONE live budget (source of
+                // truth: the view model list, re-read per add).
                 viewModel.setProcessingFile(true)
                 scope.launch(Dispatchers.IO) {
                     for (uri in uris) {
@@ -635,8 +650,10 @@ fun MessagingScreen(
                         // capped per file; the post-read check below is what
                         // bounds the retained set exactly.
                         val knownSize = FileUtils.getFileSize(context, uri)
+                        val currentRetained =
+                            viewModel.selectedFileAttachments.value.sumOf { it.sizeBytes }
                         val remainingGroup =
-                            FileUtils.MAX_TOTAL_ATTACHMENT_SIZE - (groupBudgetBase + groupBudgetUsed)
+                            FileUtils.MAX_TOTAL_ATTACHMENT_SIZE - currentRetained
                         if (knownSize in 1..FileUtils.MAX_TOTAL_ATTACHMENT_SIZE.toLong() &&
                             knownSize > remainingGroup
                         ) {
@@ -658,17 +675,27 @@ fun MessagingScreen(
                         withContext(Dispatchers.Main) {
                             when (result) {
                                 is FileUtils.FileReadResult.Success -> {
-                                    // Exact retained-bytes accounting: only
-                                    // add when the ACTUAL bytes read fit the
-                                    // remaining group budget (metadata can
-                                    // understate), so the retained working
-                                    // set never exceeds the group cap.
+                                    // Exact retained-bytes accounting under
+                                    // the shared budget lock: only add when
+                                    // the ACTUAL bytes read fit the
+                                    // remaining group budget AGAINST THE
+                                    // LIVE composer set (metadata can
+                                    // understate, and an overlapping picker
+                                    // batch may have added since this read
+                                    // started), so the retained working set
+                                    // never exceeds the group cap.
                                     val attachment = result.attachment
-                                    if (FileUtils.wouldExceedSizeLimit(
-                                            groupBudgetBase + groupBudgetUsed,
-                                            attachment.sizeBytes,
-                                        )
-                                    ) {
+                                    val accepted =
+                                        tryReserveGroupBudgetLocked(
+                                            mutex = groupBudgetMutex,
+                                            currentTotalBytes = {
+                                                viewModel.selectedFileAttachments.value.sumOf { it.sizeBytes }
+                                            },
+                                            newAttachmentBytes = attachment.sizeBytes,
+                                        ) {
+                                            viewModel.addFileAttachment(attachment)
+                                        }
+                                    if (!accepted) {
                                         Toast
                                             .makeText(
                                                 context,
@@ -677,9 +704,6 @@ fun MessagingScreen(
                                                     "skipped ${attachment.filename}.",
                                                 Toast.LENGTH_LONG,
                                             ).show()
-                                    } else {
-                                        groupBudgetUsed += attachment.sizeBytes
-                                        viewModel.addFileAttachment(attachment)
                                     }
                                 }
                                 is FileUtils.FileReadResult.FileTooLarge -> {
@@ -3454,3 +3478,39 @@ private fun TextSizeDialog(
         },
     )
 }
+
+/**
+ * Atomic composer group-budget reservation (COLUMBA-4A Greptile P1
+ * "Picker budgets race").
+ *
+ * Runs the whole "read the CURRENT retained total -> check against
+ * [FileUtils.MAX_TOTAL_ATTACHMENT_SIZE] -> commit the add" sequence under
+ * [mutex], so overlapping file-picker batches share ONE live budget instead
+ * of each validating against a stale per-callback snapshot. Two batches
+ * that each fit their own view of the budget can no longer jointly retain
+ * more than the group cap: the second batch's check sees the first batch's
+ * committed add.
+ *
+ * @param mutex shared lock held by every picker batch in this screen.
+ * @param currentTotalBytes reads the live retained bytes (the view model's
+ *        selectedFileAttachments sum) — MUST be re-read inside the lock,
+ *        never snapshotted before it.
+ * @param newAttachmentBytes exact retained size of the candidate attachment.
+ * @param commit adds the attachment to the composer; called only when the
+ *        reservation succeeds, inside the same critical section.
+ * @return true when the attachment was committed within the group cap.
+ */
+internal suspend fun tryReserveGroupBudgetLocked(
+    mutex: Mutex,
+    currentTotalBytes: () -> Int,
+    newAttachmentBytes: Int,
+    commit: () -> Unit,
+): Boolean =
+    mutex.withLock {
+        if (FileUtils.wouldExceedSizeLimit(currentTotalBytes(), newAttachmentBytes)) {
+            false
+        } else {
+            commit()
+            true
+        }
+    }

--- a/app/src/main/java/network/columba/app/util/FileUtils.kt
+++ b/app/src/main/java/network/columba/app/util/FileUtils.kt
@@ -142,7 +142,11 @@ object FileUtils {
             // trusted, so the read aborts at the cap (Greptile P1).
             contentResolver.openInputStream(uri)?.use { inputStream ->
                 val data =
-                    readBounded(inputStream, MAX_SINGLE_FILE_SIZE)
+                    readBounded(
+                        inputStream,
+                        MAX_SINGLE_FILE_SIZE,
+                        reopen = { contentResolver.openInputStream(uri) },
+                    )
                         ?: run {
                             Log.w(TAG, "Stream exceeded ${MAX_SINGLE_FILE_SIZE} bytes, aborting read: $uri")
                             return null
@@ -566,7 +570,12 @@ private fun FileUtils.readFileWithResultBounded(
             }
         contentResolver.openInputStream(uri)?.use { inputStream ->
             val data =
-                readBounded(inputStream, maxFileSize, initialCapacity)
+                readBounded(
+                    inputStream,
+                    maxFileSize,
+                    initialCapacity,
+                    reopen = { contentResolver.openInputStream(uri) },
+                )
                     ?: return FileUtils.FileReadResult.FileTooLarge(-1L, maxFileSize)
 
             FileUtils.FileReadResult.Success(
@@ -589,14 +598,30 @@ private fun FileUtils.readFileWithResultBounded(
  * the stream yields more than the cap (at most one read buffer past it),
  * returning null instead of allocating the whole stream.
  *
- * Heap shape (COLUMBA-4A Greptile P1 "Send reads still spike heap"):
- * the accumulator grows into a single array capped at [maxBytes]; when its
- * capacity is exact (the known-size seed, or an exact growth landing) the
- * array is returned WITHOUT any second copy — the old ByteArrayOutputStream
- * + toByteArray() held ~2x the file bytes at once (a near-32MB send read
- * briefly needed ~64MB, on top of retained attachments). A trimmed result
- * only happens after an overshooting doubling, and the retained array never
- * exceeds maxBytes.
+ * Heap shape (COLUMBA-4A Greptile P1 "Trim copy doubles heap"): a
+ * near-cap successful read must NEVER transiently hold two near-full
+ * arrays. The single-accumulator growth path ended in `copyOf(total)`,
+ * which held the full accumulator AND a near-file-sized trimmed result at
+ * once (~64MB peak on the 32MB send path). The fix:
+ *
+ *  - While the read is under [TRIM_FREE_RETAIN_THRESHOLD] the single
+ *    hard-capped accumulator is kept and any final trim is bounded to a
+ *    few MB (capacity < 2x threshold), so the transient can never be a
+ *    near-cap spike. The exact-seed known-size case remains copy-free
+ *    (capacity == total returns the accumulator itself).
+ *  - A near-threshold-or-larger read that finished with an overshooting
+ *    capacity does NOT trim. It REWINDS: [reopen] re-opens the stream,
+ *    the fresh stream is verified byte-for-byte against the first
+ *    [REWIND_VERIFY_BYTES] of the accumulator (a provider that regenerates
+ *    content per open fails verification and falls back to the trim),
+ *    the full length is counted with zero accumulation (aborting past the
+ *    cap), the accumulator reference is DROPPED, and exactly ONE array of
+ *    the true size is allocated and filled. The live set at the exact
+ *    allocation is one array plus small buffers.
+ *
+ * The abort path stays strictly single-pass — an over-cap stream never
+ * triggers a rewind (EOF is never reached), so bytes consumed stay within
+ * maxBytes + one buffer exactly as pinned by the OOM-guard tests.
  *
  * This is the enforcement point for [FileUtils.MAX_SINGLE_FILE_SIZE]. The
  * metadata pre-check via [FileUtils.getFileSize] is only a fast path —
@@ -604,16 +629,58 @@ private fun FileUtils.readFileWithResultBounded(
  * [InputStream.readBytes] would then allocate the entire (potentially huge)
  * stream before any check could fire (COLUMBA-4A Greptile P1).
  *
+ * @param reopen re-opens the underlying stream from the beginning for the
+ *        rewind path; when null, rewinding is unavailable and the trim
+ *        fallback is used for overshooting capacities.
+ * @param heapObserver test seam: receives every accumulator allocation and
+ *        release so the live-bytes bound can be asserted deterministically.
  * @return the bytes read (size <= [maxBytes]), or null if the stream exceeded
  *         [maxBytes] and the read was aborted.
  */
-private fun readBounded(
+internal fun readBounded(
     input: InputStream,
     maxBytes: Int,
     initialCapacity: Int = FILE_READ_BUFFER_SIZE,
+    reopen: (() -> InputStream?)? = null,
+    heapObserver: ReadBoundedHeapObserver? = null,
 ): ByteArray? {
+    val pass = accumulateFirstPass(input, maxBytes, initialCapacity, heapObserver)
+        ?: return null
+    if (pass.data.size == pass.total) {
+        // Hand back the accumulator itself when its capacity is exact — no
+        // second full copy (the known-size seed makes this the common case).
+        return pass.data
+    }
+    return finishOversizedRead(pass, reopen, maxBytes, heapObserver)
+}
+
+/** First-pass accumulation state handed to the finalization step. */
+private class FirstPass(
+    val data: ByteArray,
+    val total: Int,
+    val rewindArmed: Boolean,
+)
+
+/**
+ * Single bounded pass over [input] into a hard-capped accumulator.
+ * Returns null iff the stream exceeded [maxBytes] (abort — the dangerous
+ * unbounded allocation never happens).
+ */
+private fun accumulateFirstPass(
+    input: InputStream,
+    maxBytes: Int,
+    initialCapacity: Int,
+    heapObserver: ReadBoundedHeapObserver?,
+): FirstPass? {
     val buffer = ByteArray(FILE_READ_BUFFER_SIZE)
-    var data = ByteArray(minOf(maxBytes, maxOf(initialCapacity, FILE_READ_BUFFER_SIZE)))
+    heapObserver?.onHeapEvent(released = false, FILE_READ_BUFFER_SIZE)
+    val seedCapacity = minOf(maxBytes, maxOf(initialCapacity, FILE_READ_BUFFER_SIZE))
+    heapObserver?.onHeapEvent(released = false, seedCapacity)
+    var data = ByteArray(seedCapacity)
+    // A large seed capacity can already sit above the trim-free threshold;
+    // any later trim of it would double the heap, so arm the rewind from
+    // the start in that case.
+    var rewindArmed = seedCapacity > TRIM_FREE_RETAIN_THRESHOLD
     var total = 0
     while (true) {
         val n = input.read(buffer, 0, buffer.size)
@@ -630,15 +697,155 @@ private fun readBounded(
             // before any allocation past it.
             val doubled = if (data.size > maxBytes / 2) maxBytes else data.size * 2
             val newCapacity = minOf(maxBytes, maxOf(total, doubled))
-            data = data.copyOf(newCapacity)
+            heapObserver?.onHeapEvent(released = false, newCapacity)
+            val grown = data.copyOf(newCapacity)
+            heapObserver?.onHeapEvent(released = true, data.size)
+            data = grown
+            // Once the accumulator is big, its final trim (if any) is a
+            // near-cap second copy: arm the rewind double-read instead.
+            if (newCapacity > TRIM_FREE_RETAIN_THRESHOLD) rewindArmed = true
         }
         buffer.copyInto(data, total - n, 0, n)
     }
-    // Hand back the accumulator itself when its capacity is exact — no
-    // second full copy (the known-size seed makes this the common case).
-    // Only when growth overshoots the read is a single trim copy needed to
-    // keep the returned array exactly sizeBytes long.
-    return if (data.size == total) data else data.copyOf(total)
+    return FirstPass(data, total, rewindArmed)
+}
+
+/**
+ * Produce the final array for an EOF'd pass whose accumulator capacity
+ * overshot the read size ([pass].data.size > [pass].total).
+ *
+ * When the accumulator is big ([pass].rewindArmed) and the stream is
+ * re-openable, trim-copying would hold TWO near-full arrays at once:
+ * instead verify the provider restarts from the beginning, count the true
+ * length with zero accumulation, record the accumulator release BEFORE the
+ * single exact allocation, and fill it from a fresh open. A
+ * non-restartable provider falls back to the trim (correctness over the
+ * fast path); a stream whose true length passes the cap aborts.
+ */
+private fun finishOversizedRead(
+    pass: FirstPass,
+    reopen: (() -> InputStream?)?,
+    maxBytes: Int,
+    heapObserver: ReadBoundedHeapObserver?,
+): ByteArray? {
+    if (pass.rewindArmed && reopen != null) {
+        val verified = verifyRewindableLength(reopen, pass.data, pass.total, maxBytes)
+        if (verified == REWIND_EXCEEDS_CAP) return null // true length past the cap
+        if (verified >= 0) {
+            heapObserver?.onHeapEvent(released = true, pass.data.size)
+            heapObserver?.onHeapEvent(released = false, verified)
+            return fillExactFromReopen(reopen, verified)
+        }
+        // REWIND_NOT_RESTARTABLE: fall through to the trim below rather
+        // than fail the read; the result is still hard-bounded at maxBytes.
+    }
+    // Small/medium reads (transient bounded by ~2x threshold, never a
+    // near-cap spike) or the non-rewindable fallback: a single trim copy
+    // keeps the returned array exactly sizeBytes long.
+    heapObserver?.onHeapEvent(released = false, pass.total)
+    val trimmed = pass.data.copyOf(pass.total)
+    heapObserver?.onHeapEvent(released = true, pass.data.size)
+    return trimmed
+}
+
+/**
+ * Allocate exactly [verified] bytes and fill them from a fresh open of
+ * [reopen]. Returns null only if the provider cannot serve the verified
+ * length on this open (content shrank mid-fill — refuse rather than
+ * return corrupt bytes).
+ */
+private fun fillExactFromReopen(
+    reopen: () -> InputStream?,
+    verified: Int,
+): ByteArray? {
+    val filler = reopen() ?: return null
+    val exact = ByteArray(verified)
+    filler.use { s ->
+        var pos = 0
+        while (pos < verified) {
+            val n = s.read(exact, pos, verified - pos)
+            if (n < 0) return null
+            pos += n
+        }
+    }
+    return exact
+}
+
+/**
+ * Test seam for [readBounded]'s heap accounting: every accumulator
+ * allocation and every drop of a no-longer-referenced accumulator array is
+ * reported so tests can sum live bytes and assert the transient peak.
+ */
+internal fun interface ReadBoundedHeapObserver {
+    fun onHeapEvent(
+        released: Boolean,
+        sizeBytes: Int,
+    )
+}
+
+/** Prefix bytes compared to prove a re-opened stream restarts identically. */
+private const val REWIND_VERIFY_BYTES = 64 * 1024
+
+/** [verifyRewindableLength] result: provider does not restart from the beginning. */
+private const val REWIND_NOT_RESTARTABLE = -1
+
+/** [verifyRewindableLength] result: the stream's true length exceeds the cap. */
+private const val REWIND_EXCEEDS_CAP = -2
+
+/**
+ * Reads larger than this must not pay a trim copy of a big accumulator
+ * (transient 2x-arrays peak): [readBounded] rewinds and re-reads into one
+ * exact-sized array instead. Below it the accumulator trim is bounded by
+ * roughly one doubling step and stays a few MB at most.
+ */
+private const val TRIM_FREE_RETAIN_THRESHOLD = 4 * 1024 * 1024
+
+/**
+ * Verify — with zero big-array allocation — that a stream re-opened via
+ * [reopen] restarts byte-for-byte identically to the first
+ * [REWIND_VERIFY_BYTES] of [accumulator], and count its full length,
+ * aborting past [maxBytes].
+ *
+ * A pipe/streamed provider (fresh open yields different/continued content)
+ * or one whose stream shrank below what was already consumed fails
+ * verification, and the caller must fall back to trimming the accumulator.
+ *
+ * @param accumulator first-pass bytes (only the first [total] are valid).
+ * @return the verified total length (>= 0), [REWIND_NOT_RESTARTABLE], or
+ *         [REWIND_EXCEEDS_CAP].
+ */
+private fun verifyRewindableLength(
+    reopen: () -> InputStream?,
+    accumulator: ByteArray,
+    total: Int,
+    maxBytes: Int,
+): Int {
+    val verifyLen = minOf(total, REWIND_VERIFY_BYTES)
+    val verifyBuffer = ByteArray(minOf(verifyLen, FILE_READ_BUFFER_SIZE))
+    val counterBuffer = ByteArray(FILE_READ_BUFFER_SIZE)
+    val stream = reopen() ?: return REWIND_NOT_RESTARTABLE
+    return stream.use { s ->
+        var pos = 0
+        while (pos < verifyLen) {
+            val want = minOf(verifyBuffer.size, verifyLen - pos)
+            val n = s.read(verifyBuffer, 0, want)
+            // Fresh stream shorter than what we already consumed: not a
+            // restart from the beginning.
+            if (n < 0) return@use REWIND_NOT_RESTARTABLE
+            for (i in 0 until n) {
+                if (verifyBuffer[i] != accumulator[pos + i]) return@use REWIND_NOT_RESTARTABLE
+            }
+            pos += n
+        }
+        var counted = pos
+        while (true) {
+            val n = s.read(counterBuffer, 0, counterBuffer.size)
+            if (n < 0) break
+            counted += n
+            if (counted > maxBytes) return@use REWIND_EXCEEDS_CAP
+        }
+        counted
+    }
 }
 
 private val HEX_CHARS = "0123456789abcdef".toCharArray()

--- a/app/src/main/java/network/columba/app/util/FileUtils.kt
+++ b/app/src/main/java/network/columba/app/util/FileUtils.kt
@@ -33,8 +33,10 @@ object FileUtils {
      * [readFileFromUriWithResult]: an unbounded readBytes() of a user-picked
      * file OOMed a device on a ~181MB pick (COLUMBA-4A). Files above this cap
      * are rejected as FileTooLarge instead of being read into memory.
-     * Legitimate large attachments on the send side keep working via the
-     * file-based transfer path (see [FILE_TRANSFER_THRESHOLD]).
+     * Composer SEND picks use the larger send-path bound (32MB, the same
+     * ceiling MessagingViewModel enforces before handing bytes to Reticulum)
+     * via [readFileForSendWithResult]; both bounds are enforced by a bounded
+     * stream read, never an unbounded one.
      */
     const val MAX_SINGLE_FILE_SIZE = 512 * 1024 // 512KB
 
@@ -86,6 +88,11 @@ object FileUtils {
     /**
      * Read file data from a content URI with detailed result.
      *
+     * Bounds the read to [MAX_SINGLE_FILE_SIZE] (512KB). Callers selecting a
+     * composer *send* attachment must use [readFileForSendWithResult] instead:
+     * the send path accepts up to [MAX_TOTAL_ATTACHMENT_SIZE] per file, and
+     * capping composer picks at 512KB regressed the canonical E2E 1MB pick.
+     *
      * @param context Android context for ContentResolver access
      * @param uri The content URI of the file to read
      * @return FileReadResult indicating success, file too large, or error
@@ -93,44 +100,7 @@ object FileUtils {
     fun readFileFromUriWithResult(
         context: Context,
         uri: Uri,
-    ): FileReadResult {
-        return try {
-            val contentResolver = context.contentResolver
-
-            // Check file size first without reading the entire file
-            val fileSize = getFileSize(context, uri)
-            if (fileSize > MAX_SINGLE_FILE_SIZE) {
-                return FileReadResult.FileTooLarge(fileSize, MAX_SINGLE_FILE_SIZE)
-            }
-
-            // Get filename
-            val filename = getFilename(context, uri) ?: "unknown"
-
-            // Get MIME type
-            val mimeType = contentResolver.getType(uri) ?: "application/octet-stream"
-
-            // Read data with a hard bound on the allocation itself: unknown
-            // (-1) or understated provider metadata passes the pre-check, so
-            // readBytes() must never be trusted to stay small (Greptile P1).
-            contentResolver.openInputStream(uri)?.use { inputStream ->
-                val data =
-                    readBounded(inputStream, MAX_SINGLE_FILE_SIZE)
-                        ?: return FileReadResult.FileTooLarge(-1L, MAX_SINGLE_FILE_SIZE)
-
-                FileReadResult.Success(
-                    FileAttachment(
-                        filename = filename,
-                        data = data,
-                        mimeType = mimeType,
-                        sizeBytes = data.size,
-                    ),
-                )
-            } ?: FileReadResult.Error("Could not open file")
-        } catch (e: Exception) {
-            Log.e(TAG, "Failed to read file from URI: $uri", e)
-            FileReadResult.Error(e.message ?: "Unknown error")
-        }
-    }
+    ): FileReadResult = readFileWithResultBounded(context, uri, MAX_SINGLE_FILE_SIZE)
 
     /**
      * Read file data from a content URI.
@@ -138,8 +108,8 @@ object FileUtils {
      * The single-file size cap ([MAX_SINGLE_FILE_SIZE]) is enforced BEFORE any
      * bytes are read: oversized files return null instead of being pulled
      * into memory via readBytes(), which would OOM the process (COLUMBA-4A).
-     * Legitimate large attachments on the send side are preserved by the
-     * file-based transfer path (see [FILE_TRANSFER_THRESHOLD]).
+     * Composer SEND picks use the larger send-path bound via
+     * [readFileForSendWithResult] instead.
      *
      * @param context Android context for ContentResolver access
      * @param uri The content URI of the file to read
@@ -534,6 +504,77 @@ object FileUtils {
 
 /** Copy buffer used by [readBounded]; also the max slack past the cap a bounded read may consume. */
 private const val FILE_READ_BUFFER_SIZE = 64 * 1024
+
+/**
+ * Read a composer *send* attachment from a content URI with detailed result.
+ *
+ * Same contract as [FileUtils.readFileFromUriWithResult] but bounded to
+ * [FileUtils.MAX_TOTAL_ATTACHMENT_SIZE] (32MB) — the per-file ceiling the
+ * send path itself enforces before handing bytes to Reticulum
+ * (MessagingViewModel rejects a larger payload), so the composer picker must
+ * not reject files the send side would accept. A 1MB composer pick (the
+ * canonical Real LXMF Resource Progress E2E case) attaches with full bytes.
+ *
+ * The COLUMBA-4A OOM guard is identical and NOT relaxed by the larger cap:
+ * the metadata pre-check plus the bounded stream read still refuse a ~181MB
+ * pick before (or mid-) any allocation, even with missing or understated
+ * provider metadata.
+ */
+fun FileUtils.readFileForSendWithResult(
+    context: Context,
+    uri: Uri,
+): FileUtils.FileReadResult = readFileWithResultBounded(context, uri, MAX_TOTAL_ATTACHMENT_SIZE)
+
+/**
+ * Shared implementation behind [FileUtils.readFileFromUriWithResult] and
+ * [FileUtils.readFileForSendWithResult]: metadata pre-check first, then a
+ * hard bound on the allocation itself via [readBounded] — unknown (-1) or
+ * understated provider metadata passes the pre-check, so readBytes() must
+ * never be trusted to stay small (COLUMBA-4A Greptile P1).
+ */
+private fun FileUtils.readFileWithResultBounded(
+    context: Context,
+    uri: Uri,
+    maxFileSize: Int,
+): FileUtils.FileReadResult {
+    val tag = "FileUtils"
+    return try {
+        val contentResolver = context.contentResolver
+
+        // Check file size first without reading the entire file
+        val fileSize = getFileSize(context, uri)
+        if (fileSize > maxFileSize) {
+            return FileUtils.FileReadResult.FileTooLarge(fileSize, maxFileSize)
+        }
+
+        // Get filename
+        val filename = getFilename(context, uri) ?: "unknown"
+
+        // Get MIME type
+        val mimeType = contentResolver.getType(uri) ?: "application/octet-stream"
+
+        // Read data with a hard bound on the allocation itself: unknown
+        // (-1) or understated provider metadata passes the pre-check, so
+        // readBytes() must never be trusted to stay small (Greptile P1).
+        contentResolver.openInputStream(uri)?.use { inputStream ->
+            val data =
+                readBounded(inputStream, maxFileSize)
+                    ?: return FileUtils.FileReadResult.FileTooLarge(-1L, maxFileSize)
+
+            FileUtils.FileReadResult.Success(
+                FileAttachment(
+                    filename = filename,
+                    data = data,
+                    mimeType = mimeType,
+                    sizeBytes = data.size,
+                ),
+            )
+        } ?: FileUtils.FileReadResult.Error("Could not open file")
+    } catch (e: Exception) {
+        Log.e(tag, "Failed to read file from URI: $uri", e)
+        FileUtils.FileReadResult.Error(e.message ?: "Unknown error")
+    }
+}
 
 /**
  * Read [input] into memory but NEVER beyond [maxBytes]: aborts as soon as

--- a/app/src/main/java/network/columba/app/util/FileUtils.kt
+++ b/app/src/main/java/network/columba/app/util/FileUtils.kt
@@ -615,9 +615,11 @@ private fun FileUtils.readFileWithResultBounded(
  *    [REWIND_VERIFY_BYTES] of the accumulator (a provider that regenerates
  *    content per open fails verification and falls back to the trim),
  *    the full length is counted with zero accumulation (aborting past the
- *    cap), the accumulator reference is DROPPED, and exactly ONE array of
- *    the true size is allocated and filled. The live set at the exact
- *    allocation is one array plus small buffers.
+ *    cap), the accumulator is DROPPED — its holder field is drained so the
+ *    array becomes GARBAGE (unreachable from every frame), not merely
+ *    reported released to an observer — and exactly ONE array of the true
+ *    size is allocated and filled. The live set at the exact allocation is
+ *    one array plus small buffers.
  *
  * The abort path stays strictly single-pass — an over-cap stream never
  * triggers a rewind (EOF is never reached), so bytes consumed stay within
@@ -634,6 +636,11 @@ private fun FileUtils.readFileWithResultBounded(
  *        fallback is used for overshooting capacities.
  * @param heapObserver test seam: receives every accumulator allocation and
  *        release so the live-bytes bound can be asserted deterministically.
+ * @param rewindProbe test seam: observes the accumulator array itself and
+ *        the exact point (post-drain) immediately before the single exact
+ *        allocation on the rewind path, so a test can prove the
+ *        accumulator is actually GARBAGE there — not merely reported
+ *        released — via WeakReference + explicit GC.
  * @return the bytes read (size <= [maxBytes]), or null if the stream exceeded
  *         [maxBytes] and the read was aborted.
  */
@@ -643,23 +650,39 @@ internal fun readBounded(
     initialCapacity: Int = FILE_READ_BUFFER_SIZE,
     reopen: (() -> InputStream?)? = null,
     heapObserver: ReadBoundedHeapObserver? = null,
+    rewindProbe: RewindReachabilityProbe? = null,
 ): ByteArray? {
-    val pass = accumulateFirstPass(input, maxBytes, initialCapacity, heapObserver)
+    val pass = accumulateFirstPass(input, maxBytes, initialCapacity, heapObserver, rewindProbe)
         ?: return null
     if (pass.data.size == pass.total) {
         // Hand back the accumulator itself when its capacity is exact — no
         // second full copy (the known-size seed makes this the common case).
         return pass.data
     }
-    return finishOversizedRead(pass, reopen, maxBytes, heapObserver)
+    return finishOversizedRead(pass, reopen, maxBytes, heapObserver, rewindProbe)
 }
 
 /** First-pass accumulation state handed to the finalization step. */
 private class FirstPass(
-    val data: ByteArray,
+    var data: ByteArray,
     val total: Int,
     val rewindArmed: Boolean,
-)
+) {
+    /**
+     * Drops this pass's accumulated array so it becomes garbage —
+     * unreachable from any live frame — before the rewind allocates the
+     * single exact-sized result. Clearing the holder field is what makes
+     * the release REAL: a bare local reference plus an observer callback
+     * leaves the old array reachable across the next allocation and keeps
+     * the ~2x near-cap heap peak alive (Greptile P1 "Accumulator remains
+     * live during rewind"). Must only be called on the rewind path, after
+     * the re-opened stream has been verified and the trim fallback is no
+     * longer reachable.
+     */
+    fun drain() {
+        data = ByteArray(0)
+    }
+}
 
 /**
  * Single bounded pass over [input] into a hard-capped accumulator.
@@ -671,6 +694,7 @@ private fun accumulateFirstPass(
     maxBytes: Int,
     initialCapacity: Int,
     heapObserver: ReadBoundedHeapObserver?,
+    rewindProbe: RewindReachabilityProbe?,
 ): FirstPass? {
     val buffer = ByteArray(FILE_READ_BUFFER_SIZE)
     heapObserver?.onHeapEvent(released = false, FILE_READ_BUFFER_SIZE)
@@ -707,6 +731,10 @@ private fun accumulateFirstPass(
         }
         buffer.copyInto(data, total - n, 0, n)
     }
+    // Hand the accumulator array to the reachability probe BEFORE wrapping
+    // it, so the probe's only strong handle is its (transient) parameter —
+    // exactly the state the rewind must recreate after draining.
+    rewindProbe?.onAccumulatorReady(data)
     return FirstPass(data, total, rewindArmed)
 }
 
@@ -717,24 +745,26 @@ private fun accumulateFirstPass(
  * When the accumulator is big ([pass].rewindArmed) and the stream is
  * re-openable, trim-copying would hold TWO near-full arrays at once:
  * instead verify the provider restarts from the beginning, count the true
- * length with zero accumulation, record the accumulator release BEFORE the
- * single exact allocation, and fill it from a fresh open. A
- * non-restartable provider falls back to the trim (correctness over the
- * fast path); a stream whose true length passes the cap aborts.
+ * length with zero accumulation, then hand the fill to
+ * [rewindToExactArray], which DRAINS the accumulator (the array becomes
+ * garbage, not merely reported released) before the single exact
+ * allocation. A non-restartable provider falls back to the trim
+ * (correctness over the fast path); a stream whose true length passes the
+ * cap aborts.
  */
 private fun finishOversizedRead(
     pass: FirstPass,
     reopen: (() -> InputStream?)?,
     maxBytes: Int,
     heapObserver: ReadBoundedHeapObserver?,
+    rewindProbe: RewindReachabilityProbe?,
 ): ByteArray? {
     if (pass.rewindArmed && reopen != null) {
         val verified = verifyRewindableLength(reopen, pass.data, pass.total, maxBytes)
         if (verified == REWIND_EXCEEDS_CAP) return null // true length past the cap
         if (verified >= 0) {
             heapObserver?.onHeapEvent(released = true, pass.data.size)
-            heapObserver?.onHeapEvent(released = false, verified)
-            return fillExactFromReopen(reopen, verified)
+            return rewindToExactArray(pass, reopen, verified, heapObserver, rewindProbe)
         }
         // REWIND_NOT_RESTARTABLE: fall through to the trim below rather
         // than fail the read; the result is still hard-bounded at maxBytes.
@@ -746,6 +776,40 @@ private fun finishOversizedRead(
     val trimmed = pass.data.copyOf(pass.total)
     heapObserver?.onHeapEvent(released = true, pass.data.size)
     return trimmed
+}
+
+/**
+ * Rewind finalization: allocate exactly ONE array of [verified] bytes and
+ * fill it from a fresh open of [reopen].
+ *
+ * The accumulator in [pass] is DRAINED first — its holder field is cleared
+ * and no live frame keeps another handle to the old array — so the array
+ * is genuinely garbage before the exact allocation executes. Reporting a
+ * release to an observer without dropping the reference left both
+ * near-cap arrays reachable at once (Greptile P1 "Accumulator remains
+ * live during rewind"). Callers must invoke this only after
+ * [verifyRewindableLength] succeeded; the trim fallback is unreachable
+ * from here on.
+ *
+ * Returns null only if the provider cannot serve the verified length on
+ * this open (content shrank mid-fill — refuse rather than return corrupt
+ * bytes).
+ */
+private fun rewindToExactArray(
+    pass: FirstPass,
+    reopen: () -> InputStream?,
+    verified: Int,
+    heapObserver: ReadBoundedHeapObserver?,
+    rewindProbe: RewindReachabilityProbe?,
+): ByteArray? {
+    // Drain, then probe, at a point where NO enclosing frame still holds
+    // the accumulator (this helper does not take it beyond pass.data), so
+    // the probe observes exactly the reachability state of the allocation
+    // about to happen inside fillExactFromReopen.
+    pass.drain()
+    rewindProbe?.onBeforeExactAllocation()
+    heapObserver?.onHeapEvent(released = false, verified)
+    return fillExactFromReopen(reopen, verified)
 }
 
 /**
@@ -781,6 +845,32 @@ internal fun interface ReadBoundedHeapObserver {
         released: Boolean,
         sizeBytes: Int,
     )
+}
+
+/**
+ * Test seam for [readBounded]'s rewind REACHABILITY contract (Greptile P1
+ * "Accumulator remains live during rewind"): unlike
+ * [ReadBoundedHeapObserver], which only reports the code's INTENT to
+ * release, this probe is invoked with the accumulator array itself while
+ * it is live, and again at the point immediately before the single exact
+ * allocation on the rewind path — after the accumulator has been drained.
+ * A test holds only a WeakReference to the array between the two calls and
+ * asserts it is collected at the second one, proving the old array is
+ * actually unreachable (not merely reported released) when the result
+ * array is allocated.
+ */
+internal interface RewindReachabilityProbe {
+    /** Called once with the first-pass accumulator array while still live. */
+    fun onAccumulatorReady(
+        accumulator: ByteArray,
+    )
+
+    /**
+     * Called on the rewind path AFTER the accumulator has been drained and
+     * immediately before [readBounded] allocates the exact-sized result.
+     * No live production frame holds the accumulator array at this point.
+     */
+    fun onBeforeExactAllocation()
 }
 
 /** Prefix bytes compared to prove a re-opened stream restarts identically. */

--- a/app/src/main/java/network/columba/app/util/FileUtils.kt
+++ b/app/src/main/java/network/columba/app/util/FileUtils.kt
@@ -12,7 +12,6 @@ import androidx.compose.material.icons.filled.InsertDriveFile
 import androidx.compose.material.icons.filled.PictureAsPdf
 import androidx.compose.material.icons.filled.VideoFile
 import androidx.compose.ui.graphics.vector.ImageVector
-import java.io.ByteArrayOutputStream
 import java.io.File
 import java.io.InputStream
 import java.util.Locale
@@ -556,9 +555,18 @@ private fun FileUtils.readFileWithResultBounded(
         // Read data with a hard bound on the allocation itself: unknown
         // (-1) or understated provider metadata passes the pre-check, so
         // readBytes() must never be trusted to stay small (Greptile P1).
+        // When the provider DID report a plausible size, seed the
+        // accumulator with it so the read is a single exact allocation
+        // (no doubling churn, no second copy — the heap-spike correction).
+        val initialCapacity =
+            if (fileSize in 1..maxFileSize.toLong()) {
+                fileSize.toInt()
+            } else {
+                FILE_READ_BUFFER_SIZE
+            }
         contentResolver.openInputStream(uri)?.use { inputStream ->
             val data =
-                readBounded(inputStream, maxFileSize)
+                readBounded(inputStream, maxFileSize, initialCapacity)
                     ?: return FileUtils.FileReadResult.FileTooLarge(-1L, maxFileSize)
 
             FileUtils.FileReadResult.Success(
@@ -581,6 +589,15 @@ private fun FileUtils.readFileWithResultBounded(
  * the stream yields more than the cap (at most one read buffer past it),
  * returning null instead of allocating the whole stream.
  *
+ * Heap shape (COLUMBA-4A Greptile P1 "Send reads still spike heap"):
+ * the accumulator grows into a single array capped at [maxBytes]; when its
+ * capacity is exact (the known-size seed, or an exact growth landing) the
+ * array is returned WITHOUT any second copy — the old ByteArrayOutputStream
+ * + toByteArray() held ~2x the file bytes at once (a near-32MB send read
+ * briefly needed ~64MB, on top of retained attachments). A trimmed result
+ * only happens after an overshooting doubling, and the retained array never
+ * exceeds maxBytes.
+ *
  * This is the enforcement point for [FileUtils.MAX_SINGLE_FILE_SIZE]. The
  * metadata pre-check via [FileUtils.getFileSize] is only a fast path —
  * providers may report statSize as -1 or understate the stream size, and
@@ -593,9 +610,10 @@ private fun FileUtils.readFileWithResultBounded(
 private fun readBounded(
     input: InputStream,
     maxBytes: Int,
+    initialCapacity: Int = FILE_READ_BUFFER_SIZE,
 ): ByteArray? {
     val buffer = ByteArray(FILE_READ_BUFFER_SIZE)
-    val out = ByteArrayOutputStream(minOf(maxBytes, FILE_READ_BUFFER_SIZE))
+    var data = ByteArray(minOf(maxBytes, maxOf(initialCapacity, FILE_READ_BUFFER_SIZE)))
     var total = 0
     while (true) {
         val n = input.read(buffer, 0, buffer.size)
@@ -606,9 +624,21 @@ private fun readBounded(
             // unbounded allocation never happens.
             return null
         }
-        out.write(buffer, 0, n)
+        if (total > data.size) {
+            // Grow, capped hard at maxBytes: the accumulator can NEVER
+            // exceed the cap, so an oversized/unknown stream is refused
+            // before any allocation past it.
+            val doubled = if (data.size > maxBytes / 2) maxBytes else data.size * 2
+            val newCapacity = minOf(maxBytes, maxOf(total, doubled))
+            data = data.copyOf(newCapacity)
+        }
+        buffer.copyInto(data, total - n, 0, n)
     }
-    return out.toByteArray()
+    // Hand back the accumulator itself when its capacity is exact — no
+    // second full copy (the known-size seed makes this the common case).
+    // Only when growth overshoots the read is a single trim copy needed to
+    // keep the returned array exactly sizeBytes long.
+    return if (data.size == total) data else data.copyOf(total)
 }
 
 private val HEX_CHARS = "0123456789abcdef".toCharArray()

--- a/app/src/main/java/network/columba/app/util/FileUtils.kt
+++ b/app/src/main/java/network/columba/app/util/FileUtils.kt
@@ -25,16 +25,25 @@ object FileUtils {
     private const val TAG = "FileUtils"
 
     /**
-     * Maximum total size for all file attachments combined.
-     * No practical limit - large files will be delivered via propagation node.
+     * Maximum size for a single file attachment, in bytes (512KB).
+     *
+     * Bounds the in-memory read performed by [readFileFromUri] /
+     * [readFileFromUriWithResult]: an unbounded readBytes() of a user-picked
+     * file OOMed a device on a ~181MB pick (COLUMBA-4A). Files above this cap
+     * are rejected as FileTooLarge instead of being read into memory.
+     * Legitimate large attachments on the send side keep working via the
+     * file-based transfer path (see [FILE_TRANSFER_THRESHOLD]).
      */
-    const val MAX_TOTAL_ATTACHMENT_SIZE = Int.MAX_VALUE
+    const val MAX_SINGLE_FILE_SIZE = 512 * 1024 // 512KB
 
     /**
-     * Maximum size for a single file attachment.
-     * No practical limit - large files will be delivered via propagation node.
+     * Maximum total size for all file attachments combined, in bytes (32MB).
+     *
+     * Used by [wouldExceedSizeLimit] to bound the combined in-memory working
+     * set for the message composer. Must stay below Int.MAX_VALUE — that value
+     * disabled the guard (COLUMBA-4A regression).
      */
-    const val MAX_SINGLE_FILE_SIZE = Int.MAX_VALUE
+    const val MAX_TOTAL_ATTACHMENT_SIZE = 512 * 1024 * 64 // 32MB
 
     /**
      * Result of attempting to read a file attachment.
@@ -122,14 +131,16 @@ object FileUtils {
     /**
      * Read file data from a content URI.
      *
-     * File attachments have no size limit - they are sent uncompressed.
-     * For large files, users should be aware that transmission over mesh
-     * networks may be slow or unreliable.
+     * The single-file size cap ([MAX_SINGLE_FILE_SIZE]) is enforced BEFORE any
+     * bytes are read: oversized files return null instead of being pulled
+     * into memory via readBytes(), which would OOM the process (COLUMBA-4A).
+     * Legitimate large attachments on the send side are preserved by the
+     * file-based transfer path (see [FILE_TRANSFER_THRESHOLD]).
      *
      * @param context Android context for ContentResolver access
      * @param uri The content URI of the file to read
      * @return FileAttachment containing the file data and metadata, or null if the file
-     *         couldn't be read
+     *         couldn't be read (including when it exceeds [MAX_SINGLE_FILE_SIZE])
      */
     fun readFileFromUri(
         context: Context,
@@ -137,6 +148,15 @@ object FileUtils {
     ): FileAttachment? =
         try {
             val contentResolver = context.contentResolver
+
+            // Check file size first without reading the entire file. Without
+            // this guard an oversized pick is read fully into a ByteArray and
+            // can crash the process (COLUMBA-4A).
+            val fileSize = getFileSize(context, uri)
+            if (fileSize > MAX_SINGLE_FILE_SIZE) {
+                Log.w(TAG, "File exceeds ${MAX_SINGLE_FILE_SIZE} bytes, refusing to read: $uri")
+                return null
+            }
 
             // Get filename
             val filename = getFilename(context, uri) ?: "unknown"

--- a/app/src/main/java/network/columba/app/util/FileUtils.kt
+++ b/app/src/main/java/network/columba/app/util/FileUtils.kt
@@ -12,7 +12,9 @@ import androidx.compose.material.icons.filled.InsertDriveFile
 import androidx.compose.material.icons.filled.PictureAsPdf
 import androidx.compose.material.icons.filled.VideoFile
 import androidx.compose.ui.graphics.vector.ImageVector
+import java.io.ByteArrayOutputStream
 import java.io.File
+import java.io.InputStream
 import java.util.Locale
 
 /**
@@ -54,6 +56,8 @@ object FileUtils {
         ) : FileReadResult()
 
         data class FileTooLarge(
+            /** Actual size in bytes, or -1 when the provider never revealed a
+             *  size and the bounded stream read tripped the cap mid-stream. */
             val actualSize: Long,
             val maxSize: Int,
         ) : FileReadResult()
@@ -105,13 +109,13 @@ object FileUtils {
             // Get MIME type
             val mimeType = contentResolver.getType(uri) ?: "application/octet-stream"
 
-            // Read data
+            // Read data with a hard bound on the allocation itself: unknown
+            // (-1) or understated provider metadata passes the pre-check, so
+            // readBytes() must never be trusted to stay small (Greptile P1).
             contentResolver.openInputStream(uri)?.use { inputStream ->
-                val data = inputStream.readBytes()
-
-                if (data.size > MAX_SINGLE_FILE_SIZE) {
-                    return FileReadResult.FileTooLarge(data.size.toLong(), MAX_SINGLE_FILE_SIZE)
-                }
+                val data =
+                    readBounded(inputStream, MAX_SINGLE_FILE_SIZE)
+                        ?: return FileReadResult.FileTooLarge(-1L, MAX_SINGLE_FILE_SIZE)
 
                 FileReadResult.Success(
                     FileAttachment(
@@ -164,9 +168,16 @@ object FileUtils {
             // Get MIME type
             val mimeType = contentResolver.getType(uri) ?: "application/octet-stream"
 
-            // Read data
+            // Read data with a hard bound on the allocation itself (sibling
+            // parity with readFileFromUriWithResult): metadata alone cannot be
+            // trusted, so the read aborts at the cap (Greptile P1).
             contentResolver.openInputStream(uri)?.use { inputStream ->
-                val data = inputStream.readBytes()
+                val data =
+                    readBounded(inputStream, MAX_SINGLE_FILE_SIZE)
+                        ?: run {
+                            Log.w(TAG, "Stream exceeded ${MAX_SINGLE_FILE_SIZE} bytes, aborting read: $uri")
+                            return null
+                        }
 
                 FileAttachment(
                     filename = filename,
@@ -519,6 +530,44 @@ object FileUtils {
                 }
             } ?: 0
     }
+}
+
+/** Copy buffer used by [readBounded]; also the max slack past the cap a bounded read may consume. */
+private const val FILE_READ_BUFFER_SIZE = 64 * 1024
+
+/**
+ * Read [input] into memory but NEVER beyond [maxBytes]: aborts as soon as
+ * the stream yields more than the cap (at most one read buffer past it),
+ * returning null instead of allocating the whole stream.
+ *
+ * This is the enforcement point for [FileUtils.MAX_SINGLE_FILE_SIZE]. The
+ * metadata pre-check via [FileUtils.getFileSize] is only a fast path —
+ * providers may report statSize as -1 or understate the stream size, and
+ * [InputStream.readBytes] would then allocate the entire (potentially huge)
+ * stream before any check could fire (COLUMBA-4A Greptile P1).
+ *
+ * @return the bytes read (size <= [maxBytes]), or null if the stream exceeded
+ *         [maxBytes] and the read was aborted.
+ */
+private fun readBounded(
+    input: InputStream,
+    maxBytes: Int,
+): ByteArray? {
+    val buffer = ByteArray(FILE_READ_BUFFER_SIZE)
+    val out = ByteArrayOutputStream(minOf(maxBytes, FILE_READ_BUFFER_SIZE))
+    var total = 0
+    while (true) {
+        val n = input.read(buffer, 0, buffer.size)
+        if (n < 0) break
+        total += n
+        if (total > maxBytes) {
+            // Abort before accumulating the overflow — the dangerous
+            // unbounded allocation never happens.
+            return null
+        }
+        out.write(buffer, 0, n)
+    }
+    return out.toByteArray()
 }
 
 private val HEX_CHARS = "0123456789abcdef".toCharArray()

--- a/app/src/test/java/network/columba/app/util/FileUtilsPickerLargeFileTest.kt
+++ b/app/src/test/java/network/columba/app/util/FileUtilsPickerLargeFileTest.kt
@@ -1,0 +1,98 @@
+package network.columba.app.util
+
+import android.content.ContentResolver
+import android.content.Context
+import android.database.Cursor
+import android.net.Uri
+import android.os.ParcelFileDescriptor
+import android.provider.OpenableColumns
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.unmockkAll
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+import java.io.ByteArrayInputStream
+import java.io.InputStream
+
+/**
+ * Regression tests for the COLUMBA-4A canonical-CI regression (Greploop
+ * iteration 2 on PR #1113): the restored 512KB single-file cap made the Real
+ * LXMF Resource Progress E2E red, because that test picks a 1MB file in the
+ * composer (tests/transfer_progress_e2e FILE_SIZE = 1024 * 1024) and asserts
+ * it reaches the outgoing bubble with verified progress. With the cap at
+ * 512KB the pick was rejected (FileTooLarge -> toast -> never attached), so
+ * the legitimate >512KB send flow regressed.
+ *
+ * The contract pinned here mirrors the E2E's pick -> attach -> outgoing
+ * bubble flow at the seam MessagingScreen.filePickerLauncher actually calls:
+ * a 1MB pick MUST attach with its full bytes. The COLUMBA-4A OOM guard is
+ * simultaneously pinned: a ~181MB pick must still be refused WITHOUT an
+ * unbounded read — the allocation is bounded even when provider metadata is
+ * missing (statSize == -1) or understates the stream.
+ */
+// Suppress NoRelaxedMocks for Android framework classes (Context, ContentResolver, Cursor, Uri)
+// which have many methods that are not relevant to these tests
+@Suppress("NoRelaxedMocks")
+class FileUtilsPickerLargeFileTest {
+    private lateinit var mockContext: Context
+    private lateinit var mockContentResolver: ContentResolver
+
+    @Before
+    fun setUp() {
+        mockContext = mockk(relaxed = true)
+        mockContentResolver = mockk(relaxed = true)
+        every { mockContext.contentResolver } returns mockContentResolver
+    }
+
+    @After
+    fun tearDown() {
+        unmockkAll()
+    }
+
+    private fun stubPick(
+        uri: Uri,
+        filename: String,
+        statSize: Long,
+        streamProvider: () -> InputStream,
+    ) {
+        val mockCursor = mockk<Cursor>(relaxed = true)
+        every { mockContentResolver.query(uri, null, null, null, null) } returns mockCursor
+        every { mockCursor.moveToFirst() } returns true
+        every { mockCursor.getColumnIndex(OpenableColumns.DISPLAY_NAME) } returns 0
+        every { mockCursor.getString(0) } returns filename
+        every { mockContentResolver.getType(uri) } returns "application/octet-stream"
+        val mockPfd = mockk<ParcelFileDescriptor>(relaxed = true)
+        every { mockPfd.statSize } returns statSize
+        every { mockContentResolver.openFileDescriptor(uri, "r") } returns mockPfd
+        every { mockContentResolver.openInputStream(uri) } answers { streamProvider() }
+    }
+
+    @Test
+    fun `composer pick of the canonical E2E 1MB file must attach with full bytes`() {
+        // Mirrors tests/transfer_progress_e2e: FILE_SIZE = 1024 * 1024 pushed to
+        // the device and picked via the composer file picker. At head 25f97257
+        // this pick returns FileTooLarge (512KB cap) and the E2E's
+        // wait_text(FILE_NAME) times out — the regression this test pins RED.
+        val e2eFileSize = 1024 * 1024
+        val payload = ByteArray(e2eFileSize) { (it % 251).toByte() }
+        val testUri = mockk<Uri>(relaxed = true)
+        stubPick(testUri, "columba-progress-e2e.bin", payload.size.toLong()) {
+            ByteArrayInputStream(payload)
+        }
+
+        val result = FileUtils.readFileFromUriWithResult(mockContext, testUri)
+
+        assertTrue(
+            "Expected Success for the canonical 1MB E2E pick, got: " +
+                result::class.java.simpleName,
+            result is FileUtils.FileReadResult.Success,
+        )
+        val attachment = (result as FileUtils.FileReadResult.Success).attachment
+        assertEquals("columba-progress-e2e.bin", attachment.filename)
+        assertEquals(e2eFileSize, attachment.sizeBytes)
+        assertTrue("Attached bytes must match the picked file", payload.contentEquals(attachment.data))
+    }
+}

--- a/app/src/test/java/network/columba/app/util/FileUtilsPickerLargeFileTest.kt
+++ b/app/src/test/java/network/columba/app/util/FileUtilsPickerLargeFileTest.kt
@@ -9,6 +9,7 @@ import android.provider.OpenableColumns
 import io.mockk.every
 import io.mockk.mockk
 import io.mockk.unmockkAll
+import io.mockk.verify
 import org.junit.After
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertTrue
@@ -24,14 +25,19 @@ import java.io.InputStream
  * composer (tests/transfer_progress_e2e FILE_SIZE = 1024 * 1024) and asserts
  * it reaches the outgoing bubble with verified progress. With the cap at
  * 512KB the pick was rejected (FileTooLarge -> toast -> never attached), so
- * the legitimate >512KB send flow regressed.
+ * the legitimate >512KB send flow regressed. RED at 25f97257 as
+ * 'Expected Success for the canonical 1MB E2E pick, got: FileTooLarge'.
  *
- * The contract pinned here mirrors the E2E's pick -> attach -> outgoing
- * bubble flow at the seam MessagingScreen.filePickerLauncher actually calls:
- * a 1MB pick MUST attach with its full bytes. The COLUMBA-4A OOM guard is
- * simultaneously pinned: a ~181MB pick must still be refused WITHOUT an
- * unbounded read — the allocation is bounded even when provider metadata is
- * missing (statSize == -1) or understates the stream.
+ * The fix routes composer SEND picks through FileUtils.readFileForSendWithResult
+ * bounded to MAX_TOTAL_ATTACHMENT_SIZE (32MB) — the same per-file ceiling
+ * MessagingViewModel already enforces before handing bytes to Reticulum —
+ * while the generic readFileFromUriWithResult keeps the 512KB fast-path cap.
+ *
+ * These tests mirror the E2E's pick -> attach -> outgoing bubble contract at
+ * the seam MessagingScreen.filePickerLauncher calls, and pin that the
+ * COLUMBA-4A OOM guard is NOT relaxed: a ~181MB pick must be refused WITHOUT
+ * an unbounded read, including when provider metadata is missing
+ * (statSize == -1) or understates the stream.
  */
 // Suppress NoRelaxedMocks for Android framework classes (Context, ContentResolver, Cursor, Uri)
 // which have many methods that are not relevant to these tests
@@ -71,11 +77,11 @@ class FileUtilsPickerLargeFileTest {
     }
 
     @Test
-    fun `composer pick of the canonical E2E 1MB file must attach with full bytes`() {
-        // Mirrors tests/transfer_progress_e2e: FILE_SIZE = 1024 * 1024 pushed to
-        // the device and picked via the composer file picker. At head 25f97257
-        // this pick returns FileTooLarge (512KB cap) and the E2E's
-        // wait_text(FILE_NAME) times out — the regression this test pins RED.
+    fun `composer send pick of the canonical E2E 1MB file must attach with full bytes`() {
+        // Mirrors tests/transfer_progress_e2e: FILE_SIZE = 1024 * 1024 pushed
+        // to the device and picked via the composer file picker. At head
+        // 25f97257 this pick returned FileTooLarge (512KB cap) and the E2E's
+        // wait_text(FILE_NAME) timed out — the regression this test pins RED.
         val e2eFileSize = 1024 * 1024
         val payload = ByteArray(e2eFileSize) { (it % 251).toByte() }
         val testUri = mockk<Uri>(relaxed = true)
@@ -83,7 +89,7 @@ class FileUtilsPickerLargeFileTest {
             ByteArrayInputStream(payload)
         }
 
-        val result = FileUtils.readFileFromUriWithResult(mockContext, testUri)
+        val result = FileUtils.readFileForSendWithResult(mockContext, testUri)
 
         assertTrue(
             "Expected Success for the canonical 1MB E2E pick, got: " +
@@ -94,5 +100,121 @@ class FileUtilsPickerLargeFileTest {
         assertEquals("columba-progress-e2e.bin", attachment.filename)
         assertEquals(e2eFileSize, attachment.sizeBytes)
         assertTrue("Attached bytes must match the picked file", payload.contentEquals(attachment.data))
+    }
+
+    @Test
+    fun `composer send pick rejects the Sentry 181MB file via pre-check before any bytes are read`() {
+        // The COLUMBA-4A OOM scenario (Sentry fatal on a ~181MB pick) must
+        // stay refused after the send-path cap is raised to 32MB: the size
+        // pre-check must short-circuit BEFORE openInputStream is touched.
+        val oversize = 181_374_640L
+        val testUri = mockk<Uri>(relaxed = true)
+        stubPick(oversizeUri = testUri, oversize = oversize)
+
+        val result = FileUtils.readFileForSendWithResult(mockContext, testUri)
+
+        assertTrue(
+            "Expected FileTooLarge for ${oversize}B send pick, got: " +
+                result::class.java.simpleName,
+            result is FileUtils.FileReadResult.FileTooLarge,
+        )
+        result as FileUtils.FileReadResult.FileTooLarge
+        assertEquals(oversize, result.actualSize)
+        assertEquals(FileUtils.MAX_TOTAL_ATTACHMENT_SIZE, result.maxSize)
+        verify(exactly = 0) { mockContentResolver.openInputStream(testUri) }
+    }
+
+    @Test
+    fun `composer send pick rejects unknown statSize oversize stream with a bounded read`() {
+        // Even on the send path, metadata alone cannot be trusted: statSize
+        // -1 over a ~181MB lazy stream must abort near the 32MB cap, never
+        // allocating the full stream (the original OOM hole, Greptile P1).
+        val streamSize = 181_374_640
+        val testUri = mockk<Uri>(relaxed = true)
+        val counting = CountingLazyStream(streamSize)
+        stubPick(testUri, "mystery.bin", -1L) { counting }
+
+        val result = FileUtils.readFileForSendWithResult(mockContext, testUri)
+
+        assertTrue(
+            "Expected FileTooLarge for unknown-size ${streamSize}B send pick, got: " +
+                result::class.java.simpleName,
+            result is FileUtils.FileReadResult.FileTooLarge,
+        )
+        assertTrue(
+            "Bounded send read must abort near the cap, but consumed ${counting.totalRead}B " +
+                "of a ${streamSize}B stream (cap ${FileUtils.MAX_TOTAL_ATTACHMENT_SIZE})",
+            counting.totalRead <= FileUtils.MAX_TOTAL_ATTACHMENT_SIZE + MAX_SLACK_BYTES,
+        )
+    }
+
+    @Test
+    fun `generic readFileFromUriWithResult keeps the 512KB fast-path cap`() {
+        // The larger bound is scoped to the composer send seam only. The
+        // generic reader used elsewhere must keep rejecting files above
+        // MAX_SINGLE_FILE_SIZE so its accepted 181MB pre-check test and all
+        // existing callers stay byte-for-byte in contract.
+        val oneMB = 1024 * 1024
+        val testUri = mockk<Uri>(relaxed = true)
+        stubPick(testUri, "one-mb.bin", oneMB.toLong()) {
+            ByteArrayInputStream(ByteArray(oneMB))
+        }
+
+        val result = FileUtils.readFileFromUriWithResult(mockContext, testUri)
+
+        assertTrue(
+            "Expected FileTooLarge for 1MB on the generic 512KB-capped reader, got: " +
+                result::class.java.simpleName,
+            result is FileUtils.FileReadResult.FileTooLarge,
+        )
+        result as FileUtils.FileReadResult.FileTooLarge
+        assertEquals(FileUtils.MAX_SINGLE_FILE_SIZE, result.maxSize)
+    }
+
+    private fun stubPick(
+        oversizeUri: Uri,
+        oversize: Long,
+    ) = stubPick(oversizeUri, "huge.bin", oversize) {
+        // Must never be reached when the pre-check works; hand back a lazy
+        // zero-allocation stream so an accidental read cannot OOM the JVM.
+        CountingLazyStream(oversize.toInt())
+    }
+
+    /** Allowed slack beyond the cap for one read buffer before aborting. */
+    private companion object {
+        const val MAX_SLACK_BYTES = 64 * 1024
+    }
+
+    /**
+     * InputStream that serves [size] bytes with zero upfront allocation and
+     * counts every byte actually consumed, so tests can assert the read was
+     * aborted near the cap instead of pulling the whole stream into memory.
+     */
+    private class CountingLazyStream(size: Int) : InputStream() {
+        @Volatile
+        var totalRead: Int = 0
+            private set
+
+        private var remaining = size
+
+        override fun read(): Int {
+            if (remaining <= 0) return -1
+            remaining--
+            totalRead++
+            return 0
+        }
+
+        override fun read(
+            b: ByteArray,
+            off: Int,
+            len: Int,
+        ): Int {
+            if (remaining <= 0) return -1
+            val toRead = minOf(len, remaining)
+            b.fill(0, off, off + toRead)
+            remaining -= toRead
+            totalRead += toRead
+            return toRead
+        }
     }
 }

--- a/app/src/test/java/network/columba/app/util/FileUtilsRobolectricTest.kt
+++ b/app/src/test/java/network/columba/app/util/FileUtilsRobolectricTest.kt
@@ -4,10 +4,12 @@ import android.content.ContentResolver
 import android.content.Context
 import android.database.Cursor
 import android.net.Uri
+import android.os.ParcelFileDescriptor
 import android.provider.OpenableColumns
 import io.mockk.every
 import io.mockk.mockk
 import io.mockk.unmockkAll
+import io.mockk.verify
 import org.junit.After
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
@@ -20,6 +22,7 @@ import org.junit.Test
 import org.junit.rules.TemporaryFolder
 import java.io.ByteArrayInputStream
 import java.io.File
+import java.io.InputStream
 
 /**
  * Unit tests for FileUtils Android-specific functions using MockK.
@@ -200,6 +203,56 @@ class FileUtilsRobolectricTest {
         assertNull(result)
     }
 
+    // ========== readFileFromUriWithResult Tests ==========
+
+    @Test
+    fun `readFileFromUriWithResult returns FileTooLarge for oversized file before reading bytes`() {
+        // Sentry COLUMBA-4A: picking a ~181MB file made readFileFromUriWithResult
+        // allocate the ENTIRE file in memory via readBytes() because both size
+        // guards were disabled at Int.MAX_VALUE (regression 30075665). The
+        // pre-check (getFileSize via openFileDescriptor().statSize) must
+        // short-circuit BEFORE any bytes are read.
+        //
+        // Honesty: a literal Android heap OOM cannot be deterministically forced
+        // in a JVM unit test. This deterministic seam reproduces the Sentry
+        // SYMPTOM — the guard trips before the unbounded allocation — not the
+        // literal OOM.
+        val oversize = 181_374_640L // mirrors the Sentry allocation size
+        val testUri = mockk<Uri>(relaxed = true)
+        val mockPfd = mockk<ParcelFileDescriptor>(relaxed = true)
+        every { mockPfd.statSize } returns oversize
+        every { mockContentResolver.openFileDescriptor(testUri, "r") } returns mockPfd
+        // Deterministic mirror of the Sentry event: the mocked resolver hands
+        // over the full 181MB file as a LAZY stream — zero allocation until a
+        // read() actually happens. On the buggy base (guard disabled at
+        // Int.MAX_VALUE) readFileFromUriWithResult reads all of it via
+        // readBytes() and returns Success with 181MB of data — the unbounded
+        // allocation that OOMed the device. The fix must return FileTooLarge
+        // BEFORE this stream is touched at all (lazy stream stays unallocated,
+        // proving no unbounded read happened).
+        every { mockContentResolver.openInputStream(testUri) } returns
+            lazyOversizeStream(oversize.toInt())
+
+        val result = FileUtils.readFileFromUriWithResult(mockContext, testUri)
+
+        // Bounded message: on the buggy base `result` is a Success whose
+        // toString() embeds the full 181MB payload — printing it would blow
+        // the test JVM / report writer. Only the class name is needed as
+        // failure evidence.
+        assertTrue(
+            "Expected FileTooLarge for ${oversize}B file, got: " +
+                result::class.java.simpleName,
+            result is FileUtils.FileReadResult.FileTooLarge,
+        )
+        result as FileUtils.FileReadResult.FileTooLarge
+        assertEquals(oversize, result.actualSize)
+        assertEquals(FileUtils.MAX_SINGLE_FILE_SIZE, result.maxSize)
+        // The guard must short-circuit before readBytes(): the full-byte read
+        // (and even filename lookup) must never start.
+        verify(exactly = 0) { mockContentResolver.openInputStream(testUri) }
+        verify(exactly = 0) { mockContentResolver.query(testUri, null, null, null, null) }
+    }
+
     // ========== getFilename Tests ==========
 
     @Test
@@ -301,4 +354,32 @@ class FileUtilsRobolectricTest {
 
         assertEquals("exception_fallback.txt", result)
     }
+
+    // ========== Test helpers ==========
+
+    /**
+     * Build an InputStream that serves [size] bytes with zero upfront
+     * allocation — memory is only consumed as read() is actually called.
+     * Used to model an oversized picked file: a correct size-cap guard
+     * returns before any read() call (nothing allocated); the unbounded base
+     * code triggers the full read and returns the entire 181MB payload —
+     * making the failure evidence "read 181MB into memory" instead of a JVM OOM.
+     */
+    private fun lazyOversizeStream(size: Int): InputStream =
+        object : InputStream() {
+            private var remaining = size
+            override fun read(): Int {
+                if (remaining <= 0) return -1
+                remaining--
+                return 0
+            }
+
+            override fun read(b: ByteArray, off: Int, len: Int): Int {
+                if (remaining <= 0) return -1
+                val toRead = minOf(len, remaining)
+                b.fill(0, off, off + toRead)
+                remaining -= toRead
+                return toRead
+            }
+        }
 }

--- a/app/src/test/java/network/columba/app/util/FileUtilsSendHeapSpikeTest.kt
+++ b/app/src/test/java/network/columba/app/util/FileUtilsSendHeapSpikeTest.kt
@@ -1,0 +1,337 @@
+package network.columba.app.util
+
+import android.content.ContentResolver
+import android.content.Context
+import android.database.Cursor
+import android.net.Uri
+import android.os.ParcelFileDescriptor
+import android.provider.OpenableColumns
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.unmockkAll
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+import java.io.InputStream
+
+/**
+ * Regression tests for the COLUMBA-4A correction (Greptile P1 on PR #1113,
+ * head 4fda09e2): "Send reads still spike heap".
+ *
+ * The approved send path reads composer picks up to
+ * [FileUtils.MAX_TOTAL_ATTACHMENT_SIZE] (32MB) into memory. At 4fda09e2 a
+ * successful near-32MB read temporarily held BOTH the growing
+ * ByteArrayOutputStream AND a full [ByteArray] copy returned by
+ * toByteArray() (~2x per-file bytes), and a multi-file selection retained
+ * every individually-valid array until the send-time aggregate check.
+ *
+ * These tests pin the corrected contract at the deterministic seams:
+ *  1. [readBounded] (via the public readers) returns the accumulator itself
+ *     — exact byte count, correct content, for every size shape (small,
+ *     doubling-growth, exactly-at-cap, seeded-capacity) — while the
+ *     unknown-size abort stays bounded to cap + one buffer of slack.
+ *  2. The composer group-budget accounting the picker performs
+ *     (MessagingScreen.filePickerLauncher, using
+ *     [FileUtils.wouldExceedSizeLimit] before/at each add) provably bounds
+ *     the retained working set at MAX_TOTAL_ATTACHMENT_SIZE, so the
+ *     multi-file retention window the finding named cannot approach an
+ *     unbounded multiple of the ceiling.
+ */
+// Suppress NoRelaxedMocks for Android framework classes (Context, ContentResolver, Cursor, Uri)
+// which have many methods that are not relevant to these tests
+@Suppress("NoRelaxedMocks")
+class FileUtilsSendHeapSpikeTest {
+    private lateinit var mockContext: Context
+    private lateinit var mockContentResolver: ContentResolver
+
+    @Before
+    fun setUp() {
+        mockContext = mockk(relaxed = true)
+        mockContentResolver = mockk(relaxed = true)
+        every { mockContext.contentResolver } returns mockContentResolver
+    }
+
+    @After
+    fun tearDown() {
+        unmockkAll()
+    }
+
+    private fun stubPick(
+        uri: Uri,
+        filename: String,
+        statSize: Long,
+        streamProvider: () -> InputStream,
+    ) {
+        val mockCursor = mockk<Cursor>(relaxed = true)
+        every { mockContentResolver.query(uri, null, null, null, null) } returns mockCursor
+        every { mockCursor.moveToFirst() } returns true
+        every { mockCursor.getColumnIndex(OpenableColumns.DISPLAY_NAME) } returns 0
+        every { mockCursor.getString(0) } returns filename
+        every { mockContentResolver.getType(uri) } returns "application/octet-stream"
+        val mockPfd = mockk<ParcelFileDescriptor>(relaxed = true)
+        every { mockPfd.statSize } returns statSize
+        every { mockContentResolver.openFileDescriptor(uri, "r") } returns mockPfd
+        every { mockContentResolver.openInputStream(uri) } answers { streamProvider() }
+    }
+
+    // ---------- 1. readBounded heap shape: single buffer, exact result ----------
+
+    @Test
+    fun `send read returns exact bytes with no second-copy corruption across size shapes`() {
+        // The corrected readBounded hands back its accumulator (no
+        // toByteArray() second full copy). Pin correctness across the shapes
+        // that exercise seeding and doubling growth: tiny, mid-size,
+        // doubling boundaries past the 64KB initial buffer, and exactly
+        // MAX_SINGLE_FILE_SIZE on the generic reader.
+        val shapes =
+            intArrayOf(
+                1,
+                64 * 1024, // exactly the initial buffer
+                64 * 1024 + 1, // first growth step
+                100 * 1024, // mid doubling
+                FileUtils.MAX_SINGLE_FILE_SIZE, // exactly the generic cap
+            )
+        for (size in shapes) {
+            val payload = ByteArray(size) { ((it * 31 + 7) % 251).toByte() }
+            val testUri = mockk<Uri>(relaxed = true)
+            stubPick(testUri, "shape-$size.bin", -1L) {
+                ChunkedStream(payload, 7 * 1024) // awkward chunk sizes
+            }
+
+            val result = FileUtils.readFileFromUriWithResult(mockContext, testUri)
+
+            assertTrue(
+                "Expected Success for ${size}B unknown-size stream, got: " +
+                    result::class.java.simpleName,
+                result is FileUtils.FileReadResult.Success,
+            )
+            val attachment = (result as FileUtils.FileReadResult.Success).attachment
+            assertEquals(size, attachment.sizeBytes)
+            assertEquals(size, attachment.data.size)
+            assertTrue(
+                "Bytes must survive the grow-into-single-buffer read exactly (size=$size)",
+                payload.contentEquals(attachment.data),
+            )
+        }
+    }
+
+    @Test
+    fun `seeded-capacity send read of a known-size file returns exact bytes`() {
+        // Known provider size seeds the accumulator exactly (single
+        // allocation, no doubling, no copy). 3MB > 512KB so it must go
+        // through the send-path reader.
+        val size = 3 * 1024 * 1024
+        val payload = ByteArray(size) { ((it * 17 + 3) % 253).toByte() }
+        val testUri = mockk<Uri>(relaxed = true)
+        stubPick(testUri, "seeded-3mb.bin", size.toLong()) {
+            ChunkedStream(payload, 911 * 1024)
+        }
+
+        val result = FileUtils.readFileForSendWithResult(mockContext, testUri)
+
+        assertTrue(
+            "Expected Success for seeded 3MB send pick, got: " +
+                result::class.java.simpleName,
+            result is FileUtils.FileReadResult.Success,
+        )
+        val attachment = (result as FileUtils.FileReadResult.Success).attachment
+        assertEquals(size, attachment.sizeBytes)
+        assertTrue(payload.contentEquals(attachment.data))
+    }
+
+    @Test
+    fun `unknown-size send read just over the 32MB cap aborts near the cap`() {
+        // Heap-shape correction must NOT weaken the OOM guard: statSize -1
+        // over a ~33MB lazy stream must be refused with the read stopped at
+        // cap + one buffer of slack, never returning a huge array.
+        val streamSize = FileUtils.MAX_TOTAL_ATTACHMENT_SIZE + 1024 * 1024
+        val testUri = mockk<Uri>(relaxed = true)
+        val counting = CountingLazyStream(streamSize)
+        stubPick(testUri, "just-over-32mb.bin", -1L) { counting }
+
+        val result = FileUtils.readFileForSendWithResult(mockContext, testUri)
+
+        assertTrue(
+            "Expected FileTooLarge for unknown-size ${streamSize}B send pick, got: " +
+                result::class.java.simpleName,
+            result is FileUtils.FileReadResult.FileTooLarge,
+        )
+        assertTrue(
+            "Bounded send read must abort near the cap, but consumed ${counting.totalRead}B " +
+                "of a ${streamSize}B stream (cap ${FileUtils.MAX_TOTAL_ATTACHMENT_SIZE})",
+            counting.totalRead <= FileUtils.MAX_TOTAL_ATTACHMENT_SIZE + MAX_SLACK_BYTES,
+        )
+    }
+
+    @Test
+    fun `understated-size send read grows the accumulator never past the cap`() {
+        // Provider understates statSize below the 64KB initial buffer while
+        // the stream is ~2MB: the accumulator must seed small, grow by
+        // doubling, and still return exact bytes on the send path.
+        val size = 2 * 1024 * 1024
+        val payload = ByteArray(size) { ((it * 13 + 11) % 251).toByte() }
+        val testUri = mockk<Uri>(relaxed = true)
+        stubPick(testUri, "understated-2mb.bin", 100L) {
+            ChunkedStream(payload, 200 * 1024)
+        }
+
+        val result = FileUtils.readFileForSendWithResult(mockContext, testUri)
+
+        assertTrue(
+            "Expected Success for understated 2MB send pick, got: " +
+                result::class.java.simpleName,
+            result is FileUtils.FileReadResult.Success,
+        )
+        val attachment = (result as FileUtils.FileReadResult.Success).attachment
+        assertEquals(size, attachment.sizeBytes)
+        assertTrue(payload.contentEquals(attachment.data))
+    }
+
+    // ---------- 2. Group-budget accounting bounds the retained working set ----------
+
+    /**
+     * Mirrors the exact accounting MessagingScreen.filePickerLauncher
+     * performs per pick (pre-check on known size, then exact post-read
+     * accounting with [FileUtils.wouldExceedSizeLimit] before adding).
+     * [size] is the provider statSize, or -1 for unknown — in which case
+     * the bounded reader may hand back up to the full per-file cap and the
+     * simulation conservatively retains that worst case. Asserts at every
+     * step that the retained working set never exceeds the group ceiling.
+     */
+    private fun simulateGroupBudget(sizes: List<Long>): Int {
+        var retained = 0
+        for (size in sizes) {
+            // Skip (no allocation, no retention) when the per-file cap
+            // refuses the pick outright, or when a KNOWN size already busts
+            // the remaining group budget before any read happens.
+            val refusedBeforeRead =
+                size > FileUtils.MAX_TOTAL_ATTACHMENT_SIZE ||
+                    (size >= 1 && FileUtils.wouldExceedSizeLimit(retained, size.toInt()))
+            if (!refusedBeforeRead) {
+                // Exact post-read accounting: known size retains exactly; an
+                // unknown-size bounded read retains at most the per-file cap.
+                val retainedBytes =
+                    if (size >= 1) size.toInt() else FileUtils.MAX_TOTAL_ATTACHMENT_SIZE
+                if (!FileUtils.wouldExceedSizeLimit(retained, retainedBytes)) {
+                    retained += retainedBytes
+                }
+                assertTrue(
+                    "Retained attachment working set must never exceed the group cap " +
+                        "(was $retained after a ${size}B pick)",
+                    retained <= FileUtils.MAX_TOTAL_ATTACHMENT_SIZE,
+                )
+            }
+        }
+        return retained
+    }
+
+    @Test
+    fun `group budget accounting retains every file that fits and refuses the first that does not`() {
+        // 20 files x 1MB all fit the 32MB group budget.
+        val retained = simulateGroupBudget(List(20) { 1024L * 1024 })
+        assertEquals(20 * 1024 * 1024, retained)
+
+        // 30 files x 1.5MB = 45MB: accounting keeps the retained total at or
+        // below 32MB no matter how many individually-valid picks arrive.
+        val many = simulateGroupBudget(List(30) { 1536L * 1024 })
+        assertTrue(
+            "Retained total must stay <= group cap, was $many",
+            many <= FileUtils.MAX_TOTAL_ATTACHMENT_SIZE,
+        )
+    }
+
+    @Test
+    fun `group budget accounting with multiple near-cap files bounds the retained set`() {
+        // The exact Greptile scenario: several individually-valid ~30MB
+        // picks. The first attaches; every later near-cap pick is refused by
+        // the group accounting BEFORE its read is retained, so the composer
+        // working set is bounded at ~1x cap instead of N x cap.
+        val near = 30L * 1024 * 1024
+        val retained = simulateGroupBudget(List(5) { near })
+        assertEquals(near.toInt(), retained)
+    }
+
+    @Test
+    fun `group budget accounting with unknown sizes bounds the retained set`() {
+        // statSize -1 picks bypass the pre-check; the per-file bounded read
+        // plus exact post-read accounting still bound the retained total:
+        // even four consecutive unknown-size picks retain at most 1x cap.
+        val retained = simulateGroupBudget(List(4) { -1L })
+        assertEquals(FileUtils.MAX_TOTAL_ATTACHMENT_SIZE, retained)
+        // And mixed known/unknown where known files consume the budget:
+        // 30MB fits; the second 30MB is pre-check-skipped; the 1MB fits
+        // (31MB total); the unknown-size pick (worst case 32MB) does not.
+        val mixed =
+            simulateGroupBudget(
+                listOf(
+                    30L * 1024 * 1024,
+                    30L * 1024 * 1024,
+                    1L * 1024 * 1024,
+                    -1L,
+                ),
+            )
+        assertEquals(31 * 1024 * 1024, mixed)
+    }
+
+    /** Allowed slack beyond the cap for one read buffer before aborting. */
+    private companion object {
+        const val MAX_SLACK_BYTES = 64 * 1024
+    }
+
+    /** Serves [data] in fixed-size chunks (exercises growth boundaries). */
+    private class ChunkedStream(
+        private val data: ByteArray,
+        private val chunk: Int,
+    ) : InputStream() {
+        private var pos = 0
+
+        override fun read(): Int = if (pos >= data.size) -1 else data[pos++].toInt() and 0xFF
+
+        override fun read(
+            b: ByteArray,
+            off: Int,
+            len: Int,
+        ): Int {
+            if (pos >= data.size) return -1
+            val n = minOf(len, chunk, data.size - pos)
+            data.copyInto(b, off, pos, pos + n)
+            pos += n
+            return n
+        }
+    }
+
+    /**
+     * InputStream that serves [size] bytes with zero upfront allocation and
+     * counts every byte actually consumed, so tests can assert the read was
+     * aborted near the cap instead of pulling the whole stream into memory.
+     */
+    private class CountingLazyStream(size: Int) : InputStream() {
+        @Volatile
+        var totalRead: Int = 0
+            private set
+
+        private var remaining = size
+
+        override fun read(): Int {
+            if (remaining <= 0) return -1
+            remaining--
+            totalRead++
+            return 0
+        }
+
+        override fun read(
+            b: ByteArray,
+            off: Int,
+            len: Int,
+        ): Int {
+            if (remaining <= 0) return -1
+            val toRead = minOf(len, remaining)
+            b.fill(0, off, off + toRead)
+            remaining -= toRead
+            totalRead += toRead
+            return toRead
+        }
+    }
+}

--- a/app/src/test/java/network/columba/app/util/FileUtilsSendHeapSpikeTest.kt
+++ b/app/src/test/java/network/columba/app/util/FileUtilsSendHeapSpikeTest.kt
@@ -18,6 +18,7 @@ import org.junit.Before
 import org.junit.Test
 import java.io.ByteArrayInputStream
 import java.io.InputStream
+import java.lang.ref.WeakReference
 import kotlinx.coroutines.async
 import kotlinx.coroutines.awaitAll
 import kotlinx.coroutines.coroutineScope
@@ -341,6 +342,75 @@ class FileUtilsSendHeapSpikeTest {
                 "(events: $events)",
             FILE_READ_BUF,
             liveBeforeFinalAlloc,
+        )
+    }
+
+    // Greptile P1 "Accumulator remains live during rewind" at a69311dd:
+    // the release ABOVE is a synthetic event — the accumulator array stayed
+    // REACHABLE through the `pass` local across the fillExactFromReopen
+    // allocation, so the ~2x near-cap heap peak the PR exists to eliminate
+    // survived. The corrected rewind DRAINS the accumulator holder before
+    // allocating. Pin that with real GC evidence, not observer events: hold
+    // only a WeakReference to the accumulator (captured at the seam while
+    // live), and at the point immediately before the exact allocation force
+    // a GC and require the accumulator to be unreachable — while a control
+    // garbage array in the same frame proves the GC actually ran.
+    @Test
+    fun `near-cap rewind accumulator is garbage at the point of the exact allocation`() {
+        val size = FileUtils.MAX_TOTAL_ATTACHMENT_SIZE - 512 * 1024
+        val payload = ByteArray(size) { ((it * 7 + 13) % 251).toByte() }
+
+        var accumulatorRef: WeakReference<ByteArray>? = null
+        var accumulatorCollectedAtAllocPoint: Boolean? = null
+        var controlCollectedAtAllocPoint: Boolean? = null
+
+        val probe =
+            object : RewindReachabilityProbe {
+                override fun onAccumulatorReady(accumulator: ByteArray) {
+                    // Weak handle ONLY — the test must never keep the
+                    // accumulator strongly reachable itself.
+                    accumulatorRef = WeakReference(accumulator)
+                }
+
+                override fun onBeforeExactAllocation() {
+                    var control: ByteArray? = ByteArray(8 * 1024)
+                    val controlRef = WeakReference(control)
+                    control = null
+                    // Force real collections, then observe reachability at
+                    // the exact point the result array is about to be
+                    // allocated (the allocation happens inside this very
+                    // call stack, right after this method returns).
+                    repeat(4) {
+                        System.gc()
+                        Thread.sleep(20)
+                    }
+                    controlCollectedAtAllocPoint = controlRef.get() == null
+                    accumulatorCollectedAtAllocPoint = accumulatorRef?.get() == null
+                }
+            }
+
+        val result =
+            readBounded(
+                ByteArrayInputStream(payload),
+                FileUtils.MAX_TOTAL_ATTACHMENT_SIZE,
+                reopen = { ByteArrayInputStream(payload) },
+                rewindProbe = probe,
+            )
+
+        assertNotNull(result)
+        assertEquals(size, result!!.size)
+        assertTrue(payload.contentEquals(result))
+        // The seams must have fired on the rewind path at all.
+        assertNotNull(accumulatorRef)
+        assertEquals(true, accumulatorCollectedAtAllocPoint)
+        // GC-collaboration guard: if the control array survived, no
+        // collection happened and the reachability assertion above is
+        // meaningless — fail loudly instead of passing vacuously.
+        assertEquals(
+            "Explicit GC did not collect control garbage — the reachability " +
+                "evidence below would be vacuous on this JVM configuration",
+            true,
+            controlCollectedAtAllocPoint,
         )
     }
 

--- a/app/src/test/java/network/columba/app/util/FileUtilsSendHeapSpikeTest.kt
+++ b/app/src/test/java/network/columba/app/util/FileUtilsSendHeapSpikeTest.kt
@@ -11,10 +11,19 @@ import io.mockk.mockk
 import io.mockk.unmockkAll
 import org.junit.After
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertNull
 import org.junit.Assert.assertTrue
 import org.junit.Before
 import org.junit.Test
+import java.io.ByteArrayInputStream
 import java.io.InputStream
+import kotlinx.coroutines.async
+import kotlinx.coroutines.awaitAll
+import kotlinx.coroutines.coroutineScope
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.test.runTest
+import network.columba.app.ui.screens.tryReserveGroupBudgetLocked
 
 /**
  * Regression tests for the COLUMBA-4A correction (Greptile P1 on PR #1113,
@@ -275,9 +284,270 @@ class FileUtilsSendHeapSpikeTest {
         assertEquals(31 * 1024 * 1024, mixed)
     }
 
+    // ---------- 3. F1: near-cap trim copy must not double the heap ----------
+    // Greptile P1 "Trim copy doubles heap" at 51603ecb: `data.copyOf(total)`
+    // allocated a near-file-sized result while the full accumulator stayed
+    // live (~63MB peak on the 32MB send path). The corrected readBounded
+    // rewinds a verified-restartable provider and fills ONE exact array
+    // AFTER dropping the accumulator. The heapObserver seam reports every
+    // accumulator allocation/release so the live-bytes shape is asserted
+    // deterministically (no GC-timing assumptions).
+
+    @Test
+    fun `near-cap unknown-size read releases the accumulator before the final allocation`() {
+        // Unknown-size (~31.5MB, just below the 32MB cap) stream: growth
+        // caps the accumulator at 32MB, EOF lands at 31.5MB. The old code
+        // trim-copied HERE, holding 32MB + 31.5MB at once. The fix rewinds:
+        // the final event pair MUST be release(accumulator) followed by
+        // alloc(exact), with only the 64KB scan buffer still live in
+        // between — never two near-full arrays.
+        val size = FileUtils.MAX_TOTAL_ATTACHMENT_SIZE - 512 * 1024
+        val payload = ByteArray(size) { ((it * 7 + 13) % 251).toByte() }
+        val events = mutableListOf<Pair<Boolean, Int>>()
+        var live = 0
+        var liveBeforeFinalAlloc = -1
+
+        val result =
+            readBounded(
+                ByteArrayInputStream(payload),
+                FileUtils.MAX_TOTAL_ATTACHMENT_SIZE,
+                reopen = { ByteArrayInputStream(payload) },
+                heapObserver =
+                    ReadBoundedHeapObserver { released, sizeBytes ->
+                        if (released) {
+                            live -= sizeBytes
+                        } else {
+                            // Remember live bytes at EVERY allocation — the
+                            // last one is the final result array.
+                            liveBeforeFinalAlloc = live
+                            live += sizeBytes
+                        }
+                        events += released to sizeBytes
+                    },
+            )
+
+        assertNotNull(result)
+        assertEquals(size, result!!.size)
+        assertTrue(payload.contentEquals(result))
+        val lastAlloc = events.indexOfLast { !it.first }
+        // The last allocation is the exact-sized result...
+        assertEquals(size, events[lastAlloc].second)
+        // ...immediately preceded by the accumulator release (32MB cap),
+        // i.e. the two near-full arrays were NEVER live at the same time.
+        assertEquals(true to FileUtils.MAX_TOTAL_ATTACHMENT_SIZE, events[lastAlloc - 1])
+        assertEquals(
+            "Live accumulator bytes when the final array was allocated must be just the " +
+                "64KB scan buffer — the accumulator must have been released first " +
+                "(events: $events)",
+            FILE_READ_BUF,
+            liveBeforeFinalAlloc,
+        )
+    }
+
+    @Test
+    fun `exact-seed known-size send read remains copy-free`() {
+        // Heap-shape contract that must NOT regress: a plausible known
+        // statSize seeds the accumulator exactly and the accumulator itself
+        // is returned — one accumulator allocation, zero releases, no trim.
+        val size = 3 * 1024 * 1024
+        val payload = ByteArray(size) { ((it * 11 + 5) % 251).toByte() }
+        val events = mutableListOf<Pair<Boolean, Int>>()
+
+        val result =
+            readBounded(
+                ByteArrayInputStream(payload),
+                FileUtils.MAX_TOTAL_ATTACHMENT_SIZE,
+                initialCapacity = size,
+                reopen = { ByteArrayInputStream(payload) },
+                heapObserver =
+                    ReadBoundedHeapObserver { released, sizeBytes ->
+                        events += released to sizeBytes
+                    },
+            )
+
+        assertNotNull(result)
+        assertTrue(payload.contentEquals(result))
+        val accumulatorEvents = events.filter { it.second != FILE_READ_BUF }
+        assertEquals(
+            "Exact-seed read must allocate the accumulator once and never grow/trim it " +
+                "(events: $events)",
+            listOf(false to size),
+            accumulatorEvents,
+        )
+    }
+
+    @Test
+    fun `near-cap read on a non-restartable provider falls back to a correct trim`() {
+        // The rewind is only taken when a fresh open provably restarts the
+        // same content. A provider whose re-opened stream differs (e.g. a
+        // regenerating/streamed source) must still return the exact
+        // first-pass bytes via the bounded trim fallback — correctness over
+        // the fast path.
+        val size = TRIM_THRESHOLD + 512 * 1024
+        val payload = ByteArray(size) { ((it * 3 + 7) % 251).toByte() }
+        val mutated = payload.clone().also { it[0] = (it[0].toInt() + 1).toByte() }
+
+        val result =
+            readBounded(
+                ByteArrayInputStream(payload),
+                FileUtils.MAX_TOTAL_ATTACHMENT_SIZE,
+                reopen = { ByteArrayInputStream(mutated) },
+            )
+
+        assertNotNull(result)
+        assertEquals(size, result!!.size)
+        assertTrue(payload.contentEquals(result))
+    }
+
+    @Test
+    fun `near-cap read with no reopen capability still returns exact bytes`() {
+        // reopen = null (callers without a re-openable source): the trim
+        // fallback must stay correct — never weaker.
+        val size = TRIM_THRESHOLD + 1024
+        val payload = ByteArray(size) { ((it * 5 + 11) % 249).toByte() }
+
+        val result =
+            readBounded(
+                ByteArrayInputStream(payload),
+                FileUtils.MAX_TOTAL_ATTACHMENT_SIZE,
+            )
+
+        assertNotNull(result)
+        assertTrue(payload.contentEquals(result))
+    }
+
+    @Test
+    fun `rewind path aborts an over-cap stream without allocating past the cap`() {
+        // The OOM guard must survive the rewind rewrite on EVERY branch:
+        // a 33MB unknown-size stream on the 32MB send bound must be refused
+        // (null) with consumption bounded at cap + one buffer.
+        val streamSize = FileUtils.MAX_TOTAL_ATTACHMENT_SIZE + 1024 * 1024
+        val counting = CountingLazyStream(streamSize)
+
+        val result =
+            readBounded(
+                counting,
+                FileUtils.MAX_TOTAL_ATTACHMENT_SIZE,
+                reopen = { CountingLazyStream(streamSize) },
+            )
+
+        assertNull(result)
+        assertTrue(
+            "Rewind-aware bounded read must abort near the cap, but consumed " +
+                "${counting.totalRead}B of a ${streamSize}B stream",
+            counting.totalRead <= FileUtils.MAX_TOTAL_ATTACHMENT_SIZE + MAX_SLACK_BYTES,
+        )
+    }
+
+    // ---------- 4. F2: overlapping picker callbacks share ONE budget ----------
+    // Greptile P1 "Picker budgets race" at 51603ecb: each picker callback
+    // snapshotted groupBudgetBase at entry and kept a callback-local
+    // groupBudgetUsed, so two overlapping batches could jointly retain
+    // more than MAX_TOTAL_ATTACHMENT_SIZE in the composer. The fix routes
+    // every check-and-add through tryReserveGroupBudgetLocked, which
+    // re-reads the LIVE retained total inside a shared mutex.
+
+    @Test
+    fun `overlapping picker batches sharing one budget never exceed the group cap`() =
+        runTest {
+            // Stand-in for viewModel.selectedFileAttachments: the live
+            // retained byte totals. 24 concurrent "picks" interleave
+            // through the shared mutex exactly like two picker batches do.
+            val mutex = Mutex()
+            val composer = java.util.Collections.synchronizedList(mutableListOf<Int>())
+            val pick = 2 * 1024 * 1024
+
+            val accepted =
+                coroutineScope {
+                    (1..24).map {
+                        async {
+                            tryReserveGroupBudgetLocked(
+                                mutex = mutex,
+                                currentTotalBytes = { composer.sum() },
+                                newAttachmentBytes = pick,
+                            ) {
+                                composer.add(pick)
+                            }
+                        }
+                    }.awaitAll()
+                }
+
+            val retained = composer.sum()
+            assertTrue(
+                "Retained composer working set must never exceed the group cap, was $retained",
+                retained <= FileUtils.MAX_TOTAL_ATTACHMENT_SIZE,
+            )
+            // 16 x 2MB exactly fills the 32MB cap; the other 8 must be
+            // refused — the stale-snapshot design could accept all 24 from
+            // each batch's own point of view.
+            assertEquals(16, accepted.count { it })
+            assertEquals(8, accepted.count { !it })
+            assertEquals(accepted.count { it } * pick, retained)
+        }
+
+    @Test
+    fun `budget reservation sees adds committed by an earlier overlapping batch`() =
+        runTest {
+            // The race Greptile named: batch B's read finished while batch
+            // A already added 30MB. B's check MUST see A's committed 30MB
+            // (live total), not a stale entry-time snapshot of 0, and
+            // refuse the second near-cap 30MB pick.
+            val mutex = Mutex()
+            val composer = mutableListOf<Int>()
+
+            val first =
+                tryReserveGroupBudgetLocked(mutex, { composer.sum() }, 30 * 1024 * 1024) {
+                    composer.add(30 * 1024 * 1024)
+                }
+            val second =
+                tryReserveGroupBudgetLocked(mutex, { composer.sum() }, 30 * 1024 * 1024) {
+                    composer.add(30 * 1024 * 1024)
+                }
+
+            assertTrue(first)
+            assertTrue("Second near-cap pick must be refused against the LIVE composer total", !second)
+            assertEquals(30 * 1024 * 1024, composer.sum())
+
+            // Room for exactly 2MB more (32MB cap): accepted, UX for
+            // small follow-up picks preserved.
+            val third =
+                tryReserveGroupBudgetLocked(mutex, { composer.sum() }, 2 * 1024 * 1024) {
+                    composer.add(2 * 1024 * 1024)
+                }
+            assertTrue(third)
+            assertEquals(FileUtils.MAX_TOTAL_ATTACHMENT_SIZE, composer.sum())
+        }
+
+    @Test
+    fun `refused reservation never commits to the composer`() =
+        runTest {
+            // FileTooLarge-adjacent semantics: a rejected reservation must
+            // not touch the composer at all (no half-added attachment).
+            val mutex = Mutex()
+            val composer = mutableListOf<Int>()
+
+            val accepted =
+                tryReserveGroupBudgetLocked(
+                    mutex,
+                    { FileUtils.MAX_TOTAL_ATTACHMENT_SIZE },
+                    1,
+                ) {
+                    composer.add(1)
+                }
+
+            assertTrue(!accepted)
+            assertTrue(composer.isEmpty())
+        }
+
     /** Allowed slack beyond the cap for one read buffer before aborting. */
     private companion object {
         const val MAX_SLACK_BYTES = 64 * 1024
+
+        /** Mirrors FileUtils' private TRIM_FREE_RETAIN_THRESHOLD (4MB). */
+        const val TRIM_THRESHOLD = 4 * 1024 * 1024
+
+        /** Mirrors FileUtils' private FILE_READ_BUFFER_SIZE (64KB). */
+        const val FILE_READ_BUF = 64 * 1024
     }
 
     /** Serves [data] in fixed-size chunks (exercises growth boundaries). */

--- a/app/src/test/java/network/columba/app/util/FileUtilsTempAttachmentTest.kt
+++ b/app/src/test/java/network/columba/app/util/FileUtilsTempAttachmentTest.kt
@@ -185,25 +185,30 @@ class FileUtilsTempAttachmentTest {
     }
 
     // ========== wouldExceedSizeLimit Tests ==========
-    // Note: With MAX_TOTAL_ATTACHMENT_SIZE = Int.MAX_VALUE, the limit is effectively unlimited.
-    // Testing "exceeding" the limit would require integer overflow, so we only test normal cases.
+    // Regression COLUMBA-4A: the total attachment limit must be bounded, so
+    // large files MUST trip wouldExceedSizeLimit (limit was Int.MAX_VALUE).
 
     @Test
-    fun `wouldExceedSizeLimit returns false for typical file sizes`() {
-        // With Int.MAX_VALUE limit, normal file sizes never exceed
-        assertTrue(!FileUtils.wouldExceedSizeLimit(0, 100 * 1024 * 1024)) // 100MB
-        assertTrue(!FileUtils.wouldExceedSizeLimit(500 * 1024 * 1024, 500 * 1024 * 1024)) // 1GB total
+    fun `wouldExceedSizeLimit returns true for large file sizes`() {
+        // Bounded limit: a 100MB single file and a 1GB combined total must both
+        // exceed MAX_TOTAL_ATTACHMENT_SIZE (regression: limit was Int.MAX_VALUE).
+        assertTrue(FileUtils.wouldExceedSizeLimit(0, 100 * 1024 * 1024)) // 100MB
+        assertTrue(FileUtils.wouldExceedSizeLimit(500 * 1024 * 1024, 500 * 1024 * 1024)) // 1GB total
     }
 
     // ========== Size Constants Tests ==========
 
     @Test
-    fun `MAX_TOTAL_ATTACHMENT_SIZE is Int MAX_VALUE`() {
-        assertEquals(Int.MAX_VALUE, FileUtils.MAX_TOTAL_ATTACHMENT_SIZE)
+    fun `MAX_TOTAL_ATTACHMENT_SIZE is bounded below Int MAX_VALUE`() {
+        // A disabled (Int.MAX_VALUE) limit allowed unbounded file reads
+        // (Sentry COLUMBA-4A fatal OutOfMemoryError).
+        assertTrue(FileUtils.MAX_TOTAL_ATTACHMENT_SIZE < Int.MAX_VALUE)
     }
 
     @Test
-    fun `MAX_SINGLE_FILE_SIZE is Int MAX_VALUE`() {
-        assertEquals(Int.MAX_VALUE, FileUtils.MAX_SINGLE_FILE_SIZE)
+    fun `MAX_SINGLE_FILE_SIZE is bounded below Int MAX_VALUE`() {
+        // A disabled (Int.MAX_VALUE) single-file limit allowed unbounded
+        // in-memory reads (Sentry COLUMBA-4A).
+        assertTrue(FileUtils.MAX_SINGLE_FILE_SIZE < Int.MAX_VALUE)
     }
 }

--- a/app/src/test/java/network/columba/app/util/FileUtilsTest.kt
+++ b/app/src/test/java/network/columba/app/util/FileUtilsTest.kt
@@ -174,8 +174,9 @@ class FileUtilsTest {
     }
 
     // ========== wouldExceedSizeLimit Tests ==========
-    // Note: With MAX_TOTAL_ATTACHMENT_SIZE = Int.MAX_VALUE, the limit is effectively unlimited.
-    // Testing "exceeding" would require integer overflow, so we only test normal use cases.
+    // Regression COLUMBA-4A: the total attachment limit must be bounded.
+    // Regression commit 30075665 set MAX_TOTAL_ATTACHMENT_SIZE = Int.MAX_VALUE,
+    // disabling the guard and allowing unbounded in-memory file reads.
 
     @Test
     fun `wouldExceedSizeLimit returns false when within limit`() {
@@ -185,17 +186,20 @@ class FileUtilsTest {
     }
 
     @Test
-    fun `wouldExceedSizeLimit returns false for large file sizes`() {
-        // With Int.MAX_VALUE limit, realistic file sizes never exceed
-        assertFalse(FileUtils.wouldExceedSizeLimit(0, 100 * 1024 * 1024)) // 100MB
-        assertFalse(FileUtils.wouldExceedSizeLimit(500 * 1024 * 1024, 500 * 1024 * 1024)) // 1GB total
+    fun `wouldExceedSizeLimit returns true for large file sizes`() {
+        // Bounded limit: a 100MB single file and a 1GB combined total must both
+        // exceed MAX_TOTAL_ATTACHMENT_SIZE (regression: limit was Int.MAX_VALUE).
+        assertTrue(FileUtils.wouldExceedSizeLimit(0, 100 * 1024 * 1024)) // 100MB
+        assertTrue(FileUtils.wouldExceedSizeLimit(500 * 1024 * 1024, 500 * 1024 * 1024)) // 1GB total
     }
 
     // ========== Constants Tests ==========
 
     @Test
-    fun `MAX_TOTAL_ATTACHMENT_SIZE is Int MAX_VALUE`() {
-        assertEquals(Int.MAX_VALUE, FileUtils.MAX_TOTAL_ATTACHMENT_SIZE)
+    fun `MAX_TOTAL_ATTACHMENT_SIZE is bounded below Int MAX_VALUE`() {
+        // A disabled (Int.MAX_VALUE) limit allowed unbounded file reads
+        // (Sentry COLUMBA-4A fatal OutOfMemoryError).
+        assertTrue(FileUtils.MAX_TOTAL_ATTACHMENT_SIZE < Int.MAX_VALUE)
     }
 
     // ========== Additional getMimeTypeFromFilename Tests ==========
@@ -330,8 +334,18 @@ class FileUtilsTest {
     }
 
     @Test
-    fun `MAX_SINGLE_FILE_SIZE is Int MAX_VALUE`() {
-        assertEquals(Int.MAX_VALUE, FileUtils.MAX_SINGLE_FILE_SIZE)
+    fun `MAX_SINGLE_FILE_SIZE is bounded below Int MAX_VALUE`() {
+        // A disabled (Int.MAX_VALUE) single-file limit let readFileFromUriWithResult
+        // read the entire selected file into memory via readBytes() — the unbounded
+        // allocation behind Sentry COLUMBA-4A (fatal OutOfMemoryError, ~181MB file).
+        assertTrue(FileUtils.MAX_SINGLE_FILE_SIZE < Int.MAX_VALUE)
+    }
+
+    @Test
+    fun `wouldExceedSizeLimit returns true one byte over restored MAX_TOTAL_ATTACHMENT_SIZE`() {
+        // With a bounded total limit, adding a single byte past the cap must trip
+        // the guard (regression: Int.MAX_VALUE limit never tripped).
+        assertTrue(FileUtils.wouldExceedSizeLimit(FileUtils.MAX_TOTAL_ATTACHMENT_SIZE, 1))
     }
 
     // ========== Additional getFileIconForMimeType Edge Case Tests ==========

--- a/app/src/test/java/network/columba/app/util/FileUtilsUnknownSizeReadTest.kt
+++ b/app/src/test/java/network/columba/app/util/FileUtilsUnknownSizeReadTest.kt
@@ -1,0 +1,224 @@
+package network.columba.app.util
+
+import android.content.ContentResolver
+import android.content.Context
+import android.database.Cursor
+import android.net.Uri
+import android.os.ParcelFileDescriptor
+import android.provider.OpenableColumns
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.unmockkAll
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+import java.io.InputStream
+
+/**
+ * Regression tests for the COLUMBA-4A correction (Greptile P1 on PR #1113):
+ * "Unknown sizes bypass read cap".
+ *
+ * The approved fix relies on a metadata pre-check (statSize from
+ * openFileDescriptor) to reject oversized picks BEFORE reading. A content
+ * provider may report statSize == -1 (unknown) or understate the stream size,
+ * which passes the pre-check and lands in readBytes() — the exact unbounded
+ * in-memory allocation this ticket exists to eliminate.
+ *
+ * These tests pin the deterministic seam: a provider with unknown/understated
+ * metadata over a stream larger than MAX_SINGLE_FILE_SIZE. The read must be
+ * REJECTED (FileTooLarge / null) and the stream read itself must be BOUNDED —
+ * the implementation may never consume more than a constant slack beyond the
+ * cap, so no unbounded allocation can happen regardless of provider metadata.
+ */
+// Suppress NoRelaxedMocks for Android framework classes (Context, ContentResolver, Cursor, Uri)
+// which have many methods that are not relevant to these tests
+@Suppress("NoRelaxedMocks")
+class FileUtilsUnknownSizeReadTest {
+    private lateinit var mockContext: Context
+    private lateinit var mockContentResolver: ContentResolver
+
+    @Before
+    fun setUp() {
+        mockContext = mockk(relaxed = true)
+        mockContentResolver = mockk(relaxed = true)
+        every { mockContext.contentResolver } returns mockContentResolver
+    }
+
+    @After
+    fun tearDown() {
+        unmockkAll()
+    }
+
+    private fun stubMetadataOnly(uri: Uri) {
+        val mockCursor = mockk<Cursor>(relaxed = true)
+        every { mockContentResolver.query(uri, null, null, null, null) } returns mockCursor
+        every { mockCursor.moveToFirst() } returns true
+        every { mockCursor.getColumnIndex(OpenableColumns.DISPLAY_NAME) } returns 0
+        every { mockCursor.getString(0) } returns "mystery.bin"
+        every { mockContentResolver.getType(uri) } returns "application/octet-stream"
+    }
+
+    private fun stubStatSize(
+        uri: Uri,
+        statSize: Long,
+    ) {
+        val mockPfd = mockk<ParcelFileDescriptor>(relaxed = true)
+        every { mockPfd.statSize } returns statSize
+        every { mockContentResolver.openFileDescriptor(uri, "r") } returns mockPfd
+    }
+
+    @Test
+    fun `readFileFromUriWithResult rejects unknown statSize stream and bounds the read`() {
+        // Provider reports statSize = -1 (unknown) over a ~8MB lazy stream.
+        // The pre-check cannot fire; the stream read itself MUST be bounded
+        // and the result MUST be FileTooLarge, not Success with 8MB in RAM.
+        val streamSize = 8 * 1024 * 1024
+        val testUri = mockk<Uri>(relaxed = true)
+        stubMetadataOnly(testUri)
+        stubStatSize(testUri, -1L)
+        val counting = CountingLazyStream(streamSize)
+        every { mockContentResolver.openInputStream(testUri) } returns counting
+
+        val result = FileUtils.readFileFromUriWithResult(mockContext, testUri)
+
+        assertTrue(
+            "Expected FileTooLarge for unknown-size ${streamSize}B stream, got: " +
+                result::class.java.simpleName,
+            result is FileUtils.FileReadResult.FileTooLarge,
+        )
+        result as FileUtils.FileReadResult.FileTooLarge
+        assertEquals(FileUtils.MAX_SINGLE_FILE_SIZE, result.maxSize)
+        // Rejecting AFTER reading everything is still an OOM: the read itself
+        // must stop shortly after the cap (one buffer of slack allowed).
+        assertTrue(
+            "Bounded read must abort near the cap, but consumed ${counting.totalRead}B " +
+                "of a ${streamSize}B stream (cap ${FileUtils.MAX_SINGLE_FILE_SIZE})",
+            counting.totalRead <= FileUtils.MAX_SINGLE_FILE_SIZE + BoundedReadAssertion.MAX_SLACK_BYTES,
+        )
+    }
+
+    @Test
+    fun `readFileFromUriWithResult rejects understated statSize stream and bounds the read`() {
+        // Provider lies (or is simply wrong): statSize = 100, stream is ~8MB.
+        val streamSize = 8 * 1024 * 1024
+        val testUri = mockk<Uri>(relaxed = true)
+        stubMetadataOnly(testUri)
+        stubStatSize(testUri, 100L)
+        val counting = CountingLazyStream(streamSize)
+        every { mockContentResolver.openInputStream(testUri) } returns counting
+
+        val result = FileUtils.readFileFromUriWithResult(mockContext, testUri)
+
+        assertTrue(
+            "Expected FileTooLarge for understated-size stream, got: " +
+                result::class.java.simpleName,
+            result is FileUtils.FileReadResult.FileTooLarge,
+        )
+        assertTrue(
+            "Bounded read must abort near the cap, but consumed ${counting.totalRead}B " +
+                "of a ${streamSize}B stream (cap ${FileUtils.MAX_SINGLE_FILE_SIZE})",
+            counting.totalRead <= FileUtils.MAX_SINGLE_FILE_SIZE + BoundedReadAssertion.MAX_SLACK_BYTES,
+        )
+    }
+
+    @Test
+    fun `readFileFromUri returns null for unknown statSize stream and bounds the read`() {
+        // Sibling parity: readFileFromUri has no post-read cap at all today.
+        val streamSize = 8 * 1024 * 1024
+        val testUri = mockk<Uri>(relaxed = true)
+        stubMetadataOnly(testUri)
+        stubStatSize(testUri, -1L)
+        val counting = CountingLazyStream(streamSize)
+        every { mockContentResolver.openInputStream(testUri) } returns counting
+
+        val result = FileUtils.readFileFromUri(mockContext, testUri)
+
+        assertNull(result)
+        assertTrue(
+            "Bounded read must abort near the cap, but consumed ${counting.totalRead}B " +
+                "of a ${streamSize}B stream (cap ${FileUtils.MAX_SINGLE_FILE_SIZE})",
+            counting.totalRead <= FileUtils.MAX_SINGLE_FILE_SIZE + BoundedReadAssertion.MAX_SLACK_BYTES,
+        )
+    }
+
+    @Test
+    fun `readFileFromUriWithResult still succeeds for unknown statSize within the cap`() {
+        // The bounded reader must not regress small unknown-size streams
+        // (e.g. pipes / streamed providers that report -1 but fit in memory).
+        val data = ByteArray(64 * 1024) { (it % 251).toByte() }
+        val testUri = mockk<Uri>(relaxed = true)
+        stubMetadataOnly(testUri)
+        stubStatSize(testUri, -1L)
+        every { mockContentResolver.openInputStream(testUri) } returns java.io.ByteArrayInputStream(data)
+
+        val result = FileUtils.readFileFromUriWithResult(mockContext, testUri)
+
+        assertTrue(
+            "Expected Success for in-cap unknown-size stream, got: " +
+                result::class.java.simpleName,
+            result is FileUtils.FileReadResult.Success,
+        )
+        result as FileUtils.FileReadResult.Success
+        assertEquals(data.size, result.attachment.sizeBytes)
+    }
+
+    @Test
+    fun `readFileFromUriWithResult accepts a stream exactly at the cap`() {
+        // Boundary: exactly MAX_SINGLE_FILE_SIZE bytes must still be accepted
+        // (the cap rejects strictly-larger files, matching the pre-check '>').
+        val data = ByteArray(FileUtils.MAX_SINGLE_FILE_SIZE)
+        val testUri = mockk<Uri>(relaxed = true)
+        stubMetadataOnly(testUri)
+        stubStatSize(testUri, -1L)
+        every { mockContentResolver.openInputStream(testUri) } returns java.io.ByteArrayInputStream(data)
+
+        val result = FileUtils.readFileFromUriWithResult(mockContext, testUri)
+
+        assertTrue(
+            "Expected Success for exactly-cap-sized stream, got: " +
+                result::class.java.simpleName,
+            result is FileUtils.FileReadResult.Success,
+        )
+    }
+
+    /** Allowed slack beyond the cap for one read buffer before aborting. */
+    private object BoundedReadAssertion {
+        const val MAX_SLACK_BYTES = 64 * 1024
+    }
+
+    /**
+     * InputStream that serves [size] bytes with zero upfront allocation and
+     * counts every byte actually consumed, so tests can assert the read was
+     * aborted near the cap instead of pulling the whole stream into memory.
+     */
+    private class CountingLazyStream(size: Int) : InputStream() {
+        @Volatile
+        var totalRead: Int = 0
+            private set
+
+        private var remaining = size
+
+        override fun read(): Int {
+            if (remaining <= 0) return -1
+            remaining--
+            totalRead++
+            return 0
+        }
+
+        override fun read(
+            b: ByteArray,
+            off: Int,
+            len: Int,
+        ): Int {
+            if (remaining <= 0) return -1
+            val toRead = minOf(len, remaining)
+            b.fill(0, off, off + toRead)
+            remaining -= toRead
+            totalRead += toRead
+            return toRead
+        }
+    }
+}


### PR DESCRIPTION
## Summary

**COLUMBA-4A — restore attachment size caps, bound the stream read against unknown/understated provider sizes, reconcile the composer send path with the accepted 32MB send contract, and kill the double-array heap peak in bounded reads.**

Multi-part fix. Part 1 (`7d9b5dba`) restored the disabled size caps. Part 2 (`25f97257`) closed the remaining hole found by the exact-head automated review gate (iteration 1): provider metadata can report an unknown or understated size, which bypasses the metadata pre-check, so the read itself is now bounded. Part 3 (`791b96e7` RED + `4fda09e2`) fixed the regression that Parts 1–2 introduced on the composer send path: the 512KB single-file cap was being applied to composer picks, rejecting files the send side itself accepts (the canonical Real LXMF Resource Progress E2E 1MB pick). Correction 2 (`51603ecb`) fixed the second exact-head review finding: the send-path read still spiked heap (~2x per-file bytes peak from a double-array copy) and multi-file selections retained every array until the send-time aggregate check. Correction 3 (`a69311dd`) fixed the third exact-head review finding: a near-cap read trim still held both the full accumulator and the near-file-sized copy at once (~63MB transient on the 32MB send path), and overlapping picker callbacks each validated against a stale group-budget snapshot so two batches could jointly retain >32MB in the composer until the send-time rejection. Correction 4 (`746905a6`) fixed the fourth exact-head review finding: on the rewind path the near-cap accumulator was still live (reachable) at the moment the exact-sized array was allocated, so the two arrays briefly coexisted — the accumulator is now drained (its holder cleared) before the single exact allocation so it is garbage at that point.

### Observed production symptom

A user picked a ~181MB file in the MessagingScreen file picker. `FileUtils.readFileFromUriWithResult` read the entire file into a `ByteArray` in memory, causing a fatal uncaught `OutOfMemoryError` crash on-device (Sentry regression `30075665`). Affected release: `v2.2.4-beta` (current pre-release channel; the crash was observed on a shipped app build). No user, device, geography, or trace identifiers are included in this description.

A second, review-discovered symptom: at heads `7d9b5dba`/`25f97257` the restored 512KB cap made the composer file picker reject a legitimate 1MB send pick, so the canonical Real LXMF Resource Progress E2E (1MB file picked in the composer) failed with `FileTooLarge` and the outgoing bubble never appeared. Part 3 restores that contract without relaxing the OOM guard.

A third, review-discovered symptom: at head `4fda09e2` send-path reads still spiked heap — `readBounded` grew a full `ByteArrayOutputStream` and `toByteArray()` created a second complete array (peak ~2x per-file bytes on a near-32MB send read), and every pick of a multi-file selection was retained until the send-time aggregate check, keeping the attachment OOM path reachable. Correction 2 eliminates both: the read now holds a single hard-capped buffer, and the composer working set is bounded at one 32MB group budget.

A fourth, review-discovered symptom: at head `51603ecb` the near-cap trim path in `readBounded` still kept the full accumulator alive alongside the near-file-sized exact copy (~63MB transient on the 32MB send path), and each overlapping picker callback validated its picks against a stale entry-time group-budget snapshot with a callback-local counter, so two interleaved batches could jointly retain >32MB until the send-time rejection. Correction 3 eliminates both: the accumulator is released before the single exact allocation, and one remembered mutex makes "read live total → check → add" a single critical section shared by every picker batch.

A fifth, review-discovered symptom: at head `a69311dd` the Correction-3 rewind path still left the near-cap accumulator *reachable* at the exact moment the exact-sized array was allocated — the `FirstPass` holder still backed the old array, so for that instant both arrays were simultaneously live and the old one was not yet garbage. Correction 4 closes this: before the single exact allocation the accumulator is drained (its `FirstPass` holder cleared) so it is provably garbage at the point of allocation — pinned by a GC-reachability test that cannot pass vacuously.

### Root cause (OOM)

Both size guards in `FileUtils.kt` were disabled at `Int.MAX_VALUE` (stale kdoc read "No practical limit"), so:
- `MAX_SINGLE_FILE_SIZE = Int.MAX_VALUE` — the pre-read and post-read checks in `readFileFromUriWithResult` could never trip.
- `MAX_TOTAL_ATTACHMENT_SIZE = Int.MAX_VALUE` — `wouldExceedSizeLimit` was mathematically ineffective.

The sibling path `readFileFromUri` had no size pre-check at all and called `readBytes()` unconditionally.

### Part 1 — restore the size caps (commit `7d9b5dba`)

- `MAX_SINGLE_FILE_SIZE` restored to `512 * 1024` (512KB) — re-activates the pre- and post-read checks in `readFileFromUriWithResult`.
- `MAX_TOTAL_ATTACHMENT_SIZE` restored to `512 * 1024 * 64` (32MB) — makes `wouldExceedSizeLimit` effective.
- Identical size pre-check added to `readFileFromUri`, which now returns `null` for oversized files instead of calling `readBytes()` (sibling parity for the same unbounded read; this function has no main-source callers — test-only).
- Stale "No practical limit" kdoc updated.

### Part 2 — bound the stream read against unknown/understated sizes (commit `25f97257`)

The exact-head automated review gate (iteration 1) found P1 "Unknown sizes bypass read cap": a provider that reports `statSize == -1` (unknown) or understates the stream size passes the metadata pre-check, and `InputStream.readBytes()` then allocates the entire stream — the OOM path is still reachable via a lying or unknown provider.

Correction:
- A new top-level private `readBounded()` in `FileUtils.kt` copies through a fixed 64KB buffer and **aborts (returns `null`) the moment the stream exceeds the cap, before accumulating overflow** — peak allocation is capped at the cap + one 64KB buffer regardless of what the provider metadata claims.
- Wired into `readFileFromUriWithResult` (returns `FileTooLarge`; `actualSize = -1`, documented as "size never revealed") and `readFileFromUri` (returns `null`, sibling parity).
- The metadata pre-check is preserved as a fast path; the bounded read is the authoritative last line of defense.

`readBounded` is top-level `private` (an object member would trip the pre-existing `TooManyFunctions` `thresholdInObjects=15`).

### Part 3 — reconcile the composer send path with the 32MB send contract (commits `791b96e7` RED + `4fda09e2`)

The restored 512KB cap was applied to the composer file picker, rejecting files the send side itself accepts: the canonical Real LXMF Resource Progress E2E picks a 1MB file, which now returned `FileTooLarge` → toast → never attached, so the outgoing bubble never appeared (RED at `7d9b5dba` and `25f97257`, green on base/main where the cap was `Int.MAX_VALUE`). The `7d9b5dba` message claimed large SEND-side picks keep working via the file-based transfer path, but that path is only wired to the incoming-share flow — not the picker.

Regression-first correction:
- `791b96e7` (test-only): new `FileUtilsPickerLargeFileTest` pinned the contract RED — "Expected Success for the canonical 1MB E2E pick, got: FileTooLarge".
- `4fda09e2`: new `FileUtils.readFileForSendWithResult` — same contract as `readFileFromUriWithResult` but bounded to `MAX_TOTAL_ATTACHMENT_SIZE` (32MB), exactly the per-file ceiling `MessagingViewModel` already enforces before handing bytes to Reticulum. `MessagingScreen.filePickerLauncher` now routes picks through the send-bounded reader, so the 1MB E2E pick attaches with full bytes. The generic `readFileFromUriWithResult` / `readFileFromUri` keep the 512KB cap untouched for all other callers.
- The COLUMBA-4A OOM guard is **NOT relaxed**: both caps share one implementation (`readFileWithResultBounded`) — metadata pre-check first, then the allocation-bounded `readBounded()` read. An 181MB pick is refused before any bytes are read, and an unknown/understated `statSize` over an 181MB lazy stream aborts within one buffer of the 32MB cap (pinned by new tests).
- Stale kdoc claim about the file-based transfer path replaced with the actual wiring.
- The `FILE_TRANSFER_THRESHOLD` (500KB) file-based transfer path (`copyUriToTempFile` / `writeTempAttachment`) remains **untouched** (incoming-share flow only).

### Correction 2 — kill the double-array peak and bound composer group retention (commit `51603ecb`)

Exact-head automated review (Greptile P1 at `4fda09e2`): "Send reads still spike heap — readBounded grows a full ByteArrayOutputStream and toByteArray() creates another complete array; selecting multiple files retains each array before the combined-size check runs at send time."

Correction:
- `readBounded` now grows a **single hard-capped `ByteArray` accumulator that never exceeds `maxBytes`**, aborts before overflow, and returns it without a second `toByteArray()` copy in the exact-seed common case; a single trim allocation happens only after an overshooting growth step.
- `readFileWithResultBounded` seeds the accumulator from a plausible provider `statSize`, making the typical send read a single exact allocation.
- `MessagingScreen.filePickerLauncher` now processes picks **sequentially with group-budget accounting**: a known-size pre-check runs before opening each stream, and the exact post-read `wouldExceedSizeLimit` check runs before each `addFileAttachment` — so the retained composer working set is provably bounded at `MAX_TOTAL_ATTACHMENT_SIZE` (32MB) instead of N x 32MB pending the send-time check.
- New `FileUtilsSendHeapSpikeTest.kt` (7 tests) pinned the single-buffer byte-exactness across size shapes, the near-cap unknown-size abort, and the bounded group-retention invariant.
- The diff `4fda09e2..51603ecb` touches ONLY `FileUtils.kt`, `MessagingScreen.kt`, and the new test file.

### Correction 3 — drop the accumulator before the exact allocation and share one live picker budget (commit `a69311dd`)

Exact-head automated review (Greptile P1s at `51603ecb`): "Trim copy doubles heap" and "Picker budgets race" — a near-cap `readBounded` result trim held the full accumulator and the near-file-sized copy at once (~63MB transient on the 32MB send path), and overlapping picker callbacks each validated against a stale entry-time `groupBudgetBase` snapshot with a callback-local counter, so two batches could jointly retain >32MB in the composer until the send-time rejection.

Correction:
- `readBounded`: a near-cap read whose accumulator overshoots its capacity no longer trims. It verifies the provider restarts byte-for-byte via a fresh open, counts the true length with zero accumulation (aborting past the cap), **releases the accumulator BEFORE the single exact-sized allocation**, and fills it from a fresh open. Non-restartable providers fall back to the (still bounded) trim; exact-seed known-size reads stay copy-free; the unknown/understated-size OOM guard is unchanged on the 512KB generic and 32MB send paths (the abort stays single-pass at cap + one 64KB buffer — the rewind path is only reached after a first-pass EOF).
- `MessagingScreen`: replace the per-callback `groupBudgetBase`/`groupBudgetUsed` accounting with `tryReserveGroupBudgetLocked` — a single remembered `Mutex` making "read the LIVE composer total → check → add" one critical section shared by every picker batch, so overlapping callbacks share one live budget and the retained working set is provably bounded at `MAX_TOTAL_ATTACHMENT_SIZE` (32MB). Per-URI toast/skip UX is unchanged; the sole `addFileAttachment` call site in `MessagingScreen` is routed through this locked reservation.
- `FileUtilsSendHeapSpikeTest`: +8 regression tests (heap-observer shape assertions for release-before-alloc, copy-free exact-seed, non-restartable and no-reopen fallbacks, over-cap abort on the rewind branch, and concurrent/sequential group-budget invariants) → 15 tests total. All previously pinned tests remain byte-identical; the diff `51603ecb..a69311dd` touches ONLY `FileUtils.kt`, `MessagingScreen.kt`, and `FileUtilsSendHeapSpikeTest.kt` (test diff additive, 0 deleted lines).

### Correction 4 — drain the rewind accumulator so it is garbage before the exact allocation (commit `746905a6`)

Exact-head automated review (Greptile P1 3890640498 at `a69311dd`): "rewind accumulator remained live (reachable) across the exact-allocation point during rewind" — the `FirstPass` holder still backed the old array when the exact-sized array was allocated, so the two arrays were simultaneously live for that instant.

Correction:
- `rewindToExactArray` (the `readBounded` rewind path) now **drains the `FirstPass` holder before the single exact-sized allocation**, clearing the backing array so the old accumulator is garbage at the point of allocation. No frame on the path (`readBounded` / `finishOversizedRead` / `rewindToExactArray` / `fillExactFromReopen`, probe, observer) holds the old array before that allocation — no path holds two >4MB arrays.
- New GC-reachability pin `near-cap rewind accumulator is garbage at the point of the exact allocation`: a `WeakReference` is captured at the live seam, a forced GC runs at the exact allocation point, and a control-garbage anti-vacuity guard ensures the assertion cannot pass vacuously.
- `FileUtilsSendHeapSpikeTest`: +1 test → 16 tests total (was 15). All previously pinned tests remain byte-identical; the diff `a69311dd..746905a6` touches ONLY `FileUtils.kt` (+103/−13) and `FileUtilsSendHeapSpikeTest.kt` (+70, strictly additive — 0 deleted lines).

### Behavioral change (intended, flagged)

- Generic in-conversation file reads: files larger than 512KB are rejected with a toast: `File too large (NKB). Max size is 512KB.` Previously the path was effectively unlimited and would crash on large files. `MessagingScreen` handles the `FileTooLarge` result correctly (toasts, never adds the file, clears processing state).
- Composer SEND picks: bounded to 32MB (the send-side ceiling), not 512KB. A 1MB composer pick attaches with full bytes; an 181MB pick is still refused (before or mid-read) instead of OOMing.
- Unknown/understated provider sizes are now rejected with the **read itself aborting at the cap** instead of OOMing, on both the 512KB generic and 32MB send paths, from a single hard-capped buffer. Exactly-cap streams and in-cap unknown-size streams still succeed. (Non-blocking cosmetic note: an unknown-size `FileTooLarge(-1)` renders the toast size as `0KB` because `-1/1024` truncates to `0`; the previous head OOMed on this exact path, so no approved behavior is weakened.)
- Multi-file composer selections: each pick is read sequentially and the group budget is enforced before each attachment is retained, so selecting N files can no longer hold N full file arrays in memory before the send-time check; overlapping picker batches share one live budget under a single mutex.

### Commit inventory (exactly 8, on base `9967e912`)

1. `0a07a130` — `test(fileutils): red regression tests for COLUMBA-4A disabled size caps` (immutable, test-only, 3 files)
2. `7d9b5dba` — `fix(fileutils): restore attachment size caps to stop unbounded in-memory reads (COLUMBA-4A)` (1 production file, +30/−10)
3. `25f97257` — `fix(fileutils): bound the stream read itself against unknown/understated provider sizes (COLUMBA-4A review)` (correction; exactly 2 files: `FileUtils.kt` +57/−8 and new `FileUtilsUnknownSizeReadTest.kt` +224)
4. `791b96e7` — `test(fileutils): pin canonical E2E 1MB composer pick contract (RED)` (test-only: new `FileUtilsPickerLargeFileTest.kt` +98)
5. `4fda09e2` — `fix(fileutils): bound composer send picks to the send-path 32MB ceiling (COLUMBA-4A regression)` (correction; exactly 3 files: `FileUtils.kt`, `MessagingScreen.kt`, `FileUtilsPickerLargeFileTest.kt`)
6. `51603ecb` — `fix(fileutils): kill double-array peak in bounded reads and bound composer group retention (COLUMBA-4A review)` (correction; exactly 3 files: `FileUtils.kt`, `MessagingScreen.kt`, new `FileUtilsSendHeapSpikeTest.kt`)
7. `a69311dd` — `fix(fileutils): drop accumulator before exact allocation and share picker group budget (COLUMBA-4A review)` (correction; exactly 3 files: `FileUtils.kt` +225/−18, `MessagingScreen.kt` +83/−23, `FileUtilsSendHeapSpikeTest.kt` +270)
8. `746905a6` — `fix(fileutils): drain rewind accumulator so it is garbage before the exact allocation (COLUMBA-4A review)` (correction 4; exactly 2 files: `FileUtils.kt` +103/−13 and `FileUtilsSendHeapSpikeTest.kt` +70, additive)

Changed-file scope vs base: 8 files (2 production — `FileUtils.kt`, `MessagingScreen.kt` — + 6 test files), full diff +1876/−88.

### Regression tests & verification

Deterministic automated reproductions:
- `FileUtilsUnknownSizeReadTest` (Part 2, 5 tests: unknown `-1` statSize, understated statSize, sibling-parity `null`, in-cap unknown-size still succeeds, exactly-cap stream still accepted) — RED at `7d9b5dba` (3 failures), GREEN from `25f97257` on.
- `FileUtilsPickerLargeFileTest` (Part 3, 4 tests: canonical 1MB composer send pick succeeds with full bytes, 181MB pick refused before `openInputStream`, bounded read on unknown statSize, generic reader keeps the 512KB cap) — RED at `25f97257` ("Expected Success for the canonical 1MB E2E pick, got: FileTooLarge"), GREEN at `4fda09e2`.
- `FileUtilsSendHeapSpikeTest` (Correction 2: 7 tests for single-buffer byte-exactness, exact-seed no-second-copy, near-cap unknown-size abort, bounded group-retention; Correction 3: +8; Correction 4: +1 GC-reachability pin) → 16 tests total for release-before-alloc heap shape, copy-free exact-seed, non-restartable/no-reopen fallbacks, over-cap rewind abort, the near-cap accumulator-is-garbage-at-exact-allocation reachability pin, and concurrent/sequential group-budget invariants) — GREEN at `746905a6` (16/16).
- The pinned test files remain byte-identical from `a69311dd` to `746905a6` (diff verified at review); only `FileUtilsSendHeapSpikeTest.kt` grew, additively (70 insertions, 0 deleted lines).

Verification (run fresh with `--rerun-tasks` and `--offline`, `ANDROID_HOME` set to the local SDK; independently re-run at the exact head `746905a6` by the final review):

- Full unit-test task (noSentry flavor):
  `./gradlew :app:testNoSentryKotlinBackendDebugUnitTest --offline --rerun-tasks`
  → **BUILD SUCCESSFUL**; **0 failures / 0 errors** (6125 tests). Pinned suites at this head: `FileUtilsSendHeapSpikeTest` 16/16 (incl. the new Correction-4 GC-reachability pin), `FileUtilsPickerLargeFileTest` 4/4 (canonical 1MB E2E contract), `FileUtilsUnknownSizeReadTest` 5/5, `FileUtilsRobolectricTest` 15/15, `FileUtilsTempAttachmentTest` 14/14, `FileUtilsTest` 55/55, `AttachmentViewModelTest` 22/22, `MessagingViewModelTest` 188/188.
- Quality (forced rerun at the exact head `746905a6`): `./gradlew :app:ktlintCheck :app:detekt :cpdCheck --offline --rerun-tasks` → **BUILD SUCCESSFUL** (cpd: only the pre-existing duplicate, no FileUtils involvement).
- Dispatcher audit: `./audit-dispatchers.sh` → **0 violations** (report artifact removed; tree left clean).
- Contracts preserved: generic cap 512KB (`MAX_SINGLE_FILE_SIZE`), send-path cap 32MB (`MAX_TOTAL_ATTACHMENT_SIZE`), `FileTooLarge` semantics unchanged, `readFileFromUri` sibling guard intact, `FILE_TRANSFER_THRESHOLD` (500KB) file-based path untouched.
- RED at the exact head (independently reproduced): removing the `pass.drain()` from `rewindToExactArray` fails exactly the new pin at `FileUtilsSendHeapSpikeTest.kt:405` (reachability assertion) while the other 15 spike tests pass.
- CI (Kotlin test shards, code quality, and the Real LXMF Resource Progress E2E lane) re-runs at the new head `746905a6` after this push.

### Manual end-user reproduction (deterministic)

1. Open any conversation in the Columba Android app.
2. Tap the attachment/paperclip action to open the file picker.
3. Select a file larger than 512KB (the ~181MB file that crashed production is the real-world instance; any >512KB file reproduces the guard).

**Before this fix (original head):** the picker accepts the file, `readFileFromUriWithResult` reads the whole file into memory, and the app crashes with an uncaught `OutOfMemoryError` on large files.
**After this fix:** the send pick over 32MB is refused with a size toast (no bytes allocated); a 1MB–32MB pick attaches and sends normally; the app never OOMs on a picked file.

For the unknown/understated-size variant (Part 2), the exact E2E pick contract (Part 3), the heap-shape invariants (Corrections 2–4), and the concurrent picker-budget race: these depend on a file provider misreporting its size / the scripted LXMF resource flow / sub-allocation heap shapes / overlapping picker callbacks that an end user cannot observe or trigger by hand, so they are covered deterministically by the `FileUtilsUnknownSizeReadTest`, `FileUtilsPickerLargeFileTest`, and `FileUtilsSendHeapSpikeTest` automated suites rather than an honest manual end-user sequence — synthetic state injection is used for these tests and is not claimed as a manual reproduction.

### Merge policy

Merge remains human-controlled; this PR is published for review only — no auto-merge, no squash, no branch deletion.

