### PR TITLE
User-configurable bottom navigation + NomadNet browsing polish

### DIFF
--- a/app/src/main/java/network/columba/app/MainActivity.kt
+++ b/app/src/main/java/network/columba/app/MainActivity.kt
@@ -1249,7 +1249,9 @@ fun ColumbaNavigation(
         listOf(
             "offline_map_download",
             "messaging/",
-            "announce_detail/",
+            // announce_detail (Node Details) intentionally keeps the nav bar:
+            // it sits one tap from the tabs, and hiding the bar made returning
+            // from NomadNet flows feel jarring.
             "message_detail/",
             "theme_editor",
             "rnode_wizard",

--- a/app/src/main/java/network/columba/app/MainActivity.kt
+++ b/app/src/main/java/network/columba/app/MainActivity.kt
@@ -90,6 +90,7 @@ import network.columba.app.navigation.navigateToAnsweredCall
 import network.columba.app.navigation.navigateToEntity
 import network.columba.app.navigation.navigateToIncomingCall
 import network.columba.app.navigation.shouldPresentIncomingCall
+import network.columba.app.navigation.NavTab
 import network.columba.app.notifications.CallNotificationHelper
 import network.columba.app.repository.InterfaceRepository
 import network.columba.app.repository.SettingsRepository
@@ -1328,6 +1329,25 @@ fun ColumbaNavigation(
                                     label = { Text(tab.label) },
                                     selected = tab.matchesRoute(currentRoute),
                                     onClick = {
+                                        if (currentRoute?.startsWith("nomadnet") == true) {
+                                            if (tab == NavTab.NOMADNET) {
+                                                // Already browsing; the site session ends via
+                                                // Close Site or Back, not by re-tapping the tab.
+                                                return@NavigationBarItem
+                                            }
+                                            // Browsing is modal over the tab tree: collapse
+                                            // the NomadNet stack first, then switch tabs
+                                            // normally. Popping (rather than saving state)
+                                            // guarantees a single browser view, so tab taps
+                                            // can never stack duplicates or fight over
+                                            // scroll position.
+                                            while (
+                                                navController.currentDestination?.route
+                                                    ?.startsWith("nomadnet") == true
+                                            ) {
+                                                if (!navController.popBackStack()) break
+                                            }
+                                        }
                                         navController.navigate(tab.tabRoute) {
                                             popUpTo(navController.graph.startDestinationId) {
                                                 saveState = true
@@ -2441,6 +2461,9 @@ fun ColumbaNavigation(
                                     destinationHash = destHash,
                                     initialPath = path,
                                     onBackClick = { navController.popBackStack() },
+                                    // Standalone browser: after closing the site,
+                                    // pop back the way Back does.
+                                    onCloseSite = { navController.popBackStack() },
                                     onOpenConversation = { conversationHash ->
                                         val encodedHash = Uri.encode(conversationHash)
                                         val encodedName = Uri.encode(conversationHash.take(12))
@@ -2458,6 +2481,11 @@ fun ColumbaNavigation(
                                     destinationHash = lastNodeHash.orEmpty(),
                                     showHomeEntry = lastNodeHash.isNullOrEmpty(),
                                     onBackClick = { navController.popBackStack() },
+                                    // Close Site on the tab home: closeSite() drops the
+                                    // persisted last-node hash, the state flow flips
+                                    // showHomeEntry, and the screen swaps to the address
+                                    // prompt in place - no navigation needed.
+                                    onCloseSite = {},
                                     onOpenConversation = { conversationHash ->
                                         val encodedHash = Uri.encode(conversationHash)
                                         val encodedName = Uri.encode(conversationHash.take(12))

--- a/app/src/main/java/network/columba/app/MainActivity.kt
+++ b/app/src/main/java/network/columba/app/MainActivity.kt
@@ -50,7 +50,6 @@ import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.MutableState
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
-import androidx.compose.runtime.mutableIntStateOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
@@ -741,7 +740,6 @@ fun ColumbaNavigation(
     val context = LocalContext.current
     val lifecycleOwner = LocalLifecycleOwner.current
     val navController = rememberNavController()
-    var selectedTab by remember { mutableIntStateOf(0) }
 
     LaunchedEffect(detachedUsbDeviceEvents, navController) {
         detachedUsbDeviceEvents.collect { deviceId ->
@@ -926,7 +924,6 @@ fun ColumbaNavigation(
                     }
                     is PendingNavigation.AddContact -> {
                         // Navigate to contacts tab and trigger add contact dialog
-                        selectedTab = 1 // Contacts tab
                         navController.navigate(Screen.Contacts.route) {
                             popUpTo(navController.graph.startDestinationId) {
                                 saveState = true
@@ -950,7 +947,6 @@ fun ColumbaNavigation(
                     is PendingNavigation.SharedText -> {
                         sharedTextViewModel.setText(navigation.text)
 
-                        selectedTab = 0
                         val poppedToChats = navController.popBackStack(Screen.Chats.route, inclusive = false)
                         if (!poppedToChats) {
                             navController.navigate(Screen.Chats.route) {
@@ -966,7 +962,6 @@ fun ColumbaNavigation(
                     is PendingNavigation.SharedImage -> {
                         sharedImageViewModel.setImages(navigation.uris)
 
-                        selectedTab = 0
                         val poppedToChats = navController.popBackStack(Screen.Chats.route, inclusive = false)
                         if (!poppedToChats) {
                             navController.navigate(Screen.Chats.route) {
@@ -1170,19 +1165,6 @@ fun ColumbaNavigation(
     val navBackStackEntry by navController.currentBackStackEntryAsState()
     val currentRoute = navBackStackEntry?.destination?.route
 
-    // Synchronize selectedTab with current route when navigating back
-    LaunchedEffect(currentRoute) {
-        Log.d("ColumbaNavigation", "📍 currentRoute changed to: $currentRoute")
-        selectedTab =
-            when (currentRoute) {
-                Screen.Chats.route -> 0
-                Screen.Contacts.route -> 1
-                Screen.Map.route -> 2
-                Screen.Settings.route -> 3
-                else -> selectedTab // Keep current selection for nested screens
-            }
-    }
-
     // Observe call state for incoming calls and navigate to IncomingCallScreen.
     // Composable functions can't @Inject, so the RnsTelephony seam singleton is
     // reached through Hilt's RnsTelephonyEntryPoint. Replaces the A.9-era
@@ -1277,20 +1259,15 @@ fun ColumbaNavigation(
             "voice_call/",
             "incoming_call/",
             "interface_stats/",
-            "nomadnet_browser/",
         )
     val shouldShowBottomNav =
         currentRoute != null &&
             currentRoute !in hideBottomNavScreens &&
             hideBottomNavPrefixes.none { currentRoute.startsWith(it) }
 
-    val screens =
-        listOf(
-            Screen.Chats,
-            Screen.Contacts,
-            Screen.Map,
-            Screen.Settings,
-        )
+    // User-configurable bottom bar tabs (Settings pinned last, max NavTab.MAX_TABS).
+    // The NomadNet tab is a normal tab: the bar stays visible while browsing pages.
+    val bottomNavTabs = settingsState.bottomNavTabs
 
     // Double-back-to-exit state: first back press on a root tab shows a toast,
     // second press within 2 seconds finishes the activity.
@@ -1345,14 +1322,13 @@ fun ColumbaNavigation(
                 bottomBar = {
                     if (shouldShowBottomNav) {
                         NavigationBar {
-                            screens.forEachIndexed { index, screen ->
+                            bottomNavTabs.forEach { tab ->
                                 NavigationBarItem(
-                                    icon = { Icon(screen.icon, contentDescription = null) },
-                                    label = { Text(screen.title) },
-                                    selected = selectedTab == index,
+                                    icon = { Icon(tab.icon, contentDescription = null) },
+                                    label = { Text(tab.label) },
+                                    selected = tab.matchesRoute(currentRoute),
                                     onClick = {
-                                        selectedTab = index
-                                        navController.navigate(screen.route) {
+                                        navController.navigate(tab.tabRoute) {
                                             popUpTo(navController.graph.startDestinationId) {
                                                 saveState = true
                                             }
@@ -1741,7 +1717,6 @@ fun ColumbaNavigation(
                                         navController.navigate("apk_sharing")
                                     },
                                     onNavigateToAnnounces = { filterType ->
-                                        selectedTab = 1 // Announces tab
                                         val route =
                                             if (filterType != null) {
                                                 "${Screen.Announces.route}?filterType=$filterType"
@@ -2422,7 +2397,6 @@ fun ColumbaNavigation(
                                     },
                                     onStartChat = { destHash, peerName ->
                                         // Navigate back to chats tab
-                                        selectedTab = 0
                                         navController.navigate(Screen.Chats.route) {
                                             popUpTo(navController.graph.startDestinationId) {
                                                 saveState = true
@@ -2466,6 +2440,23 @@ fun ColumbaNavigation(
                                 NomadNetBrowserScreen(
                                     destinationHash = destHash,
                                     initialPath = path,
+                                    onBackClick = { navController.popBackStack() },
+                                    onOpenConversation = { conversationHash ->
+                                        val encodedHash = Uri.encode(conversationHash)
+                                        val encodedName = Uri.encode(conversationHash.take(12))
+                                        navController.navigate("messaging/$encodedHash/$encodedName")
+                                    },
+                                )
+                            }
+
+                            // NomadNet tab home: reopens the last-browsed node,
+                            // or shows the address-entry prompt on a fresh install.
+                            appComposable(AppDestination.NOMADNET_HOME) {
+                                DoubleBackToExitHandler(AppDestination.NOMADNET_HOME.routePattern)
+                                val lastNodeHash = settingsState.nomadNetLastNodeHash
+                                NomadNetBrowserScreen(
+                                    destinationHash = lastNodeHash.orEmpty(),
+                                    showHomeEntry = lastNodeHash.isNullOrEmpty(),
                                     onBackClick = { navController.popBackStack() },
                                     onOpenConversation = { conversationHash ->
                                         val encodedHash = Uri.encode(conversationHash)

--- a/app/src/main/java/network/columba/app/navigation/AppDestination.kt
+++ b/app/src/main/java/network/columba/app/navigation/AppDestination.kt
@@ -120,6 +120,10 @@ enum class AppDestination(
             ),
         externalNavigationPolicy = ExternalNavigationPolicy.REUSE_SAME_ENTITY,
     ),
+    NOMADNET_HOME(
+        "nomadnet_home",
+        backContract = BackContract.TOP_LEVEL,
+    ),
     OFFLINE_MAPS("offline_maps"),
     OFFLINE_MAP_DOWNLOAD(
         "offline_map_download?updateRegionId={updateRegionId}",

--- a/app/src/main/java/network/columba/app/navigation/NavTab.kt
+++ b/app/src/main/java/network/columba/app/navigation/NavTab.kt
@@ -1,0 +1,84 @@
+package network.columba.app.navigation
+
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Chat
+import androidx.compose.material.icons.filled.Language
+import androidx.compose.material.icons.filled.Map
+import androidx.compose.material.icons.filled.People
+import androidx.compose.material.icons.filled.Sensors
+import androidx.compose.material.icons.filled.Settings
+import androidx.compose.ui.graphics.vector.ImageVector
+
+/**
+ * Registry of destinations that may appear in the user-configurable bottom
+ * navigation bar.
+ *
+ * The user chooses which tabs appear and in what order; the persisted form is
+ * a comma-separated list of [id] values (see SettingsRepository). [SETTINGS]
+ * is pinned: it is always present and always rendered last, so Settings can
+ * never be removed from the bar. [sanitize] is the single authority for what
+ * the bar renders - it drops unknown ids (forward/backward compatible),
+ * dedupes, enforces the pin, and clamps the total to [MAX_TABS].
+ *
+ * [routePrefix] drives tab selection: a tab is selected while the current
+ * navigation route starts with its prefix, which keeps a tab highlighted
+ * across parameterized routes (e.g. `announce_stream?filterType=all`).
+ */
+enum class NavTab(
+    val id: String,
+    val routePrefix: String,
+    val tabRoute: String,
+    val label: String,
+    val icon: ImageVector,
+) {
+    CHATS("chats", "chats", "chats", "Chats", Icons.Default.Chat),
+    ANNOUNCES("announces", "announce_stream", "announce_stream", "Announces", Icons.Default.Sensors),
+    CONTACTS("contacts", "contacts", "contacts", "Contacts", Icons.Default.People),
+    MAP("map", "map", "map", "Map", Icons.Default.Map),
+
+    // The NomadNet tab lands on nomadnet_home (which resolves the last-browsed
+    // node); its selection prefix also covers nomadnet_browser/... so the tab
+    // stays highlighted while browsing pages with the bar visible.
+    NOMADNET("nomadnet", "nomadnet", "nomadnet_home", "NomadNet", Icons.Default.Language),
+    SETTINGS("settings", "settings", "settings", "Settings", Icons.Default.Settings),
+    ;
+
+    /** True when [currentRoute] belongs to this tab. */
+    fun matchesRoute(currentRoute: String?): Boolean =
+        currentRoute != null && currentRoute.startsWith(routePrefix)
+
+    companion object {
+        /** Maximum number of tabs in the bar, including the pinned Settings tab. */
+        const val MAX_TABS = 5
+
+        /** Bar layout shown before the user configures anything. */
+        val DEFAULT: List<NavTab> = listOf(CHATS, CONTACTS, MAP, SETTINGS)
+
+        /** All tabs the user may toggle in the settings card (Settings is pinned). */
+        val CONFIGURABLE: List<NavTab> = entries.filter { it != SETTINGS }
+
+        fun fromId(id: String): NavTab? = entries.firstOrNull { it.id == id }
+
+        /**
+         * Parse and normalize a persisted CSV of tab ids into the exact list of
+         * tabs the bottom bar should render. Malformed, unknown, or duplicate
+         * entries are dropped; Settings is appended if missing; the result is
+         * clamped to [MAX_TABS] entries. Falls back to [DEFAULT] when nothing
+         * valid remains, so the bar can never render empty.
+         */
+        fun sanitize(csv: String?): List<NavTab> {
+            val parsed =
+                csv
+                    ?.split(',')
+                    ?.map { it.trim() }
+                    ?.mapNotNull { fromId(it) }
+                    ?.distinct()
+                    .orEmpty()
+            if (parsed.isEmpty()) return DEFAULT
+            val withoutSettings = parsed.filter { it != SETTINGS }
+            val overflow = withoutSettings.size - (MAX_TABS - 1)
+            val kept = if (overflow > 0) withoutSettings.dropLast(overflow) else withoutSettings
+            return kept + SETTINGS
+        }
+    }
+}

--- a/app/src/main/java/network/columba/app/repository/SettingsRepository.kt
+++ b/app/src/main/java/network/columba/app/repository/SettingsRepository.kt
@@ -141,6 +141,8 @@ class SettingsRepository
             val MAP_MARKER_DECLUTTER_ENABLED = booleanPreferencesKey("map_marker_declutter_enabled")
             val MAP_STYLE_PREFERENCE = stringPreferencesKey("map_style_preference")
             val NOMADNET_RENDERING_MODE = stringPreferencesKey("nomadnet_rendering_mode")
+            val NOMADNET_LAST_NODE = stringPreferencesKey("nomadnet_last_node")
+            val BOTTOM_NAV_TABS = stringPreferencesKey("bottom_nav_tabs")
             val HTTP_ENABLED_FOR_DOWNLOAD = booleanPreferencesKey("http_enabled_for_download")
 
             // Privacy preferences
@@ -1476,6 +1478,47 @@ class SettingsRepository
         suspend fun saveNomadNetRenderingMode(modeName: String) {
             context.dataStore.edit { preferences ->
                 preferences[PreferencesKeys.NOMADNET_RENDERING_MODE] = modeName
+            }
+        }
+
+        /**
+         * Flow of the destination hash of the last NomadNet page the user loaded,
+         * or null when none. The bottom-nav NomadNet tab navigates here so the
+         * tab reopens where the user left off; a fresh install falls back to the
+         * caller-provided default entry node.
+         */
+        val nomadNetLastNodeHashFlow: Flow<String?> =
+            context.dataStore.data
+                .map { preferences -> preferences[PreferencesKeys.NOMADNET_LAST_NODE] }
+                .distinctUntilChanged()
+
+        /**
+         * Remember the destination hash of the most recently loaded NomadNet page.
+         */
+        suspend fun saveNomadNetLastNodeHash(nodeHash: String) {
+            if (nodeHash.isBlank()) return
+            context.dataStore.edit { preferences ->
+                preferences[PreferencesKeys.NOMADNET_LAST_NODE] = nodeHash
+            }
+        }
+
+        /**
+         * Flow of the user-configured bottom navigation tabs, stored as a
+         * comma-separated list of [network.columba.app.navigation.NavTab] ids.
+         * Emits null before first configuration; consumers map through
+         * [network.columba.app.navigation.NavTab.sanitize] for a normalized list.
+         */
+        val bottomNavTabsFlow: Flow<String?> =
+            context.dataStore.data
+                .map { preferences -> preferences[PreferencesKeys.BOTTOM_NAV_TABS] }
+                .distinctUntilChanged()
+
+        /**
+         * Persist the bottom navigation tab layout as a comma-separated id list.
+         */
+        suspend fun saveBottomNavTabs(csv: String) {
+            context.dataStore.edit { preferences ->
+                preferences[PreferencesKeys.BOTTOM_NAV_TABS] = csv
             }
         }
 

--- a/app/src/main/java/network/columba/app/repository/SettingsRepository.kt
+++ b/app/src/main/java/network/columba/app/repository/SettingsRepository.kt
@@ -1494,11 +1494,21 @@ class SettingsRepository
 
         /**
          * Remember the destination hash of the most recently loaded NomadNet page.
+         * [whileActive] is evaluated inside the DataStore transaction (under the
+         * edit mutex), so callers can guard against a concurrent
+         * [clearNomadNetLastNodeHash] resurrecting a just-closed site: either the
+         * predicate fails and nothing is written, or the write lands before any
+         * later clear and is properly erased by it.
          */
-        suspend fun saveNomadNetLastNodeHash(nodeHash: String) {
+        suspend fun saveNomadNetLastNodeHash(
+            nodeHash: String,
+            whileActive: () -> Boolean = { true },
+        ) {
             if (nodeHash.isBlank()) return
             context.dataStore.edit { preferences ->
-                preferences[PreferencesKeys.NOMADNET_LAST_NODE] = nodeHash
+                if (whileActive()) {
+                    preferences[PreferencesKeys.NOMADNET_LAST_NODE] = nodeHash
+                }
             }
         }
 

--- a/app/src/main/java/network/columba/app/repository/SettingsRepository.kt
+++ b/app/src/main/java/network/columba/app/repository/SettingsRepository.kt
@@ -1503,6 +1503,17 @@ class SettingsRepository
         }
 
         /**
+         * Forget the last-browsed NomadNet page (Close Site). The bottom-nav
+         * NomadNet tab then reopens at the address-entry prompt instead of the
+         * closed site.
+         */
+        suspend fun clearNomadNetLastNodeHash() {
+            context.dataStore.edit { preferences ->
+                preferences.remove(PreferencesKeys.NOMADNET_LAST_NODE)
+            }
+        }
+
+        /**
          * Flow of the user-configured bottom navigation tabs, stored as a
          * comma-separated list of [network.columba.app.navigation.NavTab] ids.
          * Emits null before first configuration; consumers map through

--- a/app/src/main/java/network/columba/app/ui/screens/AnnounceDetailScreen.kt
+++ b/app/src/main/java/network/columba/app/ui/screens/AnnounceDetailScreen.kt
@@ -201,7 +201,10 @@ fun AnnounceDetailScreen(
                         .fillMaxSize()
                         .padding(paddingValues)
                         .verticalScroll(rememberScrollState())
-                        .padding(16.dp),
+                        // The outer bottom nav bar is visible on this screen, so
+                        // clear its height (same 88.dp convention as other
+                        // nav-visible screens) for the last card.
+                        .padding(start = 16.dp, end = 16.dp, top = 16.dp, bottom = 88.dp),
                 verticalArrangement = Arrangement.spacedBy(16.dp),
             ) {
                 // Identicon header

--- a/app/src/main/java/network/columba/app/ui/screens/NomadNetBrowserScreen.kt
+++ b/app/src/main/java/network/columba/app/ui/screens/NomadNetBrowserScreen.kt
@@ -66,7 +66,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clipToBounds
 import androidx.compose.ui.focus.FocusRequester
 import androidx.compose.ui.focus.focusRequester
-import androidx.compose.ui.focus.onFocusChanged
+import androidx.compose.ui.focus.onFocusEvent
 import androidx.compose.ui.graphics.SolidColor
 import androidx.compose.ui.graphics.TransformOrigin
 import androidx.compose.ui.input.pointer.PointerEventPass
@@ -263,7 +263,12 @@ fun NomadNetBrowserScreen(
                                 Modifier
                                     .fillMaxWidth()
                                     .focusRequester(urlFocusRequester)
-                                    .onFocusChanged { focusState ->
+                                    // onFocusEvent (not onFocusChanged): fires only on real
+                                    // focus transitions. onFocusChanged also re-fires the
+                                    // initial unfocused state when this field composes,
+                                    // which used to immediately cancel edit mode the moment
+                                    // the "Enter address" prompt turned it on.
+                                    .onFocusEvent { focusState ->
                                         if (focusState.isFocused && !isEditingUrl) {
                                             isEditingUrl = true
                                             val text = currentUrl ?: ""

--- a/app/src/main/java/network/columba/app/ui/screens/NomadNetBrowserScreen.kt
+++ b/app/src/main/java/network/columba/app/ui/screens/NomadNetBrowserScreen.kt
@@ -102,6 +102,7 @@ fun NomadNetBrowserScreen(
     initialPath: String = "/page/index.mu",
     showHomeEntry: Boolean = false,
     onBackClick: () -> Unit,
+    onCloseSite: (() -> Unit)? = null,
     onOpenConversation: (String) -> Unit = {},
     viewModel: NomadNetBrowserViewModel = hiltViewModel(),
 ) {
@@ -401,7 +402,13 @@ fun NomadNetBrowserScreen(
                             BrowserCloseSiteMenuItem(
                                 onCloseSite = {
                                     showMenu = false
-                                    onBackClick()
+                                    // Close Site is more than Back: it clears the
+                                    // session and forgets the persisted last-node
+                                    // binding. The caller decides navigation: the
+                                    // standalone browser pops, the tab home stays
+                                    // put and swaps to the address prompt.
+                                    viewModel.closeSite()
+                                    if (onCloseSite != null) onCloseSite() else onBackClick()
                                 },
                             )
                         }

--- a/app/src/main/java/network/columba/app/ui/screens/NomadNetBrowserScreen.kt
+++ b/app/src/main/java/network/columba/app/ui/screens/NomadNetBrowserScreen.kt
@@ -31,6 +31,7 @@ import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.ArrowBack
 import androidx.compose.material.icons.filled.Close
 import androidx.compose.material.icons.filled.Fingerprint
+import androidx.compose.material.icons.filled.Language
 import androidx.compose.material.icons.filled.MoreVert
 import androidx.compose.material.icons.filled.Refresh
 import androidx.compose.material3.Button
@@ -92,12 +93,14 @@ import network.columba.app.viewmodel.NomadNetBrowserViewModel.RenderingMode
 import java.io.File
 import java.util.Locale
 import kotlin.math.roundToInt
+import kotlinx.coroutines.delay
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun NomadNetBrowserScreen(
     destinationHash: String,
     initialPath: String = "/page/index.mu",
+    showHomeEntry: Boolean = false,
     onBackClick: () -> Unit,
     onOpenConversation: (String) -> Unit = {},
     viewModel: NomadNetBrowserViewModel = hiltViewModel(),
@@ -131,8 +134,18 @@ fun NomadNetBrowserScreen(
 
     // Load initial page
     LaunchedEffect(destinationHash, initialPath) {
-        if (browserState is BrowserState.Initial) {
+        if (browserState is BrowserState.Initial && destinationHash.isNotEmpty()) {
             viewModel.loadPage(destinationHash, initialPath)
+        }
+    }
+
+    // Focus the address bar when editing starts (e.g. from the home entry
+    // prompt). The TextField only composes while editing, so give it a frame
+    // before requesting focus; swallow the case where editing already ended.
+    LaunchedEffect(isEditingUrl) {
+        if (isEditingUrl) {
+            delay(100)
+            runCatching { urlFocusRequester.requestFocus() }
         }
     }
 
@@ -401,6 +414,41 @@ fun NomadNetBrowserScreen(
     ) { paddingValues ->
         when (val state = browserState) {
             is BrowserState.Initial -> {
+                if (showHomeEntry) {
+                    // Bottom-nav entry with no node yet: prompt for an address.
+                    Column(
+                        modifier =
+                            Modifier
+                                .fillMaxSize()
+                                .padding(paddingValues)
+                                .padding(horizontal = 32.dp),
+                        horizontalAlignment = Alignment.CenterHorizontally,
+                        verticalArrangement = Arrangement.Center,
+                    ) {
+                        Icon(
+                            imageVector = Icons.Default.Language,
+                            contentDescription = null,
+                            modifier = Modifier.size(56.dp),
+                            tint = MaterialTheme.colorScheme.primary,
+                        )
+                        Spacer(modifier = Modifier.height(16.dp))
+                        Text(
+                            text = "NomadNet Browser",
+                            style = MaterialTheme.typography.titleMedium,
+                            fontWeight = FontWeight.Bold,
+                        )
+                        Spacer(modifier = Modifier.height(8.dp))
+                        Text(
+                            text = "Enter a node address to start browsing.\nFormat: <hash>:/page/index.mu",
+                            style = MaterialTheme.typography.bodyMedium,
+                            color = MaterialTheme.colorScheme.onSurfaceVariant,
+                        )
+                        Spacer(modifier = Modifier.height(16.dp))
+                        TextButton(onClick = { isEditingUrl = true }) {
+                            Text("Enter address")
+                        }
+                    }
+                }
                 // Nothing to show yet
             }
 
@@ -445,10 +493,13 @@ fun NomadNetBrowserScreen(
                     // imePadding required because MainActivity uses enableEdgeToEdge(),
                     // which makes the manifest's adjustResize a no-op — without it the
                     // soft keyboard slides up on top of focused micron form fields.
+                    // 88.dp bottom clears the always-visible bottom nav bar
+                    // (matches ContactsScreen's content padding convention).
                     modifier =
                         Modifier
                             .fillMaxSize()
                             .padding(paddingValues)
+                            .padding(bottom = 88.dp)
                             .imePadding(),
                 ) {
                     if (renderingMode == RenderingMode.MONOSPACE_SCROLL) {

--- a/app/src/main/java/network/columba/app/ui/screens/NomadNetBrowserScreen.kt
+++ b/app/src/main/java/network/columba/app/ui/screens/NomadNetBrowserScreen.kt
@@ -62,6 +62,7 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
+import androidx.compose.ui.BiasAlignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clipToBounds
 import androidx.compose.ui.focus.FocusRequester
@@ -433,89 +434,94 @@ fun NomadNetBrowserScreen(
                     // with the field's focus handler and made the editor flash
                     // for a frame. This field is always present and submits
                     // directly, so there is no shared edit-state to clobber.
+                    // No auto-focus: opening the tab must not pop the keyboard;
+                    // the user taps the field when they actually want to type.
                     var homeUrlValue by remember { mutableStateOf(TextFieldValue("")) }
-                    val homeFocusRequester = remember { FocusRequester() }
-                    LaunchedEffect(Unit) {
-                        // One frame so the field is attached before focus.
-                        delay(100)
-                        runCatching { homeFocusRequester.requestFocus() }
-                    }
                     val submitHomeUrl: () -> Unit = {
                         if (homeUrlValue.text.isNotBlank()) {
                             viewModel.navigateToUrl(homeUrlValue.text)
                         }
                     }
-                    Column(
+                    Box(
                         modifier =
                             Modifier
                                 .fillMaxSize()
                                 .padding(paddingValues)
-                                .padding(horizontal = 32.dp),
-                        horizontalAlignment = Alignment.CenterHorizontally,
-                        verticalArrangement = Arrangement.Center,
+                                // Edge-to-edge makes adjustResize a no-op, so pad
+                                // for the IME explicitly; when the keyboard shows,
+                                // the box shrinks and the block rides up above it.
+                                .imePadding(),
+                        // Bias the block toward the upper third so the Go button
+                        // stays comfortably clear of the keyboard.
+                        contentAlignment = BiasAlignment(0f, -0.4f),
                     ) {
-                        Icon(
-                            imageVector = Icons.Default.Language,
-                            contentDescription = null,
-                            modifier = Modifier.size(56.dp),
-                            tint = MaterialTheme.colorScheme.primary,
-                        )
-                        Spacer(modifier = Modifier.height(16.dp))
-                        Text(
-                            text = "NomadNet Browser",
-                            style = MaterialTheme.typography.titleMedium,
-                            fontWeight = FontWeight.Bold,
-                        )
-                        Spacer(modifier = Modifier.height(8.dp))
-                        Text(
-                            text = "Enter a node address to start browsing.\nFormat: <hash>:/page/index.mu",
-                            style = MaterialTheme.typography.bodyMedium,
-                            color = MaterialTheme.colorScheme.onSurfaceVariant,
-                        )
-                        Spacer(modifier = Modifier.height(16.dp))
-                        BasicTextField(
-                            value = homeUrlValue,
-                            onValueChange = { homeUrlValue = it },
-                            singleLine = true,
-                            textStyle =
-                                TextStyle(
-                                    fontFamily = FontFamily.Monospace,
-                                    fontSize = MaterialTheme.typography.bodyMedium.fontSize,
-                                    color = MaterialTheme.colorScheme.onSurface,
-                                ),
-                            cursorBrush = SolidColor(MaterialTheme.colorScheme.primary),
-                            keyboardOptions = KeyboardOptions(imeAction = ImeAction.Go),
-                            keyboardActions = KeyboardActions(onGo = { submitHomeUrl() }),
+                        Column(
                             modifier =
                                 Modifier
                                     .fillMaxWidth()
-                                    .focusRequester(homeFocusRequester),
-                            decorationBox = { innerTextField ->
-                                Box(
-                                    modifier =
-                                        Modifier
-                                            .fillMaxWidth()
-                                            .background(
-                                                MaterialTheme.colorScheme.surface,
-                                                RoundedCornerShape(12.dp),
-                                            ).padding(horizontal = 16.dp, vertical = 12.dp),
-                                    contentAlignment = Alignment.CenterStart,
-                                ) {
-                                    if (homeUrlValue.text.isEmpty()) {
-                                        Text(
-                                            text = "<hash>:/page/index.mu",
-                                            fontFamily = FontFamily.Monospace,
-                                            fontSize = MaterialTheme.typography.bodyMedium.fontSize,
-                                            color = MaterialTheme.colorScheme.onSurfaceVariant,
-                                        )
+                                    .padding(horizontal = 32.dp),
+                            horizontalAlignment = Alignment.CenterHorizontally,
+                        ) {
+                            Icon(
+                                imageVector = Icons.Default.Language,
+                                contentDescription = null,
+                                modifier = Modifier.size(56.dp),
+                                tint = MaterialTheme.colorScheme.primary,
+                            )
+                            Spacer(modifier = Modifier.height(16.dp))
+                            Text(
+                                text = "NomadNet Browser",
+                                style = MaterialTheme.typography.titleMedium,
+                                fontWeight = FontWeight.Bold,
+                            )
+                            Spacer(modifier = Modifier.height(8.dp))
+                            Text(
+                                text = "Enter a node address to start browsing.\nFormat: <hash>:/page/index.mu",
+                                style = MaterialTheme.typography.bodyMedium,
+                                color = MaterialTheme.colorScheme.onSurfaceVariant,
+                            )
+                            Spacer(modifier = Modifier.height(16.dp))
+                            BasicTextField(
+                                value = homeUrlValue,
+                                onValueChange = { homeUrlValue = it },
+                                singleLine = true,
+                                textStyle =
+                                    TextStyle(
+                                        fontFamily = FontFamily.Monospace,
+                                        fontSize = MaterialTheme.typography.bodyMedium.fontSize,
+                                        color = MaterialTheme.colorScheme.onSurface,
+                                    ),
+                                cursorBrush = SolidColor(MaterialTheme.colorScheme.primary),
+                                keyboardOptions = KeyboardOptions(imeAction = ImeAction.Go),
+                                keyboardActions = KeyboardActions(onGo = { submitHomeUrl() }),
+                                modifier = Modifier.fillMaxWidth(),
+                                decorationBox = { innerTextField ->
+                                    Box(
+                                        modifier =
+                                            Modifier
+                                                .fillMaxWidth()
+                                                .background(
+                                                    MaterialTheme.colorScheme.surface,
+                                                    RoundedCornerShape(12.dp),
+                                                ).padding(horizontal = 16.dp, vertical = 12.dp),
+                                        contentAlignment = Alignment.CenterStart,
+                                    ) {
+                                        if (homeUrlValue.text.isEmpty()) {
+                                            Text(
+                                                text = "<hash>:/page/index.mu",
+                                                fontFamily = FontFamily.Monospace,
+                                                fontSize = MaterialTheme.typography.bodyMedium.fontSize,
+                                                color = MaterialTheme.colorScheme.onSurfaceVariant,
+                                            )
+                                        }
+                                        innerTextField()
                                     }
-                                    innerTextField()
-                                }
-                            },
-                        )
-                        Spacer(modifier = Modifier.height(12.dp))
-                        Button(onClick = submitHomeUrl) {
-                            Text("Go")
+                                },
+                            )
+                            Spacer(modifier = Modifier.height(12.dp))
+                            Button(onClick = submitHomeUrl) {
+                                Text("Go")
+                            }
                         }
                     }
                 }

--- a/app/src/main/java/network/columba/app/ui/screens/NomadNetBrowserScreen.kt
+++ b/app/src/main/java/network/columba/app/ui/screens/NomadNetBrowserScreen.kt
@@ -420,7 +420,24 @@ fun NomadNetBrowserScreen(
         when (val state = browserState) {
             is BrowserState.Initial -> {
                 if (showHomeEntry) {
-                    // Bottom-nav entry with no node yet: prompt for an address.
+                    // Bottom-nav entry with no node yet: a dedicated address
+                    // field owned by this page. Deliberately NOT the top-bar
+                    // isEditingUrl flow — toggling that state from here raced
+                    // with the field's focus handler and made the editor flash
+                    // for a frame. This field is always present and submits
+                    // directly, so there is no shared edit-state to clobber.
+                    var homeUrlValue by remember { mutableStateOf(TextFieldValue("")) }
+                    val homeFocusRequester = remember { FocusRequester() }
+                    LaunchedEffect(Unit) {
+                        // One frame so the field is attached before focus.
+                        delay(100)
+                        runCatching { homeFocusRequester.requestFocus() }
+                    }
+                    val submitHomeUrl: () -> Unit = {
+                        if (homeUrlValue.text.isNotBlank()) {
+                            viewModel.navigateToUrl(homeUrlValue.text)
+                        }
+                    }
                     Column(
                         modifier =
                             Modifier
@@ -449,8 +466,49 @@ fun NomadNetBrowserScreen(
                             color = MaterialTheme.colorScheme.onSurfaceVariant,
                         )
                         Spacer(modifier = Modifier.height(16.dp))
-                        TextButton(onClick = { isEditingUrl = true }) {
-                            Text("Enter address")
+                        BasicTextField(
+                            value = homeUrlValue,
+                            onValueChange = { homeUrlValue = it },
+                            singleLine = true,
+                            textStyle =
+                                TextStyle(
+                                    fontFamily = FontFamily.Monospace,
+                                    fontSize = MaterialTheme.typography.bodyMedium.fontSize,
+                                    color = MaterialTheme.colorScheme.onSurface,
+                                ),
+                            cursorBrush = SolidColor(MaterialTheme.colorScheme.primary),
+                            keyboardOptions = KeyboardOptions(imeAction = ImeAction.Go),
+                            keyboardActions = KeyboardActions(onGo = { submitHomeUrl() }),
+                            modifier =
+                                Modifier
+                                    .fillMaxWidth()
+                                    .focusRequester(homeFocusRequester),
+                            decorationBox = { innerTextField ->
+                                Box(
+                                    modifier =
+                                        Modifier
+                                            .fillMaxWidth()
+                                            .background(
+                                                MaterialTheme.colorScheme.surface,
+                                                RoundedCornerShape(12.dp),
+                                            ).padding(horizontal = 16.dp, vertical = 12.dp),
+                                    contentAlignment = Alignment.CenterStart,
+                                ) {
+                                    if (homeUrlValue.text.isEmpty()) {
+                                        Text(
+                                            text = "<hash>:/page/index.mu",
+                                            fontFamily = FontFamily.Monospace,
+                                            fontSize = MaterialTheme.typography.bodyMedium.fontSize,
+                                            color = MaterialTheme.colorScheme.onSurfaceVariant,
+                                        )
+                                    }
+                                    innerTextField()
+                                }
+                            },
+                        )
+                        Spacer(modifier = Modifier.height(12.dp))
+                        Button(onClick = submitHomeUrl) {
+                            Text("Go")
                         }
                     }
                 }

--- a/app/src/main/java/network/columba/app/ui/screens/SettingsScreen.kt
+++ b/app/src/main/java/network/columba/app/ui/screens/SettingsScreen.kt
@@ -62,6 +62,7 @@ import network.columba.app.util.safeOpenUrl
 import network.columba.app.ui.screens.settings.cards.AdvancedCard
 import network.columba.app.ui.screens.settings.cards.AutoAnnounceCard
 import network.columba.app.ui.screens.settings.cards.BatteryOptimizationCard
+import network.columba.app.ui.screens.settings.cards.BottomNavigationCard
 import network.columba.app.ui.screens.settings.cards.DataMigrationCard
 import network.columba.app.ui.screens.settings.cards.IdentityCard
 import network.columba.app.ui.screens.settings.cards.ImageCompressionCard
@@ -521,6 +522,13 @@ fun SettingsScreen(
                         state.detectedCompressionPreset ==
                             network.columba.app.data.model.ImageCompressionPreset.LOW,
                     onPresetChange = { viewModel.setImageCompressionPreset(it) },
+                )
+
+                BottomNavigationCard(
+                    isExpanded = state.cardExpansionStates[SettingsCardId.BOTTOM_NAVIGATION.name] ?: false,
+                    onExpandedChange = { viewModel.toggleCardExpanded(SettingsCardId.BOTTOM_NAVIGATION, it) },
+                    tabs = state.bottomNavTabs,
+                    onTabsChange = { viewModel.setBottomNavTabs(it) },
                 )
 
                 ThemeSelectionCard(

--- a/app/src/main/java/network/columba/app/ui/screens/settings/cards/BottomNavigationCard.kt
+++ b/app/src/main/java/network/columba/app/ui/screens/settings/cards/BottomNavigationCard.kt
@@ -1,0 +1,191 @@
+package network.columba.app.ui.screens.settings.cards
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Add
+import androidx.compose.material.icons.filled.KeyboardArrowDown
+import androidx.compose.material.icons.filled.KeyboardArrowUp
+import androidx.compose.material.icons.filled.Lock
+import androidx.compose.material.icons.filled.Remove
+import androidx.compose.material.icons.filled.Sensors
+import androidx.compose.material3.FilterChip
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import network.columba.app.navigation.NavTab
+import network.columba.app.ui.components.CollapsibleSettingsCard
+
+/**
+ * Settings card for configuring the bottom navigation bar.
+ *
+ * Users toggle which shortcuts appear and reorder them with up/down controls.
+ * The Settings tab is pinned (always present, always last) and rendered as a
+ * locked row. At most [NavTab.MAX_TABS] tabs total (including Settings) can be
+ * active; the add-chips disable at capacity, and the last editable tab cannot
+ * be removed so the bar is never just Settings.
+ */
+@Composable
+fun BottomNavigationCard(
+    isExpanded: Boolean,
+    onExpandedChange: (Boolean) -> Unit,
+    tabs: List<NavTab>,
+    onTabsChange: (List<NavTab>) -> Unit,
+) {
+    CollapsibleSettingsCard(
+        title = "Bottom Navigation",
+        icon = Icons.Default.Sensors,
+        isExpanded = isExpanded,
+        onExpandedChange = onExpandedChange,
+    ) {
+        Text(
+            text = "Choose which shortcuts appear in the bottom bar (max ${NavTab.MAX_TABS}) and drag them into order. Settings is always pinned to the end.",
+            style = MaterialTheme.typography.bodySmall,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+        )
+
+        // Editable list: every tab except the pinned Settings row.
+        val editable = tabs.filter { it != NavTab.SETTINGS }
+        val available = NavTab.CONFIGURABLE.filter { it !in editable }
+        val atCapacity = editable.size >= NavTab.MAX_TABS - 1
+        // Keep at least one shortcut besides Settings so the bar always has
+        // somewhere to go besides configuration.
+        val canRemoveAny = editable.size > 1
+
+        Column(verticalArrangement = Arrangement.spacedBy(4.dp)) {
+            editable.forEachIndexed { index, tab ->
+                TabRow(
+                    tab = tab,
+                    canMoveUp = index > 0,
+                    canMoveDown = index < editable.lastIndex,
+                    onMoveUp = {
+                        onTabsChange(editable.toMutableList().also { list ->
+                            list.removeAt(index)
+                            list.add(index - 1, tab)
+                        } + NavTab.SETTINGS)
+                    },
+                    onMoveDown = {
+                        onTabsChange(editable.toMutableList().also { list ->
+                            list.removeAt(index)
+                            list.add(index + 1, tab)
+                        } + NavTab.SETTINGS)
+                    },
+                    onRemove = if (canRemoveAny) {
+                        { onTabsChange((editable - tab) + NavTab.SETTINGS) }
+                    } else {
+                        null
+                    },
+                )
+            }
+
+            // Pinned Settings row — no remove/reorder affordances.
+            TabRow(
+                tab = NavTab.SETTINGS,
+                canMoveUp = false,
+                canMoveDown = false,
+                onMoveUp = {},
+                onMoveDown = {},
+                onRemove = null,
+            )
+        }
+
+        if (available.isNotEmpty()) {
+            Text(
+                text = if (atCapacity) {
+                    "Remove a tab to add another"
+                } else {
+                    "Add a shortcut:"
+                },
+                style = MaterialTheme.typography.labelMedium,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
+            Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+                available.forEach { tab ->
+                    FilterChip(
+                        selected = false,
+                        enabled = !atCapacity,
+                        onClick = {
+                            onTabsChange((editable + tab) + NavTab.SETTINGS)
+                        },
+                        leadingIcon = {
+                            Icon(
+                                imageVector = Icons.Default.Add,
+                                contentDescription = null,
+                                modifier = Modifier.size(16.dp),
+                            )
+                        },
+                        label = { Text(tab.label) },
+                    )
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun TabRow(
+    tab: NavTab,
+    canMoveUp: Boolean,
+    canMoveDown: Boolean,
+    onMoveUp: () -> Unit,
+    onMoveDown: () -> Unit,
+    onRemove: (() -> Unit)?,
+) {
+    Row(
+        modifier = Modifier.fillMaxWidth(),
+        verticalAlignment = Alignment.CenterVertically,
+        horizontalArrangement = Arrangement.SpaceBetween,
+    ) {
+        Row(
+            verticalAlignment = Alignment.CenterVertically,
+            modifier = Modifier.weight(1f),
+        ) {
+            Icon(
+                imageVector = tab.icon,
+                contentDescription = null,
+                tint = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
+            Spacer(modifier = Modifier.width(12.dp))
+            Text(tab.label, style = MaterialTheme.typography.bodyLarge)
+            if (tab == NavTab.SETTINGS) {
+                Spacer(modifier = Modifier.width(8.dp))
+                Icon(
+                    imageVector = Icons.Default.Lock,
+                    contentDescription = "Pinned",
+                    modifier = Modifier.size(14.dp),
+                    tint = MaterialTheme.colorScheme.onSurfaceVariant,
+                )
+            }
+        }
+        if (onRemove != null) {
+            IconButton(onClick = onRemove) {
+                Icon(
+                    imageVector = Icons.Default.Remove,
+                    contentDescription = "Remove ${tab.label} from bottom bar",
+                )
+            }
+        }
+        IconButton(onClick = onMoveUp, enabled = canMoveUp) {
+            Icon(
+                imageVector = Icons.Default.KeyboardArrowUp,
+                contentDescription = "Move ${tab.label} up",
+            )
+        }
+        IconButton(onClick = onMoveDown, enabled = canMoveDown) {
+            Icon(
+                imageVector = Icons.Default.KeyboardArrowDown,
+                contentDescription = "Move ${tab.label} down",
+            )
+        }
+    }
+}

--- a/app/src/main/java/network/columba/app/ui/screens/settings/cards/BottomNavigationCard.kt
+++ b/app/src/main/java/network/columba/app/ui/screens/settings/cards/BottomNavigationCard.kt
@@ -49,7 +49,7 @@ fun BottomNavigationCard(
         onExpandedChange = onExpandedChange,
     ) {
         Text(
-            text = "Choose which shortcuts appear in the bottom bar (max ${NavTab.MAX_TABS}) and drag them into order. Settings is always pinned to the end.",
+            text = "Choose which shortcuts appear in the bottom bar (max ${NavTab.MAX_TABS}) and use the arrows to arrange them. Settings is always pinned to the end.",
             style = MaterialTheme.typography.bodySmall,
             color = MaterialTheme.colorScheme.onSurfaceVariant,
         )

--- a/app/src/main/java/network/columba/app/viewmodel/NomadNetBrowserViewModel.kt
+++ b/app/src/main/java/network/columba/app/viewmodel/NomadNetBrowserViewModel.kt
@@ -628,9 +628,9 @@ class NomadNetBrowserViewModel
             // is no longer this page and the save must not resurrect the
             // closed binding behind closeSite's clear.
             viewModelScope.launch {
-                val current = _browserState.value
-                if (current is BrowserState.PageLoaded && current.nodeHash == nodeHash) {
-                    settingsRepository.saveNomadNetLastNodeHash(nodeHash)
+                settingsRepository.saveNomadNetLastNodeHash(nodeHash) {
+                    val current = _browserState.value
+                    current is BrowserState.PageLoaded && current.nodeHash == nodeHash
                 }
             }
             partialManager.detectAndLoad(document)

--- a/app/src/main/java/network/columba/app/viewmodel/NomadNetBrowserViewModel.kt
+++ b/app/src/main/java/network/columba/app/viewmodel/NomadNetBrowserViewModel.kt
@@ -603,6 +603,9 @@ class NomadNetBrowserViewModel
                     path = path,
                     nodeHash = nodeHash,
                 )
+            // Remember where the user is so the bottom-nav NomadNet tab can
+            // reopen the last-browsed node instead of a cold default.
+            viewModelScope.launch { settingsRepository.saveNomadNetLastNodeHash(nodeHash) }
             partialManager.detectAndLoad(document)
         }
 

--- a/app/src/main/java/network/columba/app/viewmodel/NomadNetBrowserViewModel.kt
+++ b/app/src/main/java/network/columba/app/viewmodel/NomadNetBrowserViewModel.kt
@@ -623,8 +623,16 @@ class NomadNetBrowserViewModel
                     nodeHash = nodeHash,
                 )
             // Remember where the user is so the bottom-nav NomadNet tab can
-            // reopen the last-browsed node instead of a cold default.
-            viewModelScope.launch { settingsRepository.saveNomadNetLastNodeHash(nodeHash) }
+            // reopen the last-browsed node instead of a cold default. Guarded:
+            // if the user hit Close Site while this page was in flight, state
+            // is no longer this page and the save must not resurrect the
+            // closed binding behind closeSite's clear.
+            viewModelScope.launch {
+                val current = _browserState.value
+                if (current is BrowserState.PageLoaded && current.nodeHash == nodeHash) {
+                    settingsRepository.saveNomadNetLastNodeHash(nodeHash)
+                }
+            }
             partialManager.detectAndLoad(document)
         }
 

--- a/app/src/main/java/network/columba/app/viewmodel/NomadNetBrowserViewModel.kt
+++ b/app/src/main/java/network/columba/app/viewmodel/NomadNetBrowserViewModel.kt
@@ -469,6 +469,25 @@ class NomadNetBrowserViewModel
             return true
         }
 
+        /**
+         * Close the browsed site: forget the persisted last-node hash (so the
+         * bottom-nav NomadNet tab reopens at the address-entry prompt instead
+         * of this site), drop in-memory history, and reset the view state.
+         */
+        fun closeSite() {
+            // Invalidate any in-flight request so its result doesn't repopulate
+            // the view after we reset to Initial.
+            fetchEpoch++
+            stopStatusCollection()
+            stopProgressCollection()
+            partialManager.clear()
+            history.clear()
+            _canGoBack.value = false
+            _formFields.value = emptyMap()
+            _browserState.value = BrowserState.Initial
+            viewModelScope.launch { settingsRepository.clearNomadNetLastNodeHash() }
+        }
+
         fun refresh() {
             val currentState = _browserState.value
             if (currentState is BrowserState.PageLoaded) {

--- a/app/src/main/java/network/columba/app/viewmodel/SettingsViewModel.kt
+++ b/app/src/main/java/network/columba/app/viewmodel/SettingsViewModel.kt
@@ -30,6 +30,7 @@ import network.columba.app.data.model.ImageCompressionPreset
 import network.columba.app.data.repository.ContactRepository
 import network.columba.app.data.repository.IdentityRepository
 import network.columba.app.map.MapTileSourceManager
+import network.columba.app.navigation.NavTab
 import network.columba.app.repository.InterfaceRepository
 import network.columba.app.repository.SettingsRepository
 import network.columba.app.rns.api.model.BatteryProfile
@@ -64,6 +65,7 @@ enum class SettingsCardId {
     MAP_SOURCES,
     MESSAGE_DELIVERY,
     IMAGE_COMPRESSION,
+    BOTTOM_NAVIGATION,
     THEME,
     BATTERY,
     DATA_MIGRATION,
@@ -208,6 +210,11 @@ data class SettingsState(
     val includePrereleaseUpdates: Boolean = false,
     // Message sort order: false = received time (default), true = sent time
     val sortMessagesBySentTime: Boolean = false,
+    // User-configured bottom navigation tabs (normalized: Settings pinned last,
+    // max NavTab.MAX_TABS entries). Matches the persisted value via sanitize().
+    val bottomNavTabs: List<network.columba.app.navigation.NavTab> = network.columba.app.navigation.NavTab.DEFAULT,
+    // Destination hash of the last-browsed NomadNet node, or null when none.
+    val nomadNetLastNodeHash: String? = null,
 )
 
 @Suppress("TooManyFunctions", "LargeClass") // ViewModel with many user interaction methods is expected
@@ -286,6 +293,8 @@ class SettingsViewModel
             loadMapSourceSettings()
             // Load notifications enabled setting
             loadNotificationsSettings()
+            // Load user-configured bottom navigation tabs
+            loadBottomNavTabs()
             // Load privacy settings
             loadPrivacySettings()
             // Load protocol versions for About screen
@@ -1720,6 +1729,44 @@ class SettingsViewModel
                 settingsRepository.notificationsEnabledFlow.collect { enabled ->
                     _state.update { it.copy(notificationsEnabled = enabled) }
                 }
+            }
+        }
+
+        /**
+         * Load the user-configured bottom navigation tabs. Subscribes to the
+         * persisted value so the bar updates live when the settings card changes.
+         * Values pass through [NavTab.sanitize] so a corrupt or stale layout can
+         * never render an empty or over-full bar.
+         */
+        private fun loadBottomNavTabs() {
+            viewModelScope.launch {
+                settingsRepository.bottomNavTabsFlow.collect { csv ->
+                    val tabs = NavTab.sanitize(csv)
+                    _state.update { current ->
+                        if (current.bottomNavTabs == tabs) current else current.copy(bottomNavTabs = tabs)
+                    }
+                }
+            }
+            viewModelScope.launch {
+                settingsRepository.nomadNetLastNodeHashFlow.collect { hash ->
+                    _state.update { current ->
+                        if (current.nomadNetLastNodeHash == hash) current else current.copy(nomadNetLastNodeHash = hash)
+                    }
+                }
+            }
+        }
+
+        /**
+         * Persist a new bottom navigation tab layout. The list is sanitized before
+         * saving (Settings pinned last, capped at [NavTab.MAX_TABS]), so callers
+         * cannot store an invalid layout.
+         */
+        fun setBottomNavTabs(tabs: List<NavTab>) {
+            val sanitized = NavTab.sanitize(tabs.joinToString(",") { it.id })
+            viewModelScope.launch {
+                settingsRepository.saveBottomNavTabs(sanitized.joinToString(",") { it.id })
+                _state.update { it.copy(bottomNavTabs = sanitized) }
+                Log.d(TAG, "Bottom navigation tabs updated: ${sanitized.map { it.id }}")
             }
         }
 

--- a/app/src/main/java/network/columba/app/viewmodel/SettingsViewModel.kt
+++ b/app/src/main/java/network/columba/app/viewmodel/SettingsViewModel.kt
@@ -596,6 +596,10 @@ class SettingsViewModel
                             incomingMessageSizeLimitKb = _state.value.incomingMessageSizeLimitKb,
                             // Preserve message sorting from loadLocationSharingSettings()
                             sortMessagesBySentTime = _state.value.sortMessagesBySentTime,
+                            // Preserve bottom nav tabs + last-browsed NomadNet node
+                            // from loadBottomNavTabs()
+                            bottomNavTabs = _state.value.bottomNavTabs,
+                            nomadNetLastNodeHash = _state.value.nomadNetLastNodeHash,
                             // Preserve protocol versions from fetchProtocolVersions()
                             reticulumVersion = _state.value.reticulumVersion,
                             lxmfVersion = _state.value.lxmfVersion,

--- a/app/src/test/java/network/columba/app/navigation/NavTabTest.kt
+++ b/app/src/test/java/network/columba/app/navigation/NavTabTest.kt
@@ -1,0 +1,79 @@
+package network.columba.app.navigation
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class NavTabTest {
+    @Test
+    fun `sanitize falls back to default for null, blank, and all-unknown input`() {
+        assertEquals(NavTab.DEFAULT, NavTab.sanitize(null))
+        assertEquals(NavTab.DEFAULT, NavTab.sanitize(""))
+        assertEquals(NavTab.DEFAULT, NavTab.sanitize(" , ,, bogus"))
+    }
+
+    @Test
+    fun `sanitize drops unknown ids and dedupes`() {
+        assertEquals(
+            listOf(NavTab.CHATS, NavTab.MAP, NavTab.SETTINGS),
+            NavTab.sanitize("chats,bogus,map,chats"),
+        )
+    }
+
+    @Test
+    fun `sanitize always appends pinned settings last`() {
+        assertEquals(
+            listOf(NavTab.CHATS, NavTab.CONTACTS, NavTab.SETTINGS),
+            NavTab.sanitize("chats,contacts"),
+        )
+        assertEquals(
+            listOf(NavTab.MAP, NavTab.SETTINGS),
+            NavTab.sanitize("settings,map,settings"),
+        )
+    }
+
+    @Test
+    fun `sanitize clamps to MAX_TABS including settings`() {
+        val result = NavTab.sanitize("chats,announces,contacts,map,nomadnet,settings")
+        assertEquals(NavTab.MAX_TABS, result.size)
+        assertEquals(NavTab.SETTINGS, result.last())
+        // Overflow drops the last editable entries; the first MAX-1 keep their place.
+        assertEquals(listOf("chats", "announces", "contacts", "map"), result.dropLast(1).map { it.id })
+    }
+
+    @Test
+    fun `sanitize of already valid layout is a fixed point`() {
+        val valid = listOf(NavTab.MAP, NavTab.NOMADNET, NavTab.SETTINGS)
+        val csv = valid.joinToString(",") { it.id }
+        assertEquals(valid, NavTab.sanitize(csv))
+        assertEquals(valid, NavTab.sanitize(NavTab.sanitize(csv).joinToString(",") { it.id }))
+    }
+
+    @Test
+    fun `settings can never be removed`() {
+        val withoutSettings = NavTab.CONFIGURABLE.take(1).map { it.id }.joinToString(",")
+        val result = NavTab.sanitize(withoutSettings)
+        assertTrue("Settings must always be present", NavTab.SETTINGS in result)
+        assertFalse(NavTab.CONFIGURABLE.contains(NavTab.SETTINGS))
+    }
+
+    @Test
+    fun `matchesRoute highlights across parameterized routes`() {
+        assertTrue(NavTab.ANNOUNCES.matchesRoute("announce_stream?filterType=all"))
+        assertTrue(NavTab.NOMADNET.matchesRoute("nomadnet_browser/0123?path=%2F"))
+        assertTrue(NavTab.NOMADNET.matchesRoute("nomadnet_home"))
+        assertFalse(NavTab.CHATS.matchesRoute("messaging/abc/Name"))
+        assertFalse(NavTab.CHATS.matchesRoute(null))
+    }
+
+    @Test
+    fun `every tab navigates to a route matching its own prefix`() {
+        NavTab.entries.forEach { tab ->
+            assertTrue(
+                "${tab.name} tab route ${tab.tabRoute} must match its own prefix",
+                tab.matchesRoute(tab.tabRoute),
+            )
+        }
+    }
+}

--- a/app/src/test/java/network/columba/app/viewmodel/NomadNetBrowserViewModelTest.kt
+++ b/app/src/test/java/network/columba/app/viewmodel/NomadNetBrowserViewModelTest.kt
@@ -67,7 +67,7 @@ class NomadNetBrowserViewModelTest {
         // No persisted rendering mode by default; individual tests can override.
         every { settingsRepository.nomadNetRenderingModeFlow } returns flowOf(null)
         coEvery { settingsRepository.saveNomadNetRenderingMode(any()) } just Runs
-        coEvery { settingsRepository.saveNomadNetLastNodeHash(any()) } just Runs
+        coEvery { settingsRepository.saveNomadNetLastNodeHash(any(), any()) } just Runs
         coEvery { settingsRepository.clearNomadNetLastNodeHash() } just Runs
         viewModel = NomadNetBrowserViewModel(protocol, pageCache, settingsRepository)
     }
@@ -98,7 +98,7 @@ class NomadNetBrowserViewModelTest {
             assertEquals("/page/index.mu", loaded.path)
             // The bottom-nav NomadNet tab reopens the last-browsed node, so
             // every successful page load must persist its node hash.
-            coVerify { settingsRepository.saveNomadNetLastNodeHash(nodeHash) }
+            coVerify { settingsRepository.saveNomadNetLastNodeHash(nodeHash, any()) }
         }
 
     @Test

--- a/app/src/test/java/network/columba/app/viewmodel/NomadNetBrowserViewModelTest.kt
+++ b/app/src/test/java/network/columba/app/viewmodel/NomadNetBrowserViewModelTest.kt
@@ -68,6 +68,7 @@ class NomadNetBrowserViewModelTest {
         every { settingsRepository.nomadNetRenderingModeFlow } returns flowOf(null)
         coEvery { settingsRepository.saveNomadNetRenderingMode(any()) } just Runs
         coEvery { settingsRepository.saveNomadNetLastNodeHash(any()) } just Runs
+        coEvery { settingsRepository.clearNomadNetLastNodeHash() } just Runs
         viewModel = NomadNetBrowserViewModel(protocol, pageCache, settingsRepository)
     }
 
@@ -450,6 +451,36 @@ class NomadNetBrowserViewModelTest {
 
             viewModel.goBack() // back to page 1
             assertFalse(viewModel.canGoBack.value)
+        }
+
+    // ── closeSite ──
+
+    @Test
+    fun `closeSite resets state clears history and forgets last node`() =
+        runTest(testDispatcher) {
+            every { pageCache.get(any(), any()) } returns simplePage
+            coEvery { protocol.requestNomadnetPage(any(), any(), any(), any()) } returns
+                Result.success(NomadnetPageResult(simplePage, "/page/second.mu"))
+
+            viewModel.loadPage(nodeHash)
+            advanceUntilIdle()
+            viewModel.updateField("query", "test")
+            viewModel.navigateToLink("/page/second.mu", emptyList())
+            advanceUntilIdle()
+            assertTrue(viewModel.canGoBack.value)
+
+            viewModel.closeSite()
+            advanceUntilIdle()
+
+            // View resets to Initial so the tab home can swap to the address prompt.
+            assertTrue(
+                "Should be Initial, was ${viewModel.browserState.value}",
+                viewModel.browserState.value is NomadNetBrowserViewModel.BrowserState.Initial,
+            )
+            assertFalse(viewModel.canGoBack.value)
+            assertTrue(viewModel.formFields.value.isEmpty())
+            // The persisted last-node binding must be forgotten.
+            coVerify { settingsRepository.clearNomadNetLastNodeHash() }
         }
 
     // ── refresh ──

--- a/app/src/test/java/network/columba/app/viewmodel/NomadNetBrowserViewModelTest.kt
+++ b/app/src/test/java/network/columba/app/viewmodel/NomadNetBrowserViewModelTest.kt
@@ -67,6 +67,7 @@ class NomadNetBrowserViewModelTest {
         // No persisted rendering mode by default; individual tests can override.
         every { settingsRepository.nomadNetRenderingModeFlow } returns flowOf(null)
         coEvery { settingsRepository.saveNomadNetRenderingMode(any()) } just Runs
+        coEvery { settingsRepository.saveNomadNetLastNodeHash(any()) } just Runs
         viewModel = NomadNetBrowserViewModel(protocol, pageCache, settingsRepository)
     }
 
@@ -94,6 +95,9 @@ class NomadNetBrowserViewModelTest {
             val loaded = state as NomadNetBrowserViewModel.BrowserState.PageLoaded
             assertEquals(nodeHash, loaded.nodeHash)
             assertEquals("/page/index.mu", loaded.path)
+            // The bottom-nav NomadNet tab reopens the last-browsed node, so
+            // every successful page load must persist its node hash.
+            coVerify { settingsRepository.saveNomadNetLastNodeHash(nodeHash) }
         }
 
     @Test

--- a/app/src/test/java/network/columba/app/viewmodel/SettingsViewModelIncomingMessageLimitTest.kt
+++ b/app/src/test/java/network/columba/app/viewmodel/SettingsViewModelIncomingMessageLimitTest.kt
@@ -109,6 +109,8 @@ class SettingsViewModelIncomingMessageLimitTest {
         SettingsViewModel.enableMonitors = false
 
         settingsRepository = mockk()
+        every { settingsRepository.bottomNavTabsFlow } returns flowOf(null)
+        every { settingsRepository.nomadNetLastNodeHashFlow } returns flowOf(null)
         identityRepository = mockk()
         rnsBackend = mockk()
         rnsCore = mockk()

--- a/app/src/test/java/network/columba/app/viewmodel/SettingsViewModelTest.kt
+++ b/app/src/test/java/network/columba/app/viewmodel/SettingsViewModelTest.kt
@@ -170,6 +170,8 @@ class SettingsViewModelTest {
         // Setup repository flow mocks
         every { settingsRepository.preferOwnInstanceFlow } returns preferOwnInstanceFlow
         every { settingsRepository.isSharedInstanceFlow } returns isSharedInstanceFlow
+        every { settingsRepository.bottomNavTabsFlow } returns flowOf(null)
+        every { settingsRepository.nomadNetLastNodeHashFlow } returns flowOf(null)
         every { settingsRepository.shareInstanceHostingEnabledFlow } returns shareInstanceHostingEnabledFlow
         coEvery { settingsRepository.getShareInstanceHostingEnabled() } returns false
         coEvery { settingsRepository.saveShareInstanceHostingEnabled(any()) } returns Unit


### PR DESCRIPTION
## Summary
- User-configurable bottom navigation bar (up to 5 tabs, Settings pinned last; persisted and sanitized).
- NomadNet tab is a normal tab: the bar stays visible while browsing; tab taps collapse the browser stack so views can never stack duplicates.
- Close Site now forgets the persisted last-node binding and resets browser state, so the tab reopens at the address-entry prompt.
- Empty NomadNet tab: dedicated always-present address field (fixes the one-frame editor flash), no auto-focus (keyboard stays hidden until the user taps the field), and the entry block is biased upward with IME padding so the Go button is never under the keyboard.
- Node Details keeps the bottom nav bar and pads its content 88.dp above it (removes the jarring bar hide/pop when returning from NomadNet).

## Test notes
- Verified on-device (S21 Ultra): tab config persistence, Close Site flow, no duplicate browser views, keyboard/focus behavior, Node Details nav bar + bottom clearance.
- Unit suites green (NomadNet screen + viewmodel incl. new closeSite regression test, navigation contract tests); ktlint clean; assembleNoSentryPythonBackendDebug green.