### PR TITLE
fix(android): treat saved contacts as saved peers for notifications

### DIFF
--- a/app/src/main/java/network/columba/app/service/MessageCollector.kt
+++ b/app/src/main/java/network/columba/app/service/MessageCollector.kt
@@ -143,13 +143,7 @@ class MessageCollector
                                 }
                             }
 
-                            val isFavorite =
-                                try {
-                                    announceRepository.getAnnounce(sourceHash)?.isFavorite ?: false
-                                } catch (e: Exception) {
-                                    Log.w(TAG, "Could not check if peer is favorite", e)
-                                    false
-                                }
+                            val isFavorite = isSavedPeer(sourceHash)
 
                             // Only notify if the message hasn't been read yet
                             // This prevents duplicate notifications after service restart
@@ -274,13 +268,7 @@ class MessageCollector
                             Log.d(TAG, "Message saved to database for peer ${sourceHash.take(16)} (hasPublicKey=${publicKey != null})")
 
                             // Check if sender is a saved peer (favorite)
-                            val isFavorite =
-                                try {
-                                    announceRepository.getAnnounce(sourceHash)?.isFavorite ?: false
-                                } catch (e: Exception) {
-                                    Log.w(TAG, "Could not check if peer is favorite", e)
-                                    false
-                                }
+                            val isFavorite = isSavedPeer(sourceHash)
 
                             // Show notification for received message
                             try {
@@ -456,6 +444,39 @@ class MessageCollector
 
             // Format the hash as a short, readable identifier
             return PeerNameResolver.formatHashAsFallback(peerHash)
+        }
+
+        /**
+         * Determine whether [sourceHash] is a "saved peer" for notification purposes.
+         *
+         * A peer is considered saved if it is either:
+         *  - flagged as a favorite on its announce row (legacy "Save Peer" via the
+         *    announce stream star), OR
+         *  - present in the active identity's contacts table (written by the
+         *    "Save to Contacts" flows in Chats/Messaging, QR import, manual entry,
+         *    and propagation-node relay setup, which do not touch the announce flag).
+         *
+         * Both signals must be checked: the contacts table is the source of truth for
+         * "saved" as the user experiences it, and the legacy flag is kept so peers saved
+         * before the contacts table existed continue to notify. Either signal being true
+         * is sufficient.
+         */
+        private suspend fun isSavedPeer(sourceHash: String): Boolean {
+            val favoriteFlag =
+                try {
+                    announceRepository.getAnnounce(sourceHash)?.isFavorite ?: false
+                } catch (e: Exception) {
+                    Log.w(TAG, "Could not check if peer is favorite", e)
+                    false
+                }
+            if (favoriteFlag) return true
+
+            return try {
+                contactRepository.hasContact(sourceHash)
+            } catch (e: Exception) {
+                Log.w(TAG, "Could not check if peer is a saved contact", e)
+                false
+            }
         }
 
         /**

--- a/app/src/test/java/network/columba/app/service/MessageCollectorTest.kt
+++ b/app/src/test/java/network/columba/app/service/MessageCollectorTest.kt
@@ -371,6 +371,51 @@ class MessageCollectorTest {
         }
 
     @Test
+    fun `processMessage treats saved contact without favorite announce as favorite`() =
+        runBlocking {
+            // Given: A message from a peer saved via "Save to Contacts" (Chats/Messaging
+            // screens). Those flows write to the contacts table and never touch the
+            // legacy announce isFavorite flag, so the announce row reports
+            // isFavorite = false even though the peer IS a saved contact.
+            val testMessage =
+                ReceivedMessage(
+                    messageHash = "contact_msg",
+                    content = "Message from saved contact",
+                    sourceHash = testSourceHash,
+                    destinationHash = testDestHash,
+                    timestamp = System.currentTimeMillis(),
+                    fieldsJson = null,
+                    publicKey = null,
+                )
+
+            // Announce row exists but is NOT favorited (Save to Contacts never sets it)
+            coEvery { announceRepository.getAnnounce(testSourceHashHex) } returns
+                mockk {
+                    every { isFavorite } returns false
+                }
+            // But the peer IS in the contacts table
+            coEvery { contactRepository.hasContact(testSourceHashHex) } returns true
+
+            // When: Start collecting and emit
+            val startResult = runCatching { messageCollector.startCollecting() }
+            assertTrue("startCollecting should complete without throwing", startResult.isSuccess)
+            kotlinx.coroutines.delay(50)
+            messageFlow.emit(testMessage)
+            kotlinx.coroutines.delay(200)
+
+            // Then: Notification should be posted with isFavorite = true, so that
+            // "Message from Saved Peer" (with "Received Message" off) still fires.
+            coVerify(timeout = 2000) {
+                notificationHelper.notifyMessageReceived(
+                    destinationHash = testSourceHashHex,
+                    peerName = any(),
+                    messagePreview = any(),
+                    isFavorite = true,
+                )
+            }
+        }
+
+    @Test
     fun `processMessage handles announce lookup failure gracefully for notifications`() =
         runBlocking {
             // Given: A message where announce lookup fails


### PR DESCRIPTION
## Summary

When **Received Message** is disabled but **Message from Saved Peer** is enabled, no notification was posted for messages from saved peers that were saved via "Save to Contacts" (Chats long-press, Messaging star), QR import, or manual entry.

`MessageCollector` resolved the saved-peer flag exclusively from the legacy `announces.isFavorite` column. Only the announce-stream star path (`AnnounceStreamViewModel.toggleContact`) sets that column; the "Save to Contacts" flows write to the `contacts` table via `ContactRepository` and never touch the flag. So `isFavorite` reached `NotificationHelper.notifyMessageReceived` as `false`, and with the general toggle off the gate `generalMessageNotifications || favoriteMessageNotifications` correctly evaluated to false and silently dropped the notification.

## Fix

`MessageCollector.isSavedPeer()` now checks both signals: the legacy announce favorite flag **OR** membership in the active identity's `contacts` table. Either being true marks the sender as a saved peer. Lookup failures keep the existing fail-safe default (`false`). Both notification call sites (new-message path and already-persisted/replay path) use the helper.

The `NotificationHelper` gate logic was already correct and is unchanged.

## Test plan

- New regression test `MessageCollectorTest > processMessage treats saved contact without favorite announce as favorite`: contacts-table-only saved peer (announce `isFavorite = false`, `hasContact = true`) asserts `notifyMessageReceived` is called with `isFavorite = true`. Verified red before the fix, green after.
- Full `:app` unit suite (noSentryKotlinBackendDebug) on the pre-rebase base: 5982 tests, 0 failures, 0 errors (15 skipped).
- Targeted `MessageCollectorTest` + `NotificationHelperTest` green on the rebased head.
- detekt + ktlint clean on the changed module.
- Device smoke pending (phone runs a dev build ahead of main; requires rebuild on that base).

## Risk / rollback

- Behavioral: contacts-table-only saved peers now also notify under the favorite-only setting. Non-contacts are unaffected (still gated by the general toggle only).
- Minor perf: one extra `contacts` table EXISTS query per received message, only when the announce flag is false.
- Rollback: revert the single commit.