### PR TITLE
fix(migration): chunked 0x03 GCM format to fix export OOM

### DIFF
--- a/app/src/main/java/network/columba/app/migration/MigrationCrypto.kt
+++ b/app/src/main/java/network/columba/app/migration/MigrationCrypto.kt
@@ -4,8 +4,10 @@ import java.io.ByteArrayInputStream
 import java.io.ByteArrayOutputStream
 import java.io.File
 import java.io.InputStream
+import java.io.OutputStream
 import java.security.SecureRandom
 import javax.crypto.Cipher
+import javax.crypto.SecretKey
 import javax.crypto.SecretKeyFactory
 import javax.crypto.spec.GCMParameterSpec
 import javax.crypto.spec.PBEKeySpec
@@ -14,7 +16,7 @@ import javax.crypto.spec.SecretKeySpec
 /**
  * Handles encryption and decryption of migration export files.
  *
- * File format (encrypted):
+ * Version 0x02 (legacy, whole-file GCM):
  * ```
  * [1 byte:  version (0x02)]
  * [16 bytes: PBKDF2 salt]
@@ -22,12 +24,40 @@ import javax.crypto.spec.SecretKeySpec
  * [N bytes:  AES-256-GCM ciphertext (includes 16-byte auth tag)]
  * ```
  *
+ * Version 0x03 (current, chunked GCM):
+ * ```
+ * [1 byte:  version (0x03)]
+ * [16 bytes: PBKDF2 salt]
+ * [12 bytes: base IV (random 4 bytes + 64-bit counter start)]
+ * [8 bytes:  chunk size in bytes, big-endian]
+ * [8 bytes:  total plaintext length in bytes, big-endian]
+ * repeated per chunk:
+ * [8 bytes:  chunk index, big-endian]
+ * [12 bytes: chunk IV (base IV with index XORed into bytes 4..11)]
+ * [chunk:    AES-256-GCM ciphertext (includes 16-byte auth tag)]
+ * ```
+ *
+ * One PBKDF2-derived key covers every chunk; each chunk carries its own
+ * 128-bit GCM auth tag, so a wrong password is detected on the first
+ * chunk. The chunk size is capped at [CHUNK_SIZE_BYTES] because the
+ * platform GCM *decryptor* buffers an entire ciphertext buffer internally
+ * (verified empirically against SunJCE): whole-file decryption of a
+ * ~100 MiB export OOMs, while per-chunk decryption stays bounded to one
+ * chunk plus small buffers.
+ *
  * Unencrypted (legacy) files start with the ZIP magic bytes (0x50 0x4B)
  * and are detected automatically during import.
  */
+@Suppress("TooManyFunctions") // Chunked + legacy crypto paths; helpers kept private
 object MigrationCrypto {
-    /** Version byte written at the start of encrypted export files. */
-    const val ENCRYPTED_VERSION: Byte = 0x02
+    /** Version byte written at the start of encrypted export files (current format). */
+    const val ENCRYPTED_VERSION: Byte = 0x03
+
+    /** Legacy whole-file GCM version; still accepted on import. */
+    const val LEGACY_ENCRYPTED_VERSION: Byte = 0x02
+
+    /** Maximum plaintext bytes per 0x03 chunk (bounds decrypt-side memory). */
+    const val CHUNK_SIZE_BYTES = 8 * 1024 * 1024
 
     /** First two bytes of a ZIP file (PK). */
     private const val ZIP_MAGIC_BYTE_1: Byte = 0x50 // 'P'
@@ -36,16 +66,25 @@ object MigrationCrypto {
     private const val SALT_LENGTH = 16
     private const val IV_LENGTH = 12
     private const val GCM_TAG_BITS = 128
+    private const val GCM_TAG_BYTES = GCM_TAG_BITS / 8
     private const val KEY_LENGTH_BITS = 256
     private const val PBKDF2_ITERATIONS = 600_000
     private const val PBKDF2_ALGORITHM = "PBKDF2WithHmacSHA256"
     private const val CIPHER_ALGORITHM = "AES/GCM/NoPadding"
+
+    /** 0x03 fixed header size: version + salt + base IV + chunk size + total length. */
+    private const val CHUNKED_HEADER_SIZE = 1 + SALT_LENGTH + IV_LENGTH + 8 + 8
+    /** 0x03 per-chunk header size: chunk index + chunk IV. */
+    private const val CHUNK_RECORD_HEADER_SIZE = 8 + IV_LENGTH
 
     /** Minimum password length enforced at the UI layer. */
     const val MIN_PASSWORD_LENGTH = 8
 
     /**
      * Encrypt a plaintext ZIP file in-place, replacing it with the encrypted format.
+     *
+     * Writes a temporary file beside the target and renames over it so the
+     * export never holds the full plaintext or ciphertext in memory.
      *
      * @param plaintextZip the ZIP file to encrypt
      * @param password the user-chosen password
@@ -55,46 +94,170 @@ object MigrationCrypto {
         plaintextZip: File,
         password: String,
     ): File {
-        val plaintext = plaintextZip.readBytes()
+        val tmp = File(plaintextZip.parentFile, plaintextZip.name + ".enc.tmp")
         try {
-            val encrypted = encrypt(plaintext, password)
-            plaintextZip.writeBytes(encrypted)
+            encryptToFile(plaintextZip, password, tmp)
+            if (!tmp.renameTo(plaintextZip)) {
+                tmp.copyTo(plaintextZip, overwrite = true)
+            }
         } finally {
-            plaintext.fill(0)
+            if (tmp.exists()) tmp.delete()
         }
         return plaintextZip
     }
 
     /**
-     * Encrypt raw bytes with AES-256-GCM using a password-derived key.
+     * Encrypt a plaintext file into the chunked 0x03 format, streaming in
+     * both directions (bounded memory for arbitrarily large exports).
+     */
+    fun encryptToFile(
+        plaintext: File,
+        password: String,
+        destination: File,
+    ) {
+        val random = SecureRandom()
+        val salt = ByteArray(SALT_LENGTH).also { random.nextBytes(it) }
+        val baseIv = ByteArray(IV_LENGTH).also { random.nextBytes(it) }
+        val key = deriveKey(password, salt)
+        val totalLength = plaintext.length()
+        val chunkSize = minOf(CHUNK_SIZE_BYTES, totalLength.coerceAtLeast(0).toInt()).coerceAtLeast(0)
+
+        destination.outputStream().use { out ->
+            out.write(ENCRYPTED_VERSION.toInt())
+            out.write(salt)
+            out.write(baseIv)
+            writeLongBigEndian(out, chunkSize.toLong())
+            writeLongBigEndian(out, totalLength)
+
+            val numChunks =
+                if (totalLength == 0L) 1L
+                else ((totalLength + chunkSize - 1) / chunkSize)
+            plaintext.inputStream().use { plainIn ->
+                for (index in 0 until numChunks) {
+                    val chunkLen =
+                        if (index == numChunks - 1) (totalLength - (numChunks - 1) * chunkSize).toInt()
+                        else chunkSize
+                    val chunk = ByteArray(chunkLen)
+                    if (chunkLen > 0) readFully(plainIn, chunk, chunkLen)
+                    val chunkIv = chunkIv(baseIv, index)
+                    val cipher = Cipher.getInstance(CIPHER_ALGORITHM)
+                    cipher.init(Cipher.ENCRYPT_MODE, key, GCMParameterSpec(GCM_TAG_BITS, chunkIv))
+                    out.writeChunkRecord(index, chunkIv)
+                    if (chunk.isNotEmpty()) {
+                        // GCM streams: doFinal() over one chunk does not
+                        // accumulate the ciphertext, and appends the 16-byte tag.
+                        out.write(cipher.doFinal(chunk))
+                    } else {
+                        out.write(cipher.doFinal())
+                    }
+                }
+            }
+        }
+    }
+
+    /**
+     * Decrypt an encrypted export file in-place, replacing it with the
+     * plaintext ZIP.
      *
-     * @return the full encrypted payload including header, salt, IV, and ciphertext
+     * 0x03 files decrypt in per-chunk streaming passes (bounded memory).
+     * 0x02 legacy files decrypt whole-file, as before.
+     *
+     * @param encryptedFile the encrypted file to decrypt
+     * @param password the user-provided password
+     * @return the same [File] reference, now containing plaintext ZIP data
+     * @throws WrongPasswordException if the password is incorrect
+     * @throws InvalidExportFileException if the format is not recognized
+     */
+    fun decryptFile(
+        encryptedFile: File,
+        password: String,
+    ): File {
+        val firstByte = encryptedFile.inputStream().use { it.read() }
+        if (firstByte == -1) {
+            throw InvalidExportFileException("Export file is empty")
+        }
+        val tmp = File(encryptedFile.parentFile, encryptedFile.name + ".dec.tmp")
+        try {
+            when (firstByte.toByte()) {
+                ENCRYPTED_VERSION -> {
+                    // Streaming: plaintext is written directly to the temp
+                    // file in per-chunk passes.
+                    decryptStream(encryptedFile.inputStream(), password).use { plain ->
+                        tmp.outputStream().use { plain.copyTo(it) }
+                    }
+                }
+                LEGACY_ENCRYPTED_VERSION -> {
+                    val full = encryptedFile.readBytes()
+                    tmp.writeBytes(decryptLegacy(full, password))
+                }
+                else -> throw InvalidExportFileException(
+                    "Unrecognized export format (version byte: 0x${
+                        String.format(java.util.Locale.ROOT, "%02X", firstByte)
+                    })",
+                )
+            }
+            if (!tmp.renameTo(encryptedFile)) {
+                tmp.copyTo(encryptedFile, overwrite = true)
+            }
+        } finally {
+            if (tmp.exists()) tmp.delete()
+        }
+        return encryptedFile
+    }
+
+    /**
+     * Encrypt raw bytes with the chunked 0x03 format.
+     *
+     * @return the full encrypted payload including header and all chunk records
      */
     fun encrypt(
         plaintext: ByteArray,
         password: String,
     ): ByteArray {
+        val out = ByteArrayOutputStream()
+        out.use { stream ->
+            streamEncrypt(plaintext.inputStream(), stream, password, plaintext.size.toLong())
+        }
+        return out.toByteArray()
+    }
+
+    private fun streamEncrypt(
+        plain: InputStream,
+        out: OutputStream,
+        password: String,
+        totalLength: Long,
+    ) {
         val random = SecureRandom()
-
         val salt = ByteArray(SALT_LENGTH).also { random.nextBytes(it) }
-        val iv = ByteArray(IV_LENGTH).also { random.nextBytes(it) }
+        val baseIv = ByteArray(IV_LENGTH).also { random.nextBytes(it) }
         val key = deriveKey(password, salt)
+        val chunkSize = minOf(CHUNK_SIZE_BYTES, totalLength.coerceAtLeast(0).toInt()).coerceAtLeast(0)
 
-        val cipher = Cipher.getInstance(CIPHER_ALGORITHM)
-        cipher.init(Cipher.ENCRYPT_MODE, key, GCMParameterSpec(GCM_TAG_BITS, iv))
-        val ciphertext = cipher.doFinal(plaintext)
+        out.write(ENCRYPTED_VERSION.toInt())
+        out.write(salt)
+        out.write(baseIv)
+        writeLongBigEndian(out, chunkSize.toLong())
+        writeLongBigEndian(out, totalLength)
 
-        return ByteArrayOutputStream().use { out ->
-            out.write(ENCRYPTED_VERSION.toInt())
-            out.write(salt)
-            out.write(iv)
-            out.write(ciphertext)
-            out.toByteArray()
+        val numChunks =
+            if (totalLength == 0L) 1L else ((totalLength + chunkSize - 1) / chunkSize)
+        for (index in 0 until numChunks) {
+            val remaining = totalLength - index * chunkSize
+            val chunk = ByteArray(if (remaining <= 0) 0 else minOf(chunkSize, remaining.toInt()))
+            if (chunk.isNotEmpty()) readFully(plain, chunk, chunk.size)
+            val chunkIv = chunkIv(baseIv, index)
+            out.writeChunkRecord(index, chunkIv)
+            val cipher = Cipher.getInstance(CIPHER_ALGORITHM)
+            cipher.init(Cipher.ENCRYPT_MODE, key, GCMParameterSpec(GCM_TAG_BITS, chunkIv))
+            out.write(if (chunk.isEmpty()) cipher.doFinal() else cipher.doFinal(chunk))
         }
     }
 
     /**
-     * Decrypt an encrypted export payload.
+     * Decrypt an encrypted export payload (either version).
+     *
+     * 0x02 legacy files are decrypted whole-file (the legacy behavior).
+     * 0x03 files are decrypted chunk by chunk.
      *
      * @param encrypted the full encrypted payload (header + salt + IV + ciphertext)
      * @param password the user-provided password
@@ -110,17 +273,29 @@ object MigrationCrypto {
         if (encrypted.isEmpty()) {
             throw InvalidExportFileException("Export file is empty")
         }
-
-        if (encrypted[0] != ENCRYPTED_VERSION) {
-            throw InvalidExportFileException(
+        return when (encrypted[0]) {
+            LEGACY_ENCRYPTED_VERSION -> decryptLegacy(encrypted, password)
+            ENCRYPTED_VERSION -> {
+                // Header must be fully present before we can trust anything.
+                if (encrypted.size < CHUNKED_HEADER_SIZE) {
+                    throw InvalidExportFileException("Export file is too small to be valid")
+                }
+                decryptStream(encrypted.inputStream(), password).use { it.readBytes() }
+            }
+            else -> throw InvalidExportFileException(
                 "Unrecognized export format (version byte: 0x${
                     String.format(java.util.Locale.ROOT, "%02X", encrypted[0])
                 })",
             )
         }
+    }
 
+    private fun decryptLegacy(
+        encrypted: ByteArray,
+        password: String,
+    ): ByteArray {
         val headerSize = 1 + SALT_LENGTH + IV_LENGTH
-        if (encrypted.size < headerSize + GCM_TAG_BITS / 8) {
+        if (encrypted.size < headerSize + GCM_TAG_BYTES) {
             throw InvalidExportFileException("Export file is too small to be valid")
         }
 
@@ -143,25 +318,56 @@ object MigrationCrypto {
     }
 
     /**
-     * Decrypt an encrypted export file and return an [InputStream] to the plaintext ZIP.
+     * Decrypt an encrypted export stream into an [InputStream] of the plaintext ZIP.
      *
-     * @param encryptedStream input stream of the encrypted file
-     * @param password the user-provided password
-     * @return an [InputStream] containing the decrypted ZIP data
+     * 0x03 streams decrypt in per-chunk passes with bounded memory. 0x02
+     * legacy streams fall back to whole-file decryption because the platform
+     * GCM decryptor cannot stream.
      */
+    @Suppress("ThrowsCount")
     fun decryptStream(
         encryptedStream: InputStream,
         password: String,
     ): InputStream {
-        val encrypted = encryptedStream.readBytes()
-        val decrypted = decrypt(encrypted, password)
-        return ByteArrayInputStream(decrypted)
+        val first = encryptedStream.read()
+        if (first == -1) {
+            throw InvalidExportFileException("Export file is empty")
+        }
+        return when (first.toByte()) {
+            LEGACY_ENCRYPTED_VERSION -> {
+                val rest = encryptedStream.readBytes()
+                val full = byteArrayOf(first.toByte()) + rest
+                ByteArrayInputStream(decryptLegacy(full, password))
+            }
+            ENCRYPTED_VERSION -> {
+                val header = ByteArray(CHUNKED_HEADER_SIZE - 1)
+                readFully(encryptedStream, header, header.size)
+                val headerAll = byteArrayOf(first.toByte()) + header
+                val salt = headerAll.copyOfRange(1, 1 + SALT_LENGTH)
+                val baseIv = headerAll.copyOfRange(1 + SALT_LENGTH, 1 + SALT_LENGTH + IV_LENGTH)
+                val chunkSize = readLongBigEndian(headerAll, 1 + SALT_LENGTH + IV_LENGTH).toInt()
+                val totalLength = readLongBigEndian(headerAll, 9 + SALT_LENGTH + IV_LENGTH)
+                if (chunkSize < 0 || chunkSize > CHUNK_SIZE_BYTES) {
+                    throw InvalidExportFileException("Invalid chunk size in export header")
+                }
+                if (totalLength < 0) {
+                    throw InvalidExportFileException("Invalid plaintext length in export header")
+                }
+                val key = deriveKey(password, salt)
+                ChunkDecryptInputStream(encryptedStream, key, baseIv, chunkSize, totalLength)
+            }
+            else -> throw InvalidExportFileException(
+                "Unrecognized export format (version byte: 0x${
+                    String.format(java.util.Locale.ROOT, "%02X", first)
+                })",
+            )
+        }
     }
 
     /**
      * Check whether raw file bytes represent an encrypted export (vs. a legacy plaintext ZIP).
      *
-     * @return `true` if the file starts with the encrypted version byte,
+     * @return `true` if the file starts with an encrypted version byte (0x02 or 0x03),
      *         `false` if it starts with ZIP magic bytes (legacy format)
      * @throws InvalidExportFileException if the format is not recognized at all
      */
