### PR TITLE
fix(android): track multi-segment Resource progress and clear bar on terminal status

### DIFF
--- a/app/src/main/java/network/columba/app/viewmodel/MessagingViewModel.kt
+++ b/app/src/main/java/network/columba/app/viewmodel/MessagingViewModel.kt
@@ -967,6 +967,21 @@ class MessagingViewModel
                     Log.w(TAG, "Ignoring delivery status without trustworthy attempt identity")
                     return
                 }
+
+                // The terminal transfer-progress update is a one-shot emission;
+                // if it was missed (app in background, IPC gap, service
+                // restart), the in-memory progress entry would linger and the
+                // progress bar would never go away even though the delivery
+                // status already shows the final state. The delivery status is
+                // the authoritative terminal event for the same transfer, so
+                // reconcile the progress map on any terminal status - before
+                // the DB bookkeeping, so a failure there can't strand the bar.
+                if (update.status == DeliveryStatus.DELIVERED
+                    || update.status == DeliveryStatus.PROPAGATED
+                    || update.status == DeliveryStatus.FAILED
+                ) {
+                    _transferProgress.value = _transferProgress.value - update.messageHash.lowercase()
+                }
                 // Retry mechanism to handle race condition where delivery proof arrives
                 // before database transaction completes
                 val maxRetries = 3
@@ -1018,6 +1033,7 @@ class MessagingViewModel
                 } else {
                     Log.w(TAG, "Delivery status update for unknown message after $maxRetries retries: ${update.messageHash.take(16)}...")
                 }
+
             } catch (e: Exception) {
                 Log.e(TAG, "Error updating message status", e)
             }

--- a/app/src/main/java/network/columba/app/viewmodel/MessagingViewModel.kt
+++ b/app/src/main/java/network/columba/app/viewmodel/MessagingViewModel.kt
@@ -368,6 +368,16 @@ class MessagingViewModel
         val transferProgress: StateFlow<Map<String, network.columba.app.rns.api.model.TransferProgressUpdate>> =
             _transferProgress.asStateFlow()
 
+        // Message hashes whose transfer was settled by an authoritative
+        // terminal delivery status. Progress cleanup is monotonic through
+        // this set: once a transfer is terminal, a delayed non-terminal
+        // progress event for the same message cannot resurrect its bar
+        // (the delivery-status and progress collectors run independently,
+        // so that out-of-order delivery is possible). Insertion-ordered
+        // and capped so long-lived processes don't accumulate state;
+        // accessed only from Main-dispatcher coroutines.
+        private val terminalTransferHashes = LinkedHashSet<String>()
+
         // Track which images have been decoded - used to trigger recomposition
         // when images become available. The UI observes this to know when to re-check the cache.
         private val _loadedImageIds = MutableStateFlow<Set<String>>(emptySet())
