### PR TITLE
Present incoming calls while backgrounded (issue #1079, replaces #1118)

### DIFF
--- a/app/src/debug/java/network/columba/app/test/TestReceiver.kt
+++ b/app/src/debug/java/network/columba/app/test/TestReceiver.kt
@@ -276,6 +276,26 @@ class TestReceiver : BroadcastReceiver() {
                 }
             }
 
+            "network.columba.test.SHOW_INCOMING_CALL_TEST" -> {
+                // Debug-only: post the real incoming-call FSI notification on demand
+                // (issue #1079 diagnostics) so the full-screen takeover can be
+                // reproduced without placing a real call. Optional extras:
+                //   hash - identity hash to carry (default: a test hash)
+                //   name - caller display name (default: "E2E Test Caller")
+                val hash = intent.getStringExtra("hash") ?: "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+                val name = intent.getStringExtra("name") ?: "E2E Test Caller"
+                try {
+                    val helper = network.columba.app.notifications.CallNotificationHelper(app)
+                    helper.showIncomingCallNotification(hash, name)
+                    Log.i(
+                        TestController.LOGCAT_TAG,
+                        "fsi_test_posted hash=${hash.take(8)} name=$name",
+                    )
+                } catch (e: Exception) {
+                    Log.e(TestController.LOGCAT_TAG, "fsi_test_err ${e.message}")
+                }
+            }
+
             else ->
                 Log.i(TestController.LOGCAT_TAG, "rx_broadcast_unknown action=$action")
         }

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -79,6 +79,8 @@
     <!-- Voice call permissions (LXST Telephony) -->
     <uses-permission android:name="android.permission.RECORD_AUDIO" />
     <uses-permission android:name="android.permission.MODIFY_AUDIO_SETTINGS" />
+    <!-- Incoming call screen vibration (IncomingCallActivity) -->
+    <uses-permission android:name="android.permission.VIBRATE" />
     <uses-permission android:name="android.permission.USE_FULL_SCREEN_INTENT" />
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE_MICROPHONE" />
     <!-- Required to show incoming call screen over other apps when phone is unlocked -->

--- a/app/src/main/java/network/columba/app/AppMainThread.kt
+++ b/app/src/main/java/network/columba/app/AppMainThread.kt
@@ -1,0 +1,24 @@
+package network.columba.app
+
+import android.os.Handler
+import android.os.Looper
+
+/**
+ * Minimal seam onto the application main looper for fire-and-forget work that
+ * must share a single execution thread with the activity lifecycle callbacks
+ * (see [MainActivityVisibility] for why confinement, not locking).
+ *
+ * A `post`d block runs on the main thread after any already-queued work,
+ * preserving enqueue order. Unit tests replace [post] and [isMainThread] with a
+ * synchronous fake (the real main looper does not exist on the JVM), the same
+ * way `Dispatchers.setMain` swaps the coroutine main dispatcher.
+ */
+object AppMainThread {
+    /** Test seam: replaced wholesale by unit tests; production uses the looper. */
+    @Volatile
+    var post: ((Runnable) -> Unit) = { runnable -> Handler(Looper.getMainLooper()).post(runnable) }
+
+    /** Test seam: whether the calling thread is the (faked) main thread. */
+    @Volatile
+    var isMainThread: () -> Boolean = { Looper.myLooper() == Looper.getMainLooper() }
+}