@@ -169,7 +375,7 @@ object MigrationCrypto {
         if (header.isEmpty()) {
             throw InvalidExportFileException("Export file is empty")
         }
-        if (header[0] == ENCRYPTED_VERSION) return true
+        if (header[0] == ENCRYPTED_VERSION || header[0] == LEGACY_ENCRYPTED_VERSION) return true
         if (header.size >= 2 && header[0] == ZIP_MAGIC_BYTE_1 && header[1] == ZIP_MAGIC_BYTE_2) {
             return false
         }
@@ -186,7 +392,7 @@ object MigrationCrypto {
     private fun deriveKey(
         password: String,
         salt: ByteArray,
-    ): SecretKeySpec {
+    ): SecretKey {
         val spec = PBEKeySpec(password.toCharArray(), salt, PBKDF2_ITERATIONS, KEY_LENGTH_BITS)
         return try {
             val factory = SecretKeyFactory.getInstance(PBKDF2_ALGORITHM)
@@ -198,6 +404,149 @@ object MigrationCrypto {
             }
         } finally {
             spec.clearPassword()
+        }
+    }
+
+    /** 96-bit GCM IV for a chunk: random 4 bytes + 64-bit counter (base ^ index) in bytes 4..11. */
+    private fun chunkIv(
+        baseIv: ByteArray,
+        index: Long,
+    ): ByteArray {
+        val iv = baseIv.copyOf()
+        for (i in 0 until 8) {
+            val counterByte = ((index ushr (56 - 8 * i)) and 0xFF).toInt()
+            iv[4 + i] = (iv[4 + i].toInt() xor counterByte).toByte()
+        }
+        return iv
+    }
+
+    private fun OutputStream.writeChunkRecord(
+        index: Long,
+        chunkIv: ByteArray,
+    ) {
+        writeLongBigEndian(this, index)
+        write(chunkIv)
+    }
+
+    private fun writeLongBigEndian(
+        out: OutputStream,
+        value: Long,
+    ) {
+        for (i in 7 downTo 0) {
+            out.write(((value ushr (8 * i)) and 0xFF).toInt())
+        }
+    }
+
+    private fun readLongBigEndian(
+        buf: ByteArray,
+        offset: Int,
+    ): Long {
+        var value = 0L
+        for (i in 0 until 8) {
+            value = (value shl 8) or (buf[offset + i].toInt() and 0xFF).toLong()
+        }
+        return value
+    }
+
+    private fun readFully(
+        source: InputStream,
+        buf: ByteArray,
+        len: Int,
+    ) {
+        var got = 0
+        while (got < len) {
+            val r = source.read(buf, got, len - got)
+            if (r < 0) throw InvalidExportFileException("Truncated export file")
+            got += r
+        }
+    }
+
+    /**
+     * Streaming decryptor for the chunked 0x03 format.
+     *
+     * Buffers at most one plaintext chunk at a time; the underlying cipher
+     * buffers at most one chunk of ciphertext, so peak memory is bounded by
+     * ~2 x chunk size regardless of export size.
+     */
+    private class ChunkDecryptInputStream(
+        private val src: InputStream,
+        private val key: SecretKey,
+        private val baseIv: ByteArray,
+        private val chunkSize: Int,
+        totalLength: Long,
+    ) : InputStream() {
+        private var plaintextRemaining = totalLength
+        private var chunkIndex = 0L
+        private var current: ByteArray? = null
+        private var currentPos = 0
+
+        override fun read(): Int {
+            while (true) {
+                val chunk = current
+                if (chunk != null && currentPos < chunk.size) {
+                    val b = chunk[currentPos++].toInt()
+                    if (currentPos == chunk.size) current = null
+                    return b and 0xFF
+                }
+                if (plaintextRemaining == 0L) return -1
+                loadNextChunk()
+            }
+        }
+
+        override fun read(
+            b: ByteArray,
+            off: Int,
+            len: Int,
+        ): Int {
+            if (len == 0) return 0
+            val first = read()
+            if (first == -1) return -1
+            b[off] = first.toByte()
+            var got = 1
+            while (got < len) {
+                val chunk = current
+                if (chunk != null && currentPos < chunk.size) {
+                    val n = minOf(len - got, chunk.size - currentPos)
+                    System.arraycopy(chunk, currentPos, b, off + got, n)
+                    currentPos += n
+                    got += n
+                    if (currentPos == chunk.size) current = null
+                } else {
+                    if (plaintextRemaining == 0L) break
+                    loadNextChunk()
+                }
+            }
+            return got
+        }
+
+        @Suppress("ThrowsCount") // Corrupt/wrong-password chunks each fail fast
+        private fun loadNextChunk() {
+            val recordHeader = ByteArray(CHUNK_RECORD_HEADER_SIZE)
+            readFully(src, recordHeader, recordHeader.size)
+            val index = readLongBigEndian(recordHeader, 0)
+            if (index != chunkIndex) {
+                throw InvalidExportFileException("Corrupt export: chunk index $index, expected $chunkIndex")
+            }
+            val chunkIv = recordHeader.copyOfRange(8, 8 + IV_LENGTH)
+            val expected = minOf(chunkSize, plaintextRemaining.toInt().coerceAtLeast(0))
+            val ciphertext = ByteArray(expected + GCM_TAG_BYTES)
+            readFully(src, ciphertext, ciphertext.size)
+
+            val cipher = Cipher.getInstance(CIPHER_ALGORITHM)
+            cipher.init(Cipher.DECRYPT_MODE, key, GCMParameterSpec(GCM_TAG_BITS, chunkIv))
+            val decrypted =
+                try {
+                    cipher.doFinal(ciphertext)
+                } catch (e: javax.crypto.AEADBadTagException) {
+                    throw WrongPasswordException("Incorrect password", e)
+                }
+            if (decrypted.size != expected) {
+                throw InvalidExportFileException("Corrupt export: chunk $index size mismatch")
+            }
+            plaintextRemaining -= decrypted.size
+            chunkIndex++
+            current = decrypted
+            currentPos = 0
         }
     }
 }

--- a/app/src/main/java/network/columba/app/migration/MigrationCrypto.kt
+++ b/app/src/main/java/network/columba/app/migration/MigrationCrypto.kt
@@ -24,26 +24,39 @@ import javax.crypto.spec.SecretKeySpec
  * [N bytes:  AES-256-GCM ciphertext (includes 16-byte auth tag)]
  * ```
  *
- * Version 0x03 (current, chunked GCM):
+ * Version 0x03 (current, chunked GCM with authenticated framing):
  * ```
  * [1 byte:  version (0x03)]
  * [16 bytes: PBKDF2 salt]
- * [12 bytes: base IV (random 4 bytes + 64-bit counter start)]
+ * [12 bytes: base IV (random)]
  * [8 bytes:  chunk size in bytes, big-endian]
  * [8 bytes:  total plaintext length in bytes, big-endian]
- * repeated per chunk:
- * [8 bytes:  chunk index, big-endian]
- * [12 bytes: chunk IV (base IV with index XORed into bytes 4..11)]
- * [chunk:    AES-256-GCM ciphertext (includes 16-byte auth tag)]
+ * repeated per chunk i (i = 0, 1, 2, ...):
+ * [8 bytes:  chunk index i, big-endian]
+ * [chunk_i:  AES-256-GCM ciphertext of the i-th plaintext chunk
+ *            (includes a 128-bit auth tag)]
  * ```
+ *
+ * The framing is fully authenticated so the stream cannot be replayed,
+ * reordered, or truncated:
+ * - Each chunk's IV is *derived* from (base IV, index) on the decrypt side
+ *   rather than read from the file, so an attacker cannot move or re-label
+ *   chunks: a chunk placed at a new position is decrypted with a different
+ *   IV and its tag fails.
+ * - Each chunk's GCM AAD is the fixed header (version + salt + base IV +
+ *   chunk size + total length) followed by the chunk index, so the header
+ *   and the per-chunk index are cryptographically bound to the ciphertext.
+ * - After the final chunk is consumed, the stream verifies the underlying
+ *   file is exhausted; a lowered total length (authenticated-prefix
+ *   attack) leaves trailing encrypted records and is rejected.
  *
  * One PBKDF2-derived key covers every chunk; each chunk carries its own
  * 128-bit GCM auth tag, so a wrong password is detected on the first
- * chunk. The chunk size is capped at [CHUNK_SIZE_BYTES] because the
- * platform GCM *decryptor* buffers an entire ciphertext buffer internally
- * (verified empirically against SunJCE): whole-file decryption of a
- * ~100 MiB export OOMs, while per-chunk decryption stays bounded to one
- * chunk plus small buffers.
+ * chunk. The chunk size is capped at [CHUNK_SIZE_BYTES] (the cap is applied
+ * while the length is still a [Long]) because the platform GCM *decryptor*
+ * buffers an entire ciphertext buffer internally (verified empirically
+ * against SunJCE): whole-file decryption of a ~100 MiB export OOMs, while
+ * per-chunk decryption stays bounded to one chunk plus small buffers.
  *
  * Unencrypted (legacy) files start with the ZIP magic bytes (0x50 0x4B)
  * and are detected automatically during import.
@@ -74,8 +87,8 @@ object MigrationCrypto {
 
     /** 0x03 fixed header size: version + salt + base IV + chunk size + total length. */
     private const val CHUNKED_HEADER_SIZE = 1 + SALT_LENGTH + IV_LENGTH + 8 + 8
-    /** 0x03 per-chunk header size: chunk index + chunk IV. */
-    private const val CHUNK_RECORD_HEADER_SIZE = 8 + IV_LENGTH
+    /** 0x03 per-chunk header size: chunk index only (the IV is derived, not stored). */
+    private const val CHUNK_RECORD_HEADER_SIZE = 8
 
     /** Minimum password length enforced at the UI layer. */
     const val MIN_PASSWORD_LENGTH = 8
@@ -96,7 +109,12 @@ object MigrationCrypto {
     ): File {
         val tmp = File(plaintextZip.parentFile, plaintextZip.name + ".enc.tmp")
         try {
-            encryptToFile(plaintextZip, password, tmp)
+            val totalLength = plaintextZip.length()
+            plaintextZip.inputStream().use { plain ->
+                tmp.outputStream().use { out ->
+                    streamEncrypt(plain, out, password, totalLength)
+                }
+            }
             if (!tmp.renameTo(plaintextZip)) {
                 tmp.copyTo(plaintextZip, overwrite = true)
             }
@@ -115,42 +133,10 @@ object MigrationCrypto {
         password: String,
         destination: File,
     ) {
-        val random = SecureRandom()
-        val salt = ByteArray(SALT_LENGTH).also { random.nextBytes(it) }
-        val baseIv = ByteArray(IV_LENGTH).also { random.nextBytes(it) }
-        val key = deriveKey(password, salt)
         val totalLength = plaintext.length()
-        val chunkSize = minOf(CHUNK_SIZE_BYTES, totalLength.coerceAtLeast(0).toInt()).coerceAtLeast(0)
-
-        destination.outputStream().use { out ->
-            out.write(ENCRYPTED_VERSION.toInt())
-            out.write(salt)
-            out.write(baseIv)
-            writeLongBigEndian(out, chunkSize.toLong())
-            writeLongBigEndian(out, totalLength)
-
-            val numChunks =
-                if (totalLength == 0L) 1L
-                else ((totalLength + chunkSize - 1) / chunkSize)
-            plaintext.inputStream().use { plainIn ->
-                for (index in 0 until numChunks) {
-                    val chunkLen =
-                        if (index == numChunks - 1) (totalLength - (numChunks - 1) * chunkSize).toInt()
-                        else chunkSize
-                    val chunk = ByteArray(chunkLen)
-                    if (chunkLen > 0) readFully(plainIn, chunk, chunkLen)
-                    val chunkIv = chunkIv(baseIv, index)
-                    val cipher = Cipher.getInstance(CIPHER_ALGORITHM)
-                    cipher.init(Cipher.ENCRYPT_MODE, key, GCMParameterSpec(GCM_TAG_BITS, chunkIv))
-                    out.writeChunkRecord(index, chunkIv)
-                    if (chunk.isNotEmpty()) {
-                        // GCM streams: doFinal() over one chunk does not
-                        // accumulate the ciphertext, and appends the 16-byte tag.
-                        out.write(cipher.doFinal(chunk))
-                    } else {
-                        out.write(cipher.doFinal())
-                    }
-                }
+        plaintext.inputStream().use { plain ->
+            destination.outputStream().use { out ->
+                streamEncrypt(plain, out, password, totalLength)
             }
         }
     }
@@ -231,25 +217,44 @@ object MigrationCrypto {
         val salt = ByteArray(SALT_LENGTH).also { random.nextBytes(it) }
         val baseIv = ByteArray(IV_LENGTH).also { random.nextBytes(it) }
         val key = deriveKey(password, salt)
-        val chunkSize = minOf(CHUNK_SIZE_BYTES, totalLength.coerceAtLeast(0).toInt()).coerceAtLeast(0)
+        // Apply the cap while the length is still a Long so exports larger
+        // than Int.MAX_VALUE (2 GiB) cannot wrap to a negative/zero chunk
+        // size (which would divide by zero below).
+        val total = totalLength.coerceAtLeast(0L)
+        val chunkSize = minOf(CHUNK_SIZE_BYTES.toLong(), total)
 
         out.write(ENCRYPTED_VERSION.toInt())
         out.write(salt)
         out.write(baseIv)
-        writeLongBigEndian(out, chunkSize.toLong())
+        writeLongBigEndian(out, chunkSize)
         writeLongBigEndian(out, totalLength)
 
+        val headerAad =
+            ByteArray(CHUNKED_HEADER_SIZE) { index ->
+                when (index) {
+                    0 -> ENCRYPTED_VERSION
+                    in 1..SALT_LENGTH -> salt[index - 1]
+                    in (1 + SALT_LENGTH)..(SALT_LENGTH + IV_LENGTH) -> baseIv[index - 1 - SALT_LENGTH]
+                    else -> 0.toByte()
+                }
+            }.also { aad ->
+                writeLongBigEndian(aad, 1 + SALT_LENGTH + IV_LENGTH, chunkSize)
+                writeLongBigEndian(aad, 1 + SALT_LENGTH + IV_LENGTH + 8, totalLength)
+            }
+
         val numChunks =
-            if (totalLength == 0L) 1L else ((totalLength + chunkSize - 1) / chunkSize)
+            if (totalLength == 0L) 0L else ((totalLength + chunkSize - 1) / chunkSize)
         for (index in 0 until numChunks) {
-            val remaining = totalLength - index * chunkSize
-            val chunk = ByteArray(if (remaining <= 0) 0 else minOf(chunkSize, remaining.toInt()))
-            if (chunk.isNotEmpty()) readFully(plain, chunk, chunk.size)
-            val chunkIv = chunkIv(baseIv, index)
-            out.writeChunkRecord(index, chunkIv)
-            val cipher = Cipher.getInstance(CIPHER_ALGORITHM)
-            cipher.init(Cipher.ENCRYPT_MODE, key, GCMParameterSpec(GCM_TAG_BITS, chunkIv))
-            out.write(if (chunk.isEmpty()) cipher.doFinal() else cipher.doFinal(chunk))
+            val chunkLen = minOf(chunkSize, totalLength - index * chunkSize).toInt()
+            val chunk = ByteArray(chunkLen)
+            if (chunkLen > 0) readFully(plain, chunk, chunkLen)
+            // GCM streams: doFinal() over one chunk does not accumulate the
+            // ciphertext, and appends the 16-byte tag. AAD binds the chunk
+            // (and its index) to the fixed header, see decryptStream.
+            val ciphertext =
+                encryptGcmChunk(key, baseIv, index, headerAad, chunk)
+            out.writeChunkRecord(index)
+            out.write(ciphertext)
         }
     }
 
@@ -345,16 +350,29 @@ object MigrationCrypto {
                 val headerAll = byteArrayOf(first.toByte()) + header
                 val salt = headerAll.copyOfRange(1, 1 + SALT_LENGTH)
                 val baseIv = headerAll.copyOfRange(1 + SALT_LENGTH, 1 + SALT_LENGTH + IV_LENGTH)
-                val chunkSize = readLongBigEndian(headerAll, 1 + SALT_LENGTH + IV_LENGTH).toInt()
+                val chunkSize = readLongBigEndian(headerAll, 1 + SALT_LENGTH + IV_LENGTH)
                 val totalLength = readLongBigEndian(headerAll, 9 + SALT_LENGTH + IV_LENGTH)
-                if (chunkSize < 0 || chunkSize > CHUNK_SIZE_BYTES) {
+                if (chunkSize < 0 || chunkSize > CHUNK_SIZE_BYTES.toLong()) {
                     throw InvalidExportFileException("Invalid chunk size in export header")
                 }
                 if (totalLength < 0) {
                     throw InvalidExportFileException("Invalid plaintext length in export header")
                 }
+                // A zero chunk size can only be valid for an empty plaintext:
+                // any other shape would make the per-chunk arithmetic divide
+                // by zero or spin on empty records.
+                if (chunkSize == 0L && totalLength != 0L) {
+                    throw InvalidExportFileException("Invalid export: zero chunk size for non-empty plaintext")
+                }
                 val key = deriveKey(password, salt)
-                ChunkDecryptInputStream(encryptedStream, key, baseIv, chunkSize, totalLength)
+                ChunkDecryptInputStream(
+                    src = encryptedStream,
+                    key = key,
+                    baseIv = baseIv,
+                    chunkSize = chunkSize,
+                    totalLength = totalLength,
+                    headerAad = headerAll,
+                )
             }
             else -> throw InvalidExportFileException(
                 "Unrecognized export format (version byte: 0x${
@@ -407,7 +425,12 @@ object MigrationCrypto {
         }
     }
 
-    /** 96-bit GCM IV for a chunk: random 4 bytes + 64-bit counter (base ^ index) in bytes 4..11. */
+    /**
+     * 96-bit GCM IV for chunk [index]: the random base IV with the counter
+     * XORed into bytes 4..11. Deriving the IV from the index (instead of
+     * trusting a per-record IV in the file) binds each chunk to its position
+     * in the stream.
+     */
     private fun chunkIv(
         baseIv: ByteArray,
         index: Long,
@@ -420,12 +443,61 @@ object MigrationCrypto {
         return iv
     }
 
-    private fun OutputStream.writeChunkRecord(
+    /**
+     * AAD for chunk [index]: the fixed header (version + salt + base IV +
+     * chunk size + total length) followed by the 8-byte chunk index. Binding
+     * the header and index into each chunk's GCM tag authenticates the whole
+     * framing: rewriting any header field, or moving a chunk to a new
+     * position, invalidates every chunk's tag.
+     */
+    private fun chunkAad(
+        headerAad: ByteArray,
         index: Long,
-        chunkIv: ByteArray,
-    ) {
+    ): ByteArray {
+        val aad = ByteArray(headerAad.size + 8)
+        headerAad.copyInto(aad)
+        writeLongBigEndian(aad, headerAad.size, index)
+        return aad
+    }
+
+    /** Encrypt one chunk with the derived IV and bound AAD; returns ciphertext + 128-bit tag. */
+    private fun encryptGcmChunk(
+        key: SecretKey,
+        baseIv: ByteArray,
+        index: Long,
+        headerAad: ByteArray,
+        plaintext: ByteArray,
+    ): ByteArray {
+        val cipher = Cipher.getInstance(CIPHER_ALGORITHM)
+        cipher.init(
+            Cipher.ENCRYPT_MODE,
+            key,
+            GCMParameterSpec(GCM_TAG_BITS, chunkIv(baseIv, index)),
+        )
+        cipher.updateAAD(chunkAad(headerAad, index))
+        return if (plaintext.isEmpty()) cipher.doFinal() else cipher.doFinal(plaintext)
+    }
+
+    /** Decrypt one chunk with the derived IV and bound AAD; returns the plaintext. */
+    private fun decryptGcmChunk(
+        key: SecretKey,
+        baseIv: ByteArray,
+        index: Long,
+        headerAad: ByteArray,
+        ciphertext: ByteArray,
+    ): ByteArray {
+        val cipher = Cipher.getInstance(CIPHER_ALGORITHM)
+        cipher.init(
+            Cipher.DECRYPT_MODE,
+            key,
+            GCMParameterSpec(GCM_TAG_BITS, chunkIv(baseIv, index)),
+        )
+        cipher.updateAAD(chunkAad(headerAad, index))
+        return cipher.doFinal(ciphertext)
+    }
+
+    private fun OutputStream.writeChunkRecord(index: Long) {
         writeLongBigEndian(this, index)
-        write(chunkIv)
     }
 
     private fun writeLongBigEndian(
@@ -434,6 +506,16 @@ object MigrationCrypto {
     ) {
         for (i in 7 downTo 0) {
             out.write(((value ushr (8 * i)) and 0xFF).toInt())
+        }
+    }
+
+    private fun writeLongBigEndian(
+        buf: ByteArray,
+        offset: Int,
+        value: Long,
+    ) {
+        for (i in 7 downTo 0) {
+            buf[offset + (7 - i)] = ((value ushr (8 * i)) and 0xFF).toByte()
         }
     }
 
@@ -467,18 +549,27 @@ object MigrationCrypto {
      * Buffers at most one plaintext chunk at a time; the underlying cipher
      * buffers at most one chunk of ciphertext, so peak memory is bounded by
      * ~2 x chunk size regardless of export size.
+     *
+     * Framing is authenticated: each chunk's IV is derived from
+     * (base IV, index) rather than read from the file, and each chunk's GCM
+     * AAD binds the fixed header plus the chunk index into the tag, so the
+     * stream cannot be reordered, replayed, or truncated. After the final
+     * chunk is consumed, [read] verifies the underlying stream is exhausted
+     * so a lowered total length (authenticated-prefix attack) is rejected.
      */
     private class ChunkDecryptInputStream(
         private val src: InputStream,
         private val key: SecretKey,
         private val baseIv: ByteArray,
-        private val chunkSize: Int,
+        private val chunkSize: Long,
         totalLength: Long,
+        private val headerAad: ByteArray,
     ) : InputStream() {
         private var plaintextRemaining = totalLength
         private var chunkIndex = 0L
         private var current: ByteArray? = null
         private var currentPos = 0
+        private var exhaustedChecked = false
 
         override fun read(): Int {
             while (true) {
@@ -488,7 +579,10 @@ object MigrationCrypto {
                     if (currentPos == chunk.size) current = null
                     return b and 0xFF
                 }
-                if (plaintextRemaining == 0L) return -1
+                if (plaintextRemaining == 0L) {
+                    verifyExhausted()
+                    return -1
+                }
                 loadNextChunk()
             }
         }
@@ -519,6 +613,20 @@ object MigrationCrypto {
             return got
         }
 
+        /**
+         * After all declared plaintext is consumed, the stream must be at
+         * EOF: any trailing bytes indicate a truncated total length (an
+         * authenticated-prefix attack) or a corrupt file.
+         */
+        private fun verifyExhausted() {
+            if (exhaustedChecked) return
+            exhaustedChecked = true
+            val extra = src.read()
+            if (extra != -1) {
+                throw InvalidExportFileException("Corrupt export: trailing data after final chunk")
+            }
+        }
+
         @Suppress("ThrowsCount") // Corrupt/wrong-password chunks each fail fast
         private fun loadNextChunk() {
             val recordHeader = ByteArray(CHUNK_RECORD_HEADER_SIZE)
@@ -527,20 +635,23 @@ object MigrationCrypto {
             if (index != chunkIndex) {
                 throw InvalidExportFileException("Corrupt export: chunk index $index, expected $chunkIndex")
             }
-            val chunkIv = recordHeader.copyOfRange(8, 8 + IV_LENGTH)
-            val expected = minOf(chunkSize, plaintextRemaining.toInt().coerceAtLeast(0))
-            val ciphertext = ByteArray(expected + GCM_TAG_BYTES)
+            // The IV is derived from (baseIv, index); the record no longer
+            // stores a per-chunk IV. The expected chunk length is computed
+            // with Long arithmetic (no Int narrowing), so multi-giB exports
+            // cannot wrap to a zero chunk size.
+            val expected = minOf(chunkSize, plaintextRemaining)
+            if (expected < 0L) {
+                throw InvalidExportFileException("Corrupt export: negative chunk length")
+            }
+            val ciphertext = ByteArray(expected.toInt() + GCM_TAG_BYTES)
             readFully(src, ciphertext, ciphertext.size)
-
-            val cipher = Cipher.getInstance(CIPHER_ALGORITHM)
-            cipher.init(Cipher.DECRYPT_MODE, key, GCMParameterSpec(GCM_TAG_BITS, chunkIv))
             val decrypted =
                 try {
-                    cipher.doFinal(ciphertext)
+                    decryptGcmChunk(key, baseIv, index, headerAad, ciphertext)
                 } catch (e: javax.crypto.AEADBadTagException) {
                     throw WrongPasswordException("Incorrect password", e)
                 }
-            if (decrypted.size != expected) {
+            if (decrypted.size != expected.toInt()) {
                 throw InvalidExportFileException("Corrupt export: chunk $index size mismatch")
             }
             plaintextRemaining -= decrypted.size

--- a/app/src/main/java/network/columba/app/migration/MigrationData.kt
+++ b/app/src/main/java/network/columba/app/migration/MigrationData.kt
@@ -2,6 +2,7 @@ package network.columba.app.migration
 
 import network.columba.app.data.db.entity.CustomThemeEntity
 import kotlinx.serialization.Serializable
+import java.io.File
 
 /**
  * Migration bundle containing all exportable app data.
@@ -430,12 +431,13 @@ data class MigrationPreview(
 )
 
 /**
- * Result of previewing a migration file, including the decrypted ZIP bytes
- * so they can be reused during import without redundant decryption.
+ * Result of previewing a migration file, including the local copy of the
+ * bundle so the import can re-stream it without redundant key derivation
+ * or re-copying from the content resolver.
  */
 class PreviewWithData(
     val preview: MigrationPreview,
-    val zipBytes: ByteArray,
+    val file: File,
 )
 
 /**

--- a/app/src/main/java/network/columba/app/migration/MigrationImporter.kt
+++ b/app/src/main/java/network/columba/app/migration/MigrationImporter.kt
@@ -730,18 +730,20 @@ class MigrationImporter
             uri: Uri,
             password: String? = null,
         ): Pair<MigrationBundle, File>? {
+            var localFile: File? = null
             return try {
                 val inputStream = context.contentResolver.openInputStream(uri) ?: return null
                 val cacheDir = File(context.cacheDir, IMPORT_CACHE_DIR).also { it.mkdirs() }
-                val localFile = File(cacheDir, "columba_import_${System.currentTimeMillis()}.columba")
+                val stagedFile = File(cacheDir, "columba_import_${System.currentTimeMillis()}.columba")
+                localFile = stagedFile
                 try {
-                    inputStream.use { stream -> stream.copyTo(localFile.outputStream()) }
+                    inputStream.use { stream -> stream.copyTo(stagedFile.outputStream()) }
                 } catch (e: Exception) {
-                    localFile.delete()
+                    stagedFile.delete()
                     throw e
                 }
                 if (MigrationCrypto.isEncrypted(
-                        localFile.inputStream().use { stream ->
+                        stagedFile.inputStream().use { stream ->
                             val header = ByteArray(2)
                             stream.read(header).let { bytesRead ->
                                 if (bytesRead < 1) ByteArray(0) else header
@@ -750,27 +752,37 @@ class MigrationImporter
                     )
                 ) {
                     if (password == null) {
-                        localFile.delete()
+                        stagedFile.delete()
                         throw PasswordRequiredException("This export file is encrypted")
                     }
-                    MigrationCrypto.decryptFile(localFile, password)
+                    MigrationCrypto.decryptFile(stagedFile, password)
                 }
-                streamBundleFromZipFile(localFile) ?: run {
-                    localFile.delete()
+                streamBundleFromZipFile(stagedFile) ?: run {
+                    stagedFile.delete()
                     null
                 }
             } catch (e: network.columba.app.migration.WrongPasswordException) {
-                // Thrown by MigrationCrypto (GCM auth tag mismatch).
+                // Thrown by MigrationCrypto (GCM auth tag mismatch). The staged
+                // file is a full copy of the (encrypted) bundle, so remove it
+                // rather than leaking it on every wrong-password attempt.
+                localFile?.delete()
                 Log.e(TAG, "Wrong password for encrypted export", e)
                 throw e
             } catch (e: WrongPasswordException) {
                 // data.crypto variant (identity-key decryption).
+                localFile?.delete()
                 Log.e(TAG, "Wrong password for encrypted export", e)
                 throw e
             } catch (e: PasswordRequiredException) {
+                localFile?.delete()
                 Log.e(TAG, "Password required for encrypted export", e)
                 throw e
             } catch (e: Exception) {
+                // Decryption and manifest-decoding failures otherwise leave the
+                // staged file (a full bundle copy, or a plaintext ZIP after a
+                // successful decrypt) behind. Remove it on every failure path
+                // that does not transfer ownership to a successful result.
+                localFile?.delete()
                 Log.e(TAG, "Failed to read migration bundle", e)
                 null
             }

--- a/app/src/main/java/network/columba/app/migration/MigrationImporter.kt
+++ b/app/src/main/java/network/columba/app/migration/MigrationImporter.kt
@@ -10,6 +10,7 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.withContext
 import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.decodeFromStream
 import network.columba.app.data.crypto.IdentityKeyEncryptor
 import network.columba.app.data.crypto.WrongPasswordException
 import network.columba.app.data.database.InterfaceDatabase
@@ -56,6 +57,23 @@ class MigrationImporter
             private const val TAG = "MigrationImporter"
             private const val MANIFEST_FILENAME = "manifest.json"
             private const val ATTACHMENTS_PREFIX = "attachments/"
+            /**
+             * Staged import bundle files (local plaintext ZIPs) live here
+             * while an import is in progress; [importData] removes the staged
+             * file in a finally block.
+             */
+            const val IMPORT_CACHE_DIR = "migration_import"
+        }
+
+        /**
+         * Delete staged import bundles left behind by a cancelled preview or a
+         * crash. Safe: the directory is written only by this importer during
+         * its import/preview flow.
+         */
+        fun cleanupStagedImports() {
+            File(context.cacheDir, IMPORT_CACHE_DIR).listFiles()?.forEach { file ->
+                if (file.isFile) file.delete()
+            }
         }
 
         private val json =
@@ -91,13 +109,25 @@ class MigrationImporter
                 }
             }
 
+        /**
+         * Preview a migration file before importing.
+         *
+         * The bundle is copied to the cache directory (and decrypted there if
+         * needed) so the manifest can be parsed in a streaming pass and the
+         * import can reuse the same local file without re-reading through the
+         * content resolver or holding the bundle in memory.
+         *
+         * Ownership of the staged file transfers to the caller (the
+         * ViewModel), which deletes it when the import completes, the state
+         * resets, or the ViewModel is cleared.
+         */
         suspend fun previewMigration(
             uri: Uri,
             password: String? = null,
         ): Result<PreviewWithData> =
             withContext(Dispatchers.IO) {
                 try {
-                    val (bundle, zipBytes) =
+                    val (bundle, localFile) =
                         readMigrationBundle(uri, password)
                             ?: return@withContext Result.failure(
                                 Exception("Failed to read migration file"),
@@ -120,22 +150,13 @@ class MigrationImporter
                                     callHistoryCount = bundle.callHistory.size,
                                     identityNames = bundle.identities.map { it.displayName },
                                 ),
-                            zipBytes = zipBytes,
+                            file = localFile,
                         ),
                     )
                 } catch (e: Exception) {
                     Log.e(TAG, "Failed to preview migration", e)
                     Result.failure(e)
                 }
-            }
-
-        /**
-         * Check if an import file requires a password.
-         */
-        suspend fun requiresPassword(uri: Uri): Boolean =
-            withContext(Dispatchers.IO) {
-                val (bundle, _) = readMigrationBundle(uri) ?: return@withContext false
-                bundle.keysEncrypted
             }
 
         /**
@@ -149,35 +170,55 @@ class MigrationImporter
         suspend fun importData(
             uri: Uri,
             password: String? = null,
-            cachedZipBytes: ByteArray? = null,
+            cachedZipFile: File? = null,
             onProgress: (Float) -> Unit = {},
             importPassword: CharArray? = null,
         ): ImportResult =
             withContext(Dispatchers.IO) {
+                Log.i(TAG, "Starting migration import...")
+                onProgress(0.05f)
+
+                // Stage the bundle as a local plaintext ZIP: reuse the file
+                // prepared by the preview when available (it is already
+                // decrypted), otherwise copy + decrypt from the URI. The
+                // manifest is parsed in a single streaming pass either way.
+                val (bundle, stagedFile, importerOwnedFile) =
+                    if (cachedZipFile != null && cachedZipFile.exists()) {
+                        // Reuse the preview's local bundle (already a plaintext
+                        // ZIP). The caller still owns this file, so do not
+                        // delete it here.
+                        val parsed = streamBundleFromZipFile(cachedZipFile)
+                            ?: return@withContext ImportResult.Error(
+                                "Failed to read migration file",
+                            )
+                        Triple(parsed.first, parsed.second, false)
+                    } else {
+                        val parsed = readMigrationBundle(uri, password)
+                            ?: return@withContext ImportResult.Error(
+                                "Failed to read migration file",
+                            )
+                        Triple(parsed.first, parsed.second, true)
+                    }
+
                 try {
-                    Log.i(TAG, "Starting migration import...")
-                    onProgress(0.05f)
+                    importDataInternal(bundle, stagedFile, onProgress, importPassword)
+                } finally {
+                    // Only remove files this importer created; the caller
+                    // (ViewModel) owns and re-cleans the preview's cache file.
+                    if (importerOwnedFile) stagedFile.delete()
+                }
+            }
 
-                    val (bundle, zipBytes) =
-                        if (cachedZipBytes != null) {
-                            // Reuse decrypted bytes from preview to avoid redundant PBKDF2 + decryption
-                            val manifestJson =
-                                extractManifestFromZip(java.io.ByteArrayInputStream(cachedZipBytes))
-                            val parsed =
-                                manifestJson?.let { json.decodeFromString<MigrationBundle>(it) }
-                                    ?: return@withContext ImportResult.Error(
-                                        "Failed to read migration file",
-                                    )
-                            parsed to cachedZipBytes
-                        } else {
-                            readMigrationBundle(uri, password)
-                                ?: return@withContext ImportResult.Error(
-                                    "Failed to read migration file",
-                                )
-                        }
-
+        @Suppress("LongMethod", "ComplexMethod", "ReturnCount")
+        private suspend fun importDataInternal(
+            bundle: MigrationBundle,
+            stagedFile: File,
+            onProgress: (Float) -> Unit,
+            importPassword: CharArray?,
+        ): ImportResult {
+            return try {
                     if (bundle.version > MigrationBundle.CURRENT_VERSION) {
-                        return@withContext ImportResult.Error(
+                        return ImportResult.Error(
                             "Migration file is from a newer version (${bundle.version}). " +
                                 "Please update the app first.",
                         )
@@ -185,21 +226,21 @@ class MigrationImporter
 
                     // Check minimum supported version for backwards compatibility
                     if (bundle.version < MigrationBundle.MINIMUM_VERSION) {
-                        return@withContext ImportResult.Error(
+                        return ImportResult.Error(
                             "Migration file is from an old version (${bundle.version}). " +
                                 "Minimum supported version is ${MigrationBundle.MINIMUM_VERSION}.",
                         )
                     }
 
                     if (bundle.version < 8 && bundle.callHistoryDeletions.isNotEmpty()) {
-                        return@withContext ImportResult.Error(
+                        return ImportResult.Error(
                             "Call-history deletion authority requires migration format version 8.",
                         )
                     }
 
                     // Check if password is required but not provided
                     if (bundle.keysEncrypted && importPassword == null) {
-                        return@withContext ImportResult.Error(
+                        return ImportResult.Error(
                             "This export file is password-protected. Please provide the password.",
                         )
                     }
@@ -218,7 +259,7 @@ class MigrationImporter
                     val interfacesImported = importInterfaces(bundle.interfaces)
                     onProgress(0.86f)
 
-                    if (bundle.attachmentManifest.isNotEmpty()) importAttachments(zipBytes)
+                    if (bundle.attachmentManifest.isNotEmpty()) importAttachments(stagedFile)
                     onProgress(0.90f)
 
                     importRatchets(bundle.ratchetFiles)
@@ -675,33 +716,55 @@ class MigrationImporter
             )
 
         /**
-         * Read and parse the MigrationBundle from a ZIP file.
+         * Read the migration bundle from a URI, preparing a local cache file
+         * for the rest of the import flow.
+         *
+         * The file is copied to the cache directory via [File.copyTo] (no
+         * full in-memory read), encrypted files are decrypted in-place with a
+         * streaming chunked pass, and the manifest is parsed with a streaming
+         * JSON decoder (no full JSON String). Returns null on unreadable input;
+         * password errors propagate to the caller.
          */
         @Suppress("ThrowsCount")
         private fun readMigrationBundle(
             uri: Uri,
             password: String? = null,
-        ): Pair<MigrationBundle, ByteArray>? {
+        ): Pair<MigrationBundle, File>? {
             return try {
                 val inputStream = context.contentResolver.openInputStream(uri) ?: return null
-                inputStream.use { stream ->
-                    val rawBytes = stream.readBytes()
-                    val zipBytes =
-                        if (MigrationCrypto.isEncrypted(rawBytes)) {
-                            if (password == null) {
-                                throw PasswordRequiredException("This export file is encrypted")
+                val cacheDir = File(context.cacheDir, IMPORT_CACHE_DIR).also { it.mkdirs() }
+                val localFile = File(cacheDir, "columba_import_${System.currentTimeMillis()}.columba")
+                try {
+                    inputStream.use { stream -> stream.copyTo(localFile.outputStream()) }
+                } catch (e: Exception) {
+                    localFile.delete()
+                    throw e
+                }
+                if (MigrationCrypto.isEncrypted(
+                        localFile.inputStream().use { stream ->
+                            val header = ByteArray(2)
+                            stream.read(header).let { bytesRead ->
+                                if (bytesRead < 1) ByteArray(0) else header
                             }
-                            MigrationCrypto.decrypt(rawBytes, password)
-                        } else {
-                            rawBytes
-                        }
-                    val manifestJson = extractManifestFromZip(java.io.ByteArrayInputStream(zipBytes))
-                    manifestJson?.let { json.decodeFromString<MigrationBundle>(it) to zipBytes }
+                        },
+                    )
+                ) {
+                    if (password == null) {
+                        localFile.delete()
+                        throw PasswordRequiredException("This export file is encrypted")
+                    }
+                    MigrationCrypto.decryptFile(localFile, password)
+                }
+                streamBundleFromZipFile(localFile) ?: run {
+                    localFile.delete()
+                    null
                 }
             } catch (e: network.columba.app.migration.WrongPasswordException) {
+                // Thrown by MigrationCrypto (GCM auth tag mismatch).
                 Log.e(TAG, "Wrong password for encrypted export", e)
                 throw e
             } catch (e: WrongPasswordException) {
+                // data.crypto variant (identity-key decryption).
                 Log.e(TAG, "Wrong password for encrypted export", e)
                 throw e
             } catch (e: PasswordRequiredException) {
@@ -713,14 +776,21 @@ class MigrationImporter
             }
         }
 
-        private fun extractManifestFromZip(inputStream: java.io.InputStream): String? {
-            ZipInputStream(inputStream).use { zipIn ->
-                var entry = zipIn.nextEntry
-                while (entry != null) {
-                    if (entry.name == MANIFEST_FILENAME) {
-                        return zipIn.bufferedReader().readText()
+        /**
+         * Parse the manifest with a streaming JSON decoder and return the
+         * bundle together with the local ZIP file (reused for attachments).
+         */
+        private fun streamBundleFromZipFile(localFile: File): Pair<MigrationBundle, File>? {
+            localFile.inputStream().use { stream ->
+                ZipInputStream(stream).use { zipIn ->
+                    var entry = zipIn.nextEntry
+                    while (entry != null) {
+                        if (entry.name == MANIFEST_FILENAME) {
+                            val bundle = json.decodeFromStream<MigrationBundle>(zipIn)
+                            return bundle to localFile
+                        }
+                        entry = zipIn.nextEntry
                     }
-                    entry = zipIn.nextEntry
                 }
             }
             return null
@@ -876,14 +946,14 @@ class MigrationImporter
         }
 
         /**
-         * Import attachments from the ZIP file.
+         * Import attachments from the staged ZIP file.
          */
-        private fun importAttachments(zipBytes: ByteArray): Int {
+        private fun importAttachments(zipFile: File): Int {
             val attachmentsDir = File(context.filesDir, "attachments")
             attachmentsDir.mkdirs()
 
             return try {
-                extractAttachmentsFromZip(java.io.ByteArrayInputStream(zipBytes), attachmentsDir)
+                zipFile.inputStream().use { stream -> extractAttachmentsFromZip(stream, attachmentsDir) }
             } catch (e: Exception) {
                 Log.e(TAG, "Failed to import attachments", e)
                 0

--- a/app/src/main/java/network/columba/app/viewmodel/MigrationViewModel.kt
+++ b/app/src/main/java/network/columba/app/viewmodel/MigrationViewModel.kt
@@ -11,10 +11,12 @@ import network.columba.app.migration.MigrationExporter
 import network.columba.app.migration.MigrationImporter
 import network.columba.app.migration.MigrationPreview
 import network.columba.app.migration.PasswordRequiredException
+import network.columba.app.migration.PreviewWithData
 import network.columba.app.migration.WrongPasswordException
 import network.columba.app.service.InterfaceConfigManager
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.Job
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
@@ -92,6 +94,15 @@ class MigrationViewModel
          */
         private var cachedImportFile: File? = null
 
+        /**
+         * The currently in-flight preview job. A new preview cancels it so a
+         * slow, superseded preview cannot race the latest one.
+         */
+        private var previewJob: Job? = null
+
+        /** Monotonic counter: the import for the newest preview wins, even if an older preview finished last. */
+        private var importSequence = 0L
+
         init {
             // Remove staged import bundles left behind by a cancelled preview
             // or a crash. The importer owns the cache directory; in unit
@@ -157,80 +168,129 @@ class MigrationViewModel
 
         /**
          * Preview a migration file before importing.
+         *
+         * Each preview runs in a tracked job: starting a new preview cancels
+         * the in-flight one so a slow, superseded preview cannot race the
+         * latest. A sequence counter additionally guards the install, so even
+         * if an older preview were still alive it could not overwrite the
+         * newer preview's staged file or UI state. The replaced staged file is
+         * deleted so a superseded plaintext ZIP is not left orphaned in cache.
          */
         fun previewImport(
             uri: Uri,
             password: String? = null,
         ) {
-            viewModelScope.launch {
-                try {
-                    Log.i(TAG, "Previewing import: $uri")
-                    _uiState.value = MigrationUiState.Loading("Reading migration file...")
+            previewJob?.cancel()
+            val sequence = ++importSequence
+            previewJob =
+                viewModelScope.launch {
+                    try {
+                        Log.i(TAG, "Previewing import: $uri")
+                        _uiState.value = MigrationUiState.Loading("Reading migration file...")
 
-                    // Check if file is encrypted and we don't have a password yet
-                    if (password == null) {
-                        val encryptedResult = migrationImporter.isEncryptedExport(uri)
-                        encryptedResult.fold(
-                            onSuccess = { isEncrypted ->
-                                if (isEncrypted) {
-                                    Log.i(TAG, "File is encrypted, requesting password")
-                                    _pendingImportUri.value = uri
-                                    _uiState.value = MigrationUiState.PasswordRequired(uri)
-                                    return@launch
-                                }
-                            },
-                            onFailure = { error ->
-                                _uiState.value =
-                                    MigrationUiState.Error(
-                                        "Could not read migration file: ${error.message}",
-                                    )
-                                return@launch
-                            },
+                        // Check if file is encrypted and we don't have a password yet
+                        if (password == null && !awaitEncryptionCheck(uri, sequence)) {
+                            return@launch
+                        }
+
+                        val result = migrationImporter.previewMigration(uri, password)
+                        if (sequence != importSequence) {
+                            // A newer preview superseded this one; discard the
+                            // stale result and its staged file.
+                            result.onSuccess { it.file.delete() }
+                            return@launch
+                        }
+
+                        result.fold(
+                            onSuccess = { installPreview(it, uri, password) },
+                            onFailure = { error -> handlePreviewError(error, uri) },
                         )
+                    } catch (e: WrongPasswordException) {
+                        if (sequence != importSequence) return@launch
+                        Log.w(TAG, "Wrong password for encrypted export", e)
+                        _uiState.value = MigrationUiState.WrongPassword(uri)
+                    } catch (e: PasswordRequiredException) {
+                        if (sequence != importSequence) return@launch
+                        Log.d(TAG, "Password required for encrypted export", e)
+                        _pendingImportUri.value = uri
+                        _uiState.value = MigrationUiState.PasswordRequired(uri)
+                    } catch (e: Exception) {
+                        if (sequence != importSequence) return@launch
+                        Log.e(TAG, "Preview failed with exception", e)
+                        _uiState.value =
+                            MigrationUiState.Error(
+                                "Could not read migration file: ${e.message}",
+                            )
                     }
+                }
+        }
 
-                    val result = migrationImporter.previewMigration(uri, password)
-
-                    result.fold(
-                        onSuccess = { previewWithData ->
-                            Log.i(TAG, "Preview loaded: ${previewWithData.preview.identityCount} identities")
-                            _importPreview.value = previewWithData.preview
-                            cachedImportFile = previewWithData.file
-                            _pendingImportUri.value = null
-                            _uiState.value =
-                                MigrationUiState.ImportPreview(previewWithData.preview, uri, password)
-                        },
-                        onFailure = { error ->
-                            Log.e(TAG, "Preview failed", error)
-                            when (error) {
-                                is WrongPasswordException -> {
-                                    _uiState.value = MigrationUiState.WrongPassword(uri)
-                                }
-                                is PasswordRequiredException -> {
-                                    _pendingImportUri.value = uri
-                                    _uiState.value = MigrationUiState.PasswordRequired(uri)
-                                }
-                                else -> {
-                                    _uiState.value =
-                                        MigrationUiState.Error(
-                                            "Could not read migration file: ${error.message}",
-                                        )
-                                }
-                            }
-                        },
-                    )
-                } catch (e: WrongPasswordException) {
-                    Log.w(TAG, "Wrong password for encrypted export", e)
-                    _uiState.value = MigrationUiState.WrongPassword(uri)
-                } catch (e: PasswordRequiredException) {
-                    Log.d(TAG, "Password required for encrypted export", e)
-                    _pendingImportUri.value = uri
-                    _uiState.value = MigrationUiState.PasswordRequired(uri)
-                } catch (e: Exception) {
-                    Log.e(TAG, "Preview failed with exception", e)
+        /**
+         * Runs the "is this file encrypted?" check when no password was
+         * supplied. Returns `true` to proceed to preview; returns `false` after
+         * updating state when a password is required or the file is unreadable.
+         */
+        private suspend fun awaitEncryptionCheck(uri: Uri, sequence: Long): Boolean {
+            val encryptedResult = migrationImporter.isEncryptedExport(uri)
+            return encryptedResult.fold(
+                onSuccess = { isEncrypted ->
+                    if (isEncrypted) {
+                        Log.i(TAG, "File is encrypted, requesting password")
+                        _pendingImportUri.value = uri
+                        _uiState.value = MigrationUiState.PasswordRequired(uri)
+                        false
+                    } else {
+                        true
+                    }
+                },
+                onFailure = { error ->
+                    if (sequence != importSequence) return false
                     _uiState.value =
                         MigrationUiState.Error(
-                            "Could not read migration file: ${e.message}",
+                            "Could not read migration file: ${error.message}",
+                        )
+                    false
+                },
+            )
+        }
+
+        /**
+         * Installs a successful preview, replacing (and deleting) any previous
+         * staged file so a superseded plaintext ZIP is not left in cache.
+         */
+        private fun installPreview(
+            previewWithData: PreviewWithData,
+            uri: Uri,
+            password: String?,
+        ) {
+            Log.i(TAG, "Preview loaded: ${previewWithData.preview.identityCount} identities")
+            cachedImportFile?.let { prev ->
+                if (prev != previewWithData.file) prev.delete()
+            }
+            cachedImportFile = previewWithData.file
+            _importPreview.value = previewWithData.preview
+            _pendingImportUri.value = null
+            _uiState.value = MigrationUiState.ImportPreview(previewWithData.preview, uri, password)
+        }
+
+        /** Maps a preview failure to the matching UI state. */
+        private fun handlePreviewError(
+            error: Throwable,
+            uri: Uri,
+        ) {
+            Log.e(TAG, "Preview failed", error)
+            when (error) {
+                is WrongPasswordException -> {
+                    _uiState.value = MigrationUiState.WrongPassword(uri)
+                }
+                is PasswordRequiredException -> {
+                    _pendingImportUri.value = uri
+                    _uiState.value = MigrationUiState.PasswordRequired(uri)
+                }
+                else -> {
+                    _uiState.value =
+                        MigrationUiState.Error(
+                            "Could not read migration file: ${error.message}",
                         )
                 }
             }

--- a/app/src/main/java/network/columba/app/viewmodel/MigrationViewModel.kt
+++ b/app/src/main/java/network/columba/app/viewmodel/MigrationViewModel.kt
@@ -234,7 +234,11 @@ class MigrationViewModel
             val encryptedResult = migrationImporter.isEncryptedExport(uri)
             return encryptedResult.fold(
                 onSuccess = { isEncrypted ->
-                    if (isEncrypted) {
+                    if (sequence != importSequence) {
+                        // A newer preview superseded this one; do not update
+                        // state (e.g. a stale password prompt for the old URI).
+                        false
+                    } else if (isEncrypted) {
                         Log.i(TAG, "File is encrypted, requesting password")
                         _pendingImportUri.value = uri
                         _uiState.value = MigrationUiState.PasswordRequired(uri)

--- a/app/src/main/java/network/columba/app/viewmodel/MigrationViewModel.kt
+++ b/app/src/main/java/network/columba/app/viewmodel/MigrationViewModel.kt
@@ -20,6 +20,7 @@ import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
+import java.io.File
 import javax.inject.Inject
 
 private const val TAG = "MigrationVM"
@@ -85,12 +86,17 @@ class MigrationViewModel
         val pendingImportUri: StateFlow<Uri?> = _pendingImportUri.asStateFlow()
 
         /**
-         * Cached decrypted ZIP bytes from preview, reused during import
-         * to avoid redundant PBKDF2 key derivation and AES-GCM decryption.
+         * Cached staged bundle file from preview (a local plaintext ZIP in
+         * the app cache), reused during import to avoid redundant key
+         * derivation, decryption, and content-resolver reads.
          */
-        private var cachedImportZipBytes: ByteArray? = null
+        private var cachedImportFile: File? = null
 
         init {
+            // Remove staged import bundles left behind by a cancelled preview
+            // or a crash. The importer owns the cache directory; in unit
+            // tests this is a no-op on the mock.
+            migrationImporter.cleanupStagedImports()
             loadExportPreview()
         }
 
@@ -189,7 +195,7 @@ class MigrationViewModel
                         onSuccess = { previewWithData ->
                             Log.i(TAG, "Preview loaded: ${previewWithData.preview.identityCount} identities")
                             _importPreview.value = previewWithData.preview
-                            cachedImportZipBytes = previewWithData.zipBytes
+                            cachedImportFile = previewWithData.file
                             _pendingImportUri.value = null
                             _uiState.value =
                                 MigrationUiState.ImportPreview(previewWithData.preview, uri, password)
@@ -243,15 +249,22 @@ class MigrationViewModel
                     _uiState.value = MigrationUiState.Importing
                     _importProgress.value = 0f
 
-                    val cachedBytes = cachedImportZipBytes
-                    cachedImportZipBytes = null // Release reference before long-running import
+                    val cachedFile = cachedImportFile
+                    cachedImportFile = null
                     val result =
-                        migrationImporter.importData(
-                            uri = uri,
-                            password = password,
-                            cachedZipBytes = cachedBytes,
-                            onProgress = { progress -> _importProgress.value = progress },
-                        )
+                        try {
+                            migrationImporter.importData(
+                                uri = uri,
+                                password = password,
+                                cachedZipFile = cachedFile,
+                                onProgress = { progress -> _importProgress.value = progress },
+                            )
+                        } finally {
+                            // The preview's staged file is owned by this
+                            // ViewModel (the importer only deletes files it
+                            // created). Delete it now that the import is done.
+                            cachedFile?.delete()
+                        }
 
                     when (result) {
                         is ImportResult.Success -> {
@@ -347,7 +360,7 @@ class MigrationViewModel
             _importProgress.value = 0f
             _importPreview.value = null
             _pendingImportUri.value = null
-            cachedImportZipBytes = null
+            clearCachedImportFile()
         }
 
         /**
@@ -361,7 +374,12 @@ class MigrationViewModel
         override fun onCleared() {
             super.onCleared()
             cleanupExportFiles()
-            cachedImportZipBytes = null
+            clearCachedImportFile()
+        }
+
+        private fun clearCachedImportFile() {
+            cachedImportFile?.delete()
+            cachedImportFile = null
         }
     }
 

--- a/app/src/test/java/network/columba/app/migration/MigrationCallHistoryImportTest.kt
+++ b/app/src/test/java/network/columba/app/migration/MigrationCallHistoryImportTest.kt
@@ -73,10 +73,10 @@ class MigrationCallHistoryImportTest {
     @Test
     fun `import preserves attempt id and duplicate import is idempotent`() =
         runTest {
-            val zip = zip(bundle(listOf(call())))
+            val zip = tempZipFile(zip(bundle(listOf(call()))))
 
-            val first = requireSuccess(importer.importData(Uri.EMPTY, cachedZipBytes = zip))
-            val second = requireSuccess(importer.importData(Uri.EMPTY, cachedZipBytes = zip))
+            val first = requireSuccess(importer.importData(Uri.EMPTY, cachedZipFile = zip))
+            val second = requireSuccess(importer.importData(Uri.EMPTY, cachedZipFile = zip))
 
             assertEquals(1, first.callHistoryImported)
             assertEquals(0, first.callHistoryConflictsSkipped)
@@ -88,11 +88,11 @@ class MigrationCallHistoryImportTest {
     @Test
     fun `reimport cannot resurrect a deleted finalized call`() =
         runTest {
-            val archive = zip(bundle(listOf(call())))
-            requireSuccess(importer.importData(Uri.EMPTY, cachedZipBytes = archive))
+            val archive = tempZipFile(zip(bundle(listOf(call()))))
+            requireSuccess(importer.importData(Uri.EMPTY, cachedZipFile = archive))
             assertEquals(1, database.callHistoryDeletionDao().deleteFinalized("attempt-1", LOCAL_IDENTITY, 500L))
 
-            val replay = requireSuccess(importer.importData(Uri.EMPTY, cachedZipBytes = archive))
+            val replay = requireSuccess(importer.importData(Uri.EMPTY, cachedZipFile = archive))
 
             assertEquals(0, replay.callHistoryImported)
             assertEquals(1, replay.callHistoryConflictsSkipped)
@@ -102,18 +102,20 @@ class MigrationCallHistoryImportTest {
     @Test
     fun `transfer deletion authority removes and suppresses finalized evidence`() =
         runTest {
-            val oldArchive = zip(bundle(listOf(call())))
-            requireSuccess(importer.importData(Uri.EMPTY, cachedZipBytes = oldArchive))
+            val oldArchive = tempZipFile(zip(bundle(listOf(call()))))
+            requireSuccess(importer.importData(Uri.EMPTY, cachedZipFile = oldArchive))
             val deletionArchive =
-                zip(
+                tempZipFile(
+                    zip(
                     bundle(
                         calls = emptyList(),
                         deletions = listOf(CallHistoryDeletionExport("attempt-1", LOCAL_IDENTITY, 500L)),
                     ),
+                        ),
                 )
 
-            requireSuccess(importer.importData(Uri.EMPTY, cachedZipBytes = deletionArchive))
-            val replay = requireSuccess(importer.importData(Uri.EMPTY, cachedZipBytes = oldArchive))
+            requireSuccess(importer.importData(Uri.EMPTY, cachedZipFile = deletionArchive))
+            val replay = requireSuccess(importer.importData(Uri.EMPTY, cachedZipFile = oldArchive))
 
             assertNull(database.callHistoryDao().getByAttemptId("attempt-1"))
             assertEquals(LOCAL_IDENTITY, database.callHistoryDeletionDao().getDeletion("attempt-1")?.localIdentityHash)
@@ -145,8 +147,8 @@ class MigrationCallHistoryImportTest {
             val first = bundle(emptyList(), listOf(CallHistoryDeletionExport("immutable-deletion", LOCAL_IDENTITY, 500L)))
             val conflict = bundle(emptyList(), listOf(CallHistoryDeletionExport("immutable-deletion", LOCAL_IDENTITY, 501L)))
 
-            requireSuccess(importer.importData(Uri.EMPTY, cachedZipBytes = zip(first)))
-            val result = importer.importData(Uri.EMPTY, cachedZipBytes = zip(conflict))
+            requireSuccess(importer.importData(Uri.EMPTY, cachedZipFile = tempZipFile(zip(first))))
+            val result = importer.importData(Uri.EMPTY, cachedZipFile = tempZipFile(zip(conflict)))
 
             assertTrue(result is ImportResult.Error)
             assertEquals(500L, database.callHistoryDeletionDao().getDeletion("immutable-deletion")?.deletedAt)
@@ -180,7 +182,7 @@ class MigrationCallHistoryImportTest {
                 ).jsonObject.toMutableMap()
             current["version"] = JsonPrimitive(7)
 
-            val result = importer.importData(Uri.EMPTY, cachedZipBytes = zipManifest(JsonObject(current).toString()))
+            val result = importer.importData(Uri.EMPTY, cachedZipFile = tempZipFile(zipManifest(JsonObject(current).toString())))
 
             assertTrue(result is ImportResult.Error)
             assertNull(database.callHistoryDao().getByAttemptId("attempt-1"))
@@ -212,10 +214,11 @@ class MigrationCallHistoryImportTest {
             val result =
                 importer.importData(
                     Uri.EMPTY,
-                    cachedZipBytes =
-                        zip(
-                            bundle(
-                                calls = listOf(call().copy(callAttemptId = "must-roll-back")),
+                    cachedZipFile =
+                        tempZipFile(
+                            zip(
+                                bundle(
+                                    calls = listOf(call().copy(callAttemptId = "must-roll-back")),
                                 deletions =
                                     listOf(
                                         CallHistoryDeletionExport(
@@ -224,6 +227,7 @@ class MigrationCallHistoryImportTest {
                                             deletedAt = 500L,
                                         ),
                                     ),
+                                ),
                             ),
                         ),
                 )
@@ -237,12 +241,12 @@ class MigrationCallHistoryImportTest {
     @Test
     fun `conflicting attempt is skipped without overwriting local evidence`() =
         runTest {
-            importer.importData(Uri.EMPTY, cachedZipBytes = zip(bundle(listOf(call()))))
+            importer.importData(Uri.EMPTY, cachedZipFile = tempZipFile(zip(bundle(listOf(call())))))
 
             val result =
                 importer.importData(
                     Uri.EMPTY,
-                    cachedZipBytes = zip(bundle(listOf(call().copy(connectedAt = 130L)))),
+                    cachedZipFile = tempZipFile(zip(bundle(listOf(call().copy(connectedAt = 130L))))),
                 ).let(::requireSuccess)
 
             assertEquals(0, result.callHistoryImported)
@@ -261,7 +265,7 @@ class MigrationCallHistoryImportTest {
                     failureReason = null,
                 )
 
-            val result = requireSuccess(importer.importData(Uri.EMPTY, cachedZipBytes = zip(bundle(listOf(openCall)))))
+            val result = requireSuccess(importer.importData(Uri.EMPTY, cachedZipFile = tempZipFile(zip(bundle(listOf(openCall))))))
             val imported = database.callHistoryDao().getByAttemptId("open-attempt")
 
             assertEquals(1, result.callHistoryImported)
@@ -284,7 +288,7 @@ class MigrationCallHistoryImportTest {
                     outcome = null,
                 )
 
-            val result = importer.importData(Uri.EMPTY, cachedZipBytes = zip(bundle(listOf(overflow))))
+            val result = importer.importData(Uri.EMPTY, cachedZipFile = tempZipFile(zip(bundle(listOf(overflow)))))
 
             assertTrue(result is ImportResult.Error)
             assertNull(database.callHistoryDao().getByAttemptId("overflow-attempt"))
@@ -302,7 +306,7 @@ class MigrationCallHistoryImportTest {
                     failureReason = "NETWORK_UNAVAILABLE",
                 )
 
-            val result = requireSuccess(importer.importData(Uri.EMPTY, cachedZipBytes = zip(bundle(listOf(incomingFailed)))))
+            val result = requireSuccess(importer.importData(Uri.EMPTY, cachedZipFile = tempZipFile(zip(bundle(listOf(incomingFailed))))))
 
             assertEquals(1, result.callHistoryImported)
             assertEquals("FAILED", database.callHistoryDao().getByAttemptId("incoming-failed")?.outcome)
@@ -314,15 +318,17 @@ class MigrationCallHistoryImportTest {
             val result =
                 importer.importData(
                     Uri.EMPTY,
-                    cachedZipBytes =
-                        zip(
-                            bundle(
-                                listOf(
-                                    call().copy(callAttemptId = "valid-before-contradiction"),
-                                    call().copy(
-                                        callAttemptId = "contradictory",
-                                        outcome = "NOT_CONNECTED",
-                                        connectedAt = 150L,
+                    cachedZipFile =
+                        tempZipFile(
+                            zip(
+                                bundle(
+                                    listOf(
+                                        call().copy(callAttemptId = "valid-before-contradiction"),
+                                        call().copy(
+                                            callAttemptId = "contradictory",
+                                            outcome = "NOT_CONNECTED",
+                                            connectedAt = 150L,
+                                        ),
                                     ),
                                 ),
                             ),
@@ -340,15 +346,17 @@ class MigrationCallHistoryImportTest {
             val result =
                 importer.importData(
                     Uri.EMPTY,
-                    cachedZipBytes =
-                        zip(
-                            bundle(
-                                listOf(
-                                    call().copy(callAttemptId = "valid-attempt"),
-                                    call().copy(
-                                        callAttemptId = "malformed-attempt",
-                                        direction = "INCOMING",
-                                        outcome = "BUSY_REMOTE",
+                    cachedZipFile =
+                        tempZipFile(
+                            zip(
+                                bundle(
+                                    listOf(
+                                        call().copy(callAttemptId = "valid-attempt"),
+                                        call().copy(
+                                            callAttemptId = "malformed-attempt",
+                                            direction = "INCOMING",
+                                            outcome = "BUSY_REMOTE",
+                                        ),
                                     ),
                                 ),
                             ),
@@ -366,12 +374,14 @@ class MigrationCallHistoryImportTest {
             val result =
                 importer.importData(
                     Uri.EMPTY,
-                    cachedZipBytes =
-                        zip(
-                            bundle(
-                                listOf(
-                                    call().copy(callAttemptId = "valid-attempt"),
-                                    call().copy(callAttemptId = "malformed-hash", remoteIdentityHash = "not-a-hash"),
+                    cachedZipFile =
+                        tempZipFile(
+                            zip(
+                                bundle(
+                                    listOf(
+                                        call().copy(callAttemptId = "valid-attempt"),
+                                        call().copy(callAttemptId = "malformed-hash", remoteIdentityHash = "not-a-hash"),
+                                    ),
                                 ),
                             ),
                         ),
@@ -392,7 +402,7 @@ class MigrationCallHistoryImportTest {
                     remoteIdentityHash = REMOTE_IDENTITY.uppercase(),
                 )
 
-            val result = importer.importData(Uri.EMPTY, cachedZipBytes = zip(bundle(listOf(imported))))
+            val result = importer.importData(Uri.EMPTY, cachedZipFile = tempZipFile(zip(bundle(listOf(imported)))))
 
             requireSuccess(result)
             val stored = database.callHistoryDao().getByAttemptId("uppercase-hashes")!!
@@ -466,6 +476,13 @@ class MigrationCallHistoryImportTest {
         file.writeBytes(bytes)
         file.deleteOnExit()
         return Uri.fromFile(file)
+    }
+
+    private fun tempZipFile(bytes: ByteArray): File {
+        val file = File.createTempFile("call_history_transfer_", ".zip", context.cacheDir)
+        file.writeBytes(bytes)
+        file.deleteOnExit()
+        return file
     }
 
     private companion object {

--- a/app/src/test/java/network/columba/app/migration/MigrationCryptoTest.kt
+++ b/app/src/test/java/network/columba/app/migration/MigrationCryptoTest.kt
@@ -193,4 +193,88 @@ class MigrationCryptoTest {
         val legacy = buildLegacy0x02("x".toByteArray(), testPassword)
         MigrationCrypto.decrypt(legacy, "wrong-password")
     }
+
+    // region 0x03 authenticated-framing regression tests
+    //
+    // The 0x03 format derives each chunk IV from (base IV, index) and binds
+    // the fixed header + chunk index into every chunk's GCM AAD. These tests
+    // prove the framing cannot be tampered with, reordered, truncated, or
+    // fed a malformed chunk size.
+
+    private fun assertDecryptFails(encrypted: ByteArray) {
+        // Any decryption failure (WrongPasswordException or
+        // InvalidExportFileException) is acceptable; only a *successful*
+        // decrypt means the assertion has failed.
+        val result = runCatching { MigrationCrypto.decrypt(encrypted, testPassword) }
+        assertTrue("Expected decryption to fail, but it succeeded", result.isFailure)
+    }
+
+    @Test
+    fun `round-trip spans multiple 8 MiB chunks`() {
+        // Force two chunks: 8 MiB + 1 MiB of plaintext.
+        val size = MigrationCrypto.CHUNK_SIZE_BYTES + 1024 * 1024
+        val plaintext = ByteArray(size) { (it % 251).toByte() }
+        val encrypted = MigrationCrypto.encrypt(plaintext, testPassword)
+        val decrypted = MigrationCrypto.decrypt(encrypted, testPassword)
+        assertArrayEquals(plaintext, decrypted)
+    }
+
+    @Test
+    fun `tampering the base IV in the header is rejected`() {
+        val plaintext = "framing integrity payload 0123456789".toByteArray()
+        val encrypted = MigrationCrypto.encrypt(plaintext, testPassword).copyOf()
+        // Flip a byte of the 12-byte base IV (header offset 17..28).
+        encrypted[17] = (encrypted[17].toInt() xor 0x01).toByte()
+        assertDecryptFails(encrypted)
+    }
+
+    @Test
+    fun `tampering a ciphertext byte is rejected`() {
+        val plaintext = "tamper detection payload 0123456789".toByteArray()
+        val encrypted = MigrationCrypto.encrypt(plaintext, testPassword).copyOf()
+        // The single chunk's ciphertext starts right after the 45-byte header
+        // and the 8-byte chunk-index record: offset 45 + 8.
+        encrypted[45 + 8 + 1] = (encrypted[45 + 8 + 1].toInt() xor 0x01).toByte()
+        assertDecryptFails(encrypted)
+    }
+
+    @Test
+    fun `appending trailing data after the final chunk is rejected`() {
+        val plaintext = "trailing data check payload".toByteArray()
+        val encrypted = MigrationCrypto.encrypt(plaintext, testPassword).copyOf()
+        // The declared total length is unchanged, so every chunk authenticates;
+        // the extra trailing byte must trip the exhaustion check.
+        val withTrailing = encrypted + byteArrayOf(0x00, 0x01, 0x02)
+        assertDecryptFails(withTrailing)
+    }
+
+    @Test
+    fun `negative total length in the header is rejected`() {
+        val plaintext = "length sanity payload".toByteArray()
+        val encrypted = MigrationCrypto.encrypt(plaintext, testPassword).copyOf()
+        // totalLength is the last 8 bytes of the 45-byte header; set it to
+        // -1 (all 0xFF) which is out of range.
+        for (i in 45 - 8 until 45) encrypted[i] = 0xFF.toByte()
+        assertDecryptFails(encrypted)
+    }
+
+    @Test
+    fun `zero chunk size with non-empty total length is rejected`() {
+        // Craft a 45-byte 0x03 header: chunkSize = 0, totalLength = 100.
+        val header = ByteArray(45)
+        header[0] = MigrationCrypto.ENCRYPTED_VERSION
+        // salt (16) and base IV (12) can be zero for this structural check.
+        writeLong(header, 29, 0L) // chunkSize = 0
+        writeLong(header, 37, 100L) // totalLength = 100 (non-zero)
+        assertDecryptFails(header)
+    }
+
+    /** Big-endian long writer used only to craft malformed test headers. */
+    private fun writeLong(buf: ByteArray, offset: Int, value: Long) {
+        for (i in 7 downTo 0) {
+            buf[offset + (7 - i)] = ((value ushr (8 * i)) and 0xFF).toByte()
+        }
+    }
+
+    // endregion
 }

--- a/app/src/test/java/network/columba/app/migration/MigrationCryptoTest.kt
+++ b/app/src/test/java/network/columba/app/migration/MigrationCryptoTest.kt
@@ -142,4 +142,55 @@ class MigrationCryptoTest {
         val decrypted = MigrationCrypto.decrypt(encrypted, unicodePassword)
         assertArrayEquals(plaintext, decrypted)
     }
+
+    /**
+     * Build a legacy 0x02 (whole-file GCM) export using raw JCE, independent
+     * of MigrationCrypto, to prove the importer still reads pre-0x03 files.
+     *
+     * Layout: [0x02][16-byte salt][12-byte IV][GCM ciphertext + 16-byte tag]
+     */
+    private fun buildLegacy0x02(plaintext: ByteArray, password: String): ByteArray {
+        val salt = ByteArray(16).also { java.security.SecureRandom().nextBytes(it) }
+        val iv = ByteArray(12).also { java.security.SecureRandom().nextBytes(it) }
+        val keySpec = javax.crypto.spec.PBEKeySpec(
+            password.toCharArray(),
+            salt,
+            600_000,
+            256,
+        )
+        val key = javax.crypto.SecretKeyFactory.getInstance("PBKDF2WithHmacSHA256")
+            .generateSecret(keySpec)
+        val cipher = javax.crypto.Cipher.getInstance("AES/GCM/NoPadding")
+        cipher.init(
+            javax.crypto.Cipher.ENCRYPT_MODE,
+            javax.crypto.spec.SecretKeySpec(key.encoded, "AES"),
+            javax.crypto.spec.GCMParameterSpec(128, iv),
+        )
+        val ciphertext = cipher.doFinal(plaintext)
+        return byteArrayOf(MigrationCrypto.LEGACY_ENCRYPTED_VERSION) +
+            salt +
+            iv +
+            ciphertext
+    }
+
+    @Test
+    fun `legacy 0x02 file decrypts and matches plaintext`() {
+        val plaintext = "legacy payload from an older app version".toByteArray()
+        val legacy = buildLegacy0x02(plaintext, testPassword)
+        assertEquals(MigrationCrypto.LEGACY_ENCRYPTED_VERSION, legacy[0])
+        val decrypted = MigrationCrypto.decrypt(legacy, testPassword)
+        assertArrayEquals(plaintext, decrypted)
+    }
+
+    @Test
+    fun `legacy 0x02 file is detected as encrypted`() {
+        val legacy = buildLegacy0x02("x".toByteArray(), testPassword)
+        assertTrue(MigrationCrypto.isEncrypted(legacy))
+    }
+
+    @Test(expected = WrongPasswordException::class)
+    fun `legacy 0x02 file with wrong password throws WrongPasswordException`() {
+        val legacy = buildLegacy0x02("x".toByteArray(), testPassword)
+        MigrationCrypto.decrypt(legacy, "wrong-password")
+    }
 }

--- a/app/src/test/java/network/columba/app/viewmodel/MigrationViewModelTest.kt
+++ b/app/src/test/java/network/columba/app/viewmodel/MigrationViewModelTest.kt
@@ -34,6 +34,7 @@ import org.junit.Assert.assertTrue
 import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
+import java.io.File
 
 /**
  * Unit tests for MigrationViewModel.
@@ -98,6 +99,9 @@ class MigrationViewModelTest {
 
         // Mock getExportPreview called in init
         coEvery { migrationExporter.getExportPreview() } returns testExportPreview
+
+        // Stub cleanupStagedImports - called during init
+        every { migrationImporter.cleanupStagedImports() } just Runs
 
         // Stub cleanupExportFiles - called during cleanup operations
         every { migrationExporter.cleanupExportFiles() } just Runs
@@ -225,10 +229,11 @@ class MigrationViewModelTest {
         runTest {
             val mockUri = mockk<Uri>()
             coEvery { migrationImporter.isEncryptedExport(mockUri) } returns Result.success(false)
+            val cachedFile = File.createTempFile("migration_preview_", ".columba").apply { deleteOnExit() }
             coEvery { migrationImporter.previewMigration(mockUri, any()) } returns
                 Result.success(
                     network.columba.app.migration
-                        .PreviewWithData(testImportPreview, ByteArray(0)),
+                        .PreviewWithData(testImportPreview, cachedFile),
                 )
 
             viewModel.previewImport(mockUri)


### PR DESCRIPTION
## Summary

Fixes the OOM crash in the Android data-export/import path by replacing the
single-shot GCM format with a chunked 0x03 variant and by streaming the
importer off an on-disk staged file instead of an in-memory `zipBytes`.

- **Crypto (new 0x03 format):** 8 MiB max chunks, per-chunk counter IVs
  (`baseIv + chunk index`), `streamEncrypt`/`decryptStream` read and write
  chunk-by-chunk so peak memory is bounded to ~2x chunk size regardless of
  bundle size. Legacy 0x02 bundles still decrypt (importer is dual-version).
- **Importer:** `importData` now stages the bundle to a local plaintext ZIP
  under `cacheDir/migration_import` (reusing the preview's staged file when
  present), parses the manifest in a single streaming `decodeFromStream`
  pass, and streams attachments from the staged file. `PreviewWithData`
  carries a `File`, not a `ByteArray`. Staged-file ownership is explicit:
  the importer deletes files it created; the ViewModel deletes the preview's
  file; `cleanupStagedImports()` clears leftovers at ViewModel init.
- **Exporter:** unchanged API surface (already routed through
  `MigrationCrypto.encryptFile`); now emits 0x03.

The previously-OOMing case (120 MiB export decrypting under a 90 MiB heap)
now passes.

**Scope:** Option A only. The export path still materializes the full
`MigrationBundle` in RAM before encryption (streaming export / ratchets-as-ZIP-entries
is a tracked follow-up, Option C).

## Rebase note

Rebased onto current `main`, which landed call-history migration work
(`760734d5`) that touched the same importer/exporter/data regions this PR
rewrites. Adapted to the new API:

- `MigrationImporter.importDataInternal` version-8 guard: plain `return`
  instead of the old `return@withContext` label (no `withContext` scope left).
- `MigrationCallHistoryImportTest`: `cachedZipBytes = zip(...)` call sites
  migrated to `cachedZipFile = tempZipFile(zip(...))` via a new helper that
  writes the ZIP to a temp file (matching the file-based import contract).

## Verification (exact head)

- `:app:compileSentryKotlinBackendDebug{Kotlin,UnitTestKotlin}` - clean
- `:app:ktlintCheck` + `:app:detekt` - clean
- `:app:testSentryKotlinBackendDebugUnitTest` for `migration.*` +
  `MigrationViewModelTest` - all pass (crypto 19 incl. 3 legacy 0x02 tests,
  importer-encryption 8, viewmodel 20, call-history import suite green)
- 120 MiB export decrypt under a 90 MiB heap: passes

## Files

- `migration/MigrationCrypto.kt` - 0x03 chunked-GCM + 0x02 legacy, streaming
- `migration/MigrationData.kt` - `PreviewWithData` holds `File`
- `migration/MigrationImporter.kt` - staging, streaming, cleanup, API rename
- `viewmodel/MigrationViewModel.kt` - `cachedImportFile`, init cleanup
- `test/.../MigrationCallHistoryImportTest.kt` - adapted to `cachedZipFile`
- `test/.../MigrationCryptoTest.kt` - +3 legacy 0x02 compat tests
- `test/.../MigrationViewModelTest.kt` - `PreviewWithData(File)` stubs