@@ -893,6 +903,11 @@ class MessagingViewModel
                 try {
                     rnsLxmf.observeTransferProgress().collect { update ->
                         val key = (update.messageHash ?: update.transferId).lowercase()
+                        // Monotonic cleanup: skip delayed non-terminal
+                        // updates for transfers already settled by a
+                        // terminal delivery status, so the bar can't
+                        // reappear after delivery finished.
+                        if (!update.isTerminal && key in terminalTransferHashes) return@collect
                         _transferProgress.value = if (update.isTerminal) {
                             _transferProgress.value - key
                         } else {
@@ -980,7 +995,12 @@ class MessagingViewModel
                     || update.status == DeliveryStatus.PROPAGATED
                     || update.status == DeliveryStatus.FAILED
                 ) {
-                    _transferProgress.value = _transferProgress.value - update.messageHash.lowercase()
+                    val progressKey = update.messageHash.lowercase()
+                    _transferProgress.value = _transferProgress.value - progressKey
+                    terminalTransferHashes.add(progressKey)
+                    while (terminalTransferHashes.size > 256) {
+                        terminalTransferHashes.remove(terminalTransferHashes.first())
+                    }
                 }
                 // Retry mechanism to handle race condition where delivery proof arrives
                 // before database transaction completes

--- a/app/src/test/java/network/columba/app/viewmodel/MessagingViewModelTest.kt
+++ b/app/src/test/java/network/columba/app/viewmodel/MessagingViewModelTest.kt
@@ -1685,6 +1685,97 @@ class MessagingViewModelTest {
         }
 
     @Test
+    fun `delayed non-terminal progress event cannot reappear bar after terminal status`() =
+        runViewModelTest {
+            val deliveryStatusFlow = MutableSharedFlow<DeliveryStatusUpdate>()
+            val transferProgressFlow = MutableSharedFlow<TransferProgressUpdate>()
+            every { rnsLxmf.observeDeliveryStatus() } returns deliveryStatusFlow
+            every { rnsLxmf.observeTransferProgress() } returns transferProgressFlow
+
+            val testMessageHash = "delayed_progress_hash"
+            val existingMessage =
+                MessageEntity(
+                    id = testMessageHash,
+                    conversationHash = testPeerHash,
+                    identityHash = "test_identity_hash",
+                    content = "Test message",
+                    timestamp = 1000L,
+                    isFromMe = true,
+                    status = "sent",
+                )
+            coEvery {
+                conversationRepository.applyDeliveryStatus(testMessageHash, any(), "test_identity_hash")
+            } returns existingMessage
+            coEvery { conversationRepository.updateMessageDeliveryDetails(any(), any(), any()) } just Runs
+            every { conversationLinkManager.recordPeerActivity(any(), any()) } just Runs
+
+            val viewModel =
+                MessagingViewModel(
+                    applicationContext,
+                    rnsCore,
+                    rnsLxmf,
+                    rnsTransportAdmin,
+                    conversationRepository,
+                    announceRepository,
+                    contactRepository,
+                    activeConversationManager,
+                    settingsRepository,
+                    propagationNodeManager,
+                    locationSharingManager,
+                    identityRepository,
+                    conversationLinkManager,
+                    receivedLocationRepository,
+                    blockedPeerRepository,
+                    identityResolutionManager,
+                    notificationHelper,
+                    rnsTelephony,
+                )
+            advanceUntilIdle()
+
+            // Transfer in progress
+            transferProgressFlow.emit(
+                TransferProgressUpdate(
+                    transferId = testMessageHash,
+                    messageHash = testMessageHash,
+                    direction = Direction.OUT,
+                    progress = 0.5f,
+                    phase = TransferPhase.TRANSFERRING,
+                ),
+            )
+            advanceUntilIdle()
+            assertEquals(1, viewModel.transferProgress.value.size)
+
+            // Terminal delivery status settles the transfer and clears the bar
+            deliveryStatusFlow.emit(
+                DeliveryStatusUpdate(
+                    messageHash = testMessageHash,
+                    status = DeliveryStatus.DELIVERED,
+                    timestamp = System.currentTimeMillis(),
+                    originatingIdentityHash = "test_identity_hash",
+                ),
+            )
+            advanceUntilIdle()
+            assertTrue(viewModel.transferProgress.value.isEmpty())
+
+            // A non-terminal event queued before the terminal status lands
+            // after it: it must not resurrect the bar
+            transferProgressFlow.emit(
+                TransferProgressUpdate(
+                    transferId = testMessageHash,
+                    messageHash = testMessageHash,
+                    direction = Direction.OUT,
+                    progress = 0.5f,
+                    phase = TransferPhase.TRANSFERRING,
+                ),
+            )
+            advanceUntilIdle()
+            assertTrue(
+                "delayed non-terminal progress must not resurrect the bar after terminal status",
+                viewModel.transferProgress.value.isEmpty(),
+            )
+        }
+
+    @Test
     fun `delivery enrichment keeps callback identity after active identity switch with duplicate hash`() =
         runViewModelTest {
             val deliveryStatusFlow = MutableSharedFlow<DeliveryStatusUpdate>()

--- a/app/src/test/java/network/columba/app/viewmodel/MessagingViewModelTest.kt
+++ b/app/src/test/java/network/columba/app/viewmodel/MessagingViewModelTest.kt
@@ -1602,6 +1602,89 @@ class MessagingViewModelTest {
         }
 
     @Test
+    fun `terminal delivery status clears lingering transfer progress entry`() =
+        runViewModelTest {
+            // Setup: flows let the test seed a non-terminal progress entry and
+            // then emit only the authoritative delivery status
+            val deliveryStatusFlow = MutableSharedFlow<DeliveryStatusUpdate>()
+            val transferProgressFlow = MutableSharedFlow<TransferProgressUpdate>()
+            every { rnsLxmf.observeDeliveryStatus() } returns deliveryStatusFlow
+            every { rnsLxmf.observeTransferProgress() } returns transferProgressFlow
+
+            val testMessageHash = "lingering_progress_hash"
+            val existingMessage =
+                MessageEntity(
+                    id = testMessageHash,
+                    conversationHash = testPeerHash,
+                    identityHash = "test_identity_hash",
+                    content = "Test message",
+                    timestamp = 1000L,
+                    isFromMe = true,
+                    status = "sent",
+                )
+            coEvery {
+                conversationRepository.applyDeliveryStatus(testMessageHash, any(), "test_identity_hash")
+            } returns existingMessage
+            coEvery { conversationRepository.updateMessageDeliveryDetails(any(), any(), any()) } just Runs
+            every { conversationLinkManager.recordPeerActivity(any(), any()) } just Runs
+
+            val viewModel =
+                MessagingViewModel(
+                    applicationContext,
+                    rnsCore,
+                    rnsLxmf,
+                    rnsTransportAdmin,
+                    conversationRepository,
+                    announceRepository,
+                    contactRepository,
+                    activeConversationManager,
+                    settingsRepository,
+                    propagationNodeManager,
+                    locationSharingManager,
+                    identityRepository,
+                    conversationLinkManager,
+                    receivedLocationRepository,
+                    blockedPeerRepository,
+                    identityResolutionManager,
+                    notificationHelper,
+                    rnsTelephony,
+                )
+            advanceUntilIdle()
+
+            // Simulate a live (non-terminal) progress entry for the message
+            transferProgressFlow.emit(
+                TransferProgressUpdate(
+                    transferId = testMessageHash,
+                    messageHash = testMessageHash,
+                    direction = Direction.OUT,
+                    progress = 0.25f,
+                    phase = TransferPhase.TRANSFERRING,
+                ),
+            )
+            advanceUntilIdle()
+            assertEquals(1, viewModel.transferProgress.value.size)
+
+            // When: the one-shot terminal progress update is missed and only
+            // the authoritative delivery status arrives
+            deliveryStatusFlow.emit(
+                DeliveryStatusUpdate(
+                    messageHash = testMessageHash,
+                    status = DeliveryStatus.DELIVERED,
+                    timestamp = System.currentTimeMillis(),
+                    originatingIdentityHash = "test_identity_hash",
+                ),
+            )
+            advanceUntilIdle()
+
+            // Then: the lingering progress entry is reconciled away so the
+            // progress bar goes away with the double checkmark
+            assertTrue(
+                "lingering transfer progress entry must be cleared on terminal status",
+                viewModel.transferProgress.value.isEmpty(),
+            )
+        }
+
+    @Test
     fun `delivery enrichment keeps callback identity after active identity switch with duplicate hash`() =
         runViewModelTest {
             val deliveryStatusFlow = MutableSharedFlow<DeliveryStatusUpdate>()

--- a/rns-backend-py/src/main/kotlin/network/columba/app/rns/backend/py/PythonRnsLxmf.kt
+++ b/rns-backend-py/src/main/kotlin/network/columba/app/rns/backend/py/PythonRnsLxmf.kt
@@ -347,14 +347,14 @@ class PythonRnsLxmf(
         lxmessage: PyObject,
         state: Int,
     ): TransferProgressUpdate {
-        val resource = lxmessage["resource_representation"]?.takeUnless { it.toString() == "None" }
+        val resource = lxmessage["resource_representation"]?.takeUnless { it.isPythonNone() }
         val phase = when (state) {
             LXMF_STATE_SENT, LXMF_STATE_DELIVERED -> TransferPhase.COMPLETE
             LXMF_STATE_REJECTED, LXMF_STATE_CANCELLED, LXMF_STATE_FAILED -> TransferPhase.FAILED
             else -> outgoingTransferPhase(state)
         }
         val resourceProgress = if (phase == TransferPhase.TRANSFERRING) {
-            resource?.pyDoubleCall("get_progress") ?: 0.0
+            outgoingResourceProgress(resource)
         } else {
             0.0
         }
@@ -373,6 +373,43 @@ class PythonRnsLxmf(
             maxAttempts = runtime.lxmRouter?.pyInt("MAX_DELIVERY_ATTEMPTS"),
         )
     }
+
+    /**
+     * Overall progress of an outgoing (possibly split) RNS resource.
+     *
+     * Resources larger than RNS's MAX_EFFICIENT_SIZE transfer one segment at a
+     * time over a CHAIN of Resource objects linked by `next_segment`. The
+     * LXMessage's `resource_representation` stays pinned to the first segment
+     * object, whose `get_progress()` freezes at 1/total_segments once segment
+     * 1 concludes (e.g. a 6-segment file reports a stuck 16.7% for the whole
+     * rest of the transfer). Walk the chain to the current tip and read its
+     * progress, which already accounts for the previously completed segments.
+     */
+    private fun outgoingResourceProgress(resource: PyObject?): Double {
+        var chain = resource ?: return 0.0
+        var hops = 0
+        while (hops < 128) {
+            val next = runCatching { chain["next_segment"] }
+                .getOrNull()
+                ?.takeUnless { it.isPythonNone() } ?: break
+            chain = next
+            hops++
+        }
+        return runCatching { chain.pyDoubleCall("get_progress") }.getOrNull() ?: 0.0
+    }
+
+    /**
+     * None-check that never invokes the object's `__str__`/`__repr__`.
+     *
+     * Chaquopy's `PyObject.toString()` calls Python's `str()`, and
+     * `RNS.Resource.__str__` dereferences `self.link.link_id` - which throws
+     * `AttributeError` once the segment's link is gone. That crash used to
+     * kill the whole outgoing progress update (see the stuck progress bar),
+     * so None checks on Resource objects must go through `repr()`, which is
+     * the type default and never throws here.
+     */
+    private fun PyObject.isPythonNone(): Boolean =
+        runCatching { repr() == "None" }.getOrDefault(false)
 
     private fun incomingTransferProgress(): Flow<TransferProgressUpdate> = flow {
         val previous = LinkedHashMap<String, TransferProgressUpdate>()

--- a/tests/transfer_progress_e2e/test_transfer_progress_e2e.py
+++ b/tests/transfer_progress_e2e/test_transfer_progress_e2e.py
@@ -22,7 +22,12 @@ PKG = "network.columba.app.debug"
 ACTIVITY = f"{PKG}/network.columba.app.MainActivity"
 RECEIVER = f"{PKG}/network.columba.app.test.TestReceiver"
 FILE_NAME = "columba-progress-e2e.bin"
-FILE_SIZE = 1024 * 1024
+# 3 MiB packs into 4 RNS resource segments (MAX_EFFICIENT_SIZE is 1 MiB - 1),
+# so the sender-side transfer crosses multiple `next_segment` objects. A
+# progress reader pinned to the first segment freezes at 1/total_segments
+# (25% here) for the rest of the transfer - the multi-segment size is the
+# point of this E2E.
+FILE_SIZE = 3 * 1024 * 1024
 
 
 @dataclass(frozen=True)
@@ -250,26 +255,41 @@ def outgoing_resource_percentage(snapshot: UiSnapshot) -> int | None:
     return snapshot.semantic_percentage("Transferring Resource")
 
 
-def capture_verified_progress(driver: AdbUiDriver, timeout: float = 45) -> int:
-    """Capture a screenshot bracketed by matching intermediate UI semantics."""
+def sample_outgoing_progress(
+    driver: AdbUiDriver,
+    timeout: float = 120,
+) -> tuple[list[int], bool]:
+    """Sample the outgoing progress bar across the whole transfer.
+
+    Returns (percentages observed over time, whether the bar went away).
+    The bar is considered gone once it has been visible a few times and the
+    "Transferring Resource" semantic stops appearing.
+    """
+    percentages: list[int] = []
+    verified_screenshot = False
+    none_streak = 0
     deadline = time.monotonic() + timeout
     while time.monotonic() < deadline:
         try:
-            before = outgoing_resource_percentage(driver.snapshot())
-            if before is None:
-                time.sleep(0.2)
-                continue
-            screenshot = driver.screenshot("outgoing-resource-progress.png")
-            after = outgoing_resource_percentage(driver.snapshot())
-            if after is not None and screenshot.stat().st_size > 10_000:
-                return after
-        except (OSError, subprocess.SubprocessError, ET.ParseError):
-            pass
-        time.sleep(0.2)
-    raise TimeoutError("Could not capture verified outgoing Resource progress")
+            percentage = outgoing_resource_percentage(driver.snapshot())
+        except (subprocess.CalledProcessError, ET.ParseError):
+            percentage = None
+        if percentage is not None:
+            none_streak = 0
+            percentages.append(percentage)
+            if not verified_screenshot and percentage > 60:
+                screenshot = driver.screenshot("outgoing-resource-progress.png")
+                if screenshot.stat().st_size > 10_000:
+                    verified_screenshot = True
+        else:
+            none_streak += 1
+            if len(percentages) >= 3 and none_streak >= 3:
+                return percentages, True
+        time.sleep(0.4)
+    return percentages, False
 
 
-@pytest.mark.timeout(300)
+@pytest.mark.timeout(420)
 def test_real_resource_progress_reaches_outgoing_bubble(tmp_path: Path) -> None:
     apk = Path(os.environ["COLUMBA_E2E_APK"]).resolve()
     serial = os.environ.get("COLUMBA_EMULATOR_SERIAL", "emulator-5554")
@@ -354,15 +374,32 @@ def test_real_resource_progress_reaches_outgoing_bubble(tmp_path: Path) -> None:
         driver.wait_text(FILE_NAME, timeout=30)
         driver.click_description("Send message")
 
-        percentage = capture_verified_progress(driver)
-        assert 0 < percentage < 100
+        percentages, bar_disappeared = sample_outgoing_progress(driver, timeout=120)
+        assert percentages, "outgoing progress bar never appeared"
+        # Progress must track the whole multi-segment transfer, not stall
+        # after the first segment (which would cap it at 25% for this file).
+        assert max(percentages) > 60, (
+            f"progress stalled after early segments: max={max(percentages)} "
+            f"samples={percentages[:20]}...{percentages[-5:]}"
+        )
 
-        wait_file(peer.result_file, 90)
+        wait_file(peer.result_file, 120)
         received = json.loads(peer.result_file.read_text(encoding="utf-8"))
         assert received["filename"] == FILE_NAME
         assert received["size"] == FILE_SIZE
         assert received["sha256"] == expected_sha
         assert re.fullmatch(r"[0-9a-f]{64}", received["message_hash"])
+
+        if not bar_disappeared:
+            # The terminal update lands with the receiver-side conclusion;
+            # give it a moment before failing on the lingering bar.
+            grace = time.monotonic() + 30
+            while time.monotonic() < grace:
+                time.sleep(1)
+                if outgoing_resource_percentage(driver.snapshot()) is None:
+                    bar_disappeared = True
+                    break
+        assert bar_disappeared, "progress bar did not go away after the transfer completed"
     finally:
         try:
             driver.screenshot("final-screen.png")


### PR DESCRIPTION
## Summary

Fixes the outgoing progress bar bug reported while testing the large-file fix: sending a large resource shows a progress bar that **freezes at ~16-17%** and **never goes away** after delivery, even though the double checkmark appears and the transfer completes.

## Root cause

Two independent faults in the sender-side progress poll (`PythonRnsLxmf.startOutgoingTransferPoll`), plus a missing reconciliation on the UI side:

1. **Frozen value.** RNS transfers resources larger than `MAX_EFFICIENT_SIZE` (1 MiB - 1) one segment at a time over a *chain* of `Resource` objects linked by `next_segment`. The poll read `lxmessage.resource_representation.get_progress()` - the **first segment** object, whose progress freezes at `1/total_segments` once segment 1 concludes (6-segment file = stuck 16.7%; the user's file matched exactly).
2. **Terminal update dropped.** Once a segment's link is gone, `RNS.Resource.__str__` dereferences `self.link.link_id` and raises `AttributeError`. The poll's `takeUnless { it.toString() == "None" }` invokes `__str__` through Chaquopy, so every subsequent update generation - including the one-shot terminal `COMPLETE` - raised and was dropped. The bar stranded at the last value forever. The delivery-status event travels a separate flow, which is why the double checkmark still appeared.

## Changes

- **PythonRnsLxmf**: walk the `next_segment` chain to the current tip and read its `get_progress()` (it already accounts for completed segments) - the bar now tracks the whole transfer, 0% to 100%.
- **PythonRnsLxmf**: None checks on `Resource` objects use `repr()` (`isPythonNone`) instead of `toString()`, which never triggers the crashing `__str__`.
- **MessagingViewModel**: on a terminal delivery status (`delivered` / `propagated` / `failed`) for a message, clear its in-memory transfer-progress entry, so the bar is reconciled by the authoritative terminal event even if the one-shot terminal progress update is missed (app backgrounded, IPC gap, service restart).
- **E2E** (`tests/transfer_progress_e2e`): file size bumped to 3 MiB (4 segments); the test now samples the bar across the whole transfer, asserts progress advances past the early segments, and asserts the bar goes away after delivery.
- **Unit test**: `MessagingViewModelTest` covers terminal-status reconciliation of a lingering progress entry.

## Verification

- **Red/green on an emulator (api 34, x86_64, real two-peer E2E through the throttled proxy):**
  - Unfixed build: `samples=[3, 12, 17, 25, 25, 25, ...]` - stalls at max=25%, test fails.
  - Fixed build: progress tracks the full transfer, bar clears after delivery, file received intact - test passes.
- `MessagingViewModelTest` (191 tests) and `:rns-backend-py` unit tests pass; ktlint, detekt, Android lint clean.

No user-facing setting or wire-format changes.