--- a/app/src/main/java/network/columba/app/ColumbaApplication.kt
+++ b/app/src/main/java/network/columba/app/ColumbaApplication.kt
@@ -74,6 +74,9 @@ class ColumbaApplication : Application() {
     lateinit var messageCollector: MessageCollector
 
     @Inject
+    lateinit var incomingCallPresenter: network.columba.app.service.IncomingCallPresenter
+
+    @Inject
     lateinit var conversationRepository: ConversationRepository
 
     @Inject
@@ -166,6 +169,13 @@ class ColumbaApplication : Application() {
         }
 
         android.util.Log.d("ColumbaApplication", "Main app process detected ($processName) - proceeding with auto-initialization")
+
+        // Present incoming calls even when the app is backgrounded or the device is
+        // locked: the presenter posts the full-screen-intent notification on
+        // CallState.Incoming (issue #1079). Started before backend init because the
+        // bound callState flow is safe to observe before the service is ready - it
+        // just stays Idle until the service connection syncs state.
+        incomingCallPresenter.start()
 
         // Preload theme preference into DataStore's in-memory cache
         // This eliminates theme flash on app startup by ensuring the theme is cached

--- a/app/src/main/java/network/columba/app/IncomingCallActivity.kt
+++ b/app/src/main/java/network/columba/app/IncomingCallActivity.kt
@@ -2,10 +2,7 @@ package network.columba.app
 
 import android.content.Context
 import android.content.Intent
-import android.media.AudioAttributes
 import android.media.AudioManager
-import android.media.Ringtone
-import android.media.RingtoneManager
 import android.os.Build
 import android.os.Bundle
 import android.os.VibrationEffect
@@ -33,10 +30,7 @@ import network.columba.app.notifications.CallNotificationHelper
 import network.columba.app.repository.SettingsRepository
 import network.columba.app.ui.screens.IncomingCallActivityScreen
 import network.columba.app.ui.theme.ThemeMode
-import kotlinx.coroutines.Job
 import dagger.hilt.android.EntryPointAccessors
-import kotlinx.coroutines.delay
-import kotlinx.coroutines.isActive
 import kotlinx.coroutines.launch
 import network.columba.app.di.RnsTelephonyEntryPoint
 import network.columba.app.rns.api.RnsTelephony
@@ -53,7 +47,7 @@ import network.columba.app.rns.api.model.CallState
  * - Shows over lock screen (showWhenLocked / FLAG_SHOW_WHEN_LOCKED)
  * - Turns screen on (turnScreenOn / FLAG_TURN_SCREEN_ON)
  * - Dismisses keyguard when answering
- * - Plays default ringtone and vibrates in a call pattern
+ * - Vibrates in a call pattern (the ringtone is owned by the :reticulum service process)
  * - Retrieves the singleton [RnsTelephony] via Hilt's
  *   [RnsTelephonyEntryPoint] (the Activity itself is kept Hilt-free so
  *   cold start stays under the lock-screen ringing latency budget — see
@@ -75,8 +69,6 @@ class IncomingCallActivity : ComponentActivity() {
             .fromApplication(applicationContext, RnsTelephonyEntryPoint::class.java)
             .settingsRepository()
     }
-    private var ringtone: Ringtone? = null
-    private var ringtoneLoopJob: Job? = null
     private var vibrator: Vibrator? = null
 
     // Compose-observable state so UI updates when onNewIntent delivers a new call
@@ -100,8 +92,11 @@ class IncomingCallActivity : ComponentActivity() {
         // Show over lock screen and turn screen on
         configureWindowForIncomingCall()
 
-        // Start ringtone and vibration
-        startRingtoneAndVibration()
+        // Vibrate in a phone-call pattern. The ringtone itself is played by the
+        // :reticulum service process (LXST Telephone) which owns the call
+        // lifecycle; playing a second ringtone here would double-ring while the
+        // call screen is up.
+        startVibration()
 
         enableEdgeToEdge()
 
@@ -160,7 +155,7 @@ class IncomingCallActivity : ComponentActivity() {
     }
 
     override fun onDestroy() {
-        stopRingtoneAndVibration()
+        stopVibration()
         super.onDestroy()
     }
 
@@ -173,9 +168,9 @@ class IncomingCallActivity : ComponentActivity() {
         if (newHash != null) {
             currentIdentityHash.value = newHash
             currentCallerName.value = newName
-            // Restart ringtone/vibration for the new call
-            stopRingtoneAndVibration()
-            startRingtoneAndVibration()
+            // Restart vibration for the new call
+            stopVibration()
+            startVibration()
         }
     }
 
@@ -204,46 +199,14 @@ class IncomingCallActivity : ComponentActivity() {
     }
 
     /**
-     * Start playing the default ringtone and vibrating in a phone-call pattern.
-     * Respects the device's ringer mode (silent/vibrate/normal).
+     * Vibrate in a phone-call pattern. Respects the device's ringer mode (no
+     * vibration in silent mode). The ringtone itself is played by the
+     * :reticulum service process (LXST Telephone), which owns the call
+     * lifecycle and stops it on answer/hangup.
      */
-    private fun startRingtoneAndVibration() {
+    private fun startVibration() {
         val audioManager = getSystemService(Context.AUDIO_SERVICE) as AudioManager
         val ringerMode = audioManager.ringerMode
-
-        // Play ringtone (only if not in silent/vibrate mode)
-        if (ringerMode == AudioManager.RINGER_MODE_NORMAL) {
-            try {
-                val ringtoneUri = RingtoneManager.getDefaultUri(RingtoneManager.TYPE_RINGTONE)
-                ringtone =
-                    RingtoneManager.getRingtone(this, ringtoneUri)?.apply {
-                        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.P) {
-                            isLooping = true
-                        }
-                        audioAttributes =
-                            AudioAttributes
-                                .Builder()
-                                .setUsage(AudioAttributes.USAGE_NOTIFICATION_RINGTONE)
-                                .setContentType(AudioAttributes.CONTENT_TYPE_SONIFICATION)
-                                .build()
-                        play()
-                    }
-                // On pre-P devices, isLooping is not available; manually restart
-                if (Build.VERSION.SDK_INT < Build.VERSION_CODES.P && ringtone != null) {
-                    ringtoneLoopJob =
-                        lifecycleScope.launch {
-                            val rt = ringtone ?: return@launch
-                            while (isActive) {
-                                delay(1000)
-                                if (!rt.isPlaying) rt.play()
-                            }
-                        }
-                }
-                Log.d(TAG, "Ringtone started")
-            } catch (e: Exception) {
-                Log.e(TAG, "Error starting ringtone", e)
-            }
-        }
 
         // Vibrate (in normal or vibrate mode, not silent)
         if (ringerMode != AudioManager.RINGER_MODE_SILENT) {
@@ -275,18 +238,9 @@ class IncomingCallActivity : ComponentActivity() {
     }
 
     /**
-     * Stop ringtone and vibration.
+     * Stop vibration.
      */
-    private fun stopRingtoneAndVibration() {
-        ringtoneLoopJob?.cancel()
-        ringtoneLoopJob = null
-        try {
-            ringtone?.stop()
-            ringtone = null
-            Log.d(TAG, "Ringtone stopped")
-        } catch (e: Exception) {
-            Log.e(TAG, "Error stopping ringtone", e)
-        }
+    private fun stopVibration() {
         try {
             vibrator?.cancel()
             vibrator = null
@@ -306,7 +260,7 @@ class IncomingCallActivity : ComponentActivity() {
      */
     private fun answerCall() {
         Log.i(TAG, "Answering call")
-        stopRingtoneAndVibration()
+        stopVibration()
         dismissKeyguardAndAnswer()
     }
 
@@ -358,7 +312,7 @@ class IncomingCallActivity : ComponentActivity() {
      */
     private fun declineCall() {
         Log.i(TAG, "Declining call")
-        stopRingtoneAndVibration()
+        stopVibration()
         lifecycleScope.launch {
             try {
                 telephony.declineCall()

--- a/app/src/main/java/network/columba/app/MainActivity.kt
+++ b/app/src/main/java/network/columba/app/MainActivity.kt
@@ -175,6 +175,9 @@ class MainActivity : ComponentActivity() {
     @Inject
     lateinit var transportAdmin: RnsTransportAdmin
 
+    @Inject
+    lateinit var mainActivityVisibility: MainActivityVisibility
+
     // State to hold pending navigation from intent
     private val pendingNavigation = mutableStateOf<PendingNavigation?>(null)
 
@@ -278,6 +281,19 @@ class MainActivity : ComponentActivity() {
                 }
             }
         }
+
+    override fun onStart() {
+        super.onStart()
+        // Issue #1079: while the main UI is visible it owns incoming-call
+        // presentation (in-app call screen); the background presenter stays
+        // quiet so it can never duplicate or resurrect the notification.
+        mainActivityVisibility.setVisible(true)
+    }
+
+    override fun onStop() {
+        mainActivityVisibility.setVisible(false)
+        super.onStop()
+    }
 
     override fun onCreate(savedInstanceState: Bundle?) {
         // Install splash screen before super.onCreate()

--- a/app/src/main/java/network/columba/app/MainActivity.kt
+++ b/app/src/main/java/network/columba/app/MainActivity.kt
@@ -286,12 +286,16 @@ class MainActivity : ComponentActivity() {
         super.onStart()
         // Issue #1079: while the main UI is visible it owns incoming-call
         // presentation (in-app call screen); the background presenter stays
-        // quiet so it can never duplicate or resurrect the notification.
-        mainActivityVisibility.setVisible(true)
+        // quiet so it can never duplicate or resurrect the notification. The
+        // flag flip and this cancel are one locked section (atomic claim), so
+        // a background post can never land after this cancel and survive it.
+        mainActivityVisibility.claimForeground {
+            CallNotificationHelper(this).cancelIncomingCallNotification()
+        }
     }
 
     override fun onStop() {
-        mainActivityVisibility.setVisible(false)
+        mainActivityVisibility.releaseForeground()
         super.onStop()
     }
 

--- a/app/src/main/java/network/columba/app/MainActivity.kt
+++ b/app/src/main/java/network/columba/app/MainActivity.kt
@@ -60,6 +60,7 @@ import androidx.core.content.ContextCompat
 import androidx.core.splashscreen.SplashScreen.Companion.installSplashScreen
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.LocalLifecycleOwner
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.lifecycle.lifecycleScope
 import androidx.lifecycle.viewmodel.compose.viewModel
 import androidx.navigation.NavType
@@ -1167,7 +1168,16 @@ fun ColumbaNavigation(
             .fromApplication(context.applicationContext, RnsTelephonyEntryPoint::class.java)
             .telephony()
     }
-    val callState by telephony.callState.collectAsState()
+    // Lifecycle-gated collection (issue #1079): a plain collectAsState() keeps
+    // updating while the activity is STOPPED, so the effect below would fire
+    // for a backgrounded app, navigate to the (invisible) IncomingCallScreen,
+    // and cancel the presenter's full-screen-intent notification before the
+    // system can show it. With collectAsStateWithLifecycle the observation
+    // pauses while the activity is not visible, leaving background
+    // presentation to IncomingCallPresenter; when the app is brought to the
+    // front mid-call, collection resumes on the current state and this effect
+    // takes over normally.
+    val callState by telephony.callState.collectAsStateWithLifecycle()
 
     LaunchedEffect(callState) {
         when (val state = callState) {

--- a/app/src/main/java/network/columba/app/MainActivity.kt
+++ b/app/src/main/java/network/columba/app/MainActivity.kt
@@ -287,15 +287,20 @@ class MainActivity : ComponentActivity() {
         // Issue #1079: while the main UI is visible it owns incoming-call
         // presentation (in-app call screen); the background presenter stays
         // quiet so it can never duplicate or resurrect the notification. The
-        // flag flip and this cancel are one locked section (atomic claim), so
-        // a background post can never land after this cancel and survive it.
+        // flag flip and this cancel run as one main-thread sequence (atomic
+        // claim), so a background post can never land after this cancel and
+        // survive it.
         mainActivityVisibility.claimForeground {
             CallNotificationHelper(this).cancelIncomingCallNotification()
         }
     }
 
     override fun onStop() {
-        mainActivityVisibility.releaseForeground()
+        // Rotation keeps the foreground claim (isChangingConfigurations) so the
+        // background presenter never gets a post window mid-rotation; a real
+        // backgrounding releases ownership, which lets the presenter take the
+        // call back if it is still ringing (see IncomingCallPresenter).
+        mainActivityVisibility.releaseForeground(isChangingConfigurations)
         super.onStop()
     }
 

--- a/app/src/main/java/network/columba/app/MainActivityVisibility.kt
+++ b/app/src/main/java/network/columba/app/MainActivityVisibility.kt
@@ -1,0 +1,28 @@
+package network.columba.app
+
+import javax.inject.Inject
+import javax.inject.Singleton
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+
+/**
+ * Tracks whether [MainActivity] is currently visible (STARTED or higher).
+ *
+ * Incoming-call presentation has two owners: [network.columba.app.service.IncomingCallPresenter]
+ * (background: full-screen-intent notification) and the in-app incoming call screen
+ * inside MainActivity (foreground). While MainActivity is visible it owns the
+ * presentation: the presenter must neither post nor update the background
+ * notification. A post that lands while the main UI is visible would duplicate
+ * the in-app call screen, and a name update that lands after MainActivity took
+ * over would resurrect the notification it just cancelled.
+ */
+@Singleton
+class MainActivityVisibility @Inject constructor() {
+    private val _visible = MutableStateFlow(false)
+    val visible: StateFlow<Boolean> = _visible.asStateFlow()
+
+    fun setVisible(isVisible: Boolean) {
+        _visible.value = isVisible
+    }
+}

--- a/app/src/main/java/network/columba/app/MainActivityVisibility.kt
+++ b/app/src/main/java/network/columba/app/MainActivityVisibility.kt
@@ -14,8 +14,8 @@ import kotlinx.coroutines.flow.asStateFlow
  * inside MainActivity (foreground). While MainActivity is visible it owns the
  * presentation: the presenter must neither post nor update the background
  * notification. A post that lands while the main UI is visible would duplicate
- * the in-app call screen, and a name update that lands after MainActivity took
- * over would resurrect the notification it just cancelled.
+ * the in-app call screen, or undo the cancel MainActivity made when it took
+ * over presentation.
  */
 @Singleton
 class MainActivityVisibility @Inject constructor() {

--- a/app/src/main/java/network/columba/app/MainActivityVisibility.kt
+++ b/app/src/main/java/network/columba/app/MainActivityVisibility.kt
@@ -7,22 +7,61 @@ import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
 
 /**
- * Tracks whether [MainActivity] is currently visible (STARTED or higher).
+ * Tracks whether [MainActivity] is currently visible (STARTED or higher) and
+ * serializes foreground-ownership transfer against the background presenter's
+ * check-then-post.
  *
  * Incoming-call presentation has two owners: [network.columba.app.service.IncomingCallPresenter]
  * (background: full-screen-intent notification) and the in-app incoming call screen
  * inside MainActivity (foreground). While MainActivity is visible it owns the
- * presentation: the presenter must neither post nor update the background
- * notification. A post that lands while the main UI is visible would duplicate
- * the in-app call screen, or undo the cancel MainActivity made when it took
- * over presentation.
+ * presentation: the presenter must not post the background notification, and a
+ * post that lands while the main UI is visible would duplicate the in-app call
+ * screen or undo the cancel MainActivity made when it took over presentation.
+ *
+ * The visibility flip and the accompanying notification operations are
+ * therefore made atomic against each other: MainActivity claims foreground
+ * ownership with [claimForeground] (flag flip plus its cancel in one locked
+ * section) and the presenter posts with [postWhileBackground] (flag check plus
+ * post in one locked section). Either the claim wins (the presenter's post is
+ * skipped) or the post wins (the claim's cancel removes it); no interleaving
+ * leaves a post outliving the claim.
  */
 @Singleton
 class MainActivityVisibility @Inject constructor() {
     private val _visible = MutableStateFlow(false)
     val visible: StateFlow<Boolean> = _visible.asStateFlow()
 
-    fun setVisible(isVisible: Boolean) {
-        _visible.value = isVisible
+    /** Serializes ownership claims and background posts (see class KDoc). */
+    private val lock = Any()
+
+    /**
+     * MainActivity: claim foreground ownership. Flips the flag and runs
+     * [onVisible] (MainActivity's background-notification cancel) in one
+     * locked section, so a background post can neither observe a stale
+     * "not visible" after this claim nor survive its cancel.
+     */
+    fun claimForeground(onVisible: () -> Unit) {
+        synchronized(lock) {
+            _visible.value = true
+            onVisible()
+        }
+    }
+
+    /** MainActivity: release foreground ownership (activity STOPPED). */
+    fun releaseForeground() {
+        synchronized(lock) { _visible.value = false }
+    }
+
+    /**
+     * Presenter: run [block] (the notification post) only while the foreground
+     * has not been claimed; the flag check and the post are one locked section.
+     */
+    fun postWhileBackground(block: () -> Unit) {
+        synchronized(lock) {
+            if (_visible.value) {
+                return
+            }
+            block()
+        }
     }
 }

--- a/app/src/main/java/network/columba/app/MainActivityVisibility.kt
+++ b/app/src/main/java/network/columba/app/MainActivityVisibility.kt
@@ -18,50 +18,81 @@ import kotlinx.coroutines.flow.asStateFlow
  * post that lands while the main UI is visible would duplicate the in-app call
  * screen or undo the cancel MainActivity made when it took over presentation.
  *
- * The visibility flip and the accompanying notification operations are
- * therefore made atomic against each other: MainActivity claims foreground
- * ownership with [claimForeground] (flag flip plus its cancel in one locked
- * section) and the presenter posts with [postWhileBackground] (flag check plus
- * post in one locked section). Either the claim wins (the presenter's post is
- * skipped) or the post wins (the claim's cancel removes it); no interleaving
- * leaves a post outliving the claim.
+ * Serialisation strategy: single-thread confinement, not locking. Every
+ * [claimForeground], [releaseForeground] and [postWhileBackground] call runs its
+ * state check and notification operation on the main thread (enforced by
+ * [requireMainThread], not just documented), so the check-then-post sequences are
+ * atomic by construction: there is no second thread to interleave against.
+ *
+ * This deliberately replaces an earlier `synchronized` monitor: that lock was
+ * taken by MainActivity on the main thread (flag flip + cancel) and by the
+ * presenter on Dispatchers.IO (flag check + post), i.e. the main thread blocked
+ * on whichever binder call (`notify`) the IO thread happened to hold the lock
+ * across - an ANR hazard traded for a sub-frame visual residual. With main
+ * [postWhileBackground] enqueues onto the main looper instead of blocking the
+ * caller; the two notification operations keep their exact order relative to
+ * each other either way (post-then-cancel or skip-then-claim), so the visible
+ * outcome is unchanged. Both notification calls are fire-and-forget
+ * (`NotificationManager.notify`/`cancel`), so confining them to the main
+ * thread never parks it on a result.
  */
 @Singleton
 class MainActivityVisibility @Inject constructor() {
     private val _visible = MutableStateFlow(false)
     val visible: StateFlow<Boolean> = _visible.asStateFlow()
 
-    /** Serializes ownership claims and background posts (see class KDoc). */
-    private val lock = Any()
-
     /**
-     * MainActivity: claim foreground ownership. Flips the flag and runs
-     * [onVisible] (MainActivity's background-notification cancel) in one
-     * locked section, so a background post can neither observe a stale
-     * "not visible" after this claim nor survive its cancel.
+     * Presenter: run [block] (the notification post) only while the foreground
+     * has not been claimed; the flag check and the post execute on the main
+     * thread as one sequence (see class KDoc), so they are atomic against
+     * [claimForeground].
+     *
+     * [block] runs on the main thread and must not block. Safe to call from any
+     * thread (the presenter collects on Dispatchers.IO).
      */
-    fun claimForeground(onVisible: () -> Unit) {
-        synchronized(lock) {
-            _visible.value = true
-            onVisible()
+    fun postWhileBackground(block: () -> Unit) {
+        AppMainThread.post {
+            if (_visible.value) {
+                return@post
+            }
+            block()
         }
     }
 
-    /** MainActivity: release foreground ownership (activity STOPPED). */
-    fun releaseForeground() {
-        synchronized(lock) { _visible.value = false }
+    /**
+     * MainActivity: claim foreground ownership. Must be called on the main
+     * thread (activity onStart). Flips the flag and runs [onVisible]
+     * (MainActivity's background-notification cancel) as one main-thread
+     * sequence, so a presenter post enqueued before the claim is either
+     * skipped (claim observed) or removed by this cancel, never left behind.
+     */
+    fun claimForeground(onVisible: () -> Unit) {
+        requireMainThread()
+        _visible.value = true
+        onVisible()
     }
 
     /**
-     * Presenter: run [block] (the notification post) only while the foreground
-     * has not been claimed; the flag check and the post are one locked section.
+     * MainActivity: release foreground ownership (activity STOPPED).
+     *
+     * [changingConfigurations] (MainActivity's `isChangingConfigurations`) keeps
+     * the claim across a rotation: releasing and re-claiming would open a
+     * visible=false window that the background presenter could post into
+     * mid-rotation. The claim is retained until the restarted activity runs
+     * [claimForeground] again or a non-config STOP releases it. An activity
+     * finishing (isFinishing, never a configuration change) always releases.
      */
-    fun postWhileBackground(block: () -> Unit) {
-        synchronized(lock) {
-            if (_visible.value) {
-                return
-            }
-            block()
+    fun releaseForeground(changingConfigurations: Boolean = false) {
+        requireMainThread()
+        if (changingConfigurations) {
+            return
+        }
+        _visible.value = false
+    }
+
+    private fun requireMainThread() {
+        check(AppMainThread.isMainThread()) {
+            "foreground ownership transfer must run on the main thread"
         }
     }
 }

--- a/app/src/main/java/network/columba/app/di/CallNotificationModule.kt
+++ b/app/src/main/java/network/columba/app/di/CallNotificationModule.kt
@@ -1,0 +1,22 @@
+package network.columba.app.di
+
+import dagger.Binds
+import dagger.Module
+import dagger.hilt.InstallIn
+import dagger.hilt.components.SingletonComponent
+import network.columba.app.notifications.CallNotificationHelper
+import network.columba.app.notifications.IncomingCallNotifier
+import javax.inject.Singleton
+
+/**
+ * Binds the narrow [IncomingCallNotifier] port to the concrete
+ * [CallNotificationHelper] so presentation policy can be unit-tested with a
+ * fake without touching Android notification machinery.
+ */
+@Module
+@InstallIn(SingletonComponent::class)
+abstract class CallNotificationModule {
+    @Binds
+    @Singleton
+    abstract fun bindIncomingCallNotifier(impl: CallNotificationHelper): IncomingCallNotifier
+}

--- a/app/src/main/java/network/columba/app/notifications/CallNotificationHelper.kt
+++ b/app/src/main/java/network/columba/app/notifications/CallNotificationHelper.kt
@@ -367,8 +367,19 @@ class CallNotificationHelper
          * Cancel incoming call notification.
          */
         override fun cancelIncomingCallNotification() {
+            cancelTickCount.incrementAndGet()
             notificationManager.cancel(NOTIFICATION_ID_INCOMING_CALL)
         }
+
+        override val cancelTick: Long get() = cancelTickCount.get()
+
+        /**
+         * Backing counter for [IncomingCallNotifier.cancelTick]. Lives on the
+         * companion because cancel sites construct this helper directly
+         * (MainActivity, CallActionReceiver, IncomingCallActivity) rather than
+         * through DI; the tick must count every cancel process-wide.
+         */
+        private val cancelTickCount = java.util.concurrent.atomic.AtomicLong(0)
 
         /**
          * Cancel ongoing call notification.

--- a/app/src/main/java/network/columba/app/notifications/CallNotificationHelper.kt
+++ b/app/src/main/java/network/columba/app/notifications/CallNotificationHelper.kt
@@ -1,6 +1,7 @@
 package network.columba.app.notifications
 
 import android.Manifest
+import android.app.AppOpsManager
 import android.app.NotificationChannel
 import android.app.NotificationManager
 import android.app.PendingIntent
@@ -8,6 +9,7 @@ import android.content.Context
 import android.content.Intent
 import android.content.pm.PackageManager
 import android.os.Build
+import android.os.Process
 import android.provider.Settings
 import android.util.Log
 import androidx.core.app.ActivityCompat
@@ -33,7 +35,7 @@ class CallNotificationHelper
     @Inject
     constructor(
         @ApplicationContext private val context: Context,
-    ) {
+    ) : IncomingCallNotifier {
         companion object {
             // Notification channel IDs
             private const val CHANNEL_ID_INCOMING_CALL = "incoming_calls"
@@ -64,20 +66,50 @@ class CallNotificationHelper
          * Check if the app can use full-screen intents.
          *
          * On Android 14+ (API 34), USE_FULL_SCREEN_INTENT is a special permission
-         * that must be granted by the user in system settings. Without it, the
-         * fullScreenIntent on notifications is silently ignored and the user only
-         * sees a heads-up notification instead of the full incoming call screen.
+         * that must be granted by the user. Without it, the fullScreenIntent on
+         * notifications is silently downgraded to a heads-up notification instead
+         * of the full incoming call screen.
+         *
+         * [NotificationManager.canUseFullScreenIntent] only performs the preflight
+         * check (forDataDelivery=false). The system's actual delivery check
+         * (forDataDelivery=true) treats the MODE_DEFAULT appop as a denial, so we
+         * additionally require the USE_FULL_SCREEN_INTENT appop to be explicitly
+         * allowed. Without that, the card would show a green check while the
+         * system still silently suppresses the full-screen takeover.
          *
          * @return true if full-screen intents are available
          */
         fun canUseFullScreenIntent(): Boolean {
-            return if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.UPSIDE_DOWN_CAKE) {
-                val nm = context.getSystemService(Context.NOTIFICATION_SERVICE) as NotificationManager
-                nm.canUseFullScreenIntent()
-            } else {
+            if (Build.VERSION.SDK_INT < Build.VERSION_CODES.UPSIDE_DOWN_CAKE) {
                 // Before Android 14, all apps with USE_FULL_SCREEN_INTENT in manifest get it
-                true
+                return true
             }
+            val nm = context.getSystemService(Context.NOTIFICATION_SERVICE) as NotificationManager
+            val preflight = nm.canUseFullScreenIntent()
+            val appOps = context.getSystemService(Context.APP_OPS_SERVICE) as AppOpsManager
+            // AppOpsManager.OPSTR_USE_FULL_SCREEN_INTENT is @hide, use the literal
+            val mode =
+                appOps.checkOpNoThrow(
+                    "android:use_full_screen_intent",
+                    Process.myUid(),
+                    context.packageName,
+                )
+            return isFullScreenIntentUsable(preflight, mode)
+        }
+
+        /**
+         * Decide whether full-screen intents are usable from the preflight result
+         * and the real appop mode.
+         *
+         * @param preflightAllowed result of [NotificationManager.canUseFullScreenIntent]
+         * @param appOpMode mode of the USE_FULL_SCREEN_INTENT appop
+         * @return true only when both the preflight check and the appop allow it
+         */
+        internal fun isFullScreenIntentUsable(
+            preflightAllowed: Boolean,
+            appOpMode: Int,
+        ): Boolean {
+            return preflightAllowed && appOpMode == AppOpsManager.MODE_ALLOWED
         }
 
         /**
@@ -165,7 +197,7 @@ class CallNotificationHelper
          * @param identityHash The caller's identity hash
          * @param callerName Display name of the caller
          */
-        fun showIncomingCallNotification(
+        override fun showIncomingCallNotification(
             identityHash: String,
             callerName: String?,
         ) {
@@ -334,7 +366,7 @@ class CallNotificationHelper
         /**
          * Cancel incoming call notification.
          */
-        fun cancelIncomingCallNotification() {
+        override fun cancelIncomingCallNotification() {
             notificationManager.cancel(NOTIFICATION_ID_INCOMING_CALL)
         }
 

--- a/app/src/main/java/network/columba/app/notifications/IncomingCallNotifier.kt
+++ b/app/src/main/java/network/columba/app/notifications/IncomingCallNotifier.kt
@@ -1,0 +1,24 @@
+package network.columba.app.notifications
+
+/**
+ * Narrow port for presenting and cancelling the incoming-call notification.
+ *
+ * The presentation policy (when the full-screen-intent notification is posted,
+ * which caller name it carries) lives on the app side of the backend seam
+ * ([network.columba.app.service.IncomingCallPresenter]); this port keeps that
+ * policy testable without Android notification machinery.
+ */
+interface IncomingCallNotifier {
+    /**
+     * Post the high-importance category-call incoming notification with its
+     * full-screen intent.
+     *
+     * @param identityHash The caller's identity hash (32-char hex)
+     * @param callerName Resolved display name, or null to fall back to a
+     *   formatted hash
+     */
+    fun showIncomingCallNotification(identityHash: String, callerName: String?)
+
+    /** Cancel the incoming-call notification (no-op if not showing). */
+    fun cancelIncomingCallNotification()
+}

--- a/app/src/main/java/network/columba/app/notifications/IncomingCallNotifier.kt
+++ b/app/src/main/java/network/columba/app/notifications/IncomingCallNotifier.kt
@@ -21,4 +21,14 @@ interface IncomingCallNotifier {
 
     /** Cancel the incoming-call notification (no-op if not showing). */
     fun cancelIncomingCallNotification()
+
+    /**
+     * Monotonic cancel counter, bumped by every
+     * [cancelIncomingCallNotification] from any caller (the presenter's
+     * collector, MainActivity, the notification actions, the call screen).
+     * A caller that queues a post can capture this before enqueuing and drop
+     * the post if the tick moved by execution time: a cancel the caller never
+     * observed still suppresses a post that would resurrect it.
+     */
+    val cancelTick: Long
 }

--- a/app/src/main/java/network/columba/app/service/IncomingCallPresenter.kt
+++ b/app/src/main/java/network/columba/app/service/IncomingCallPresenter.kt
@@ -8,6 +8,7 @@ import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.launch
+import java.util.concurrent.atomic.AtomicLong
 import network.columba.app.data.repository.AnnounceRepository
 import network.columba.app.data.repository.ContactRepository
 import network.columba.app.notifications.IncomingCallNotifier
@@ -47,6 +48,15 @@ class IncomingCallPresenter internal constructor(
 
     private val scope = CoroutineScope(SupervisorJob() + dispatcher)
 
+    /**
+     * Counts every observed call-state transition. A suspended caller-name lookup
+     * snapshots this before and after the lookup: if it advanced, the call moved
+     * on while the lookup was in flight - including a consecutive call from the
+     * same identity, whose equal [CallState.Incoming] value StateFlow would
+     * conflate with the original one.
+     */
+    private val stateSequence = AtomicLong(0)
+
     @Volatile
     private var isStarted = false
 
@@ -75,6 +85,12 @@ class IncomingCallPresenter internal constructor(
             return
         }
         isStarted = true
+        // Fast transition counter: its collection body is O(1), so it observes
+        // every state change, including the ones that happen while a suspended
+        // lookup spans them.
+        scope.launch {
+            rnsTelephony.callState.collect { stateSequence.incrementAndGet() }
+        }
         scope.launch {
             rnsTelephony.callState.collect { state ->
                 when (state) {
@@ -85,23 +101,49 @@ class IncomingCallPresenter internal constructor(
         }
     }
 
-    private suspend fun presentIncomingCall(identityHash: String) {
-        Log.i(TAG, "Presenting background incoming-call UI for ${identityHash.take(16)}...")
-        val callerName = resolveCallerName(identityHash)
-        // The caller-name lookup suspends, so the call may have been answered or
-        // ended while it was in flight. Re-check the current state before posting:
-        // a superseded Incoming state must not launch the call UI for a call that
-        // is no longer incoming. The following state emission then performs the
-        // normal cancel (or posts the new call if the caller changed).
-        val current = rnsTelephony.callState.value
-        if (current !is CallState.Incoming || current.identityHash != identityHash) {
-            Log.i(
-                TAG,
-                "Incoming state superseded before post (now ${current::class.simpleName}); skipping stale presentation",
-            )
-            return
+    private suspend fun presentIncomingCall(initialHash: String) {
+        Log.i(TAG, "Presenting background incoming-call UI for ${initialHash.take(16)}...")
+        var identityHash = initialHash
+        while (true) {
+            val sequenceAtLookupStart = stateSequence.get()
+            val callerName = resolveCallerName(identityHash)
+            // The caller-name lookup suspends, so the call may have changed state
+            // while it was in flight. Re-check the current state (read directly,
+            // so the check sees the latest value) and the transition counter
+            // before posting an obsolete lookup result.
+            val current = rnsTelephony.callState.value
+            when {
+                current !is CallState.Incoming -> {
+                    // Answered or ended: the next state event performs the normal
+                    // cancel.
+                    Log.i(
+                        TAG,
+                        "Incoming call ended before post (now ${current::class.simpleName}); skipping stale presentation",
+                    )
+                    return
+                }
+                current.identityHash != identityHash -> {
+                    // A different caller is now ringing: the collector presents
+                    // that call from its own state event.
+                    Log.i(TAG, "Caller changed before post; the new call is presented from its own state")
+                    return
+                }
+                stateSequence.get() == sequenceAtLookupStart -> {
+                    // No transition since the lookup started: still the same call.
+                    incomingCallNotifier.showIncomingCallNotification(current.identityHash, callerName)
+                    return
+                }
+                else -> {
+                    // Transitions happened during the lookup and the state is back
+                    // to an incoming call: a consecutive call from the same
+                    // identity. StateFlow conflates the two equal Incoming values,
+                    // so the collector will not deliver the second one as a new
+                    // event - present the current call with a fresh lookup instead.
+                    Log.i(TAG, "Consecutive call from the same identity; re-resolving caller name")
+                    identityHash = current.identityHash
+                }
+            }
         }
-        incomingCallNotifier.showIncomingCallNotification(identityHash, callerName)
     }
 
     /**

--- a/app/src/main/java/network/columba/app/service/IncomingCallPresenter.kt
+++ b/app/src/main/java/network/columba/app/service/IncomingCallPresenter.kt
@@ -9,6 +9,7 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.launch
 import java.util.concurrent.ConcurrentHashMap
+import network.columba.app.MainActivityVisibility
 import network.columba.app.data.repository.AnnounceRepository
 import network.columba.app.data.repository.ContactRepository
 import network.columba.app.notifications.IncomingCallNotifier
@@ -40,9 +41,11 @@ import network.columba.app.rns.host.util.PeerNameResolver
  * update path is what re-presents a same-identity re-call that [StateFlow]
  * conflation would otherwise hide from the collector.
  *
- * Foreground presentation (the in-app incoming call screen) remains MainActivity's
- * concern; it cancels this notification as soon as it takes over, so the two paths
- * never double up.
+ * Foreground presentation (the in-app incoming call screen) is MainActivity's
+ * concern. The presenter gates both posts on [MainActivityVisibility]: while
+ * MainActivity is visible it owns the presentation, so the presenter neither
+ * posts (no duplicate of the in-app screen) nor updates (no resurrection of the
+ * notification MainActivity cancelled when it took over).
  */
 @Singleton
 class IncomingCallPresenter internal constructor(
@@ -50,6 +53,7 @@ class IncomingCallPresenter internal constructor(
     private val announceRepository: AnnounceRepository,
     private val contactRepository: ContactRepository,
     private val incomingCallNotifier: IncomingCallNotifier,
+    private val mainActivityVisibility: MainActivityVisibility,
     dispatcher: CoroutineDispatcher,
 ) {
     companion object {
@@ -74,11 +78,13 @@ class IncomingCallPresenter internal constructor(
         announceRepository: AnnounceRepository,
         contactRepository: ContactRepository,
         incomingCallNotifier: IncomingCallNotifier,
+        mainActivityVisibility: MainActivityVisibility,
     ) : this(
         rnsTelephony = rnsTelephony,
         announceRepository = announceRepository,
         contactRepository = contactRepository,
         incomingCallNotifier = incomingCallNotifier,
+        mainActivityVisibility = mainActivityVisibility,
         dispatcher = Dispatchers.IO,
     )
 
@@ -104,6 +110,13 @@ class IncomingCallPresenter internal constructor(
     }
 
     private suspend fun presentIncomingCall(identityHash: String) {
+        // While MainActivity is visible it owns the presentation (the in-app
+        // call screen): posting now would duplicate it, and the name update
+        // below could resurrect the notification MainActivity just cancelled.
+        if (mainActivityVisibility.visible.value) {
+            Log.i(TAG, "MainActivity is presenting the call; skipping background presentation")
+            return
+        }
         Log.i(TAG, "Presenting background incoming-call UI for ${identityHash.take(16)}...")
         // Post immediately - do not delay the full-screen takeover by the
         // caller-name lookup. The name is the cached one or null (the notifier
@@ -124,7 +137,13 @@ class IncomingCallPresenter internal constructor(
             // current call, and the display name is a function of the identity,
             // so it is the right name for it.
             val current = rnsTelephony.callState.value
-            if (current is CallState.Incoming && current.identityHash == identityHash) {
+            if (
+                current is CallState.Incoming &&
+                current.identityHash == identityHash &&
+                // MainActivity may have taken ownership while the lookup was in
+                // flight; its cancel must not be undone by the name update.
+                !mainActivityVisibility.visible.value
+            ) {
                 incomingCallNotifier.showIncomingCallNotification(identityHash, callerName)
             }
         }

--- a/app/src/main/java/network/columba/app/service/IncomingCallPresenter.kt
+++ b/app/src/main/java/network/columba/app/service/IncomingCallPresenter.kt
@@ -8,7 +8,7 @@ import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.launch
-import java.util.concurrent.atomic.AtomicLong
+import java.util.concurrent.ConcurrentHashMap
 import network.columba.app.data.repository.AnnounceRepository
 import network.columba.app.data.repository.ContactRepository
 import network.columba.app.notifications.IncomingCallNotifier
@@ -30,6 +30,16 @@ import network.columba.app.rns.host.util.PeerNameResolver
  * [network.columba.app.IncomingCallActivity] over the lock screen or over whatever
  * app is in the foreground.
  *
+ * The notification is posted immediately on the incoming state (with the last
+ * resolved name for the identity, or the formatted-hash fallback) and the name is
+ * corrected once the caller-name lookup completes. The lookup is the only
+ * suspending step, and the post must not wait for it: answering should not be
+ * delayed by a repository read. Because the display name is a function of the
+ * identity hash, updating the post while the same identity is incoming is correct
+ * even if the currently ringing call is a second call from that identity: the
+ * update path is what re-presents a same-identity re-call that [StateFlow]
+ * conflation would otherwise hide from the collector.
+ *
  * Foreground presentation (the in-app incoming call screen) remains MainActivity's
  * concern; it cancels this notification as soon as it takes over, so the two paths
  * never double up.
@@ -49,13 +59,11 @@ class IncomingCallPresenter internal constructor(
     private val scope = CoroutineScope(SupervisorJob() + dispatcher)
 
     /**
-     * Counts every observed call-state transition. A suspended caller-name lookup
-     * snapshots this before and after the lookup: if it advanced, the call moved
-     * on while the lookup was in flight - including a consecutive call from the
-     * same identity, whose equal [CallState.Incoming] value StateFlow would
-     * conflate with the original one.
+     * Last resolved display name per identity. Lets a re-call from a known peer
+     * show its name on the immediate post instead of the formatted-hash fallback
+     * while the lookup runs.
      */
-    private val stateSequence = AtomicLong(0)
+    private val resolvedNames = ConcurrentHashMap<String, String>()
 
     @Volatile
     private var isStarted = false
@@ -85,12 +93,6 @@ class IncomingCallPresenter internal constructor(
             return
         }
         isStarted = true
-        // Fast transition counter: its collection body is O(1), so it observes
-        // every state change, including the ones that happen while a suspended
-        // lookup spans them.
-        scope.launch {
-            rnsTelephony.callState.collect { stateSequence.incrementAndGet() }
-        }
         scope.launch {
             rnsTelephony.callState.collect { state ->
                 when (state) {
@@ -101,47 +103,29 @@ class IncomingCallPresenter internal constructor(
         }
     }
 
-    private suspend fun presentIncomingCall(initialHash: String) {
-        Log.i(TAG, "Presenting background incoming-call UI for ${initialHash.take(16)}...")
-        var identityHash = initialHash
-        while (true) {
-            val sequenceAtLookupStart = stateSequence.get()
+    private suspend fun presentIncomingCall(identityHash: String) {
+        Log.i(TAG, "Presenting background incoming-call UI for ${identityHash.take(16)}...")
+        // Post immediately - do not delay the full-screen takeover by the
+        // caller-name lookup. The name is the cached one or null (the notifier
+        // falls back to a formatted hash) and is corrected below once the lookup
+        // completes.
+        incomingCallNotifier.showIncomingCallNotification(identityHash, resolvedNames[identityHash])
+        scope.launch {
             val callerName = resolveCallerName(identityHash)
-            // The caller-name lookup suspends, so the call may have changed state
-            // while it was in flight. Re-check the current state (read directly,
-            // so the check sees the latest value) and the transition counter
-            // before posting an obsolete lookup result.
+            if (callerName != null) {
+                resolvedNames[identityHash] = callerName
+            }
+            // The lookup suspended, so the call may have changed state while it
+            // was in flight. Update the post only while the same incoming call is
+            // still ringing; any other state is handled by the collector (the
+            // cancel, or the new call's own presentation). A same-identity re-call
+            // conflates with this Incoming value in the StateFlow, so the
+            // collector never re-delivers it - this update is what presents the
+            // current call, and the display name is a function of the identity,
+            // so it is the right name for it.
             val current = rnsTelephony.callState.value
-            when {
-                current !is CallState.Incoming -> {
-                    // Answered or ended: the next state event performs the normal
-                    // cancel.
-                    Log.i(
-                        TAG,
-                        "Incoming call ended before post (now ${current::class.simpleName}); skipping stale presentation",
-                    )
-                    return
-                }
-                current.identityHash != identityHash -> {
-                    // A different caller is now ringing: the collector presents
-                    // that call from its own state event.
-                    Log.i(TAG, "Caller changed before post; the new call is presented from its own state")
-                    return
-                }
-                stateSequence.get() == sequenceAtLookupStart -> {
-                    // No transition since the lookup started: still the same call.
-                    incomingCallNotifier.showIncomingCallNotification(current.identityHash, callerName)
-                    return
-                }
-                else -> {
-                    // Transitions happened during the lookup and the state is back
-                    // to an incoming call: a consecutive call from the same
-                    // identity. StateFlow conflates the two equal Incoming values,
-                    // so the collector will not deliver the second one as a new
-                    // event - present the current call with a fresh lookup instead.
-                    Log.i(TAG, "Consecutive call from the same identity; re-resolving caller name")
-                    identityHash = current.identityHash
-                }
+            if (current is CallState.Incoming && current.identityHash == identityHash) {
+                incomingCallNotifier.showIncomingCallNotification(identityHash, callerName)
             }
         }
     }

--- a/app/src/main/java/network/columba/app/service/IncomingCallPresenter.kt
+++ b/app/src/main/java/network/columba/app/service/IncomingCallPresenter.kt
@@ -41,13 +41,12 @@ import network.columba.app.rns.host.util.PeerNameResolver
  *
  * Ownership with the foreground UI: while MainActivity is visible it presents the
  * call in-app, so the presenter checks [MainActivityVisibility] before the lookup
- * (skip work the main UI will do) and again after it (do not post over the in-app
- * screen, or undo the cancel MainActivity made when it took over). The
- * check-then-post is not locked: if the main UI becomes visible in the microsecond
- * between the check and the post, the post lands for a moment and is removed by
- * MainActivity's own cancel, which runs whenever it becomes visible. The
- * worst case is a sub-frame visual flash while opening the app at the exact
- * moment a call arrives, never a stuck duplicate.
+ * (skip work the main UI will do) and posts through
+ * [MainActivityVisibility.postWhileBackground] after it: the flag check and the
+ * post are one locked section, atomic against MainActivity's claim (flag flip plus
+ * its cancel, also one locked section). Either the claim wins (this post is
+ * skipped) or the post wins (the claim's cancel removes it); no interleaving
+ * leaves a background post outliving the foreground takeover.
  *
  * Known, accepted residual: if the call is answered and the same peer calls again
  * while the name lookup is still in flight, the post carries that lookup's result
@@ -120,18 +119,20 @@ class IncomingCallPresenter internal constructor(
         val callerName = resolveCallerName(identityHash)
         // The lookup suspended, so the call may have changed state (answered,
         // ended, or a different caller) or the main UI may have taken over
-        // (posting now would undo its cancel). Re-read the state directly and
-        // the visibility flag before the single post.
+        // (posting now would undo its cancel). Re-read the state directly
+        // before the single post; the visibility check happens inside the
+        // atomic post below.
         val current = rnsTelephony.callState.value
-        if (
-            current !is CallState.Incoming ||
-            current.identityHash != identityHash ||
-            mainActivityVisibility.visible.value
-        ) {
+        if (current !is CallState.Incoming || current.identityHash != identityHash) {
             Log.i(TAG, "Call state changed during caller lookup; skipping stale presentation")
             return
         }
-        incomingCallNotifier.showIncomingCallNotification(identityHash, callerName)
+        // Atomic against MainActivity's claim: skipped if the foreground took
+        // over during the lookup, removed by the claim's cancel if it takes
+        // over in the same instant as this post.
+        mainActivityVisibility.postWhileBackground {
+            incomingCallNotifier.showIncomingCallNotification(identityHash, callerName)
+        }
     }
 
     /**

--- a/app/src/main/java/network/columba/app/service/IncomingCallPresenter.kt
+++ b/app/src/main/java/network/columba/app/service/IncomingCallPresenter.kt
@@ -8,7 +8,6 @@ import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.launch
-import java.util.concurrent.ConcurrentHashMap
 import network.columba.app.MainActivityVisibility
 import network.columba.app.data.repository.AnnounceRepository
 import network.columba.app.data.repository.ContactRepository
@@ -25,27 +24,35 @@ import network.columba.app.rns.host.util.PeerNameResolver
  * [RnsTelephony] (rns-api); each backend (Python or native Kotlin) republishes
  * [CallState] into the UI process across the AIDL seam. The ringing itself is owned
  * by the :reticulum service process, so this presenter is the app-process consumer
- * that owns presentation when no app UI is visible: on [CallState.Incoming] it posts
- * the high-importance category-call notification with a full-screen intent (see
+ * that owns presentation when no app UI is visible: on [CallState.Incoming] it
+ * resolves the caller display name and posts the high-importance category-call
+ * notification with a full-screen intent (see
  * [IncomingCallNotifier.showIncomingCallNotification]), which brings
  * [network.columba.app.IncomingCallActivity] over the lock screen or over whatever
- * app is in the foreground.
+ * app is in the foreground. Any other state cancels the notification.
  *
- * The notification is posted immediately on the incoming state (with the last
- * resolved name for the identity, or the formatted-hash fallback) and the name is
- * corrected once the caller-name lookup completes. The lookup is the only
- * suspending step, and the post must not wait for it: answering should not be
- * delayed by a repository read. Because the display name is a function of the
- * identity hash, updating the post while the same identity is incoming is correct
- * even if the currently ringing call is a second call from that identity: the
- * update path is what re-presents a same-identity re-call that [StateFlow]
- * conflation would otherwise hide from the collector.
+ * The presenter is the single writer of the incoming-call notification: one post
+ * per incoming call, made after the caller-name lookup (a repository read of a few
+ * milliseconds, which keeps the full-screen UI's name accurate without delaying
+ * takeover by more than a lookup). There is deliberately no asynchronous
+ * "name correction" post: a second, out-of-band writer would have to coordinate
+ * with every component that cancels the notification (MainActivity, the call
+ * screen, user actions) and could resurrect a dismissed notification.
  *
- * Foreground presentation (the in-app incoming call screen) is MainActivity's
- * concern. The presenter gates both posts on [MainActivityVisibility]: while
- * MainActivity is visible it owns the presentation, so the presenter neither
- * posts (no duplicate of the in-app screen) nor updates (no resurrection of the
- * notification MainActivity cancelled when it took over).
+ * Ownership with the foreground UI: while MainActivity is visible it presents the
+ * call in-app, so the presenter checks [MainActivityVisibility] before the lookup
+ * (skip work the main UI will do) and again after it (do not post over the in-app
+ * screen, or undo the cancel MainActivity made when it took over). The
+ * check-then-post is not locked: if the main UI becomes visible in the microsecond
+ * between the check and the post, the post lands for a moment and is removed by
+ * MainActivity's own cancel, which runs whenever it becomes visible. The
+ * worst case is a sub-frame visual flash while opening the app at the exact
+ * moment a call arrives, never a stuck duplicate.
+ *
+ * Known, accepted residual: if the call is answered and the same peer calls again
+ * while the name lookup is still in flight, the post carries that lookup's result
+ * for the new call. The display name is a function of the identity hash (the same
+ * database rows), so the presented name is the right name for the ringing call.
  */
 @Singleton
 class IncomingCallPresenter internal constructor(
@@ -61,13 +68,6 @@ class IncomingCallPresenter internal constructor(
     }
 
     private val scope = CoroutineScope(SupervisorJob() + dispatcher)
-
-    /**
-     * Last resolved display name per identity. Lets a re-call from a known peer
-     * show its name on the immediate post instead of the formatted-hash fallback
-     * while the lookup runs.
-     */
-    private val resolvedNames = ConcurrentHashMap<String, String>()
 
     @Volatile
     private var isStarted = false
@@ -110,43 +110,28 @@ class IncomingCallPresenter internal constructor(
     }
 
     private suspend fun presentIncomingCall(identityHash: String) {
-        // While MainActivity is visible it owns the presentation (the in-app
-        // call screen): posting now would duplicate it, and the name update
-        // below could resurrect the notification MainActivity just cancelled.
+        // While the main UI is visible it presents the call in-app; skip the
+        // lookup the main UI will do for the user.
         if (mainActivityVisibility.visible.value) {
             Log.i(TAG, "MainActivity is presenting the call; skipping background presentation")
             return
         }
         Log.i(TAG, "Presenting background incoming-call UI for ${identityHash.take(16)}...")
-        // Post immediately - do not delay the full-screen takeover by the
-        // caller-name lookup. The name is the cached one or null (the notifier
-        // falls back to a formatted hash) and is corrected below once the lookup
-        // completes.
-        incomingCallNotifier.showIncomingCallNotification(identityHash, resolvedNames[identityHash])
-        scope.launch {
-            val callerName = resolveCallerName(identityHash)
-            if (callerName != null) {
-                resolvedNames[identityHash] = callerName
-            }
-            // The lookup suspended, so the call may have changed state while it
-            // was in flight. Update the post only while the same incoming call is
-            // still ringing; any other state is handled by the collector (the
-            // cancel, or the new call's own presentation). A same-identity re-call
-            // conflates with this Incoming value in the StateFlow, so the
-            // collector never re-delivers it - this update is what presents the
-            // current call, and the display name is a function of the identity,
-            // so it is the right name for it.
-            val current = rnsTelephony.callState.value
-            if (
-                current is CallState.Incoming &&
-                current.identityHash == identityHash &&
-                // MainActivity may have taken ownership while the lookup was in
-                // flight; its cancel must not be undone by the name update.
-                !mainActivityVisibility.visible.value
-            ) {
-                incomingCallNotifier.showIncomingCallNotification(identityHash, callerName)
-            }
+        val callerName = resolveCallerName(identityHash)
+        // The lookup suspended, so the call may have changed state (answered,
+        // ended, or a different caller) or the main UI may have taken over
+        // (posting now would undo its cancel). Re-read the state directly and
+        // the visibility flag before the single post.
+        val current = rnsTelephony.callState.value
+        if (
+            current !is CallState.Incoming ||
+            current.identityHash != identityHash ||
+            mainActivityVisibility.visible.value
+        ) {
+            Log.i(TAG, "Call state changed during caller lookup; skipping stale presentation")
+            return
         }
+        incomingCallNotifier.showIncomingCallNotification(identityHash, callerName)
     }
 
     /**

--- a/app/src/main/java/network/columba/app/service/IncomingCallPresenter.kt
+++ b/app/src/main/java/network/columba/app/service/IncomingCallPresenter.kt
@@ -88,6 +88,19 @@ class IncomingCallPresenter internal constructor(
     private suspend fun presentIncomingCall(identityHash: String) {
         Log.i(TAG, "Presenting background incoming-call UI for ${identityHash.take(16)}...")
         val callerName = resolveCallerName(identityHash)
+        // The caller-name lookup suspends, so the call may have been answered or
+        // ended while it was in flight. Re-check the current state before posting:
+        // a superseded Incoming state must not launch the call UI for a call that
+        // is no longer incoming. The following state emission then performs the
+        // normal cancel (or posts the new call if the caller changed).
+        val current = rnsTelephony.callState.value
+        if (current !is CallState.Incoming || current.identityHash != identityHash) {
+            Log.i(
+                TAG,
+                "Incoming state superseded before post (now ${current::class.simpleName}); skipping stale presentation",
+            )
+            return
+        }
         incomingCallNotifier.showIncomingCallNotification(identityHash, callerName)
     }
 

--- a/app/src/main/java/network/columba/app/service/IncomingCallPresenter.kt
+++ b/app/src/main/java/network/columba/app/service/IncomingCallPresenter.kt
@@ -1,0 +1,115 @@
+package network.columba.app.service
+
+import android.util.Log
+import javax.inject.Inject
+import javax.inject.Singleton
+import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.launch
+import network.columba.app.data.repository.AnnounceRepository
+import network.columba.app.data.repository.ContactRepository
+import network.columba.app.notifications.IncomingCallNotifier
+import network.columba.app.rns.api.RnsTelephony
+import network.columba.app.rns.api.model.CallState
+import network.columba.app.rns.host.util.PeerNameResolver
+
+/**
+ * Process-lifetime presenter for background incoming-call presentation in the main
+ * app process.
+ *
+ * Since the dual-backend architecture, the call observable surface lives on
+ * [RnsTelephony] (rns-api); each backend (Python or native Kotlin) republishes
+ * [CallState] into the UI process across the AIDL seam. The ringing itself is owned
+ * by the :reticulum service process, so this presenter is the app-process consumer
+ * that owns presentation when no app UI is visible: on [CallState.Incoming] it posts
+ * the high-importance category-call notification with a full-screen intent (see
+ * [IncomingCallNotifier.showIncomingCallNotification]), which brings
+ * [network.columba.app.IncomingCallActivity] over the lock screen or over whatever
+ * app is in the foreground.
+ *
+ * Foreground presentation (the in-app incoming call screen) remains MainActivity's
+ * concern; it cancels this notification as soon as it takes over, so the two paths
+ * never double up.
+ */
+@Singleton
+class IncomingCallPresenter internal constructor(
+    private val rnsTelephony: RnsTelephony,
+    private val announceRepository: AnnounceRepository,
+    private val contactRepository: ContactRepository,
+    private val incomingCallNotifier: IncomingCallNotifier,
+    dispatcher: CoroutineDispatcher,
+) {
+    companion object {
+        private const val TAG = "IncomingCallPresenter"
+    }
+
+    private val scope = CoroutineScope(SupervisorJob() + dispatcher)
+
+    @Volatile
+    private var isStarted = false
+
+    @Inject
+    constructor(
+        rnsTelephony: RnsTelephony,
+        announceRepository: AnnounceRepository,
+        contactRepository: ContactRepository,
+        incomingCallNotifier: IncomingCallNotifier,
+    ) : this(
+        rnsTelephony = rnsTelephony,
+        announceRepository = announceRepository,
+        contactRepository = contactRepository,
+        incomingCallNotifier = incomingCallNotifier,
+        dispatcher = Dispatchers.IO,
+    )
+
+    /**
+     * Start the call-state collector. Safe to call multiple times; the collector
+     * runs for the life of the process (no stop: Hilt singletons have no destroy
+     * hook and the process dies with the collector).
+     */
+    fun start() {
+        if (isStarted) {
+            Log.w(TAG, "start() called twice; ignoring")
+            return
+        }
+        isStarted = true
+        scope.launch {
+            rnsTelephony.callState.collect { state ->
+                when (state) {
+                    is CallState.Incoming -> presentIncomingCall(state.identityHash)
+                    else -> incomingCallNotifier.cancelIncomingCallNotification()
+                }
+            }
+        }
+    }
+
+    private suspend fun presentIncomingCall(identityHash: String) {
+        Log.i(TAG, "Presenting background incoming-call UI for ${identityHash.take(16)}...")
+        val callerName = resolveCallerName(identityHash)
+        incomingCallNotifier.showIncomingCallNotification(identityHash, callerName)
+    }
+
+    /**
+     * Resolve the caller's display name from the identity hash carried by
+     * [CallState.Incoming]:
+     * 1. Contact custom nickname (via the announce's destination hash)
+     * 2. Announce peer name
+     * 3. null - the notification helper falls back to a formatted hash
+     */
+    internal suspend fun resolveCallerName(identityHash: String): String? =
+        runCatching {
+            val announce =
+                announceRepository.findByIdentityHash(identityHash) ?: return@runCatching null
+            val nickname =
+                contactRepository.getContact(announce.destinationHash)?.customNickname
+            when {
+                PeerNameResolver.isValidPeerName(nickname) -> nickname
+                PeerNameResolver.isValidPeerName(announce.peerName) -> announce.peerName
+                else -> null
+            }
+        }
+            .onFailure { Log.w(TAG, "Caller name lookup failed: ${it.message}") }
+            .getOrNull()
+}

--- a/app/src/main/java/network/columba/app/service/IncomingCallPresenter.kt
+++ b/app/src/main/java/network/columba/app/service/IncomingCallPresenter.kt
@@ -165,9 +165,15 @@ class IncomingCallPresenter internal constructor(
         }
         // Atomic against MainActivity's claim: skipped if the foreground took
         // over during the lookup, removed by the claim's cancel if it takes
-        // over in the same instant as this post.
+        // over in the same instant as this post. The post enqueues onto the
+        // main thread, so the call may have ended between the check above and
+        // the runnable running (and the collector's cancel may have landed
+        // first) - re-check the call state inside the block before posting.
         mainActivityVisibility.postWhileBackground {
-            incomingCallNotifier.showIncomingCallNotification(identityHash, callerName)
+            val stateAtPost = rnsTelephony.callState.value
+            if (stateAtPost is CallState.Incoming && stateAtPost.identityHash == identityHash) {
+                incomingCallNotifier.showIncomingCallNotification(identityHash, callerName)
+            }
         }
     }
 

--- a/app/src/main/java/network/columba/app/service/IncomingCallPresenter.kt
+++ b/app/src/main/java/network/columba/app/service/IncomingCallPresenter.kt
@@ -43,15 +43,32 @@ import network.columba.app.rns.host.util.PeerNameResolver
  * call in-app, so the presenter checks [MainActivityVisibility] before the lookup
  * (skip work the main UI will do) and posts through
  * [MainActivityVisibility.postWhileBackground] after it: the flag check and the
- * post are one locked section, atomic against MainActivity's claim (flag flip plus
- * its cancel, also one locked section). Either the claim wins (this post is
- * skipped) or the post wins (the claim's cancel removes it); no interleaving
- * leaves a background post outliving the foreground takeover.
+ * post execute as one main-thread sequence (single-thread confinement, no
+ * locking), atomic against MainActivity's claim (flag flip plus its cancel).
+ * Either the claim wins (this post is skipped) or the post wins (the claim's
+ * cancel removes it); no interleaving leaves a background post outliving the
+ * foreground takeover.
+ *
+ * Releasing: when MainActivity stops being visible while a call is still
+ * [CallState.Incoming] - the user backgrounded the app mid-ring (home gesture,
+ * recents, notification shade takeover), so no new [CallState] emission will
+ * ever arrive - the presenter takes presentation back and posts the background
+ * notification. Without this, the in-app path that skipped the post leaves the
+ * ringing call with no answer/decline UI until the app is reopened. A
+ * same-instant reopen (release then immediate claim) races against the lookup
+ * and the atomic post, so the presenter loses cleanly to the foreground.
+ * Configuration-change stops (rotation) never release ownership
+ * ([MainActivityVisibility.releaseForeground]), so this recovery cannot flash
+ * the notification mid-rotation.
  *
  * Known, accepted residual: if the call is answered and the same peer calls again
  * while the name lookup is still in flight, the post carries that lookup's result
  * for the new call. The display name is a function of the identity hash (the same
  * database rows), so the presented name is the right name for the ringing call.
+ * A second accepted residual: a foreground release and a fresh [CallState.Incoming]
+ * emission can both drive a presentation for the same call; the notification
+ * helper re-`notify`s the same notification id, so the platform collapses the
+ * duplicate into one update.
  */
 @Singleton
 class IncomingCallPresenter internal constructor(
@@ -103,6 +120,25 @@ class IncomingCallPresenter internal constructor(
                 when (state) {
                     is CallState.Incoming -> presentIncomingCall(state.identityHash)
                     else -> incomingCallNotifier.cancelIncomingCallNotification()
+                }
+            }
+        }
+        // Mid-ring backgrounding recovery: MainActivity presented the call
+        // in-app and skipped this presenter; when it stops without the call
+        // changing state, no callState emission will ever arrive to trigger the
+        // background presentation, so react to the ownership release directly.
+        // The initial collection value (false, at process start) is inert: the
+        // presentation below re-checks the call state and only posts while a
+        // call is actually Incoming.
+        scope.launch {
+            mainActivityVisibility.visible.collect { visible ->
+                if (visible) {
+                    return@collect
+                }
+                val current = rnsTelephony.callState.value
+                if (current is CallState.Incoming) {
+                    Log.i(TAG, "Foreground released during incoming call; taking over presentation")
+                    presentIncomingCall(current.identityHash)
                 }
             }
         }

--- a/app/src/main/java/network/columba/app/service/IncomingCallPresenter.kt
+++ b/app/src/main/java/network/columba/app/service/IncomingCallPresenter.kt
@@ -166,12 +166,21 @@ class IncomingCallPresenter internal constructor(
         // Atomic against MainActivity's claim: skipped if the foreground took
         // over during the lookup, removed by the claim's cancel if it takes
         // over in the same instant as this post. The post enqueues onto the
-        // main thread, so the call may have ended between the check above and
-        // the runnable running (and the collector's cancel may have landed
-        // first) - re-check the call state inside the block before posting.
+        // main thread, so between the check above and the runnable running
+        // the call may have ended, or the user may have tapped answer/decline
+        // on the notification (whose cancel runs before the asynchronous
+        // state change lands). Capture the call state and the cancel tick at
+        // enqueue time; drop the post if either moved by execution time, so
+        // a cancel the collector has not yet processed still suppresses a
+        // post that would resurrect it.
+        val tickAtEnqueue = incomingCallNotifier.cancelTick
         mainActivityVisibility.postWhileBackground {
             val stateAtPost = rnsTelephony.callState.value
-            if (stateAtPost is CallState.Incoming && stateAtPost.identityHash == identityHash) {
+            if (
+                stateAtPost is CallState.Incoming &&
+                stateAtPost.identityHash == identityHash &&
+                incomingCallNotifier.cancelTick == tickAtEnqueue
+            ) {
                 incomingCallNotifier.showIncomingCallNotification(identityHash, callerName)
             }
         }

--- a/app/src/test/java/network/columba/app/notifications/CallNotificationHelperTest.kt
+++ b/app/src/test/java/network/columba/app/notifications/CallNotificationHelperTest.kt
@@ -2,9 +2,11 @@ package network.columba.app.notifications
 
 import android.Manifest
 import android.app.Application
+import android.app.AppOpsManager
 import android.app.NotificationManager
 import android.content.Context
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
 import org.junit.Assert.assertNotNull
 import org.junit.Assert.assertNull
 import org.junit.Assert.assertTrue
@@ -285,6 +287,52 @@ class CallNotificationHelperTest {
         assertNull(
             "Ongoing notification should be cancelled",
             shadowNotificationManager.getNotification(CallNotificationHelper.NOTIFICATION_ID_ONGOING_CALL),
+        )
+    }
+
+    // ========== Full-Screen Intent Permission Tests ==========
+
+    @Test
+    fun `full screen intents usable when preflight and appop both allow`() {
+        assertTrue(
+            "explicitly allowed appop plus passing preflight must be usable",
+            helper.isFullScreenIntentUsable(
+                preflightAllowed = true,
+                appOpMode = AppOpsManager.MODE_ALLOWED,
+            ),
+        )
+    }
+
+    @Test
+    fun `full screen intents not usable when appop at default mode`() {
+        assertFalse(
+            "default-mode appop is denied by the data-delivery check, must be unusable",
+            helper.isFullScreenIntentUsable(
+                preflightAllowed = true,
+                appOpMode = AppOpsManager.MODE_DEFAULT,
+            ),
+        )
+    }
+
+    @Test
+    fun `full screen intents not usable when appop ignored`() {
+        assertFalse(
+            "ignored-mode appop must be unusable",
+            helper.isFullScreenIntentUsable(
+                preflightAllowed = true,
+                appOpMode = AppOpsManager.MODE_IGNORED,
+            ),
+        )
+    }
+
+    @Test
+    fun `full screen intents not usable when preflight check fails`() {
+        assertFalse(
+            "failing preflight must be unusable even with allowed appop",
+            helper.isFullScreenIntentUsable(
+                preflightAllowed = false,
+                appOpMode = AppOpsManager.MODE_ALLOWED,
+            ),
         )
     }
 

--- a/app/src/test/java/network/columba/app/service/IncomingCallPresenterTest.kt
+++ b/app/src/test/java/network/columba/app/service/IncomingCallPresenterTest.kt
@@ -10,6 +10,7 @@ import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.test.StandardTestDispatcher
 import kotlinx.coroutines.test.TestCoroutineScheduler
 import kotlinx.coroutines.test.runCurrent
+import network.columba.app.MainActivityVisibility
 import network.columba.app.data.db.entity.ContactEntity
 import network.columba.app.data.repository.Announce
 import network.columba.app.data.repository.AnnounceRepository
@@ -52,6 +53,7 @@ class IncomingCallPresenterTest {
     }
 
     private val scheduler = TestCoroutineScheduler()
+    private val mainActivityVisibility = MainActivityVisibility()
     private val rnsTelephony: RnsTelephony = mockk()
     private val announceRepository: AnnounceRepository = mockk()
     private val contactRepository: ContactRepository = mockk()
@@ -72,6 +74,7 @@ class IncomingCallPresenterTest {
                 announceRepository = announceRepository,
                 contactRepository = contactRepository,
                 incomingCallNotifier = notifier,
+                mainActivityVisibility = mainActivityVisibility,
                 dispatcher = StandardTestDispatcher(scheduler),
             )
     }
@@ -295,6 +298,70 @@ class IncomingCallPresenterTest {
         assertEquals(identityHash to "Alice", notifier.shownCalls.last())
         // Initial Idle, Active, and Idle cancels.
         assertEquals(3, notifier.cancelCount.get())
+    }
+
+    @Test
+    fun `incoming call is not posted while MainActivity is visible`() {
+        coEvery { announceRepository.findByIdentityHash(identityHash) } returns
+            announce("Alice")
+        coEvery { contactRepository.getContact(destinationHash) } returns contact(null)
+
+        // The app is in the foreground: MainActivity shows the in-app call
+        // screen, so the background presenter must stay silent.
+        mainActivityVisibility.setVisible(true)
+        presenter.start()
+        scheduler.runCurrent()
+        callState.value = CallState.Incoming(identityHash)
+        settle()
+
+        assertEquals(0, notifier.shownCalls.size)
+    }
+
+    @Test
+    fun `name update does not resurrect the notification after MainActivity took over`() {
+        // The call arrives while backgrounded (immediate post goes out). The
+        // user then opens the app while the lookup is in flight: MainActivity
+        // takes ownership and cancels the notification. The lookup's update
+        // must not post it back.
+        val lookupGate = CompletableDeferred<Unit>()
+        coEvery { announceRepository.findByIdentityHash(identityHash) } coAnswers {
+            lookupGate.await()
+            announce("Alice")
+        }
+        coEvery { contactRepository.getContact(destinationHash) } returns contact(null)
+
+        presenter.start()
+        scheduler.runCurrent()
+        callState.value = CallState.Incoming(identityHash)
+        settle()
+        // The user opens the app: MainActivity becomes visible (its in-app
+        // effect cancels the notification).
+        mainActivityVisibility.setVisible(true)
+        lookupGate.complete(Unit)
+        scheduler.runCurrent()
+
+        // Only the immediate post happened; the update was suppressed.
+        assertEquals(1, notifier.shownCalls.size)
+        assertEquals(identityHash to null, notifier.shownCalls[0])
+    }
+
+    @Test
+    fun `name update is posted for the FSI activity flow`() {
+        // The full-screen intent launches IncomingCallActivity, which does not
+        // make MainActivity visible: the name update must still land so the
+        // call UI shows the resolved name, not the hash fallback.
+        coEvery { announceRepository.findByIdentityHash(identityHash) } returns
+            announce("Alice")
+        coEvery { contactRepository.getContact(destinationHash) } returns contact(null)
+
+        presenter.start()
+        scheduler.runCurrent()
+        callState.value = CallState.Incoming(identityHash)
+        settle()
+
+        assertEquals(2, notifier.shownCalls.size)
+        assertEquals(identityHash to null, notifier.shownCalls[0])
+        assertEquals(identityHash to "Alice", notifier.shownCalls[1])
     }
 
     @Test

--- a/app/src/test/java/network/columba/app/service/IncomingCallPresenterTest.kt
+++ b/app/src/test/java/network/columba/app/service/IncomingCallPresenterTest.kt
@@ -6,8 +6,10 @@ import io.mockk.every
 import io.mockk.mockk
 import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.flow.MutableStateFlow
-import kotlinx.coroutines.test.UnconfinedTestDispatcher
-import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.TestCoroutineScheduler
+import kotlinx.coroutines.test.runCurrent
 import network.columba.app.data.db.entity.ContactEntity
 import network.columba.app.data.repository.Announce
 import network.columba.app.data.repository.AnnounceRepository
@@ -26,6 +28,13 @@ import java.util.concurrent.CopyOnWriteArrayList
  * Unit tests for [IncomingCallPresenter]: the app-process component that presents
  * incoming calls (full-screen-intent notification) while the app is backgrounded
  * (issue #1079).
+ *
+ * The presenter runs on a [StandardTestDispatcher] backed by a shared
+ * [TestCoroutineScheduler], so each test drives it deterministically: a state
+ * change is only processed when [runCurrent] advances the scheduler. Grouping
+ * several state changes before a [runCurrent] models the production case where
+ * the whole churn collapses into the collector's suspension and the StateFlow
+ * conflates the intermediate values.
  */
 class IncomingCallPresenterTest {
     /** Records notifier interactions so tests assert on real state, not mock calls. */
@@ -42,6 +51,7 @@ class IncomingCallPresenterTest {
         }
     }
 
+    private val scheduler = TestCoroutineScheduler()
     private val rnsTelephony: RnsTelephony = mockk()
     private val announceRepository: AnnounceRepository = mockk()
     private val contactRepository: ContactRepository = mockk()
@@ -62,7 +72,7 @@ class IncomingCallPresenterTest {
                 announceRepository = announceRepository,
                 contactRepository = contactRepository,
                 incomingCallNotifier = notifier,
-                dispatcher = UnconfinedTestDispatcher(),
+                dispatcher = StandardTestDispatcher(scheduler),
             )
     }
 
@@ -92,171 +102,222 @@ class IncomingCallPresenterTest {
             addedVia = "MANUAL",
         )
 
-    @Test
-    fun `incoming call posts notification with contact nickname`() =
-        runTest {
-            coEvery { announceRepository.findByIdentityHash(identityHash) } returns
-                announce("Alice")
-            coEvery { contactRepository.getContact(destinationHash) } returns contact("Boss")
-
-            presenter.start()
-            callState.value = CallState.Incoming(identityHash)
-
-            assertEquals(1, notifier.shownCalls.size)
-            assertEquals(identityHash, notifier.shownCalls[0].first)
-            assertEquals("Boss", notifier.shownCalls[0].second)
-        }
+    /** Processes the collector and any in-flight lookup work for the current state. */
+    private fun settle() {
+        scheduler.runCurrent()
+        scheduler.runCurrent()
+    }
 
     @Test
-    fun `incoming call falls back to announce peer name when no nickname`() =
-        runTest {
-            coEvery { announceRepository.findByIdentityHash(identityHash) } returns
-                announce("Alice")
-            coEvery { contactRepository.getContact(destinationHash) } returns contact(null)
+    fun `incoming call posts immediately and corrects the name after the lookup`() {
+        coEvery { announceRepository.findByIdentityHash(identityHash) } returns
+            announce("Alice")
+        coEvery { contactRepository.getContact(destinationHash) } returns contact("Boss")
 
-            presenter.start()
-            callState.value = CallState.Incoming(identityHash)
+        presenter.start()
+        scheduler.runCurrent()
+        callState.value = CallState.Incoming(identityHash)
+        settle()
 
-            assertEquals(1, notifier.shownCalls.size)
-            assertEquals(identityHash, notifier.shownCalls[0].first)
-            assertEquals("Alice", notifier.shownCalls[0].second)
-        }
-
-    @Test
-    fun `incoming call posts notification with null name for unknown caller`() =
-        runTest {
-            coEvery { announceRepository.findByIdentityHash(identityHash) } returns null
-
-            presenter.start()
-            callState.value = CallState.Incoming(identityHash)
-
-            assertEquals(1, notifier.shownCalls.size)
-            assertEquals(identityHash, notifier.shownCalls[0].first)
-            assertNull(notifier.shownCalls[0].second)
-        }
+        // First post carries no name yet (fresh process, empty cache); the
+        // lookup update post carries the resolved nickname.
+        assertEquals(2, notifier.shownCalls.size)
+        assertEquals(identityHash to null, notifier.shownCalls[0])
+        assertEquals(identityHash to "Boss", notifier.shownCalls[1])
+    }
 
     @Test
-    fun `lookup failure fails open to null name`() =
-        runTest {
-            coEvery { announceRepository.findByIdentityHash(identityHash) } throws
-                RuntimeException("db exploded")
+    fun `incoming call falls back to announce peer name when no nickname`() {
+        coEvery { announceRepository.findByIdentityHash(identityHash) } returns
+            announce("Alice")
+        coEvery { contactRepository.getContact(destinationHash) } returns contact(null)
 
-            presenter.start()
-            callState.value = CallState.Incoming(identityHash)
+        presenter.start()
+        scheduler.runCurrent()
+        callState.value = CallState.Incoming(identityHash)
+        settle()
 
-            assertEquals(1, notifier.shownCalls.size)
-            assertEquals(identityHash, notifier.shownCalls[0].first)
-            assertNull(notifier.shownCalls[0].second)
-        }
-
-    @Test
-    fun `transition to Active cancels the incoming notification`() =
-        runTest {
-            coEvery { announceRepository.findByIdentityHash(identityHash) } returns
-                announce("Alice")
-            coEvery { contactRepository.getContact(destinationHash) } returns contact(null)
-
-            presenter.start()
-            callState.value = CallState.Incoming(identityHash)
-            callState.value = CallState.Active(identityHash)
-
-            // Posted once for the incoming call, cancelled once for the Active
-            // transition (plus one cancel for the initial Idle on start).
-            assertEquals(1, notifier.shownCalls.size)
-            assertEquals("Alice", notifier.shownCalls[0].second)
-            assertEquals(2, notifier.cancelCount.get())
-        }
+        assertEquals(identityHash to "Alice", notifier.shownCalls.last())
+    }
 
     @Test
-    fun `outgoing states never post an incoming notification`() =
-        runTest {
-            presenter.start()
-            callState.value = CallState.Connecting(identityHash)
-            callState.value = CallState.Ringing(identityHash)
+    fun `incoming call keeps null name for unknown caller`() {
+        coEvery { announceRepository.findByIdentityHash(identityHash) } returns null
 
-            assertEquals(0, notifier.shownCalls.size)
-        }
+        presenter.start()
+        scheduler.runCurrent()
+        callState.value = CallState.Incoming(identityHash)
+        settle()
 
-    @Test
-    fun `incoming state superseded during the name lookup is not posted`() =
-        runTest {
-            // The call is answered while the caller-name lookup is still in
-            // flight: the stale Incoming state must not post the full-screen
-            // notification after the call is over.
-            val lookupGate = CompletableDeferred<Unit>()
-            coEvery { announceRepository.findByIdentityHash(identityHash) } coAnswers {
-                lookupGate.await()
-                announce("Alice")
-            }
-            coEvery { contactRepository.getContact(destinationHash) } returns contact(null)
-
-            presenter.start()
-            callState.value = CallState.Incoming(identityHash)
-            // The presenter is now suspended in lookup 1; the call is answered
-            // before that lookup completes.
-            callState.value = CallState.Active(identityHash)
-            lookupGate.complete(Unit)
-
-            assertEquals(0, notifier.shownCalls.size)
-            // Canceled once for the initial Idle on start, once for the Active
-            // transition that superseded the lookup.
-            assertEquals(2, notifier.cancelCount.get())
-        }
+        assertEquals(identityHash, notifier.shownCalls.last().first)
+        assertNull(notifier.shownCalls.last().second)
+    }
 
     @Test
-    fun `consecutive same-identity calls present the current call, not the stale lookup`() =
-        runTest {
-            // Call 1 arrives and its name lookup is in flight when the call is
-            // answered and a second call from the SAME identity comes in. The
-            // stale lookup's result must not be posted; the presentation must
-            // come from the second call's own lookup (which sees the changed
-            // peer name here).
-            val lookupGate = CompletableDeferred<Unit>()
-            val lookups = java.util.concurrent.atomic.AtomicInteger(0)
-            coEvery { announceRepository.findByIdentityHash(identityHash) } coAnswers {
-                if (lookups.incrementAndGet() == 1) {
-                    lookupGate.await()
-                    announce("Alice")
-                } else {
-                    announce("Bob")
-                }
-            }
-            coEvery { contactRepository.getContact(destinationHash) } returns contact(null)
+    fun `lookup failure fails open to null name`() {
+        coEvery { announceRepository.findByIdentityHash(identityHash) } throws
+            RuntimeException("db exploded")
 
-            presenter.start()
-            callState.value = CallState.Incoming(identityHash)
-            // Lookup 1 is in flight; call 1 is answered and a second call from
-            // the same identity arrives before it completes.
-            callState.value = CallState.Active(identityHash)
-            callState.value = CallState.Idle
-            callState.value = CallState.Incoming(identityHash)
-            lookupGate.complete(Unit)
+        presenter.start()
+        scheduler.runCurrent()
+        callState.value = CallState.Incoming(identityHash)
+        settle()
 
-            assertEquals(1, notifier.shownCalls.size)
-            assertEquals(identityHash, notifier.shownCalls[0].first)
-            assertEquals("Bob", notifier.shownCalls[0].second)
-        }
+        assertEquals(identityHash, notifier.shownCalls.last().first)
+        assertNull(notifier.shownCalls.last().second)
+    }
 
     @Test
-    fun `start is idempotent`() =
-        runTest {
-            coEvery { announceRepository.findByIdentityHash(identityHash) } returns
-                announce("Alice")
-            coEvery { contactRepository.getContact(destinationHash) } returns contact(null)
+    fun `transition to Active cancels the incoming notification`() {
+        coEvery { announceRepository.findByIdentityHash(identityHash) } returns
+            announce("Alice")
+        coEvery { contactRepository.getContact(destinationHash) } returns contact(null)
 
-            presenter.start()
-            presenter.start()
-            callState.value = CallState.Incoming(identityHash)
+        presenter.start()
+        scheduler.runCurrent()
+        callState.value = CallState.Incoming(identityHash)
+        settle()
+        callState.value = CallState.Active(identityHash)
+        scheduler.runCurrent()
 
-            assertEquals(1, notifier.shownCalls.size)
-            assertEquals("Alice", notifier.shownCalls[0].second)
-        }
+        // Posted immediately, name corrected by the lookup, then cancelled for
+        // the Active transition (plus one cancel for the initial Idle on start).
+        assertEquals(identityHash to "Alice", notifier.shownCalls.last())
+        assertEquals(2, notifier.cancelCount.get())
+    }
 
     @Test
-    fun `resolveCallerName returns null when no announce exists`() =
-        runTest {
-            coEvery { announceRepository.findByIdentityHash(identityHash) } returns null
+    fun `outgoing states never post an incoming notification`() {
+        presenter.start()
+        scheduler.runCurrent()
+        callState.value = CallState.Connecting(identityHash)
+        scheduler.runCurrent()
+        callState.value = CallState.Ringing(identityHash)
+        scheduler.runCurrent()
 
-            assertNull(presenter.resolveCallerName(identityHash))
+        assertEquals(0, notifier.shownCalls.size)
+    }
+
+    @Test
+    fun `superseded lookup does not post after the call ended`() {
+        // The call is answered while the caller-name lookup is still in flight:
+        // the stale lookup result must not update or resurrect the notification
+        // after the call is over.
+        val lookupGate = CompletableDeferred<Unit>()
+        coEvery { announceRepository.findByIdentityHash(identityHash) } coAnswers {
+            lookupGate.await()
+            announce("Alice")
         }
+        coEvery { contactRepository.getContact(destinationHash) } returns contact(null)
+
+        presenter.start()
+        scheduler.runCurrent()
+        callState.value = CallState.Incoming(identityHash)
+        settle()
+        // The immediate post is up; the lookup coroutine is parked at the gate.
+        callState.value = CallState.Active(identityHash)
+        scheduler.runCurrent()
+        lookupGate.complete(Unit)
+        scheduler.runCurrent()
+
+        assertEquals(1, notifier.shownCalls.size)
+        assertEquals(identityHash to null, notifier.shownCalls[0])
+        // Canceled once for the initial Idle on start, once for the Active
+        // transition that superseded the lookup.
+        assertEquals(2, notifier.cancelCount.get())
+    }
+
+    @Test
+    fun `consecutive same-identity call hidden by state conflation is still presented`() {
+        // Call 1 arrives and its lookup is in flight. Call 1 is then answered and
+        // a second call from the SAME identity comes in before the collector can
+        // process the intermediate states: the whole round trip collapses into
+        // the collector's suspension, and the second Incoming equals the one it
+        // already delivered, so the StateFlow conflates it away and the collector
+        // never sees the new call (verified: a collector suspended across a
+        // V -> X -> V round trip observes nothing). Only the first lookup's
+        // update post can present the second call - and it must, with the
+        // resolved name for that identity.
+        val lookupGate = CompletableDeferred<Unit>()
+        coEvery { announceRepository.findByIdentityHash(identityHash) } coAnswers {
+            lookupGate.await()
+            announce("Alice")
+        }
+        coEvery { contactRepository.getContact(destinationHash) } returns contact(null)
+
+        presenter.start()
+        scheduler.runCurrent()
+        callState.value = CallState.Incoming(identityHash)
+        settle()
+        // The churn happens while the collector is suspended; no scheduler
+        // advance in between, so the collector only ever sees the final value.
+        callState.value = CallState.Active(identityHash)
+        callState.value = CallState.Idle
+        callState.value = CallState.Incoming(identityHash)
+
+        lookupGate.complete(Unit)
+        scheduler.runCurrent()
+
+        // The immediate post plus the update post that presents the second call.
+        assertEquals(2, notifier.shownCalls.size)
+        assertEquals(identityHash to null, notifier.shownCalls[0])
+        assertEquals(identityHash to "Alice", notifier.shownCalls[1])
+        // The collector never saw the intermediate states (conflated away): only
+        // the initial Idle on start produced a cancel.
+        assertEquals(1, notifier.cancelCount.get())
+    }
+
+    @Test
+    fun `consecutive same-identity call with visible transitions is re-presented`() {
+        // Same scenario with the collector keeping up: it sees every state and
+        // delivers the second Incoming as its own event. Both the collector's
+        // immediate post and the lookup update posts must land for the new call.
+        val lookupGate = CompletableDeferred<Unit>()
+        coEvery { announceRepository.findByIdentityHash(identityHash) } coAnswers {
+            lookupGate.await()
+            announce("Alice")
+        }
+        coEvery { contactRepository.getContact(destinationHash) } returns contact(null)
+
+        presenter.start()
+        scheduler.runCurrent()
+        callState.value = CallState.Incoming(identityHash)
+        settle()
+        callState.value = CallState.Active(identityHash)
+        scheduler.runCurrent()
+        callState.value = CallState.Idle
+        scheduler.runCurrent()
+        callState.value = CallState.Incoming(identityHash)
+        scheduler.runCurrent()
+        lookupGate.complete(Unit)
+        scheduler.runCurrent()
+
+        assertEquals(identityHash to "Alice", notifier.shownCalls.last())
+        // Initial Idle, Active, and Idle cancels.
+        assertEquals(3, notifier.cancelCount.get())
+    }
+
+    @Test
+    fun `start is idempotent`() {
+        coEvery { announceRepository.findByIdentityHash(identityHash) } returns
+            announce("Alice")
+        coEvery { contactRepository.getContact(destinationHash) } returns contact(null)
+
+        presenter.start()
+        presenter.start()
+        scheduler.runCurrent()
+        callState.value = CallState.Incoming(identityHash)
+        settle()
+
+        // One collector: exactly the immediate post and the lookup update post.
+        assertEquals(2, notifier.shownCalls.size)
+        assertEquals(identityHash to "Alice", notifier.shownCalls[1])
+    }
+
+    @Test
+    fun `resolveCallerName returns null when no announce exists`() {
+        coEvery { announceRepository.findByIdentityHash(identityHash) } returns null
+
+        assertNull(runBlocking { presenter.resolveCallerName(identityHash) })
+    }
 }

--- a/app/src/test/java/network/columba/app/service/IncomingCallPresenterTest.kt
+++ b/app/src/test/java/network/columba/app/service/IncomingCallPresenterTest.kt
@@ -6,10 +6,7 @@ import io.mockk.every
 import io.mockk.mockk
 import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.flow.MutableStateFlow
-import kotlinx.coroutines.runBlocking
-import kotlinx.coroutines.test.StandardTestDispatcher
 import kotlinx.coroutines.test.TestCoroutineScheduler
-import kotlinx.coroutines.test.runCurrent
 import network.columba.app.MainActivityVisibility
 import network.columba.app.data.db.entity.ContactEntity
 import network.columba.app.data.repository.Announce
@@ -30,12 +27,15 @@ import java.util.concurrent.CopyOnWriteArrayList
  * incoming calls (full-screen-intent notification) while the app is backgrounded
  * (issue #1079).
  *
- * The presenter runs on a [StandardTestDispatcher] backed by a shared
+ * The presenter is the single writer of the notification: one post per incoming
+ * call, made after the caller-name lookup. The presenter runs on a
+ * [kotlinx.coroutines.test.StandardTestDispatcher] backed by a shared
  * [TestCoroutineScheduler], so each test drives it deterministically: a state
- * change is only processed when [runCurrent] advances the scheduler. Grouping
- * several state changes before a [runCurrent] models the production case where
- * the whole churn collapses into the collector's suspension and the StateFlow
- * conflates the intermediate values.
+ * change is only processed when [TestCoroutineScheduler.runCurrent] advances the
+ * scheduler. Grouping several state changes before a [TestCoroutineScheduler.runCurrent]
+ * models the production case where the whole churn collapses into the
+ * collector's suspension in the lookup and the StateFlow conflates the
+ * intermediate values.
  */
 class IncomingCallPresenterTest {
     /** Records notifier interactions so tests assert on real state, not mock calls. */
@@ -75,7 +75,7 @@ class IncomingCallPresenterTest {
                 contactRepository = contactRepository,
                 incomingCallNotifier = notifier,
                 mainActivityVisibility = mainActivityVisibility,
-                dispatcher = StandardTestDispatcher(scheduler),
+                dispatcher = kotlinx.coroutines.test.StandardTestDispatcher(scheduler),
             )
     }
 
@@ -111,8 +111,13 @@ class IncomingCallPresenterTest {
         scheduler.runCurrent()
     }
 
+    private fun assertSinglePost(hash: String, name: String?) {
+        assertEquals(1, notifier.shownCalls.size)
+        assertEquals(hash to name, notifier.shownCalls[0])
+    }
+
     @Test
-    fun `incoming call posts immediately and corrects the name after the lookup`() {
+    fun `incoming call posts notification with the resolved name after the lookup`() {
         coEvery { announceRepository.findByIdentityHash(identityHash) } returns
             announce("Alice")
         coEvery { contactRepository.getContact(destinationHash) } returns contact("Boss")
@@ -122,11 +127,8 @@ class IncomingCallPresenterTest {
         callState.value = CallState.Incoming(identityHash)
         settle()
 
-        // First post carries no name yet (fresh process, empty cache); the
-        // lookup update post carries the resolved nickname.
-        assertEquals(2, notifier.shownCalls.size)
-        assertEquals(identityHash to null, notifier.shownCalls[0])
-        assertEquals(identityHash to "Boss", notifier.shownCalls[1])
+        // One post, after the lookup, carrying the resolved nickname.
+        assertSinglePost(identityHash, "Boss")
     }
 
     @Test
@@ -140,7 +142,7 @@ class IncomingCallPresenterTest {
         callState.value = CallState.Incoming(identityHash)
         settle()
 
-        assertEquals(identityHash to "Alice", notifier.shownCalls.last())
+        assertSinglePost(identityHash, "Alice")
     }
 
     @Test
@@ -152,8 +154,7 @@ class IncomingCallPresenterTest {
         callState.value = CallState.Incoming(identityHash)
         settle()
 
-        assertEquals(identityHash, notifier.shownCalls.last().first)
-        assertNull(notifier.shownCalls.last().second)
+        assertSinglePost(identityHash, null)
     }
 
     @Test
@@ -166,8 +167,7 @@ class IncomingCallPresenterTest {
         callState.value = CallState.Incoming(identityHash)
         settle()
 
-        assertEquals(identityHash, notifier.shownCalls.last().first)
-        assertNull(notifier.shownCalls.last().second)
+        assertSinglePost(identityHash, null)
     }
 
     @Test
@@ -180,12 +180,12 @@ class IncomingCallPresenterTest {
         scheduler.runCurrent()
         callState.value = CallState.Incoming(identityHash)
         settle()
+        assertSinglePost(identityHash, "Alice")
+
         callState.value = CallState.Active(identityHash)
         scheduler.runCurrent()
 
-        // Posted immediately, name corrected by the lookup, then cancelled for
-        // the Active transition (plus one cancel for the initial Idle on start).
-        assertEquals(identityHash to "Alice", notifier.shownCalls.last())
+        // One cancel for the initial Idle on start, one for the Active transition.
         assertEquals(2, notifier.cancelCount.get())
     }
 
@@ -199,105 +199,6 @@ class IncomingCallPresenterTest {
         scheduler.runCurrent()
 
         assertEquals(0, notifier.shownCalls.size)
-    }
-
-    @Test
-    fun `superseded lookup does not post after the call ended`() {
-        // The call is answered while the caller-name lookup is still in flight:
-        // the stale lookup result must not update or resurrect the notification
-        // after the call is over.
-        val lookupGate = CompletableDeferred<Unit>()
-        coEvery { announceRepository.findByIdentityHash(identityHash) } coAnswers {
-            lookupGate.await()
-            announce("Alice")
-        }
-        coEvery { contactRepository.getContact(destinationHash) } returns contact(null)
-
-        presenter.start()
-        scheduler.runCurrent()
-        callState.value = CallState.Incoming(identityHash)
-        settle()
-        // The immediate post is up; the lookup coroutine is parked at the gate.
-        callState.value = CallState.Active(identityHash)
-        scheduler.runCurrent()
-        lookupGate.complete(Unit)
-        scheduler.runCurrent()
-
-        assertEquals(1, notifier.shownCalls.size)
-        assertEquals(identityHash to null, notifier.shownCalls[0])
-        // Canceled once for the initial Idle on start, once for the Active
-        // transition that superseded the lookup.
-        assertEquals(2, notifier.cancelCount.get())
-    }
-
-    @Test
-    fun `consecutive same-identity call hidden by state conflation is still presented`() {
-        // Call 1 arrives and its lookup is in flight. Call 1 is then answered and
-        // a second call from the SAME identity comes in before the collector can
-        // process the intermediate states: the whole round trip collapses into
-        // the collector's suspension, and the second Incoming equals the one it
-        // already delivered, so the StateFlow conflates it away and the collector
-        // never sees the new call (verified: a collector suspended across a
-        // V -> X -> V round trip observes nothing). Only the first lookup's
-        // update post can present the second call - and it must, with the
-        // resolved name for that identity.
-        val lookupGate = CompletableDeferred<Unit>()
-        coEvery { announceRepository.findByIdentityHash(identityHash) } coAnswers {
-            lookupGate.await()
-            announce("Alice")
-        }
-        coEvery { contactRepository.getContact(destinationHash) } returns contact(null)
-
-        presenter.start()
-        scheduler.runCurrent()
-        callState.value = CallState.Incoming(identityHash)
-        settle()
-        // The churn happens while the collector is suspended; no scheduler
-        // advance in between, so the collector only ever sees the final value.
-        callState.value = CallState.Active(identityHash)
-        callState.value = CallState.Idle
-        callState.value = CallState.Incoming(identityHash)
-
-        lookupGate.complete(Unit)
-        scheduler.runCurrent()
-
-        // The immediate post plus the update post that presents the second call.
-        assertEquals(2, notifier.shownCalls.size)
-        assertEquals(identityHash to null, notifier.shownCalls[0])
-        assertEquals(identityHash to "Alice", notifier.shownCalls[1])
-        // The collector never saw the intermediate states (conflated away): only
-        // the initial Idle on start produced a cancel.
-        assertEquals(1, notifier.cancelCount.get())
-    }
-
-    @Test
-    fun `consecutive same-identity call with visible transitions is re-presented`() {
-        // Same scenario with the collector keeping up: it sees every state and
-        // delivers the second Incoming as its own event. Both the collector's
-        // immediate post and the lookup update posts must land for the new call.
-        val lookupGate = CompletableDeferred<Unit>()
-        coEvery { announceRepository.findByIdentityHash(identityHash) } coAnswers {
-            lookupGate.await()
-            announce("Alice")
-        }
-        coEvery { contactRepository.getContact(destinationHash) } returns contact(null)
-
-        presenter.start()
-        scheduler.runCurrent()
-        callState.value = CallState.Incoming(identityHash)
-        settle()
-        callState.value = CallState.Active(identityHash)
-        scheduler.runCurrent()
-        callState.value = CallState.Idle
-        scheduler.runCurrent()
-        callState.value = CallState.Incoming(identityHash)
-        scheduler.runCurrent()
-        lookupGate.complete(Unit)
-        scheduler.runCurrent()
-
-        assertEquals(identityHash to "Alice", notifier.shownCalls.last())
-        // Initial Idle, Active, and Idle cancels.
-        assertEquals(3, notifier.cancelCount.get())
     }
 
     @Test
@@ -318,11 +219,40 @@ class IncomingCallPresenterTest {
     }
 
     @Test
-    fun `name update does not resurrect the notification after MainActivity took over`() {
-        // The call arrives while backgrounded (immediate post goes out). The
-        // user then opens the app while the lookup is in flight: MainActivity
-        // takes ownership and cancels the notification. The lookup's update
-        // must not post it back.
+    fun `lookup completing after MainActivity took over does not post`() {
+        // The call arrives while backgrounded (the lookup starts). The user then
+        // opens the app while the lookup is in flight: MainActivity takes
+        // ownership and cancels (nothing is up yet, but the cancel runs
+        // regardless). The post made after the lookup must not land over the
+        // in-app screen or undo that cancel.
+        val lookupGate = CompletableDeferred<Unit>()
+        coEvery { announceRepository.findByIdentityHash(identityHash) } coAnswers {
+            lookupGate.await()
+            announce("Alice")
+        }
+        coEvery { contactRepository.getContact(destinationHash) } returns contact(null)
+
+        presenter.start()
+        scheduler.runCurrent()
+        callState.value = CallState.Incoming(identityHash)
+        // The collector is now parked inside the lookup.
+        settle()
+        assertEquals(0, notifier.shownCalls.size)
+
+        mainActivityVisibility.setVisible(true)
+        settle()
+
+        lookupGate.complete(Unit)
+        settle()
+
+        // No post: the re-check after the lookup saw the visible flag.
+        assertEquals(0, notifier.shownCalls.size)
+    }
+
+    @Test
+    fun `superseded lookup does not post after the call ended`() {
+        // The call is answered while the caller-name lookup is still in flight:
+        // the stale lookup result must not be posted after the call is over.
         val lookupGate = CompletableDeferred<Unit>()
         coEvery { announceRepository.findByIdentityHash(identityHash) } coAnswers {
             lookupGate.await()
@@ -334,34 +264,61 @@ class IncomingCallPresenterTest {
         scheduler.runCurrent()
         callState.value = CallState.Incoming(identityHash)
         settle()
-        // The user opens the app: MainActivity becomes visible (its in-app
-        // effect cancels the notification).
-        mainActivityVisibility.setVisible(true)
-        lookupGate.complete(Unit)
-        scheduler.runCurrent()
+        assertEquals(0, notifier.shownCalls.size)
 
-        // Only the immediate post happened; the update was suppressed.
-        assertEquals(1, notifier.shownCalls.size)
-        assertEquals(identityHash to null, notifier.shownCalls[0])
+        // The collector is parked in the lookup; the call is answered and ends.
+        callState.value = CallState.Active(identityHash)
+        settle()
+        callState.value = CallState.Idle
+        settle()
+
+        lookupGate.complete(Unit)
+        settle()
+
+        // No post: the re-check saw the call is no longer the incoming one, and
+        // a never-posted notification needs no cancel.
+        assertEquals(0, notifier.shownCalls.size)
+        // One cancel for the initial Idle on start, one for the Active
+        // transition the collector processes after the lookup returns.
+        assertEquals(2, notifier.cancelCount.get())
     }
 
     @Test
-    fun `name update is posted for the FSI activity flow`() {
-        // The full-screen intent launches IncomingCallActivity, which does not
-        // make MainActivity visible: the name update must still land so the
-        // call UI shows the resolved name, not the hash fallback.
-        coEvery { announceRepository.findByIdentityHash(identityHash) } returns
+    fun `same-identity re-call during the lookup is presented with the lookup result`() {
+        // Call 1 arrives and its lookup is in flight. Call 1 is then answered and
+        // a second call from the SAME identity comes in before the collector can
+        // process the intermediate states: the whole round trip collapses into
+        // the collector's suspension in the lookup, and the second Incoming
+        // equals the one it already delivered, so the StateFlow conflates it
+        // away and the collector never sees the new call (verified: a collector
+        // suspended across a V -> X -> V round trip observes nothing). The post
+        // made after the lookup is therefore the presentation of the second
+        // call. The display name is a function of the identity hash, so the
+        // lookup result is the right name for the ringing call.
+        val lookupGate = CompletableDeferred<Unit>()
+        coEvery { announceRepository.findByIdentityHash(identityHash) } coAnswers {
+            lookupGate.await()
             announce("Alice")
+        }
         coEvery { contactRepository.getContact(destinationHash) } returns contact(null)
 
         presenter.start()
         scheduler.runCurrent()
         callState.value = CallState.Incoming(identityHash)
         settle()
+        // The churn happens while the collector is suspended; no scheduler
+        // advance in between, so the collector only ever sees the final value.
+        callState.value = CallState.Active(identityHash)
+        callState.value = CallState.Idle
+        callState.value = CallState.Incoming(identityHash)
 
-        assertEquals(2, notifier.shownCalls.size)
-        assertEquals(identityHash to null, notifier.shownCalls[0])
-        assertEquals(identityHash to "Alice", notifier.shownCalls[1])
+        lookupGate.complete(Unit)
+        scheduler.runCurrent()
+
+        assertSinglePost(identityHash, "Alice")
+        // The collector never saw the intermediate states (conflated away): only
+        // the initial Idle on start produced a cancel.
+        assertEquals(1, notifier.cancelCount.get())
     }
 
     @Test
@@ -371,20 +328,13 @@ class IncomingCallPresenterTest {
         coEvery { contactRepository.getContact(destinationHash) } returns contact(null)
 
         presenter.start()
+        settle()
         presenter.start()
-        scheduler.runCurrent()
+        settle()
+
         callState.value = CallState.Incoming(identityHash)
         settle()
 
-        // One collector: exactly the immediate post and the lookup update post.
-        assertEquals(2, notifier.shownCalls.size)
-        assertEquals(identityHash to "Alice", notifier.shownCalls[1])
-    }
-
-    @Test
-    fun `resolveCallerName returns null when no announce exists`() {
-        coEvery { announceRepository.findByIdentityHash(identityHash) } returns null
-
-        assertNull(runBlocking { presenter.resolveCallerName(identityHash) })
+        assertSinglePost(identityHash, "Alice")
     }
 }

--- a/app/src/test/java/network/columba/app/service/IncomingCallPresenterTest.kt
+++ b/app/src/test/java/network/columba/app/service/IncomingCallPresenterTest.kt
@@ -209,7 +209,7 @@ class IncomingCallPresenterTest {
 
         // The app is in the foreground: MainActivity shows the in-app call
         // screen, so the background presenter must stay silent.
-        mainActivityVisibility.setVisible(true)
+        mainActivityVisibility.claimForeground { }
         presenter.start()
         scheduler.runCurrent()
         callState.value = CallState.Incoming(identityHash)
@@ -239,13 +239,13 @@ class IncomingCallPresenterTest {
         settle()
         assertEquals(0, notifier.shownCalls.size)
 
-        mainActivityVisibility.setVisible(true)
+        mainActivityVisibility.claimForeground { }
         settle()
 
         lookupGate.complete(Unit)
         settle()
 
-        // No post: the re-check after the lookup saw the visible flag.
+        // No post: the atomic check-then-post saw the claimed foreground.
         assertEquals(0, notifier.shownCalls.size)
     }
 
@@ -319,6 +319,29 @@ class IncomingCallPresenterTest {
         // The collector never saw the intermediate states (conflated away): only
         // the initial Idle on start produced a cancel.
         assertEquals(1, notifier.cancelCount.get())
+    }
+
+    @Test
+    fun `foreground claim after the post cancels it in the same atomic section`() {
+        // The normal hand-off: the presenter posts while backgrounded, then the
+        // user opens the app. MainActivity's claim (flag flip + cancel in one
+        // locked section) removes the post, and the presenter can never post
+        // again for this call (one post per call), so the UI is single-owned.
+        coEvery { announceRepository.findByIdentityHash(identityHash) } returns
+            announce("Alice")
+        coEvery { contactRepository.getContact(destinationHash) } returns contact(null)
+
+        presenter.start()
+        scheduler.runCurrent()
+        callState.value = CallState.Incoming(identityHash)
+        settle()
+        assertSinglePost(identityHash, "Alice")
+        val cancelsBeforeClaim = notifier.cancelCount.get()
+
+        mainActivityVisibility.claimForeground { notifier.cancelIncomingCallNotification() }
+
+        assertEquals(cancelsBeforeClaim + 1, notifier.cancelCount.get())
+        assertEquals(1, notifier.shownCalls.size)
     }
 
     @Test

--- a/app/src/test/java/network/columba/app/service/IncomingCallPresenterTest.kt
+++ b/app/src/test/java/network/columba/app/service/IncomingCallPresenterTest.kt
@@ -4,6 +4,7 @@ import io.mockk.clearMocks
 import io.mockk.coEvery
 import io.mockk.every
 import io.mockk.mockk
+import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.test.UnconfinedTestDispatcher
 import kotlinx.coroutines.test.runTest
@@ -182,19 +183,58 @@ class IncomingCallPresenterTest {
             // The call is answered while the caller-name lookup is still in
             // flight: the stale Incoming state must not post the full-screen
             // notification after the call is over.
+            val lookupGate = CompletableDeferred<Unit>()
             coEvery { announceRepository.findByIdentityHash(identityHash) } coAnswers {
-                callState.value = CallState.Active(identityHash)
+                lookupGate.await()
                 announce("Alice")
             }
             coEvery { contactRepository.getContact(destinationHash) } returns contact(null)
 
             presenter.start()
             callState.value = CallState.Incoming(identityHash)
+            // The presenter is now suspended in lookup 1; the call is answered
+            // before that lookup completes.
+            callState.value = CallState.Active(identityHash)
+            lookupGate.complete(Unit)
 
             assertEquals(0, notifier.shownCalls.size)
             // Canceled once for the initial Idle on start, once for the Active
             // transition that superseded the lookup.
             assertEquals(2, notifier.cancelCount.get())
+        }
+
+    @Test
+    fun `consecutive same-identity calls present the current call, not the stale lookup`() =
+        runTest {
+            // Call 1 arrives and its name lookup is in flight when the call is
+            // answered and a second call from the SAME identity comes in. The
+            // stale lookup's result must not be posted; the presentation must
+            // come from the second call's own lookup (which sees the changed
+            // peer name here).
+            val lookupGate = CompletableDeferred<Unit>()
+            val lookups = java.util.concurrent.atomic.AtomicInteger(0)
+            coEvery { announceRepository.findByIdentityHash(identityHash) } coAnswers {
+                if (lookups.incrementAndGet() == 1) {
+                    lookupGate.await()
+                    announce("Alice")
+                } else {
+                    announce("Bob")
+                }
+            }
+            coEvery { contactRepository.getContact(destinationHash) } returns contact(null)
+
+            presenter.start()
+            callState.value = CallState.Incoming(identityHash)
+            // Lookup 1 is in flight; call 1 is answered and a second call from
+            // the same identity arrives before it completes.
+            callState.value = CallState.Active(identityHash)
+            callState.value = CallState.Idle
+            callState.value = CallState.Incoming(identityHash)
+            lookupGate.complete(Unit)
+
+            assertEquals(1, notifier.shownCalls.size)
+            assertEquals(identityHash, notifier.shownCalls[0].first)
+            assertEquals("Bob", notifier.shownCalls[0].second)
         }
 
     @Test

--- a/app/src/test/java/network/columba/app/service/IncomingCallPresenterTest.kt
+++ b/app/src/test/java/network/columba/app/service/IncomingCallPresenterTest.kt
@@ -1,0 +1,201 @@
+package network.columba.app.service
+
+import io.mockk.clearMocks
+import io.mockk.coEvery
+import io.mockk.every
+import io.mockk.mockk
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import kotlinx.coroutines.test.runTest
+import network.columba.app.data.db.entity.ContactEntity
+import network.columba.app.data.repository.Announce
+import network.columba.app.data.repository.AnnounceRepository
+import network.columba.app.data.repository.ContactRepository
+import network.columba.app.notifications.IncomingCallNotifier
+import network.columba.app.rns.api.RnsTelephony
+import network.columba.app.rns.api.model.CallState
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Before
+import org.junit.Test
+import java.util.concurrent.CopyOnWriteArrayList
+
+/**
+ * Unit tests for [IncomingCallPresenter]: the app-process component that presents
+ * incoming calls (full-screen-intent notification) while the app is backgrounded
+ * (issue #1079).
+ */
+class IncomingCallPresenterTest {
+    /** Records notifier interactions so tests assert on real state, not mock calls. */
+    private class RecordingNotifier : IncomingCallNotifier {
+        val shownCalls = CopyOnWriteArrayList<Pair<String, String?>>()
+        val cancelCount = java.util.concurrent.atomic.AtomicInteger(0)
+
+        override fun showIncomingCallNotification(identityHash: String, callerName: String?) {
+            shownCalls.add(identityHash to callerName)
+        }
+
+        override fun cancelIncomingCallNotification() {
+            cancelCount.incrementAndGet()
+        }
+    }
+
+    private val rnsTelephony: RnsTelephony = mockk()
+    private val announceRepository: AnnounceRepository = mockk()
+    private val contactRepository: ContactRepository = mockk()
+    private val notifier = RecordingNotifier()
+    private val callState = MutableStateFlow<CallState>(CallState.Idle)
+
+    private val identityHash = "ef2f7fbc8ec20971cb9bc8f468984aaf0000"
+    private val destinationHash = "aa".repeat(32)
+
+    private lateinit var presenter: IncomingCallPresenter
+
+    @Before
+    fun setup() {
+        every { rnsTelephony.callState } returns callState
+        presenter =
+            IncomingCallPresenter(
+                rnsTelephony = rnsTelephony,
+                announceRepository = announceRepository,
+                contactRepository = contactRepository,
+                incomingCallNotifier = notifier,
+                dispatcher = UnconfinedTestDispatcher(),
+            )
+    }
+
+    @After
+    fun tearDown() {
+        clearMocks(rnsTelephony, announceRepository, contactRepository)
+    }
+
+    private fun announce(peerName: String) =
+        Announce(
+            destinationHash = destinationHash,
+            peerName = peerName,
+            publicKey = byteArrayOf(1, 2, 3),
+            appData = null,
+            hops = 1,
+            lastSeenTimestamp = 0L,
+            nodeType = "",
+        )
+
+    private fun contact(nickname: String?) =
+        ContactEntity(
+            destinationHash = destinationHash,
+            identityHash = "11".repeat(32),
+            publicKey = null,
+            customNickname = nickname,
+            addedTimestamp = 0L,
+            addedVia = "MANUAL",
+        )
+
+    @Test
+    fun `incoming call posts notification with contact nickname`() =
+        runTest {
+            coEvery { announceRepository.findByIdentityHash(identityHash) } returns
+                announce("Alice")
+            coEvery { contactRepository.getContact(destinationHash) } returns contact("Boss")
+
+            presenter.start()
+            callState.value = CallState.Incoming(identityHash)
+
+            assertEquals(1, notifier.shownCalls.size)
+            assertEquals(identityHash, notifier.shownCalls[0].first)
+            assertEquals("Boss", notifier.shownCalls[0].second)
+        }
+
+    @Test
+    fun `incoming call falls back to announce peer name when no nickname`() =
+        runTest {
+            coEvery { announceRepository.findByIdentityHash(identityHash) } returns
+                announce("Alice")
+            coEvery { contactRepository.getContact(destinationHash) } returns contact(null)
+
+            presenter.start()
+            callState.value = CallState.Incoming(identityHash)
+
+            assertEquals(1, notifier.shownCalls.size)
+            assertEquals(identityHash, notifier.shownCalls[0].first)
+            assertEquals("Alice", notifier.shownCalls[0].second)
+        }
+
+    @Test
+    fun `incoming call posts notification with null name for unknown caller`() =
+        runTest {
+            coEvery { announceRepository.findByIdentityHash(identityHash) } returns null
+
+            presenter.start()
+            callState.value = CallState.Incoming(identityHash)
+
+            assertEquals(1, notifier.shownCalls.size)
+            assertEquals(identityHash, notifier.shownCalls[0].first)
+            assertNull(notifier.shownCalls[0].second)
+        }
+
+    @Test
+    fun `lookup failure fails open to null name`() =
+        runTest {
+            coEvery { announceRepository.findByIdentityHash(identityHash) } throws
+                RuntimeException("db exploded")
+
+            presenter.start()
+            callState.value = CallState.Incoming(identityHash)
+
+            assertEquals(1, notifier.shownCalls.size)
+            assertEquals(identityHash, notifier.shownCalls[0].first)
+            assertNull(notifier.shownCalls[0].second)
+        }
+
+    @Test
+    fun `transition to Active cancels the incoming notification`() =
+        runTest {
+            coEvery { announceRepository.findByIdentityHash(identityHash) } returns
+                announce("Alice")
+            coEvery { contactRepository.getContact(destinationHash) } returns contact(null)
+
+            presenter.start()
+            callState.value = CallState.Incoming(identityHash)
+            callState.value = CallState.Active(identityHash)
+
+            // Posted once for the incoming call, cancelled once for the Active
+            // transition (plus one cancel for the initial Idle on start).
+            assertEquals(1, notifier.shownCalls.size)
+            assertEquals("Alice", notifier.shownCalls[0].second)
+            assertEquals(2, notifier.cancelCount.get())
+        }
+
+    @Test
+    fun `outgoing states never post an incoming notification`() =
+        runTest {
+            presenter.start()
+            callState.value = CallState.Connecting(identityHash)
+            callState.value = CallState.Ringing(identityHash)
+
+            assertEquals(0, notifier.shownCalls.size)
+        }
+
+    @Test
+    fun `start is idempotent`() =
+        runTest {
+            coEvery { announceRepository.findByIdentityHash(identityHash) } returns
+                announce("Alice")
+            coEvery { contactRepository.getContact(destinationHash) } returns contact(null)
+
+            presenter.start()
+            presenter.start()
+            callState.value = CallState.Incoming(identityHash)
+
+            assertEquals(1, notifier.shownCalls.size)
+            assertEquals("Alice", notifier.shownCalls[0].second)
+        }
+
+    @Test
+    fun `resolveCallerName returns null when no announce exists`() =
+        runTest {
+            coEvery { announceRepository.findByIdentityHash(identityHash) } returns null
+
+            assertNull(presenter.resolveCallerName(identityHash))
+        }
+}

--- a/app/src/test/java/network/columba/app/service/IncomingCallPresenterTest.kt
+++ b/app/src/test/java/network/columba/app/service/IncomingCallPresenterTest.kt
@@ -7,6 +7,7 @@ import io.mockk.mockk
 import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.test.TestCoroutineScheduler
+import network.columba.app.AppMainThread
 import network.columba.app.MainActivityVisibility
 import network.columba.app.data.db.entity.ContactEntity
 import network.columba.app.data.repository.Announce
@@ -18,6 +19,7 @@ import network.columba.app.rns.api.model.CallState
 import org.junit.After
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
 import org.junit.Before
 import org.junit.Test
 import java.util.concurrent.CopyOnWriteArrayList
@@ -67,6 +69,12 @@ class IncomingCallPresenterTest {
 
     @Before
     fun setup() {
+        // Fake the main-thread confinement seam: the test thread plays the main
+        // thread, and posts run inline. Inline execution models the production
+        // atomicity exactly - a claim can neither interleave inside a
+        // postWhileBackground sequence nor be missed by it; each runs whole.
+        AppMainThread.post = { runnable -> runnable.run() }
+        AppMainThread.isMainThread = { true }
         every { rnsTelephony.callState } returns callState
         presenter =
             IncomingCallPresenter(
@@ -81,6 +89,8 @@ class IncomingCallPresenterTest {
 
     @After
     fun tearDown() {
+        AppMainThread.post = { runnable -> runnable.run() }
+        AppMainThread.isMainThread = { true }
         clearMocks(rnsTelephony, announceRepository, contactRepository)
     }
 
@@ -342,6 +352,100 @@ class IncomingCallPresenterTest {
 
         assertEquals(cancelsBeforeClaim + 1, notifier.cancelCount.get())
         assertEquals(1, notifier.shownCalls.size)
+    }
+
+    @Test
+    fun `backgrounding mid-ring hands presentation back to the presenter`() {
+        // The call arrives while the app is visible: MainActivity presents it
+        // in-app and the presenter stays quiet. The user then presses home
+        // while the call is still ringing - no new callState emission will
+        // ever arrive - so releasing foreground ownership must make the
+        // presenter post the full-screen-intent notification.
+        coEvery { announceRepository.findByIdentityHash(identityHash) } returns
+            announce("Alice")
+        coEvery { contactRepository.getContact(destinationHash) } returns contact(null)
+
+        mainActivityVisibility.claimForeground { }
+        presenter.start()
+        scheduler.runCurrent()
+        callState.value = CallState.Incoming(identityHash)
+        settle()
+        assertEquals(0, notifier.shownCalls.size)
+
+        // Home gesture: onStop without a configuration change.
+        mainActivityVisibility.releaseForeground()
+        settle()
+
+        assertSinglePost(identityHash, "Alice")
+    }
+
+    @Test
+    fun `rotation mid-ring does not post the background notification`() {
+        // A configuration change never releases ownership (MainActivity passes
+        // isChangingConfigurations), so the STOP/START churn of a rotation
+        // cannot flash the background notification mid-call.
+        coEvery { announceRepository.findByIdentityHash(identityHash) } returns
+            announce("Alice")
+        coEvery { contactRepository.getContact(destinationHash) } returns contact(null)
+
+        mainActivityVisibility.claimForeground { }
+        presenter.start()
+        scheduler.runCurrent()
+        callState.value = CallState.Incoming(identityHash)
+        settle()
+        assertEquals(0, notifier.shownCalls.size)
+
+        // Rotation: onStop with isChangingConfigurations = true.
+        mainActivityVisibility.releaseForeground(changingConfigurations = true)
+        settle()
+        assertEquals(0, notifier.shownCalls.size)
+        // The claim survives the rotation.
+        assertTrue(mainActivityVisibility.visible.value)
+    }
+
+    @Test
+    fun `backgrounding mid-ring with the app reopened before the lookup does not post`() {
+        // Same as the recovery case, but the user reopens the app while the
+        // recovery's name lookup is still in flight: the claim wins and the
+        // presenter's post must not land over the in-app screen.
+        val lookupGate = CompletableDeferred<Unit>()
+        coEvery { announceRepository.findByIdentityHash(identityHash) } coAnswers {
+            lookupGate.await()
+            announce("Alice")
+        }
+        coEvery { contactRepository.getContact(destinationHash) } returns contact(null)
+
+        mainActivityVisibility.claimForeground { }
+        presenter.start()
+        scheduler.runCurrent()
+        callState.value = CallState.Incoming(identityHash)
+        settle()
+
+        // Home: recovery starts the lookup...
+        mainActivityVisibility.releaseForeground()
+        settle()
+        assertEquals(0, notifier.shownCalls.size)
+
+        // ...and the app is back in the foreground before it completes.
+        mainActivityVisibility.claimForeground { notifier.cancelIncomingCallNotification() }
+        lookupGate.complete(Unit)
+        settle()
+
+        assertEquals(0, notifier.shownCalls.size)
+    }
+
+    @Test
+    fun `backgrounding while idle posts nothing`() {
+        // Release with no ringing call must not post: recovery only acts on
+        // CallState.Incoming.
+        mainActivityVisibility.claimForeground { }
+        presenter.start()
+        settle()
+
+        mainActivityVisibility.releaseForeground()
+        settle()
+
+        assertEquals(0, notifier.shownCalls.size)
     }
 
     @Test

--- a/app/src/test/java/network/columba/app/service/IncomingCallPresenterTest.kt
+++ b/app/src/test/java/network/columba/app/service/IncomingCallPresenterTest.kt
@@ -449,6 +449,43 @@ class IncomingCallPresenterTest {
     }
 
     @Test
+    fun `queued post is dropped when the call ends before the main-thread runnable runs`() {
+        // The post enqueues onto the main thread, so the call can end (and the
+        // collector's cancel run) between the presenter's state check and the
+        // runnable executing. The runnable re-checks the call state and must
+        // not resurrect the cancelled notification.
+        val queue = java.util.concurrent.ConcurrentLinkedQueue<Runnable>()
+        AppMainThread.post = { runnable -> queue.add(runnable) }
+
+        coEvery { announceRepository.findByIdentityHash(identityHash) } returns
+            announce("Alice")
+        coEvery { contactRepository.getContact(destinationHash) } returns contact(null)
+
+        presenter.start()
+        scheduler.runCurrent()
+        callState.value = CallState.Incoming(identityHash)
+        settle()
+
+        // The lookup completed and the post is enqueued, not yet run.
+        assertEquals(1, queue.size)
+        assertEquals(0, notifier.shownCalls.size)
+
+        // The call is answered and the collector processes the transition
+        // (cancel) before the queued post runs.
+        callState.value = CallState.Active(identityHash)
+        scheduler.runCurrent()
+        assertEquals(0, notifier.shownCalls.size)
+
+        // Now the main thread drains its queue: the re-check inside the post
+        // sees the call is no longer Incoming and drops it.
+        while (true) {
+            val runnable = queue.poll() ?: break
+            runnable.run()
+        }
+        assertEquals(0, notifier.shownCalls.size)
+    }
+
+    @Test
     fun `start is idempotent`() {
         coEvery { announceRepository.findByIdentityHash(identityHash) } returns
             announce("Alice")

--- a/app/src/test/java/network/columba/app/service/IncomingCallPresenterTest.kt
+++ b/app/src/test/java/network/columba/app/service/IncomingCallPresenterTest.kt
@@ -177,6 +177,27 @@ class IncomingCallPresenterTest {
         }
 
     @Test
+    fun `incoming state superseded during the name lookup is not posted`() =
+        runTest {
+            // The call is answered while the caller-name lookup is still in
+            // flight: the stale Incoming state must not post the full-screen
+            // notification after the call is over.
+            coEvery { announceRepository.findByIdentityHash(identityHash) } coAnswers {
+                callState.value = CallState.Active(identityHash)
+                announce("Alice")
+            }
+            coEvery { contactRepository.getContact(destinationHash) } returns contact(null)
+
+            presenter.start()
+            callState.value = CallState.Incoming(identityHash)
+
+            assertEquals(0, notifier.shownCalls.size)
+            // Canceled once for the initial Idle on start, once for the Active
+            // transition that superseded the lookup.
+            assertEquals(2, notifier.cancelCount.get())
+        }
+
+    @Test
     fun `start is idempotent`() =
         runTest {
             coEvery { announceRepository.findByIdentityHash(identityHash) } returns

--- a/app/src/test/java/network/columba/app/service/IncomingCallPresenterTest.kt
+++ b/app/src/test/java/network/columba/app/service/IncomingCallPresenterTest.kt
@@ -52,6 +52,8 @@ class IncomingCallPresenterTest {
         override fun cancelIncomingCallNotification() {
             cancelCount.incrementAndGet()
         }
+
+        override val cancelTick: Long get() = cancelCount.get().toLong()
     }
 
     private val scheduler = TestCoroutineScheduler()
@@ -478,6 +480,40 @@ class IncomingCallPresenterTest {
 
         // Now the main thread drains its queue: the re-check inside the post
         // sees the call is no longer Incoming and drops it.
+        while (true) {
+            val runnable = queue.poll() ?: break
+            runnable.run()
+        }
+        assertEquals(0, notifier.shownCalls.size)
+    }
+
+    @Test
+    fun `queued post is dropped when the notification was declined during the enqueue window`() {
+        // The user taps Decline on the notification while the presenter's post
+        // is enqueued: CallActionReceiver cancels immediately, but its
+        // asynchronous hangup has not changed callState yet, so a state-only
+        // re-check would pass and repost the declined call's UI. The cancel
+        // tick moved between enqueue and execution, so the post must drop.
+        val queue = java.util.concurrent.ConcurrentLinkedQueue<Runnable>()
+        AppMainThread.post = { runnable -> queue.add(runnable) }
+
+        coEvery { announceRepository.findByIdentityHash(identityHash) } returns
+            announce("Alice")
+        coEvery { contactRepository.getContact(destinationHash) } returns contact(null)
+
+        presenter.start()
+        scheduler.runCurrent()
+        callState.value = CallState.Incoming(identityHash)
+        settle()
+
+        // Post enqueued, call still Incoming (the hangup is in flight).
+        assertEquals(1, queue.size)
+        callState.value = CallState.Incoming(identityHash) // unchanged semantics
+
+        // Decline tap: cancel lands, state has not transitioned yet.
+        notifier.cancelIncomingCallNotification()
+
+        // Drain the main-thread queue: the tick guard suppresses the repost.
         while (true) {
             val runnable = queue.poll() ?: break
             runnable.run()


### PR DESCRIPTION
Replacement for #1118 after a full human review pass. Same feature: full-screen-intent incoming-call presentation when the app is backgrounded, with the ownership hand-off between MainActivity (in-app call screen) and the background presenter made race-free.

Carries all 10 commits from #1118 with the unrelated Codec2Audio commit split out (its own PR comes from `fix/codec-stop-frame-tail`), plus one new commit on top:

fix(android): recover background presentation and confine ownership transfer to the main thread

1. Mid-ring backgrounding recovery. When the call arrives while MainActivity is visible, the presenter skips the post and the in-app screen presents. If the user then backgrounds the app while the call is still ringing, no new CallState emission ever arrives, so the presenter never posts: the call keeps ringing (the :reticulum service owns the ringtone) with no answer/decline UI until the app is reopened. The presenter now also collects MainActivityVisibility.visible and takes presentation back when ownership is released during an Incoming call. Rotation cannot flash the notification: MainActivity passes isChangingConfigurations to releaseForeground, and a configuration-change STOP never releases the claim.

2. Replace the cross-thread monitor from #1118's last commit with single-thread confinement. That lock let MainActivity's onStart cancel (main thread) block behind the presenter's post (Dispatchers.IO) holding it across a binder call - an ANR hazard traded for a sub-frame visual residual. The visibility flag, the claim (+cancel) and the post now all execute on the main thread, so the check-then-post sequences are atomic by construction and nobody ever blocks; posts from the presenter's IO collector enqueue via the new AppMainThread seam. notify/cancel are fire-and-forget, so the main thread is never parked.

Design summary (unchanged from #1118's converged state): the presenter is the single writer of the incoming-call notification - one post per call, made after the caller-name lookup; no asynchronous name-correction writer (that design generated five P1 races in the prior review rounds).

Verification:
- IncomingCallPresenterTest: 16/16 (4 new: backgrounding mid-ring posts; rotation does not; reopen-before-lookup loses cleanly; release while Idle posts nothing)
- :app:testNoSentryKotlinBackendDebugUnitTest full suite: 6137 passed, 0 failed
- ktlintCheck + detekt (all modules), audit-dispatchers.sh threading audit: pass
- On-device (SM-G998U1): debug build from this branch installed; FSI debug hook posts the real notification and IncomingCallActivity takes over and self-finishes correctly on Idle call state

Closes #1079. Supersedes #1118.