### PR TITLE
fix(contacts): allow spaces in the contacts search query

### DIFF
--- a/app/src/main/java/network/columba/app/ui/screens/ContactsScreen.kt
+++ b/app/src/main/java/network/columba/app/ui/screens/ContactsScreen.kt
@@ -370,9 +370,12 @@ fun ContactsScreen(
                     OutlinedTextField(
                         value = currentSearchQuery,
                         onValueChange = { query ->
-                            // VALIDATION: Sanitize and limit search query
+                            // VALIDATION: Sanitize and limit search query.
+                            // Trailing spaces are intentionally preserved while the user
+                            // is typing (sanitizeSearchQuery does not trim); the query is
+                            // trimmed at match time in the view models.
                             val sanitized =
-                                InputValidator.sanitizeText(
+                                InputValidator.sanitizeSearchQuery(
                                     query,
                                     ValidationConstants.MAX_SEARCH_QUERY_LENGTH,
                                 )

--- a/app/src/main/java/network/columba/app/util/validation/InputValidator.kt
+++ b/app/src/main/java/network/columba/app/util/validation/InputValidator.kt
@@ -450,11 +450,15 @@ object InputValidator {
      * - Within length limit
      * - Returns empty string if blank (search queries can be empty)
      *
+     * Leading/trailing whitespace is preserved here and trimmed at match time
+     * by the consumers, so users can type spaces in live search fields without
+     * the field fighting them on every keystroke.
+     *
      * @param query The search query to validate
      * @return ValidationResult.Success with sanitized query
      */
     fun validateSearchQuery(query: String): ValidationResult<String> {
-        val sanitized = sanitizeText(query, MAX_SEARCH_QUERY_LENGTH)
+        val sanitized = sanitizeSearchQuery(query, MAX_SEARCH_QUERY_LENGTH)
         return ValidationResult.Success(sanitized)
     }
 
@@ -507,6 +511,29 @@ object InputValidator {
     ): String =
         text
             .trim()
+            .replace(Regex("\\p{C}"), "") // Remove control characters
+            .replace(Regex("\\s+"), " ") // Normalize whitespace
+            .take(maxLength)
+
+    /**
+     * Sanitizes a live search query without trimming leading/trailing whitespace.
+     *
+     * Unlike [sanitizeText], this variant keeps the text the user is currently
+     * composing: control characters are removed and runs of whitespace are
+     * normalized, but spaces typed at the end of the query are preserved so a
+     * controlled text field does not fight the user on every keystroke.
+     * Consumers trim the query at match time, so preserved trailing spaces have
+     * no effect on filtering.
+     *
+     * @param query The search query to sanitize
+     * @param maxLength Maximum allowed length after sanitization
+     * @return Sanitized query with internal spacing and trailing spaces intact
+     */
+    fun sanitizeSearchQuery(
+        query: String,
+        maxLength: Int,
+    ): String =
+        query
             .replace(Regex("\\p{C}"), "") // Remove control characters
             .replace(Regex("\\s+"), " ") // Normalize whitespace
             .take(maxLength)

--- a/app/src/main/java/network/columba/app/viewmodel/ContactsViewModel.kt
+++ b/app/src/main/java/network/columba/app/viewmodel/ContactsViewModel.kt
@@ -121,8 +121,11 @@ class ContactsViewModel
             combine(
                 contacts,
                 searchQuery,
-            ) { contacts, query ->
-                if (query.isBlank()) {
+            ) { contacts, rawQuery ->
+                // The search field preserves trailing spaces while typing, so trim at
+                // match time (mirrors AnnounceStreamViewModel's query.trim() before SQL).
+                val query = rawQuery.trim()
+                if (query.isEmpty()) {
                     contacts
                 } else {
                     contacts.filter { contact ->

--- a/app/src/test/java/network/columba/app/ui/screens/ContactsScreenTest.kt
+++ b/app/src/test/java/network/columba/app/ui/screens/ContactsScreenTest.kt
@@ -231,6 +231,37 @@ class ContactsScreenTest {
     }
 
     @Test
+    fun contactsScreen_searchBar_preservesSpacesInQuery() {
+        val mockViewModel = createMockContactsViewModel()
+
+        composeTestRule.setContent {
+            ContactsScreen(viewModel = mockViewModel, announceViewModel = createMockAnnounceStreamViewModel())
+        }
+
+        // Open search bar
+        composeTestRule.onNodeWithContentDescription("Search").performClick()
+        composeTestRule.onNodeWithText("Search by name, hash, or tag...").assertIsDisplayed()
+
+        // Regression for the "contacts search bar doesn't let you type a space" bug:
+        // the field used to run every keystroke through a validator that trimmed,
+        // so a trailing space (the state right after the user presses the space key)
+        // was eaten on the next render and the query never contained a space.
+        val field = composeTestRule.onNodeWithText("Search by name, hash, or tag...")
+        field.performTextInput("Alice")
+        composeTestRule.waitForIdle()
+
+        // User presses the space key: the field content becomes "Alice "
+        field.performTextInput("Alice ")
+        composeTestRule.waitForIdle()
+        verify { mockViewModel.onSearchQueryChanged("Alice ") }
+
+        // User continues typing: the internal space must survive into the query
+        field.performTextInput("Alice Smith")
+        composeTestRule.waitForIdle()
+        verify { mockViewModel.onSearchQueryChanged("Alice Smith") }
+    }
+
+    @Test
     fun contactsScreen_searchBar_clearButton_clearsText() {
         val mockViewModel = createMockContactsViewModel(searchQuery = "Test")
 

--- a/app/src/test/java/network/columba/app/util/validation/InputValidatorTest.kt
+++ b/app/src/test/java/network/columba/app/util/validation/InputValidatorTest.kt
@@ -519,6 +519,45 @@ class InputValidatorTest {
         assertEquals(ValidationConstants.MAX_SEARCH_QUERY_LENGTH, result.getOrNull()?.length)
     }
 
+    @Test
+    fun `sanitizeSearchQuery - preserves trailing space while typing`() {
+        // Regression: the contacts search field is controlled and round-trips every
+        // keystroke through sanitization. Trimming here made it impossible to type
+        // a space (the trailing space was eaten on each render).
+        val result = InputValidator.sanitizeSearchQuery("Alice ", 200)
+        assertEquals("Alice ", result)
+    }
+
+    @Test
+    fun `sanitizeSearchQuery - preserves leading space`() {
+        val result = InputValidator.sanitizeSearchQuery(" Alice", 200)
+        assertEquals(" Alice", result)
+    }
+
+    @Test
+    fun `sanitizeSearchQuery - normalizes internal whitespace runs`() {
+        val result = InputValidator.sanitizeSearchQuery("Alice\t\t Smith", 200)
+        assertEquals("Alice Smith", result)
+    }
+
+    @Test
+    fun `sanitizeSearchQuery - removes control characters`() {
+        val result = InputValidator.sanitizeSearchQuery("Alice\u0000 Smith", 200)
+        assertEquals("Alice Smith", result)
+    }
+
+    @Test
+    fun `sanitizeSearchQuery - truncates to max length`() {
+        val result = InputValidator.sanitizeSearchQuery("a".repeat(500), 50)
+        assertEquals(50, result.length)
+    }
+
+    @Test
+    fun `sanitizeText - still trims its generic contract`() {
+        val result = InputValidator.sanitizeText("  hello  ", 100)
+        assertEquals("hello", result)
+    }
+
     // ========== CONFIG PARAMETER VALIDATION TESTS ==========
 
     @Test

--- a/app/src/test/java/network/columba/app/viewmodel/ContactsViewModelTest.kt
+++ b/app/src/test/java/network/columba/app/viewmodel/ContactsViewModelTest.kt
@@ -187,6 +187,58 @@ class ContactsViewModelTest {
         }
 
     @Test
+    fun `filteredContacts - query with trailing space matches as if trimmed`() =
+        runTest {
+            // Given: the search field preserves trailing spaces while typing
+            val contacts =
+                listOf(
+                    TestFactories.createEnrichedContact(destinationHash = "hash1", displayName = "Alice"),
+                    TestFactories.createEnrichedContact(destinationHash = "hash2", displayName = "Alice Smith"),
+                )
+            contactsFlow.value = contacts
+            advanceUntilIdle()
+
+            // When: field holds "Alice " (user typed a space, mid-edit). Trimmed at
+            // match time, "Alice" matches both names; untrimmed, "Alice " would only
+            // match "Alice Smith".
+            viewModel.onSearchQueryChanged("Alice ")
+            advanceUntilIdle()
+
+            // Then
+            viewModel.filteredContacts.test {
+                skipItems(1) // Skip initial
+                advanceUntilIdle()
+                val filtered = awaitItem()
+                assertEquals(2, filtered.size)
+            }
+        }
+
+    @Test
+    fun `filteredContacts - whitespace-only query returns all contacts`() =
+        runTest {
+            // Given
+            val contacts =
+                listOf(
+                    TestFactories.createEnrichedContact(destinationHash = "hash1", displayName = "Alice"),
+                    TestFactories.createEnrichedContact(destinationHash = "hash2", displayName = "Bob"),
+                )
+            contactsFlow.value = contacts
+            advanceUntilIdle()
+
+            // When: the field holds only a space (user cleared to just " ")
+            viewModel.onSearchQueryChanged(" ")
+            advanceUntilIdle()
+
+            // Then: treated as an empty query, not a "contains space" match
+            viewModel.filteredContacts.test {
+                skipItems(1) // Skip initial
+                advanceUntilIdle()
+                val filtered = awaitItem()
+                assertEquals(2, filtered.size)
+            }
+        }
+
+    @Test
     fun `filteredContacts - matches destination hash`() =
         runTest {
             // Given


### PR DESCRIPTION
## Bug
The Contacts search bar does not let you type a space (user report). Affects both the My Contacts and Network tabs, which share the one search field.

## Root cause
The search field is a controlled \textfield whose onValueChange round-trips every keystroke through InputValidator.sanitizeText, which trims. The instant the user presses the space key, the space is the trailing character, so it is stripped before the field can render it and the query never contains a space. Internal spaces are unreachable for the same reason (each is trailing at the moment it is typed).

## Fix
- Add InputValidator.sanitizeSearchQuery: strips control characters, normalizes whitespace runs, enforces length, but does not trim, so a live field does not fight the user while composing.
- ContactsScreen search field uses sanitizeSearchQuery.
- ContactsViewModel trims the query at match time (mirrors AnnounceStreamViewModel, which already trims before the SQL query), so trailing spaces are harmless for filtering and an all-space query is treated as empty.
- validateSearchQuery routes through sanitizeSearchQuery; sanitizeText keeps its generic trimming contract for non-search callers.

## Tests
- Compose regression: type 'Alice', press space, then 'Alice Smith' and assert the ViewModel receives the space (fails on the old code, passes now).
- Validator unit tests for sanitizeSearchQuery (trailing/leading space, internal normalization, control chars, length) plus a guard that sanitizeText still trims.
- ViewModel tests for match-time trimming and all-space-query-as-empty.

## Verification
- Full app unit suites on both backends: 6130 + 6130 tests, 0 failures
- Data suite: 390 tests, 0 failures
- detekt + ktlint clean