### PR TITLE
fix(rns-backend-py): wire incoming message size limit to LXMF delivery gate (#1106)

### DIFF
--- a/app/src/main/java/network/columba/app/ColumbaApplication.kt
+++ b/app/src/main/java/network/columba/app/ColumbaApplication.kt
@@ -499,6 +499,11 @@ class ColumbaApplication : Application() {
                         discoverInterfaces = discoverInterfaces,
                         autoconnectDiscoveredInterfaces = autoconnectDiscoveredCount,
                         autoconnectIfacOnly = startupConfig.autoconnectIfacOnly,
+                        // Prime the backend's delivery gate with the persisted
+                        // limit at startup, before any delivery is possible
+                        // (columba#1106 startup window)
+                        incomingMessageSizeLimitKb =
+                            settingsRepository.getIncomingMessageSizeLimitKb().toLong(),
                     )
 
                 rnsCore
@@ -506,10 +511,10 @@ class ColumbaApplication : Application() {
                     .onSuccess {
                         android.util.Log.i("ColumbaApplication", "Reticulum initialized successfully")
 
-                        // Apply the saved incoming-message size limit now that the
-                        // protocol stack is up, so the first delivery of this session
-                        // already honours the user's setting instead of LXMF's
-                        // built-in ~1 MB gate (columba#1106).
+                        // Belt-and-braces: the config already primed the backend's
+                        // delivery gate at startup (columba#1106); re-pushing the
+                        // persisted value covers the reconnect-to-running-backend
+                        // path where the backend outlived a settings change.
                         applySavedIncomingMessageSizeLimit()
 
                         // A.10 follow-up: persist a sanitized snapshot so :reticulum can
@@ -627,10 +632,11 @@ class ColumbaApplication : Application() {
     /**
      * Push the persisted incoming-message size limit to the protocol stack.
      *
-     * The limit only reaches LXMF when the user changes it in Settings, so a
-     * backend (re)start would otherwise run with the default until the next
-     * change. Called on both backend-ready paths: fresh init and reconnect to
-     * an already-running backend.
+     * Primary startup coverage comes from [ReticulumConfig.incomingMessageSizeLimitKb]
+     * (primed by the backend before its delivery destination becomes reachable);
+     * this push covers the reconnect-to-running-backend path and any drift
+     * between the backend's startup value and the current persisted setting.
+     * Called on both backend-ready paths: fresh init and reconnect.
      */
     private fun applySavedIncomingMessageSizeLimit() {
         applicationScope.launch(Dispatchers.IO) {

--- a/app/src/main/java/network/columba/app/ColumbaApplication.kt
+++ b/app/src/main/java/network/columba/app/ColumbaApplication.kt
@@ -399,6 +399,7 @@ class ColumbaApplication : Application() {
                         identityResolutionManager.start(applicationScope)
                         propagationNodeManager.start()
                         telemetryCollectorManager.start()
+                        applySavedIncomingMessageSizeLimit()
                         android.util.Log.d(
                             "ColumbaApplication",
                             "MessageCollector, AutoAnnounceManager, IdentityResolutionManager, PropagationNodeManager, TelemetryCollectorManager started",
@@ -504,6 +505,12 @@ class ColumbaApplication : Application() {
                     .initialize(config)
                     .onSuccess {
                         android.util.Log.i("ColumbaApplication", "Reticulum initialized successfully")
+
+                        // Apply the saved incoming-message size limit now that the
+                        // protocol stack is up, so the first delivery of this session
+                        // already honours the user's setting instead of LXMF's
+                        // built-in ~1 MB gate (columba#1106).
+                        applySavedIncomingMessageSizeLimit()
 
                         // A.10 follow-up: persist a sanitized snapshot so :reticulum can
                         // self-init after OOM/force-stop restart when UI isn't around to
@@ -614,6 +621,29 @@ class ColumbaApplication : Application() {
                 android.util.Log.e("ColumbaApplication", "Error shutting down Reticulum", e)
             }
             // unbindService() was a legacy no-op on the kotlin backend
+        }
+    }
+
+    /**
+     * Push the persisted incoming-message size limit to the protocol stack.
+     *
+     * The limit only reaches LXMF when the user changes it in Settings, so a
+     * backend (re)start would otherwise run with the default until the next
+     * change. Called on both backend-ready paths: fresh init and reconnect to
+     * an already-running backend.
+     */
+    private fun applySavedIncomingMessageSizeLimit() {
+        applicationScope.launch(Dispatchers.IO) {
+            runCatching {
+                val limitKb = settingsRepository.getIncomingMessageSizeLimitKb()
+                rnsLxmf.setIncomingMessageSizeLimit(limitKb)
+                android.util.Log.d(
+                    "ColumbaApplication",
+                    "Applied saved incoming message size limit: ${limitKb}KB",
+                )
+            }.onFailure { e ->
+                android.util.Log.w("ColumbaApplication", "Failed to apply saved incoming message size limit", e)
+            }
         }
     }
 

--- a/app/src/main/java/network/columba/app/service/InterfaceConfigManager.kt
+++ b/app/src/main/java/network/columba/app/service/InterfaceConfigManager.kt
@@ -338,6 +338,11 @@ class InterfaceConfigManager
                     val batteryProfile = settingsRepository.getBatteryProfile()
                     Log.d(TAG, "Battery profile: $batteryProfile")
 
+                    // Load the incoming-message size limit so the restarting backend
+                    // primes the user's gate before the first delivery (columba#1106)
+                    val incomingMessageSizeLimitKb =
+                        settingsRepository.getIncomingMessageSizeLimitKb().toLong()
+
                     // Load discovery settings
                     val discoverInterfaces = settingsRepository.getDiscoverInterfacesEnabled()
                     val savedAutoconnect = settingsRepository.getAutoconnectDiscoveredCount()
@@ -368,6 +373,7 @@ class InterfaceConfigManager
                             discoverInterfaces = discoverInterfaces,
                             autoconnectDiscoveredInterfaces = autoconnectDiscoveredCount,
                             autoconnectIfacOnly = autoconnectIfacOnly,
+                            incomingMessageSizeLimitKb = incomingMessageSizeLimitKb,
                         )
 
                     rnsCore

--- a/app/src/main/java/network/columba/app/viewmodel/SettingsViewModel.kt
+++ b/app/src/main/java/network/columba/app/viewmodel/SettingsViewModel.kt
@@ -39,6 +39,7 @@ import network.columba.app.rns.api.RnsCore
 import network.columba.app.rns.api.RnsException
 import network.columba.app.rns.api.RnsLxmf
 import network.columba.app.rns.api.RnsTransportAdmin
+import network.columba.app.rns.host.persistence.ReticulumConfigSnapshot
 import network.columba.app.service.AvailableRelaysState
 import network.columba.app.service.PropagationNodeManager
 import network.columba.app.service.RelayInfo
@@ -2079,6 +2080,14 @@ class SettingsViewModel
 
                 // Apply the change at runtime via the protocol
                 rnsLxmf.setIncomingMessageSizeLimit(limitKb)
+
+                // Keep the on-disk restart snapshot in sync: a :reticulum-only
+                // recovery (UI process dead) reads it, so without this it would
+                // resurrect the previous delivery gate (columba#1106)
+                ReticulumConfigSnapshot.updateIncomingMessageSizeLimitKb(
+                    context,
+                    limitKb.toLong(),
+                )
             }
         }
 

--- a/app/src/test/java/network/columba/app/data/repository/ConversationRepositoryDatabaseTest.kt
+++ b/app/src/test/java/network/columba/app/data/repository/ConversationRepositoryDatabaseTest.kt
@@ -553,6 +553,128 @@ class ConversationRepositoryDatabaseTest : DatabaseTest() {
             assertEquals(audioPayload, storedAudio.getString(1))
         }
 
+    // ========== File attachment extraction tests ==========
+
+    @Test
+    fun `saveMessage extracts Sideband-style positional file attachment to disk`() =
+        runTest {
+            // Wire format from Sideband and other LXMF apps:
+            // "5": [["filename.mp4", "hexdata..."]]
+            val hexData = "ab".repeat(AttachmentStorageManager.SIZE_THRESHOLD / 2 + 1)
+            val storedPath = "/tmp/positional_file.hex"
+            every {
+                mockAttachmentStorage.saveAttachment("msg_positional_file", "5_0", hexData)
+            } returns storedPath
+            val fields =
+                JSONObject()
+                    .put(
+                        "5",
+                        JSONArray()
+                            .put(JSONArray().put("G4 Doorbell Pro.mp4").put(hexData)),
+                    )
+                    .toString()
+            val message =
+                Message(
+                    id = "msg_positional_file",
+                    destinationHash = TEST_PEER_HASH,
+                    content = "",
+                    timestamp = 1000L,
+                    isFromMe = false,
+                    status = "delivered",
+                    fieldsJson = fields,
+                )
+
+            repository.saveMessage(TEST_PEER_HASH, "Peer", message, null)
+            testDispatcher.scheduler.advanceUntilIdle()
+
+            val saved = messageDao.getMessageById("msg_positional_file", TEST_IDENTITY_HASH)
+            val stored = JSONObject(saved!!.fieldsJson!!).getJSONArray("5").getJSONObject(0)
+            assertEquals("G4 Doorbell Pro.mp4", stored.getString("filename"))
+            assertEquals(hexData.length / 2, stored.getInt("size"))
+            assertEquals(storedPath, stored.getString("_data_ref"))
+            verify(exactly = 1) {
+                mockAttachmentStorage.saveAttachment("msg_positional_file", "5_0", hexData)
+            }
+        }
+
+    @Test
+    fun `saveMessage decodes hex-encoded filename in positional file attachment`() =
+        runTest {
+            // Columba backends hex-encode ByteArray filename fields
+            val filename = "doc.pdf"
+            val hexFilename = filename.toByteArray().joinToString("") { "%02x".format(it) }
+            val hexData = "cd".repeat(AttachmentStorageManager.SIZE_THRESHOLD / 2 + 1)
+            val storedPath = "/tmp/hex_name_file.hex"
+            every {
+                mockAttachmentStorage.saveAttachment("msg_hex_name", "5_0", hexData)
+            } returns storedPath
+            val fields =
+                JSONObject()
+                    .put("5", JSONArray().put(JSONArray().put(hexFilename).put(hexData)))
+                    .toString()
+            val message =
+                Message(
+                    id = "msg_hex_name",
+                    destinationHash = TEST_PEER_HASH,
+                    content = "",
+                    timestamp = 1000L,
+                    isFromMe = false,
+                    status = "delivered",
+                    fieldsJson = fields,
+                )
+
+            repository.saveMessage(TEST_PEER_HASH, "Peer", message, null)
+            testDispatcher.scheduler.advanceUntilIdle()
+
+            val saved = messageDao.getMessageById("msg_hex_name", TEST_IDENTITY_HASH)
+            val stored = JSONObject(saved!!.fieldsJson!!).getJSONArray("5").getJSONObject(0)
+            assertEquals(filename, stored.getString("filename"))
+            assertEquals(storedPath, stored.getString("_data_ref"))
+        }
+
+    @Test
+    fun `saveMessage extracts object-format file attachment data to disk`() =
+        runTest {
+            // Columba's own format: "5": [{"filename", "size", "data"}]
+            val hexData = "ef".repeat(AttachmentStorageManager.SIZE_THRESHOLD / 2 + 1)
+            val storedPath = "/tmp/object_file.hex"
+            every {
+                mockAttachmentStorage.saveAttachment("msg_object_file", "5_0", hexData)
+            } returns storedPath
+            val fields =
+                JSONObject()
+                    .put(
+                        "5",
+                        JSONArray()
+                            .put(
+                                JSONObject()
+                                    .put("filename", "doc.pdf")
+                                    .put("size", hexData.length / 2)
+                                    .put("data", hexData),
+                            ),
+                    )
+                    .toString()
+            val message =
+                Message(
+                    id = "msg_object_file",
+                    destinationHash = TEST_PEER_HASH,
+                    content = "",
+                    timestamp = 1000L,
+                    isFromMe = false,
+                    status = "delivered",
+                    fieldsJson = fields,
+                )
+
+            repository.saveMessage(TEST_PEER_HASH, "Peer", message, null)
+            testDispatcher.scheduler.advanceUntilIdle()
+
+            val saved = messageDao.getMessageById("msg_object_file", TEST_IDENTITY_HASH)
+            val stored = JSONObject(saved!!.fieldsJson!!).getJSONArray("5").getJSONObject(0)
+            assertEquals("doc.pdf", stored.getString("filename"))
+            assertEquals(hexData.length / 2, stored.getInt("size"))
+            assertEquals(storedPath, stored.getString("_data_ref"))
+        }
+
     @Test
     fun `deleteConversation removes conversation and messages`() =
         runTest {

--- a/app/src/test/java/network/columba/app/data/repository/ConversationRepositoryDatabaseTest.kt
+++ b/app/src/test/java/network/columba/app/data/repository/ConversationRepositoryDatabaseTest.kt
@@ -595,6 +595,15 @@ class ConversationRepositoryDatabaseTest : DatabaseTest() {
             verify(exactly = 1) {
                 mockAttachmentStorage.saveAttachment("msg_positional_file", "5_0", hexData)
             }
+
+            // The stored row must stay far below the SQLite CursorWindow
+            // limit (~2 MB). If the hex is kept inline, the conversation
+            // query fails and the whole chat renders empty - the original
+            // bug this test guards against.
+            assertTrue(
+                "stored fieldsJson must not keep the file data inline, got ${saved.fieldsJson?.length} chars",
+                saved.fieldsJson!!.length < AttachmentStorageManager.SIZE_THRESHOLD,
+            )
         }
 
     @Test

--- a/app/src/test/java/network/columba/app/service/InterfaceConfigManagerTest.kt
+++ b/app/src/test/java/network/columba/app/service/InterfaceConfigManagerTest.kt
@@ -130,6 +130,7 @@ class InterfaceConfigManagerTest {
         coEvery { settingsRepository.getAutoconnectDiscoveredCount() } returns 0
         coEvery { settingsRepository.getAutoconnectIfacOnly() } returns false
         coEvery { settingsRepository.getShareInstanceHostingEnabled() } returns false
+        coEvery { settingsRepository.getIncomingMessageSizeLimitKb() } returns 1024
         every { settingsRepository.sortMessagesBySentTime } returns flowOf(false)
 
         // Setup identity repository mock
@@ -462,6 +463,27 @@ class InterfaceConfigManagerTest {
                 rnsCore.initialize(
                     match { config ->
                         config.enableTransport == false
+                    },
+                )
+            }
+        }
+
+    @Test
+    fun `applyInterfaceChanges - passes incoming message size limit to config`() =
+        runTest {
+            // Given: persisted limit from Settings (binary KB)
+            coEvery { settingsRepository.getIncomingMessageSizeLimitKb() } returns 131072
+
+            // When
+            val result = manager.applyInterfaceChanges()
+
+            // Then: backend receives the limit so it can prime the delivery
+            // gate before the first delivery (columba#1106)
+            assertTrue("applyInterfaceChanges should succeed", result.isSuccess)
+            coVerify {
+                rnsCore.initialize(
+                    match { config ->
+                        config.incomingMessageSizeLimitKb == 131072L
                     },
                 )
             }

--- a/app/src/test/java/network/columba/app/viewmodel/SettingsViewModelIncomingMessageLimitTest.kt
+++ b/app/src/test/java/network/columba/app/viewmodel/SettingsViewModelIncomingMessageLimitTest.kt
@@ -13,6 +13,7 @@ import network.columba.app.rns.api.RnsBackend
 import network.columba.app.rns.api.RnsCore
 import network.columba.app.rns.api.RnsLxmf
 import network.columba.app.rns.api.RnsTransportAdmin
+import network.columba.app.rns.host.persistence.ReticulumConfigSnapshot
 import network.columba.app.service.AvailableRelaysState
 import network.columba.app.service.InterfaceConfigManager
 import network.columba.app.service.LocationSharingManager
@@ -27,6 +28,8 @@ import io.mockk.coVerify
 import io.mockk.every
 import io.mockk.just
 import io.mockk.mockk
+import io.mockk.mockkObject
+import io.mockk.unmockkObject
 import io.mockk.verify
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
@@ -140,6 +143,9 @@ class SettingsViewModelIncomingMessageLimitTest {
                     }
                 every { getSharedPreferences(any(), any()) } returns mockPrefs
                 every { startForegroundService(any()) } returns null
+                // Real snapshot read-modify-write lands here (no file -> no-op)
+                every { filesDir } returns
+                    kotlin.io.path.createTempDirectory("columba-snapshot-test").toFile()
             }
 
         // Mock ContactRepository flow
@@ -323,6 +329,28 @@ class SettingsViewModelIncomingMessageLimitTest {
             // Then
             assertTrue("setIncomingMessageSizeLimit should complete without throwing", result.isSuccess)
             verify { rnsLxmf.setIncomingMessageSizeLimit(25600) }
+        }
+
+    @Test
+    fun `setIncomingMessageSizeLimit refreshes restart snapshot for service-only recovery`() =
+        runTest {
+            // Given
+            mockkObject(ReticulumConfigSnapshot)
+            every { ReticulumConfigSnapshot.updateIncomingMessageSizeLimitKb(any(), any()) } just Runs
+            viewModel = createViewModel()
+            advanceUntilIdle()
+
+            // When
+            val result = runCatching { viewModel.setIncomingMessageSizeLimit(6144) } // 6MB
+
+            advanceUntilIdle()
+
+            // Then: the on-disk restart snapshot must track the change so a
+            // :reticulum-only recovery (UI process dead) doesn't resurrect the
+            // previous delivery gate (columba#1106)
+            assertTrue("setIncomingMessageSizeLimit should complete without throwing", result.isSuccess)
+            verify { ReticulumConfigSnapshot.updateIncomingMessageSizeLimitKb(context, 6144L) }
+            unmockkObject(ReticulumConfigSnapshot)
         }
 
     @Test

--- a/data/src/main/java/network/columba/app/data/repository/ConversationRepository.kt
+++ b/data/src/main/java/network/columba/app/data/repository/ConversationRepository.kt
@@ -844,7 +844,10 @@ class ConversationRepository
 
         /**
          * Extract the first filename from LXMF file attachments field.
-         * Field 5 format: [[filename, size, mimetype, data], ...]
+         *
+         * Field 5 is a JSON array whose entries are either objects
+         * ({"filename": ...}) or positional wire-format arrays
+         * ([filename, data_hex, ...] from Sideband and other LXMF apps).
          */
         @Suppress("SwallowedException", "ReturnCount") // JSON parsing errors are expected
         private fun extractFirstFileName(fieldsJson: String): String? {
@@ -852,8 +855,14 @@ class ConversationRepository
                 val json = org.json.JSONObject(fieldsJson)
                 val field5 = json.optJSONArray("5") ?: return null
                 if (field5.length() == 0) return null
-                val firstAttachment = field5.optJSONArray(0) ?: return null
-                firstAttachment.optString(0).takeIf { it.isNotEmpty() }
+                val rawName =
+                    when (val firstAttachment = field5.opt(0)) {
+                        is JSONObject -> firstAttachment.optString("filename", "")
+                        is JSONArray -> firstAttachment.optString(0, "")
+                        else -> ""
+                    }
+                val filename = decodeHexFilenameOrNull(rawName) ?: rawName
+                filename.takeIf { it.isNotEmpty() }
             } catch (e: Exception) {
                 null
             }
@@ -1100,8 +1109,13 @@ class ConversationRepository
         /**
          * Extract file attachment data to disk for sent messages, keeping metadata inline.
          *
-         * Input format: [{"filename": "doc.pdf", "size": 12345, "data": "hex..."}, ...]
-         * Output format: [{"filename": "doc.pdf", "size": 12345, "_data_ref": "/path/to/file"}, ...]
+         * Two entry shapes are accepted (see MessageMapper.parseFileAttachmentsArray):
+         * 1. Object: {"filename": "doc.pdf", "size": 12345, "data": "hex..."}
+         * 2. Positional wire format (Sideband and other LXMF apps): [filename, data_hex]
+         *    with an optional element [2] carrying the size in bytes.
+         *
+         * Output format (normalized to objects):
+         * [{"filename": "doc.pdf", "size": 12345, "_data_ref": "/path/to/file"}, ...]
          *
          * This matches the format used by EventHandler for received messages, ensuring
          * consistent handling in MessageMapper.
@@ -1110,7 +1124,7 @@ class ConversationRepository
          * @param attachments Original file attachments array
          * @return Modified array with data extracted to disk
          */
-        @Suppress("SwallowedException", "TooGenericExceptionCaught", "NestedBlockDepth")
+        @Suppress("SwallowedException", "TooGenericExceptionCaught")
         private fun extractFileAttachmentsForSent(
             messageId: String,
             attachments: JSONArray,
@@ -1118,50 +1132,20 @@ class ConversationRepository
             val result = JSONArray()
 
             for (i in 0 until attachments.length()) {
+                val entry = attachments.opt(i)
                 try {
-                    val attachment = attachments.getJSONObject(i)
-                    val filename = attachment.optString("filename", "unknown")
-                    val size = attachment.optInt("size", 0)
-                    val data = attachment.optString("data", "")
-
                     val modifiedAttachment =
-                        JSONObject().apply {
-                            put("filename", filename)
-                            put("size", size)
+                        when (entry) {
+                            is JSONObject -> extractObjectFileAttachment(messageId, i, entry)
+                            is JSONArray -> extractPositionalFileAttachment(messageId, i, entry)
+                            else -> null
                         }
-
-                    // Pass through existing _data_ref if data was already streamed to disk
-                    if (data.isEmpty() && attachment.has("_data_ref")) {
-                        modifiedAttachment.put("_data_ref", attachment.getString("_data_ref"))
+                    if (modifiedAttachment == null) {
+                        // Unrecognized entry shape; keep it as-is
+                        result.put(entry)
+                    } else {
                         result.put(modifiedAttachment)
-                        continue
                     }
-
-                    // Extract data to disk if present and non-empty
-                    if (data.isNotEmpty()) {
-                        val filePath =
-                            attachmentStorage.saveAttachment(
-                                messageId,
-                                "5_$i", // Unique key per file: "5_0", "5_1", etc.
-                                data,
-                            )
-                        if (filePath != null) {
-                            modifiedAttachment.put("_data_ref", filePath)
-                            android.util.Log.d(
-                                "ConversationRepository",
-                                "Extracted sent file '$filename' data to: $filePath",
-                            )
-                        } else {
-                            // Keep data inline if save failed
-                            modifiedAttachment.put("data", data)
-                            android.util.Log.w(
-                                "ConversationRepository",
-                                "Failed to extract sent file '$filename', keeping inline",
-                            )
-                        }
-                    }
-
-                    result.put(modifiedAttachment)
                 } catch (e: Exception) {
                     android.util.Log.w(
                         "ConversationRepository",
@@ -1169,7 +1153,7 @@ class ConversationRepository
                         e,
                     )
                     // Keep original attachment if processing fails
-                    result.put(attachments.opt(i))
+                    result.put(entry)
                 }
             }
 
@@ -1178,5 +1162,128 @@ class ConversationRepository
                 "Extracted ${attachments.length()} sent file attachment(s) to disk",
             )
             return result
+        }
+
+        /**
+         * Extract data from an object-format attachment entry
+         * ({"filename", "size", "data"} with optional "_data_ref"/"_binary_ref").
+         */
+        private fun extractObjectFileAttachment(
+            messageId: String,
+            index: Int,
+            attachment: JSONObject,
+        ): JSONObject {
+            val filename = attachment.optString("filename", "unknown")
+            val size = attachment.optInt("size", 0)
+            val data = attachment.optString("data", "")
+
+            val modifiedAttachment =
+                JSONObject().apply {
+                    put("filename", filename)
+                    put("size", size)
+                }
+
+            // Pass through existing refs if data was already staged to disk
+            if (data.isEmpty()) {
+                if (attachment.has("_data_ref")) {
+                    modifiedAttachment.put("_data_ref", attachment.getString("_data_ref"))
+                } else if (attachment.has("_binary_ref")) {
+                    modifiedAttachment.put("_binary_ref", attachment.getString("_binary_ref"))
+                }
+                return modifiedAttachment
+            }
+
+            saveFileAttachmentData(messageId, index, filename, data, modifiedAttachment)
+            return modifiedAttachment
+        }
+
+        /**
+         * Extract data from a positional wire-format attachment entry
+         * ([filename, data_hex, size?] from Sideband and other LXMF apps).
+         *
+         * Normalizes to the object format so the stored row only ever holds
+         * one shape, which MessageMapper and the read paths already accept.
+         *
+         * @return null when the entry is too short to be a positional pair,
+         *         in which case the caller keeps the original entry.
+         */
+        @Suppress("ReturnCount")
+        private fun extractPositionalFileAttachment(
+            messageId: String,
+            index: Int,
+            entry: JSONArray,
+        ): JSONObject? {
+            if (entry.length() < 2) return null
+            val rawFilename = entry.optString(0, "unknown").ifEmpty { "unknown" }
+            val filename = decodeHexFilenameOrNull(rawFilename) ?: rawFilename
+            val data = entry.optString(1, "")
+            // Data is hex-encoded; each byte is 2 hex chars. Prefer an explicit
+            // size element when present - matches MessageMapper.parsePositionalAttachment.
+            val size = entry.optInt(2, data.length / 2)
+
+            val modifiedAttachment =
+                JSONObject().apply {
+                    put("filename", filename)
+                    put("size", size)
+                }
+
+            if (data.isNotEmpty()) {
+                saveFileAttachmentData(messageId, index, filename, data, modifiedAttachment)
+            }
+            return modifiedAttachment
+        }
+
+        /** Save hex [data] to disk under key "5_$index", keeping it inline on failure. */
+        private fun saveFileAttachmentData(
+            messageId: String,
+            index: Int,
+            filename: String,
+            data: String,
+            target: JSONObject,
+        ) {
+            val filePath =
+                attachmentStorage.saveAttachment(
+                    messageId,
+                    "5_$index", // Unique key per file: "5_0", "5_1", etc.
+                    data,
+                )
+            if (filePath != null) {
+                target.put("_data_ref", filePath)
+                android.util.Log.d(
+                    "ConversationRepository",
+                    "Extracted sent file '$filename' data to: $filePath",
+                )
+            } else {
+                // Keep data inline if save failed
+                target.put("data", data)
+                android.util.Log.w(
+                    "ConversationRepository",
+                    "Failed to extract sent file '$filename', keeping inline",
+                )
+            }
+        }
+
+        /**
+         * If [s] looks like hex (even length, all hex digits) and decodes to
+         * printable UTF-8, return the decoded string; else null.
+         *
+         * Columba backends hex-encode ByteArray filename fields while Sideband
+         * sends plain strings; this mirrors MessageMapper's decoding behavior.
+         */
+        @Suppress("SwallowedException")
+        private fun decodeHexFilenameOrNull(s: String): String? {
+            if (s.length < 2 || s.length % 2 != 0) return null
+            if (!s.all { it in '0'..'9' || it in 'a'..'f' || it in 'A'..'F' }) return null
+            return try {
+                val bytes = ByteArray(s.length / 2) {
+                    ((Character.digit(s[it * 2], 16) shl 4) + Character.digit(s[it * 2 + 1], 16)).toByte()
+                }
+                val decoded = String(bytes, Charsets.UTF_8)
+                // Filenames are practically always printable; reject if decode
+                // produced control characters (other than tab/newline)
+                if (decoded.any { it.code in 0..31 && it != '\t' && it != '\n' }) null else decoded
+            } catch (e: Exception) {
+                null
+            }
         }
     }

--- a/rns-api/src/main/java/network/columba/app/rns/api/model/ReticulumConfig.kt
+++ b/rns-api/src/main/java/network/columba/app/rns/api/model/ReticulumConfig.kt
@@ -98,6 +98,17 @@ data class ReticulumConfig(
      * providing spam prevention. Range: 8-20, default: 14.
      */
     val requiredDiscoveryValue: Int = 14,
+    /**
+     * User-configured incoming-message size cap (binary KB), applied by the
+     * backend to the LXMF delivery gate at startup - before the delivery
+     * destination becomes reachable - so the first DIRECT resource
+     * advertisement is evaluated against the user's gate, not the backend's
+     * built-in default (columba#1106 startup window).
+     *
+     * null = not set (backend keeps its built-in default);
+     * 0 = unlimited (explicit user choice).
+     */
+    val incomingMessageSizeLimitKb: Long? = null,
 ) : Parcelable {
     // Data-class-generated equals/hashCode use reference equality for ByteArray, so
     // two configs with identical key bytes would otherwise never compare equal. Override
@@ -123,7 +134,8 @@ data class ReticulumConfig(
             autoconnectDiscoveredInterfaces == other.autoconnectDiscoveredInterfaces &&
             autoconnectIfacOnly == other.autoconnectIfacOnly &&
             interfaceDiscoverySources == other.interfaceDiscoverySources &&
-            requiredDiscoveryValue == other.requiredDiscoveryValue
+            requiredDiscoveryValue == other.requiredDiscoveryValue &&
+            incomingMessageSizeLimitKb == other.incomingMessageSizeLimitKb
     }
 
     override fun hashCode(): Int {
@@ -144,6 +156,7 @@ data class ReticulumConfig(
         result = 31 * result + autoconnectIfacOnly.hashCode()
         result = 31 * result + (interfaceDiscoverySources?.hashCode() ?: 0)
         result = 31 * result + requiredDiscoveryValue
+        result = 31 * result + (incomingMessageSizeLimitKb?.hashCode() ?: 0)
         return result
     }
 
@@ -175,7 +188,8 @@ data class ReticulumConfig(
             "autoconnectDiscoveredInterfaces=$autoconnectDiscoveredInterfaces, " +
             "autoconnectIfacOnly=$autoconnectIfacOnly, " +
             "interfaceDiscoverySources=$interfaceDiscoverySources, " +
-            "requiredDiscoveryValue=$requiredDiscoveryValue" +
+            "requiredDiscoveryValue=$requiredDiscoveryValue, " +
+            "incomingMessageSizeLimitKb=$incomingMessageSizeLimitKb" +
             ")"
 }
 

--- a/rns-backend-kt/src/main/kotlin/network/columba/app/rns/backend/kt/NativeRnsBackendImpl.kt
+++ b/rns-backend-kt/src/main/kotlin/network/columba/app/rns/backend/kt/NativeRnsBackendImpl.kt
@@ -431,6 +431,19 @@ class NativeRnsBackendImpl(
                 storagePath = config.storagePath,
             )
 
+        // Apply the persisted incoming-message size limit to the fresh router
+        // BEFORE the delivery destination is registered, so the first DIRECT
+        // resource advertisement is evaluated against the user's configured
+        // gate rather than the router's built-in default (columba#1106
+        // startup window). null = host did not supply a limit (keep default).
+        config.incomingMessageSizeLimitKb?.let { limitKb ->
+            runCatching {
+                router!!.incomingMessageSizeLimitKb = if (limitKb > 0) limitKb.toInt() else null
+            }.onFailure {
+                Log.w(TAG, "Failed to prime incoming message size limit: ${it.message}", it)
+            }
+        }
+
         deliveryDestination =
             router!!.registerDeliveryIdentity(
                 identity = identity,

--- a/rns-backend-py/src/main/kotlin/network/columba/app/rns/backend/py/PythonRnsLxmf.kt
+++ b/rns-backend-py/src/main/kotlin/network/columba/app/rns/backend/py/PythonRnsLxmf.kt
@@ -780,16 +780,18 @@ class PythonRnsLxmf(
     }
 
     override fun setIncomingMessageSizeLimit(limitKb: Int) {
-        // Upstream LXMF has no inbound message-size cap of its own — its
-        // `message_storage_limit` bounds a propagation *node's* served store,
-        // not inbound delivery, so calling it here would be wrong. The lxmf-kt
-        // port (kotlin backend) enforces a real `incomingMessageSizeLimitKb`;
-        // the Python equivalent is a post-reassembly drop in event_bridge.py.
-        // Known degradation vs the kotlin backend: LXMF fully reassembles a
-        // message before its delivery callback fires, so oversized messages are
-        // rejected before reaching the UI / storage, but the bandwidth + CPU of
-        // receiving them cannot be saved (upstream LXMF exposes no earlier
-        // hook). Recorded in the RNS dual-build handoff.
+        // event_bridge.py applies the cap in two places:
+        //  - pre-transfer, on link-based (DIRECT) delivery: it mirrors the cap
+        //    onto LXMF's own gate (LXMRouter.delivery_per_transfer_limit), so
+        //    oversized resources are refused at advertisement time, before any
+        //    bytes transfer (columba#1106 — previously this gate stayed at
+        //    LXMF's built-in 1000 KB default and rejected every direct
+        //    delivery over ~1 MB no matter what the user configured);
+        //  - post-reassembly, for all methods (incl. opportunistic, which has
+        //    no pre-transfer hook): a drop in the delivery callback, so
+        //    oversized messages never reach the UI / storage.
+        // `message_storage_limit` is NOT the right knob here — it bounds a
+        // propagation *node's* served store, not inbound delivery.
         runCatching {
             runtime.eventBridge.callAttr("set_incoming_message_size_limit", limitKb)
         }.onFailure { Log.w(TAG, "setIncomingMessageSizeLimit($limitKb) failed", it) }

--- a/rns-backend-py/src/main/kotlin/network/columba/app/rns/backend/py/PythonRnsRuntime.kt
+++ b/rns-backend-py/src/main/kotlin/network/columba/app/rns/backend/py/PythonRnsRuntime.kt
@@ -305,6 +305,24 @@ class PythonRnsRuntime(
         val lxmfStorage = File(config.storagePath, "lxmf").apply { mkdirs() }
         val router = lxmfModule.callAttr("LXMRouter", identity, lxmfStorage.absolutePath)
         lxmRouter = router
+
+        // Apply the persisted incoming-message size limit to the fresh router
+        // BEFORE the delivery destination is registered, so the first DIRECT
+        // resource advertisement is evaluated against the user's configured
+        // gate rather than LXMF's built-in 1000 KB default (columba#1106
+        // startup window). null = host did not supply a limit (keep default).
+        config.incomingMessageSizeLimitKb?.let { limitKb ->
+            runCatching {
+                eventBridge.callAttr("prime_incoming_message_size_limit", router, limitKb)
+            }.onFailure {
+                Log.w(
+                    TAG,
+                    "Failed to prime incoming message size limit: ${it.message}",
+                    it,
+                )
+            }
+        }
+
         localDestination = router.callAttr(
             "register_delivery_identity",
             identity,

--- a/rns-backend-py/src/main/python/event_bridge.py
+++ b/rns-backend-py/src/main/python/event_bridge.py
@@ -713,11 +713,19 @@ class _AnnounceHandler:
 #      `LXMRouter.delivery_per_transfer_limit` (see _apply_incoming_limit_to_router()).
 #      Without it, LXMF's built-in default (LXMRouter.DELIVERY_LIMIT = 1000,
 #      i.e. 1,000,000 bytes) rejects every inbound direct-delivery resource
-#      above ~1 MB at resource-advertisement time — before a single byte is
-#      transferred — no matter what the user configured (columba#1106).
+#      above ~1 MB at resource-advertisement time (before a single byte is
+#      transferred) no matter what the user configured (columba#1106).
 #   2. Post-reassembly, for all delivery methods (incl. opportunistic, which
 #      has no pre-transfer hook): the drop in _lxmf_delivery_callback().
+#
+# `_incoming_message_size_limit_configured` tracks whether the host has pushed
+# a cap in this process. Until it has, the pre-transfer gate keeps LXMF's
+# built-in conservative default (1000 decimal KB) instead of the "unlimited"
+# sentinel: the host pushes the persisted cap asynchronously after backend
+# init, and in that window an oversized direct delivery must be refused at
+# advertisement time, not transferred and dropped after reassembly.
 _incoming_message_size_limit_kb = 0
+_incoming_message_size_limit_configured = False
 
 # Sentinel for "unlimited" on LXMF's delivery_per_transfer_limit (decimal KB,
 # ~= 1 TB). Upstream LXMF's delivery_resource_advertised() multiplies the
@@ -741,11 +749,18 @@ def _apply_incoming_limit_to_router():
 
     Unit note: Columba's setting is binary KB (the post-reassembly drop
     compares against `limit_kb * 1024`), while LXMF compares against
-    `limit_kb * 1000` — convert with a ceiling so the pre-transfer gate
+    `limit_kb * 1000` - convert with a ceiling so the pre-transfer gate
     never rejects a message the user's cap would allow; the post-reassembly
     drop remains the strict gate.
+
+    While the host has not pushed a cap yet (fresh process, pre-init window),
+    this is a no-op on purpose: the router keeps LXMF's built-in conservative
+    1000 decimal KB default instead of being widened to the "unlimited"
+    sentinel (see _incoming_message_size_limit_configured).
     """
     if _lxmf_router is None:
+        return
+    if not _incoming_message_size_limit_configured:
         return
     try:
         if _incoming_message_size_limit_kb <= 0:
@@ -768,10 +783,11 @@ def set_incoming_message_size_limit(limit_kb):
     The lxmf-kt port (kotlin backend) has a real `incomingMessageSizeLimitKb`;
     this is the Python-backend equivalent, enforced both pre-transfer
     (delivery_per_transfer_limit, link-based delivery) and post-reassembly
-    (all methods — see _lxmf_delivery_callback()).
+    (all methods - see _lxmf_delivery_callback()).
     """
-    global _incoming_message_size_limit_kb
+    global _incoming_message_size_limit_kb, _incoming_message_size_limit_configured
     _incoming_message_size_limit_kb = max(0, int(limit_kb))
+    _incoming_message_size_limit_configured = True
     _apply_incoming_limit_to_router()
     RNS.log(
         "event_bridge: incoming message size limit set to "
@@ -1243,10 +1259,11 @@ def register_callbacks(
 
     if lxmf_router is not None:
         lxmf_router.register_delivery_callback(_lxmf_delivery_callback)
-        # A fresh router starts with LXMF's built-in delivery limit (1000 KB
-        # decimal) regardless of what the user configured — re-apply the
-        # stored cap so a backend restart doesn't silently revert it
-        # (columba#1106).
+        # If the host already pushed a cap in this process (in-process
+        # backend restart / reconnect), re-apply it to the fresh router so
+        # the built-in 1000 KB default doesn't silently return (columba#1106).
+        # In a fresh process this is a no-op: the router keeps LXMF's
+        # conservative default until the host pushes the persisted cap.
         _apply_incoming_limit_to_router()
 
     RNS.log("event_bridge: callbacks registered", RNS.LOG_DEBUG)

--- a/rns-backend-py/src/main/python/event_bridge.py
+++ b/rns-backend-py/src/main/python/event_bridge.py
@@ -735,6 +735,54 @@ _incoming_message_size_limit_configured = False
 _UNLIMITED_DELIVERY_LIMIT_KB = 1024 * 1024 * 1024
 
 
+def _delivery_limit_decimal_kb(limit_kb):
+    """Convert the app's binary-KB cap to LXMF's decimal-KB gate value.
+
+    0 (unlimited) maps to the large finite sentinel (see
+    _UNLIMITED_DELIVERY_LIMIT_KB); positive values are converted with a
+    ceiling so the pre-transfer gate never rejects a message the cap
+    allows.
+    """
+    if limit_kb <= 0:
+        return _UNLIMITED_DELIVERY_LIMIT_KB
+    return -(-(limit_kb * 1024) // 1000)
+
+
+def prime_incoming_message_size_limit(router, limit_kb):
+    """Store the cap and apply it to a freshly constructed router.
+
+    Called by the backend runtime right after LXMRouter construction -
+    before register_callbacks() has wired the module-level router and
+    before the delivery destination can receive traffic - so the first
+    DIRECT resource advertisement is already evaluated against the
+    user's configured gate instead of LXMF's built-in 1000 KB default
+    (columba#1106 startup window). 0 = unlimited (sentinel).
+    """
+    global _incoming_message_size_limit_kb, _incoming_message_size_limit_configured
+    _incoming_message_size_limit_kb = max(0, int(limit_kb))
+    _incoming_message_size_limit_configured = True
+    if router is not None:
+        try:
+            router.delivery_per_transfer_limit = _delivery_limit_decimal_kb(
+                _incoming_message_size_limit_kb,
+            )
+            RNS.log(
+                "event_bridge: LXMF delivery_per_transfer_limit primed to "
+                f"{router.delivery_per_transfer_limit} KB (decimal)",
+                RNS.LOG_DEBUG,
+            )
+        except Exception as e:  # noqa: BLE001 - never fatal; host push re-applies later
+            RNS.log(
+                f"event_bridge: failed to prime incoming limit: {e}",
+                RNS.LOG_WARNING,
+            )
+    RNS.log(
+        "event_bridge: incoming message size limit primed to "
+        f"{_incoming_message_size_limit_kb or 'unlimited'} KB",
+        RNS.LOG_DEBUG,
+    )
+
+
 def _apply_incoming_limit_to_router():
     """Mirror _incoming_message_size_limit_kb onto LXMF's pre-transfer gate.
 
@@ -763,11 +811,9 @@ def _apply_incoming_limit_to_router():
     if not _incoming_message_size_limit_configured:
         return
     try:
-        if _incoming_message_size_limit_kb <= 0:
-            _lxmf_router.delivery_per_transfer_limit = _UNLIMITED_DELIVERY_LIMIT_KB
-        else:
-            limit_bytes = _incoming_message_size_limit_kb * 1024
-            _lxmf_router.delivery_per_transfer_limit = -(-limit_bytes // 1000)
+        _lxmf_router.delivery_per_transfer_limit = _delivery_limit_decimal_kb(
+            _incoming_message_size_limit_kb,
+        )
         RNS.log(
             "event_bridge: LXMF delivery_per_transfer_limit set to "
             f"{_lxmf_router.delivery_per_transfer_limit} KB (decimal)",

--- a/rns-backend-py/src/main/python/event_bridge.py
+++ b/rns-backend-py/src/main/python/event_bridge.py
@@ -708,28 +708,71 @@ class _AnnounceHandler:
 
 
 # Inbound LXMF message-size cap (KB; 0 = unlimited). Set from Kotlin via
-# set_incoming_message_size_limit(); enforced post-reassembly in
-# _lxmf_delivery_callback().
+# set_incoming_message_size_limit(); enforced in two places:
+#   1. Pre-transfer, on link-based (DIRECT) delivery: LXMF's own gate
+#      `LXMRouter.delivery_per_transfer_limit` (see _apply_incoming_limit_to_router()).
+#      Without it, LXMF's built-in default (LXMRouter.DELIVERY_LIMIT = 1000,
+#      i.e. 1,000,000 bytes) rejects every inbound direct-delivery resource
+#      above ~1 MB at resource-advertisement time — before a single byte is
+#      transferred — no matter what the user configured (columba#1106).
+#   2. Post-reassembly, for all delivery methods (incl. opportunistic, which
+#      has no pre-transfer hook): the drop in _lxmf_delivery_callback().
 _incoming_message_size_limit_kb = 0
+
+# Sentinel for "unlimited" on LXMF's delivery_per_transfer_limit (decimal KB,
+# ~= 1 TB). Upstream LXMF's delivery_resource_advertised() multiplies the
+# limit by 1000 *before* its `limit != None` check, so assigning None at
+# runtime crashes the callback with TypeError — a large finite value is the
+# only safe way to express "no cap" against the pinned LXMF.
+_UNLIMITED_DELIVERY_LIMIT_KB = 1024 * 1024 * 1024
+
+
+def _apply_incoming_limit_to_router():
+    """Mirror _incoming_message_size_limit_kb onto LXMF's pre-transfer gate.
+
+    `LXMRouter.delivery_per_transfer_limit` is checked in
+    `delivery_resource_advertised()` when a peer starts a link-based (DIRECT)
+    resource transfer: if the advertised size exceeds
+    `delivery_per_transfer_limit * 1000` bytes, the transfer is refused before
+    any data moves. LXMF's constructor default is DELIVERY_LIMIT (1000 KB
+    decimal), and nothing in Columba's Python stack updated it, so the user's
+    "incoming message size" setting was silently ignored for direct delivery
+    (columba#1106).
+
+    Unit note: Columba's setting is binary KB (the post-reassembly drop
+    compares against `limit_kb * 1024`), while LXMF compares against
+    `limit_kb * 1000` — convert with a ceiling so the pre-transfer gate
+    never rejects a message the user's cap would allow; the post-reassembly
+    drop remains the strict gate.
+    """
+    if _lxmf_router is None:
+        return
+    try:
+        if _incoming_message_size_limit_kb <= 0:
+            _lxmf_router.delivery_per_transfer_limit = _UNLIMITED_DELIVERY_LIMIT_KB
+        else:
+            limit_bytes = _incoming_message_size_limit_kb * 1024
+            _lxmf_router.delivery_per_transfer_limit = -(-limit_bytes // 1000)
+        RNS.log(
+            "event_bridge: LXMF delivery_per_transfer_limit set to "
+            f"{_lxmf_router.delivery_per_transfer_limit} KB (decimal)",
+            RNS.LOG_DEBUG,
+        )
+    except Exception as e:  # noqa: BLE001 — never fatal; post-reassembly drop still applies
+        RNS.log(f"event_bridge: failed to apply incoming limit to LXMF router: {e}", RNS.LOG_WARNING)
 
 
 def set_incoming_message_size_limit(limit_kb):
     """Set the inbound LXMF message-size cap (KB; 0 = unlimited).
 
-    Upstream LXMF has no inbound size limit of its own — `message_storage_limit`
-    bounds a propagation *node's* served store, not inbound delivery, so calling
-    it for this would be wrong. The lxmf-kt port (kotlin backend) has a real
-    `incomingMessageSizeLimitKb`; this is the Python-backend equivalent.
-
-    Enforcement is a *post-reassembly* drop in `_lxmf_delivery_callback`: LXMF
-    fully reassembles a message before invoking its delivery callback, so an
-    oversized message is rejected before it reaches the Columba UI / storage,
-    but the bandwidth + CPU of receiving it cannot be saved — upstream LXMF
-    exposes no pre-reassembly hook. This degradation-vs-kotlin is recorded in
-    the RNS dual-build handoff doc.
+    The lxmf-kt port (kotlin backend) has a real `incomingMessageSizeLimitKb`;
+    this is the Python-backend equivalent, enforced both pre-transfer
+    (delivery_per_transfer_limit, link-based delivery) and post-reassembly
+    (all methods — see _lxmf_delivery_callback()).
     """
     global _incoming_message_size_limit_kb
     _incoming_message_size_limit_kb = max(0, int(limit_kb))
+    _apply_incoming_limit_to_router()
     RNS.log(
         "event_bridge: incoming message size limit set to "
         f"{_incoming_message_size_limit_kb or 'unlimited'} KB",
@@ -1200,6 +1243,11 @@ def register_callbacks(
 
     if lxmf_router is not None:
         lxmf_router.register_delivery_callback(_lxmf_delivery_callback)
+        # A fresh router starts with LXMF's built-in delivery limit (1000 KB
+        # decimal) regardless of what the user configured — re-apply the
+        # stored cap so a backend restart doesn't silently revert it
+        # (columba#1106).
+        _apply_incoming_limit_to_router()
 
     RNS.log("event_bridge: callbacks registered", RNS.LOG_DEBUG)
 

--- a/rns-backend-py/src/test/python/test_event_bridge_incoming_size_limit.py
+++ b/rns-backend-py/src/test/python/test_event_bridge_incoming_size_limit.py
@@ -1,0 +1,124 @@
+"""
+The user's "incoming message size" setting must reach LXMF's own
+pre-transfer gate (LXMRouter.delivery_per_transfer_limit), otherwise
+upstream LXMF's built-in default (DELIVERY_LIMIT = 1000, i.e. 1,000,000
+bytes) rejects every inbound link-based (DIRECT) resource above ~1 MB at
+advertisement time, before any bytes transfer — making the setting
+ineffective for direct delivery (columba#1106).
+"""
+import importlib.util
+import sys
+import types
+import unittest
+from pathlib import Path
+
+
+EVENT_BRIDGE_PATH = Path(__file__).resolve().parents[2] / "main/python/event_bridge.py"
+
+
+class FakeRouter:
+    """Mimics the LXMF defaults the app starts out with."""
+
+    def __init__(self):
+        self.delivery_per_transfer_limit = 1000  # LXMRouter.DELIVERY_LIMIT
+        self.delivery_callbacks = []
+
+    def register_delivery_callback(self, callback):
+        self.delivery_callbacks.append(callback)
+
+
+def _noop(*args, **kwargs):
+    pass
+
+
+class IncomingMessageSizeLimitBridgeTests(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        rns = types.ModuleType("RNS")
+        setattr(rns, "LOG_DEBUG", 1)
+        setattr(rns, "LOG_WARNING", 2)
+        setattr(rns, "LOG_ERROR", 3)
+        setattr(rns, "log", lambda *args, **kwargs: None)
+        setattr(rns, "Destination", types.SimpleNamespace(
+            hash_from_name_and_identity=lambda aspect, identity: b"destination"
+        ))
+        setattr(rns, "Transport", types.SimpleNamespace(
+            PATHFINDER_M=128,
+            hops_to=lambda destination_hash: 1,
+            path_table={},
+            register_announce_handler=_noop,
+        ))
+        sys.modules["RNS"] = rns
+
+        lxmf = types.ModuleType("LXMF")
+        setattr(lxmf, "LXStamper", types.SimpleNamespace(
+            set_external_generator=lambda *args: None,
+        ))
+        sys.modules["LXMF"] = lxmf
+
+        spec = importlib.util.spec_from_file_location(
+            "event_bridge_incoming_size_limit_test", EVENT_BRIDGE_PATH
+        )
+        assert spec is not None and spec.loader is not None
+        cls.module = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(cls.module)
+
+    def setUp(self):
+        self.module._lxmf_router = None
+        self.module._incoming_message_size_limit_kb = 0
+
+    def test_set_without_router_does_not_crash_and_stores_cap(self):
+        self.module.set_incoming_message_size_limit(25600)
+        self.assertEqual(25600, self.module._incoming_message_size_limit_kb)
+        self.assertIsNone(self.module._lxmf_router)
+
+    def test_unlimited_maps_to_large_sentinel_not_none(self):
+        # None would crash the pinned LXMF: delivery_resource_advertised()
+        # computes delivery_per_transfer_limit * 1000 before its None check.
+        router = FakeRouter()
+        self.module._lxmf_router = router
+        self.module.set_incoming_message_size_limit(0)
+        self.assertIsNotNone(router.delivery_per_transfer_limit)
+        self.assertGreater(router.delivery_per_transfer_limit, 1_000_000_000)
+
+    def test_binary_kb_converted_to_lxmf_decimal_kb_with_ceiling(self):
+        router = FakeRouter()
+        self.module._lxmf_router = router
+
+        # 1024 KiB cap -> must allow >= 1024*1024 bytes (1049 decimal KB)
+        self.module.set_incoming_message_size_limit(1024)
+        self.assertEqual(1049, router.delivery_per_transfer_limit)
+        self.assertGreaterEqual(router.delivery_per_transfer_limit * 1000, 1024 * 1024)
+
+        # UI "Unlimited" chip value (131072 KiB)
+        self.module.set_incoming_message_size_limit(131072)
+        self.assertEqual(134218, router.delivery_per_transfer_limit)
+        self.assertGreaterEqual(router.delivery_per_transfer_limit * 1000, 131072 * 1024)
+
+    def test_register_callbacks_reapplies_stored_cap_to_fresh_router(self):
+        # A backend restart replaces the router; the stored cap must follow
+        # it, or the built-in 1000 KB default silently returns (columba#1106).
+        first = FakeRouter()
+        self.module._lxmf_router = first
+        self.module.set_incoming_message_size_limit(25600)
+
+        fresh = FakeRouter()  # LXMF default: 1000 KB
+        self.module.register_callbacks(
+            object(), fresh, _noop, _noop, _noop, _noop, _noop
+        )
+        self.assertEqual(26215, fresh.delivery_per_transfer_limit)
+
+    def test_default_cap_keeps_roughly_one_mb_gate(self):
+        # The app default is 1024 KiB; the pre-transfer gate should stay in
+        # the same ~1 MB neighbourhood it has always been at, not silently
+        # open up.
+        router = FakeRouter()
+        self.module._lxmf_router = router
+        self.module.set_incoming_message_size_limit(1024)
+        gate_bytes = router.delivery_per_transfer_limit * 1000
+        self.assertGreaterEqual(gate_bytes, 1024 * 1024)
+        self.assertLess(gate_bytes, 2 * 1024 * 1024)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/rns-backend-py/src/test/python/test_event_bridge_incoming_size_limit.py
+++ b/rns-backend-py/src/test/python/test_event_bridge_incoming_size_limit.py
@@ -120,6 +120,26 @@ class IncomingMessageSizeLimitBridgeTests(unittest.TestCase):
         self.assertGreaterEqual(gate_bytes, 1024 * 1024)
         self.assertLess(gate_bytes, 2 * 1024 * 1024)
 
+    def test_prime_applies_cap_to_fresh_router_before_register_callbacks(self):
+        # Startup path: the backend runtime primes the router right after
+        # construction, before register_callbacks wires the module-level
+        # router. The cap must apply immediately and must survive
+        # register_callbacks (which re-applies the stored value).
+        router = FakeRouter()
+        self.module.prime_incoming_message_size_limit(router, 131072)
+        self.assertEqual(134218, router.delivery_per_transfer_limit)
+        self.assertEqual(131072, self.module._incoming_message_size_limit_kb)
+
+        self.module.register_callbacks(
+            object(), router, _noop, _noop, _noop, _noop, _noop
+        )
+        self.assertEqual(134218, router.delivery_per_transfer_limit)
+
+    def test_prime_unlimited_maps_to_sentinel(self):
+        router = FakeRouter()
+        self.module.prime_incoming_message_size_limit(router, 0)
+        self.assertGreater(router.delivery_per_transfer_limit, 1_000_000_000)
+
     def test_fresh_process_keeps_conservative_gate_until_host_pushes_cap(self):
         # The host pushes the persisted cap asynchronously after backend
         # init (ColumbaApplication, IO coroutine). Until that push lands,

--- a/rns-backend-py/src/test/python/test_event_bridge_incoming_size_limit.py
+++ b/rns-backend-py/src/test/python/test_event_bridge_incoming_size_limit.py
@@ -66,6 +66,7 @@ class IncomingMessageSizeLimitBridgeTests(unittest.TestCase):
     def setUp(self):
         self.module._lxmf_router = None
         self.module._incoming_message_size_limit_kb = 0
+        self.module._incoming_message_size_limit_configured = False
 
     def test_set_without_router_does_not_crash_and_stores_cap(self):
         self.module.set_incoming_message_size_limit(25600)
@@ -118,6 +119,24 @@ class IncomingMessageSizeLimitBridgeTests(unittest.TestCase):
         gate_bytes = router.delivery_per_transfer_limit * 1000
         self.assertGreaterEqual(gate_bytes, 1024 * 1024)
         self.assertLess(gate_bytes, 2 * 1024 * 1024)
+
+    def test_fresh_process_keeps_conservative_gate_until_host_pushes_cap(self):
+        # The host pushes the persisted cap asynchronously after backend
+        # init (ColumbaApplication, IO coroutine). Until that push lands,
+        # the pre-transfer gate must keep LXMF's built-in conservative
+        # default (1000 decimal KB) - not the "unlimited" sentinel - so an
+        # oversized direct delivery arriving in the init window is refused
+        # at advertisement time instead of transferred and dropped after
+        # reassembly.
+        router = FakeRouter()
+        self.module.register_callbacks(
+            object(), router, _noop, _noop, _noop, _noop, _noop
+        )
+        self.assertEqual(1000, router.delivery_per_transfer_limit)
+
+        # Once the host pushes the persisted cap, the gate follows it.
+        self.module.set_incoming_message_size_limit(131072)
+        self.assertEqual(134218, router.delivery_per_transfer_limit)
 
 
 if __name__ == "__main__":

--- a/rns-host/src/main/kotlin/network/columba/app/rns/host/persistence/ReticulumConfigSnapshot.kt
+++ b/rns-host/src/main/kotlin/network/columba/app/rns/host/persistence/ReticulumConfigSnapshot.kt
@@ -36,11 +36,13 @@ import network.columba.app.rns.api.model.ReticulumConfig
 object ReticulumConfigSnapshot {
     private const val TAG = "ReticulumConfigSnapshot"
     private const val FILE_NAME = "rns_config_snapshot.bin"
-    // Bumped to 2 when ReticulumConfig.shareInstanceHosting was added. Old
-    // V1 snapshots don't include the new boolean and would unmarshal with
-    // a torn parcel layout from this version onward, so we explicitly
-    // discard them; the UI re-initialises on next launch and writes V2.
-    private const val VERSION = 2
+    // Bumped to 3 when ReticulumConfig.incomingMessageSizeLimitKb was
+    // added. Older snapshots don't include the new field and would
+    // unmarshal with a torn parcel layout from this version onward, so we
+    // explicitly discard them; the UI re-initialises on next launch and
+    // writes V3. (V2 -> V1 discard for shareInstanceHosting: see git
+    // history of this constant.)
+    private const val VERSION = 3
 
     /**
      * The deserialized snapshot: a config without an identity key plus the

--- a/rns-host/src/main/kotlin/network/columba/app/rns/host/persistence/ReticulumConfigSnapshot.kt
+++ b/rns-host/src/main/kotlin/network/columba/app/rns/host/persistence/ReticulumConfigSnapshot.kt
@@ -149,6 +149,35 @@ object ReticulumConfigSnapshot {
         }
     }
 
+    /**
+     * Update only [ReticulumConfig.incomingMessageSizeLimitKb] on the
+     * existing snapshot, without re-initializing the backend.
+     *
+     * The user can change the incoming-message size limit at runtime; the
+     * settings path then updates DataStore and the live router, but the
+     * on-disk restart snapshot would otherwise keep the initialization-time
+     * value. A `:reticulum`-only recovery (UI process dead) reads this
+     * snapshot, so it would resurrect a stale delivery gate - DIRECT
+     * transfers incorrectly accepted or rejected until the UI re-applies
+     * the setting (columba#1106).
+     *
+     * No-op (debug-logged) when no snapshot exists yet; the next full
+     * initialization writes a fresh one with the current value.
+     */
+    fun updateIncomingMessageSizeLimitKb(context: Context, limitKb: Long?) {
+        val snapshot = read(context)
+        if (snapshot == null) {
+            Log.d(TAG, "No snapshot to update for incoming limit ($limitKb KB)")
+            return
+        }
+        write(
+            context = context,
+            config = snapshot.configWithoutKey.copy(incomingMessageSizeLimitKb = limitKb),
+            identityHashHex = snapshot.identityHashHex,
+        )
+        Log.d(TAG, "Snapshot incoming limit updated: $limitKb KB")
+    }
+
     /** Delete the snapshot — used after `shutdown()` to force fresh wiring on next start. */
     fun clear(context: Context) {
         snapshotFile(context).delete()

--- a/rns-host/src/test/kotlin/network/columba/app/rns/host/persistence/ReticulumConfigSnapshotTest.kt
+++ b/rns-host/src/test/kotlin/network/columba/app/rns/host/persistence/ReticulumConfigSnapshotTest.kt
@@ -67,4 +67,31 @@ class ReticulumConfigSnapshotTest {
         ReticulumConfigSnapshot.clear(context)
         assertNull(ReticulumConfigSnapshot.read(context))
     }
+
+    @Test
+    fun `updateIncomingMessageSizeLimitKb rewrites only the limit, preserving the rest`() {
+        ReticulumConfigSnapshot.clear(context)
+        val config = sampleConfig().copy(incomingMessageSizeLimitKb = 131072L)
+
+        ReticulumConfigSnapshot.write(context, config, identityHashHex = "deadbeefcafe")
+        ReticulumConfigSnapshot.updateIncomingMessageSizeLimitKb(context, 512L)
+        val snap = ReticulumConfigSnapshot.read(context)
+
+        assertNotNull(snap)
+        assertEquals(512L, snap!!.configWithoutKey.incomingMessageSizeLimitKb)
+        assertEquals("deadbeefcafe", snap.identityHashHex)
+        assertEquals(
+            "all other config fields must survive the read-modify-write",
+            config.copy(deliveryIdentityKey = null, incomingMessageSizeLimitKb = 512L),
+            snap.configWithoutKey,
+        )
+        assertNull(snap.configWithoutKey.deliveryIdentityKey)
+    }
+
+    @Test
+    fun `updateIncomingMessageSizeLimitKb is a no-op without a snapshot`() {
+        ReticulumConfigSnapshot.clear(context)
+        ReticulumConfigSnapshot.updateIncomingMessageSizeLimitKb(context, 512L)
+        assertNull(ReticulumConfigSnapshot.read(context))
+    }
 }


### PR DESCRIPTION
## Root cause (closes #1106)

Two phones, same settings, Python backend: files >~1 MB always rejected on Direct delivery, "incoming file size" setting ignored (reporter measured the effective cap at ~900 kB).

The user's "incoming message size" setting only ever reached `event_bridge.py`'s **post-reassembly** drop. LXMF has its own inbound gate that Columba never configured:

- `LXMRouter.delivery_per_transfer_limit` is checked in `delivery_resource_advertised()` when a peer starts a link-based (DIRECT) resource transfer. At that point the receiver only knows the advertised size (no bytes transferred yet) and returns accept/refuse.
- Its constructor default is `LXMRouter.DELIVERY_LIMIT = 1000` (decimal KB = 1,000,000 bytes = 977 KiB, the ~900 kB the reporter estimated).
- Columba's Python stack builds the router with `LXMRouter(identity, storagepath)` and nothing ever updated this knob, so **every direct-delivery file above ~1 MB was refused at advertisement time regardless of the setting**. The post-reassembly drop only sees messages that already got through - which, for direct delivery over 1 MB, never happens.

The existing comment in `PythonRnsLxmf.kt` / `event_bridge.py` claimed "upstream LXMF exposes no pre-reassembly hook" - the resource-advertised callback is exactly that hook.

Secondary gap: the saved limit was only pushed to the backend when the user *changed* the setting in Settings; after an app restart the backend ran on defaults until the setting was touched again.

## Changes

- `rns-backend-py/.../event_bridge.py`
  - `set_incoming_message_size_limit()` now mirrors the cap onto `router.delivery_per_transfer_limit`. Columba's KB is binary (post-reassembly drop uses `*1024`), LXMF's is decimal (`*1000`), so the value is converted with a ceiling - the pre-transfer gate never over-rejects, and the post-reassembly drop remains the strict gate.
  - `0`/unlimited maps to a ~1 TB sentinel: the pinned LXMF computes `delivery_per_transfer_limit * 1000` *before* its `limit != None` check, so assigning `None` at runtime crashes the callback with `TypeError` (verified).
  - `register_callbacks()` re-applies the stored cap to a fresh router so an in-process backend restart can't silently revert it.
- `app/.../ColumbaApplication.kt`: push the persisted limit to the stack on both backend-ready paths (fresh init + reconnect).
- `rns-backend-py/.../PythonRnsLxmf.kt`: corrected the now-false comment.
- New unit tests: mapping/ceiling conversion, unlimited sentinel, no-crash without router, re-apply on fresh router, default cap stays ~1 MB.

The post-reassembly drop is kept as-is: it still covers opportunistic (multi-hop) delivery, which genuinely has no pre-transfer hook in LXMF. lxmf-kt (kotlin backend) is untouched.

## Verification

E2E on the exact pinned stack (RNS `5b3a6ee4`, LXMF `8912186e`): two independent RNS/LXMF processes over a localhost TCP pair (same resource-protocol path as two LAN phones), 2 MB DIRECT message, driving the **real** `event_bridge.py` exactly as `PythonRnsLxmf.kt` does.

| Case | Result |
|---|---|
| Original code, UI "Unlimited" (131072 KB - the value the chip sends) | `Rejecting 2.10 MB incoming LXMF delivery resource, since it exceeds the limit of 1.00 MB` (issue reproduced) |
| Fix, "Unlimited" (131072) | delivered, 2,097,152 bytes |
| Fix, 25 MB (25600) | delivered |
| Fix, true unlimited (0) | delivered |
| Fix, default 1 MB (1024) | rejected "exceeds the limit of 1.05 MB" (default cap still applies as designed) |

Also: Python suite 34/34 OK, `:app:compileNoSentryPythonBackendDebugKotlin` + detekt + ktlint clean, existing `*IncomingMessageLimit*` / `*MessageDeliveryRetrieval*` unit tests pass. Debug APK (noSentry pythonBackend) under device test.
