### PR TITLE
NomadNet: render inline page images with upstream-parity loading

### DIFF
--- a/app/src/main/java/network/columba/app/nomadnet/NomadNetImageCache.kt
+++ b/app/src/main/java/network/columba/app/nomadnet/NomadNetImageCache.kt
@@ -1,0 +1,128 @@
+package network.columba.app.nomadnet
+
+import android.content.Context
+import android.util.Log
+import dagger.hilt.android.qualifiers.ApplicationContext
+import java.io.File
+import java.security.MessageDigest
+import javax.inject.Inject
+import javax.inject.Singleton
+
+/**
+ * File-based, LRU-capped cache for NomadNet page images (`/media/` fetches).
+ *
+ * Upstream NomadNet caches images at `storage/cache/images/<url_hash>` keyed
+ * by URL (Browser.py `image_cache_path`); revisit cost is then zero requests.
+ * Mobile adds a hard total-size cap (default 64 MB) with LRU eviction — the
+ * cache dir is `context.cacheDir`, so the OS can reclaim it wholesale, but the
+ * cap keeps a single media-heavy session from crowding out the page cache.
+ *
+ * Files are named `<sha256(resolvedKey)>.webp`. The magic-number sniff on
+ * [put] enforces upstream's WebP-only rule for network-sourced media:
+ * "For the sake of bandwidth efficiency, images sent over the network must be
+ * in WebP format" (NomadNet guide, commit 7bd3a3a).
+ */
+@Singleton
+class NomadNetImageCache
+    @Inject
+    constructor(
+        @ApplicationContext context: Context,
+    ) {
+        companion object {
+            private const val TAG = "NomadNetImageCache"
+            private const val CACHE_DIR_NAME = "nomadnet_images"
+            const val DEFAULT_MAX_BYTES = 64L * 1024 * 1024
+
+            /** WebP files start `RIFF????WEBP`. */
+            fun isWebp(file: File): Boolean {
+                if (!file.isFile || file.length() < 12) return false
+                val header = ByteArray(12)
+                return runCatching {
+                    file.inputStream().use { it.read(header) }
+                }.getOrDefault(0) == 12 &&
+                    String(header, 0, 4, Charsets.ISO_8859_1) == "RIFF" &&
+                    String(header, 8, 4, Charsets.ISO_8859_1) == "WEBP"
+            }
+        }
+
+        private val cacheDir = File(context.cacheDir, CACHE_DIR_NAME)
+
+        /**
+         * Resolve a cached image. Returns the file if present (bumping its
+         * mtime for LRU), null on miss.
+         */
+        @Synchronized
+        fun get(resolvedKey: String): File? {
+            val file = File(cacheDir, fileNameFor(resolvedKey))
+            if (!file.isFile) return null
+            // mtime touch = LRU recency signal.
+            file.setLastModified(System.currentTimeMillis())
+            return file
+        }
+
+        /**
+         * Move a freshly fetched media file into the cache under
+         * [resolvedKey], rejecting non-WebP payloads (upstream rule). Returns
+         * the cached file, or null when rejected — [source] is deleted either
+         * way.
+         */
+        @Synchronized
+        fun put(
+            resolvedKey: String,
+            source: File,
+        ): File? {
+            if (!isWebp(source)) {
+                Log.i(TAG, "Rejected non-WebP media for $resolvedKey (upstream webp-only rule)")
+                source.delete()
+                return null
+            }
+            cacheDir.mkdirs()
+            val target = File(cacheDir, fileNameFor(resolvedKey))
+            val moved =
+                runCatching {
+                    if (target.exists()) target.delete()
+                    if (!source.renameTo(target)) {
+                        // Cross-device (backend process staging dir may be a
+                        // different mount): fall back to copy.
+                        source.copyTo(target, overwrite = true)
+                        source.delete()
+                    }
+                }.onFailure { Log.w(TAG, "Failed to cache image $resolvedKey", it) }.isSuccess
+            if (!moved) return null
+            target.setLastModified(System.currentTimeMillis())
+            evictIfNeeded()
+            return target
+        }
+
+        /** Delete a cached image (force-reload path, upstream Ctrl+X). */
+        @Synchronized
+        fun remove(resolvedKey: String) {
+            File(cacheDir, fileNameFor(resolvedKey)).delete()
+        }
+
+        @Synchronized
+        fun clear() {
+            cacheDir.listFiles()?.forEach { it.delete() }
+        }
+
+        @Synchronized
+        fun totalBytes(): Long = cacheDir.listFiles()?.sumOf { it.length() } ?: 0L
+
+        /** LRU eviction: drop oldest-touched files until under the cap. */
+        private fun evictIfNeeded(maxBytes: Long = DEFAULT_MAX_BYTES) {
+            val files = cacheDir.listFiles()?.sortedBy { it.lastModified() } ?: return
+            var total = files.sumOf { it.length() }
+            if (total <= maxBytes) return
+            for (f in files) {
+                total -= f.length()
+                f.delete()
+                if (total <= maxBytes) break
+            }
+            Log.d(TAG, "Image cache evicted to $total bytes")
+        }
+
+        private fun fileNameFor(resolvedKey: String): String {
+            val digest = MessageDigest.getInstance("SHA-256").digest(resolvedKey.toByteArray(Charsets.UTF_8))
+            return digest.joinToString("") { "%02x".format(it) } + ".webp"
+        }
+    }

--- a/app/src/main/java/network/columba/app/nomadnet/NomadNetImagePolicy.kt
+++ b/app/src/main/java/network/columba/app/nomadnet/NomadNetImagePolicy.kt
@@ -82,6 +82,14 @@ enum class PageImageStatus {
     LOADED,
     DENIED,
     FAILED,
+    /**
+     * The image URL is structurally invalid (no `:` separator, empty path,
+     * malformed node hash) so it can never be resolved to a fetch. Distinct
+     * from [FAILED] (a fetch was attempted and failed transiently, so retry is
+     * meaningful): a malformed reference is permanent, so the UI renders the
+     * error without offering a tap-to-retry affordance.
+     */
+    MALFORMED,
 }
 
 /** Per-image fetch state, mirroring upstream page_images dict entries. */

--- a/app/src/main/java/network/columba/app/nomadnet/NomadNetImagePolicy.kt
+++ b/app/src/main/java/network/columba/app/nomadnet/NomadNetImagePolicy.kt
@@ -1,0 +1,153 @@
+package network.columba.app.nomadnet
+
+import android.util.Log
+import java.util.concurrent.ConcurrentHashMap
+
+/**
+ * Image loading modes, mirroring upstream NomadNet's
+ * `[textui] image_loading` (config values lowercase in config, never/manual/
+ * auto/always, default auto).
+ */
+enum class ImageLoadingMode {
+    NEVER,
+    MANUAL,
+    AUTO,
+    ALWAYS,
+    ;
+
+    companion object {
+        fun fromName(name: String?): ImageLoadingMode =
+            entries.firstOrNull { it.name.equals(name?.trim(), ignoreCase = true) } ?: AUTO
+    }
+}
+
+/**
+ * Auto-mode gate, upstream parity (Browser.py `should_load_images`, commit
+ * 0db7d4b): load automatically only when the link RTT is under
+ * [AUTO_RTT_LIMIT_S] seconds AND the expected data rate exceeds
+ * [AUTO_EDR_LIMIT_BPS] bits/s. Loopback (the device talking to its own host
+ * service, if ever) always loads. No link data -> no load.
+ *
+ * [measuredResponseSpeedBps] is the fallback EDR source, mirroring upstream's
+ * `last_response_speed()` (page transfer size / response time * 8).
+ */
+object NomadNetImagePolicy {
+    private const val TAG = "NomadNetImagePolicy"
+
+    // Upstream constants verbatim: rtt_limit = 1.5 s, edr_limit = 10000 bps.
+    const val AUTO_RTT_LIMIT_S = 1.5
+    const val AUTO_EDR_LIMIT_BPS = 10_000L
+
+    /**
+     * Per-image transfer cap in bytes. A separate safety axis from the
+     * loading mode (Torlando 2026-09-07: "always mode still hits the size
+     * cap"): a media response larger than this fails with an explicit
+     * "too large" error in ALL modes, including always. Upstream NomadNet
+     * caps decoded payloads at 16 MiB (MAX_CONVERTED_PAYLOAD_BYTES in
+     * images/_imagedata.py); we cap the wire transfer at the same figure,
+     * which is strictly tighter for WebP (always <= its decoded form).
+     */
+    const val MAX_IMAGE_BYTES = 16L * 1024 * 1024
+
+    fun shouldLoadAutomatically(
+        mode: ImageLoadingMode,
+        isLoopback: Boolean,
+        rttSeconds: Double?,
+        expectedRateBps: Long?,
+        measuredResponseSpeedBps: Double?,
+    ): Boolean {
+        if (isLoopback) return true
+        return when (mode) {
+            ImageLoadingMode.NEVER, ImageLoadingMode.MANUAL -> false
+            ImageLoadingMode.ALWAYS -> true
+            ImageLoadingMode.AUTO -> {
+                val edr = expectedRateBps ?: measuredResponseSpeedBps?.toLong()
+                val rttOk = rttSeconds != null && rttSeconds < AUTO_RTT_LIMIT_S
+                val edrOk = edr != null && edr > AUTO_EDR_LIMIT_BPS
+                Log.d(
+                    TAG,
+                    "auto-gate: rtt=${rttSeconds?.let { "%.2fs".format(it) } ?: "unknown"} " +
+                        "edr=${edr?.let { "${it}bps" } ?: "unknown"} -> ${rttOk && edrOk}",
+                )
+                rttOk && edrOk
+            }
+        }
+    }
+}
+
+/** Per-image fetch status (upstream page_images dict's failed/updated flags). */
+enum class PageImageStatus {
+    PLACEHOLDER,
+    LOADING,
+    LOADED,
+    DENIED,
+    FAILED,
+}
+
+/** Per-image fetch state, mirroring upstream page_images dict entries. */
+data class PageImageState(
+    val status: PageImageStatus = PageImageStatus.PLACEHOLDER,
+    val file: java.io.File? = null,
+    val progress: Float = 0f,
+    val speedBps: Long? = null,
+    val receivedBytes: Long = 0L,
+    val totalBytes: Long = 0L,
+    val error: String? = null,
+    val ref: ParsedImageRef? = null,
+)
+
+/**
+ * Key a resolved image URL to a cache key: "<nodeHash>:<mediaPath>".
+ * Mirrors upstream Browser.parse_url: a leading colon means "same node as
+ * the current page"; "<hash>:<path>" is explicit; anything else is
+ * malformed (null).
+ */
+fun resolveImageUrl(
+    url: String,
+    currentNodeHash: String,
+): String? {
+    val trimmed = url.trim()
+    val colonIdx = trimmed.indexOf(':')
+    if (colonIdx < 0) return null
+    val head = trimmed.substring(0, colonIdx)
+    val path = trimmed.substring(colonIdx + 1)
+    if (path.isEmpty()) return null
+    return when {
+        head.isEmpty() && currentNodeHash.isNotEmpty() -> "$currentNodeHash:$path"
+        head.length == 32 && head.all { it in '0'..'9' || it in 'a'..'f' || it in 'A'..'F' } ->
+            "${head.lowercase()}:$path"
+        else -> null
+    }
+}
+
+/** Stable per-page key for an image element (URL + size specs distinguish). */
+fun pageImageKey(
+    url: String,
+    width: String?,
+    height: String?,
+): String = "$url#$width|$height"
+
+/** Small thread-safe state map the fetch loop and the UI both touch. */
+class PageImageStates {
+    private val map = ConcurrentHashMap<String, PageImageState>()
+
+    fun snapshot(): Map<String, PageImageState> = HashMap(map)
+
+    fun get(key: String): PageImageState? = map[key]
+
+    fun put(
+        key: String,
+        state: PageImageState,
+    ) {
+        map[key] = state
+    }
+
+    fun update(
+        key: String,
+        transform: (PageImageState) -> PageImageState,
+    ) {
+        map.compute(key) { _, existing -> if (existing == null) null else transform(existing) }
+    }
+
+    fun clear() = map.clear()
+}

--- a/app/src/main/java/network/columba/app/nomadnet/PageImageLoader.kt
+++ b/app/src/main/java/network/columba/app/nomadnet/PageImageLoader.kt
@@ -26,10 +26,9 @@ import java.io.File
  * - WebP-only rule enforced at the cache boundary (7bd3a3a); server-side
  *   `.allowed` denials surface as DENIED, not FAILED.
  *
- * Size cap ([NomadNetImagePolicy.MAX_IMAGE_BYTES]) is applied by the backend
- * media request itself (the staged body is bounded by the link's response
- * handling); a client-side pre-abort needs receipt-size plumbing on the seam
- * and is a deliberate follow-up — see plan doc.
+ * Size cap ([NomadNetImagePolicy.MAX_IMAGE_BYTES]) is enforced client-side in
+ * [fetchOne] (the backends stage whatever the link delivers, so the app layer
+ * is the enforcement point that holds for both of them).
  */
 class PageImageLoader(
     private val nomadnet: RnsNomadnet,
@@ -105,15 +104,21 @@ class PageImageLoader(
         if (forceReload) {
             // Upstream Ctrl+X: drop caches for this page's images and re-queue
             // them as placeholders so they re-download.
-            for ((key, state) in states.snapshot()) {
-                val ref = state.ref ?: continue
-                val resolved = resolveImageUrl(ref.url, currentNodeHash()) ?: continue
-                cache.remove(resolved)
-                states.put(key, PageImageState(ref = ref.withResolved(resolved)))
-            }
+            dropCachesAndReset()
             publish()
         }
         startQueueForExplicitLoad(epoch)
+    }
+
+    /** Ctrl+X step: evict each image's cache entry and reset it to placeholder. */
+    private fun dropCachesAndReset() {
+        for ((key, state) in states.snapshot()) {
+            val ref = state.ref
+            val resolved = ref?.let { resolveImageUrl(it.url, currentNodeHash()) }
+            if (ref == null || resolved == null) continue
+            cache.remove(resolved)
+            states.put(key, PageImageState(ref = ref.withResolved(resolved)))
+        }
     }
 
     /** Retry one failed/denied/placeholder image (per-image reload affordance). */
@@ -180,8 +185,8 @@ class PageImageLoader(
                 val keys = states.snapshot().keys.toList()
                 for (key in keys) {
                     if (epoch != myEpoch) return@launch
-                    val state = states.get(key) ?: continue
-                    if (state.status != PageImageStatus.PLACEHOLDER) continue
+                    val state = states.get(key)
+                    if (state == null || state.status != PageImageStatus.PLACEHOLDER) continue
                     fetchOne(key, myEpoch)
                 }
             }
@@ -191,54 +196,63 @@ class PageImageLoader(
         key: String,
         myEpoch: Int,
     ) {
-        val state = states.get(key) ?: return
-        val ref = state.ref ?: return
-        val hash = ref.nodeHash ?: return
+        val state = states.get(key)
+        val ref = state?.ref
+        val hash = ref?.nodeHash
+        if (state == null || ref == null || hash == null) return
         states.update(key) { it.copy(status = PageImageStatus.LOADING) }
         publish()
 
         val result =
             runCatching {
-                nomadnet.requestNomadnetMedia(hash, ref.mediaPath, MEDIA_TIMEOUT_SECONDS).getOrThrow()
+                val media = nomadnet.requestNomadnetMedia(hash, ref.mediaPath, MEDIA_TIMEOUT_SECONDS).getOrThrow()
+                // Client-side size cap (plan: "always mode still hits the per-image
+                // size cap"). The backends stage whatever the link delivers, so the
+                // app layer is the enforcement point that holds for both of them.
+                if (media.fileSize > NomadNetImagePolicy.MAX_IMAGE_BYTES) {
+                    runCatching { java.io.File(media.filePath).delete() }
+                    error("Image too large (${media.fileSize} bytes; cap ${NomadNetImagePolicy.MAX_IMAGE_BYTES})")
+                }
+                media
             }
 
         if (epoch != myEpoch) {
-            // Stale: drop the staged file if any.
+            // Stale (page changed mid-flight): drop the staged file if any and
+            // leave the state for the new scan to own.
             result.getOrNull()?.let { runCatching { File(it.filePath).delete() } }
-            return
-        }
-
-        result.fold(
-            onSuccess = { media ->
-                val cached = cache.put("$hash:${ref.mediaPath}", File(media.filePath))
-                if (cached != null) {
+        } else {
+            result.fold(
+                onSuccess = { media ->
+                    val cached = cache.put("$hash:${ref.mediaPath}", File(media.filePath))
+                    if (cached != null) {
+                        states.update(key) {
+                            it.copy(
+                                status = PageImageStatus.LOADED,
+                                file = cached,
+                                progress = 1f,
+                                totalBytes = media.fileSize,
+                                receivedBytes = media.fileSize,
+                            )
+                        }
+                    } else {
+                        states.update(key) {
+                            it.copy(status = PageImageStatus.FAILED, error = "Not a WebP image (rejected)")
+                        }
+                    }
+                },
+                onFailure = { error ->
+                    val denied = (error as? RnsException)?.error is RnsError.NomadnetRequestDenied
+                    Log.d(TAG, "Image $key ${if (denied) "denied by node" else "failed"}: ${error.message}")
                     states.update(key) {
                         it.copy(
-                            status = PageImageStatus.LOADED,
-                            file = cached,
-                            progress = 1f,
-                            totalBytes = media.fileSize,
-                            receivedBytes = media.fileSize,
+                            status = if (denied) PageImageStatus.DENIED else PageImageStatus.FAILED,
+                            error = error.message,
                         )
                     }
-                } else {
-                    states.update(key) {
-                        it.copy(status = PageImageStatus.FAILED, error = "Not a WebP image (rejected)")
-                    }
-                }
-            },
-            onFailure = { error ->
-                val denied = (error as? RnsException)?.error is RnsError.NomadnetRequestDenied
-                Log.d(TAG, "Image $key ${if (denied) "denied by node" else "failed"}: ${error.message}")
-                states.update(key) {
-                    it.copy(
-                        status = if (denied) PageImageStatus.DENIED else PageImageStatus.FAILED,
-                        error = error.message,
-                    )
-                }
-            },
-        )
-        publish()
+                },
+            )
+            publish()
+        }
     }
 
     private fun publish() {

--- a/app/src/main/java/network/columba/app/nomadnet/PageImageLoader.kt
+++ b/app/src/main/java/network/columba/app/nomadnet/PageImageLoader.kt
@@ -121,14 +121,20 @@ class PageImageLoader(
         }
     }
 
-    /** Retry one failed/denied/placeholder image (per-image reload affordance). */
+    /**
+     * Retry/reload one image only (per-image tap on a placeholder, or reload on
+     * a failed/denied one). Resets just that key to a fresh placeholder and
+     * fetches only it - unlike [loadImages], which loads every image on the
+     * page. Tapping a placeholder in manual mode must not drag the sibling
+     * placeholders along with it.
+     */
     fun retryImage(key: String) {
         if (imageLoadingMode() == ImageLoadingMode.NEVER) return
         val state = states.get(key) ?: return
         val ref = state.ref ?: return
         states.put(key, PageImageState(ref = ref))
         publish()
-        startQueueForExplicitLoad(epoch)
+        startQueueForSingle(key, epoch)
     }
 
     fun cancelAll() {
@@ -156,14 +162,23 @@ class PageImageLoader(
         )
     }
 
-    private fun startQueue(myEpoch: Int) = startQueue(myEpoch, respectModeAndGate = true)
+    private fun startQueue(myEpoch: Int) = startQueue(myEpoch, respectModeAndGate = true, onlyKey = null)
 
     /** Explicit (user-triggered) queue run: skips the mode/gate check but still honors NEVER. */
-    private fun startQueueForExplicitLoad(myEpoch: Int) = startQueue(myEpoch, respectModeAndGate = false)
+    private fun startQueueForExplicitLoad(myEpoch: Int) = startQueue(myEpoch, respectModeAndGate = false, onlyKey = null)
+
+    /**
+     * Fetch a single image (per-image tap/reload). Explicit, so it bypasses the
+     * mode gate (still honors NEVER), and is restricted to [onlyKey] so sibling
+     * placeholders are left untouched.
+     */
+    private fun startQueueForSingle(onlyKey: String, myEpoch: Int) =
+        startQueue(myEpoch, respectModeAndGate = false, onlyKey = onlyKey)
 
     private fun startQueue(
         myEpoch: Int,
         respectModeAndGate: Boolean,
+        onlyKey: String?,
     ) {
         queueJob?.cancel()
         queueJob =
@@ -182,7 +197,7 @@ class PageImageLoader(
                     }
                 }
                 // Snapshot keys once; a new scan bumps the epoch and restarts.
-                val keys = states.snapshot().keys.toList()
+                val keys = (states.snapshot().keys.toList()).filter { onlyKey == null || it == onlyKey }
                 for (key in keys) {
                     if (epoch != myEpoch) return@launch
                     val state = states.get(key)

--- a/app/src/main/java/network/columba/app/nomadnet/PageImageLoader.kt
+++ b/app/src/main/java/network/columba/app/nomadnet/PageImageLoader.kt
@@ -1,0 +1,264 @@
+package network.columba.app.nomadnet
+
+import android.util.Log
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import network.columba.app.rns.api.RnsError
+import network.columba.app.rns.api.RnsException
+import network.columba.app.rns.api.RnsNomadnet
+import java.io.File
+
+/**
+ * Orchestrates page-image loading for one browser session, mirroring
+ * upstream Browser.py's image updater (commits c0091db / 0db7d4b):
+ *
+ * - Parse pass ([scan]) registers every image element on the page; cache hits
+ *   render instantly with zero requests (upstream `resolve_image`).
+ * - Auto mode gates the queue on link RTT/EDR ([NomadNetImagePolicy]).
+ * - Manual mode leaves placeholders until an explicit [loadImages] (upstream
+ *   Ctrl+L) or per-image tap; forceReload drops caches first (Ctrl+X).
+ * - Sequential single-flight fetching: one image at a time, so images never
+ *   starve page traffic; cancelable via [cancelAll] / epoch bumps.
+ * - WebP-only rule enforced at the cache boundary (7bd3a3a); server-side
+ *   `.allowed` denials surface as DENIED, not FAILED.
+ *
+ * Size cap ([NomadNetImagePolicy.MAX_IMAGE_BYTES]) is applied by the backend
+ * media request itself (the staged body is bounded by the link's response
+ * handling); a client-side pre-abort needs receipt-size plumbing on the seam
+ * and is a deliberate follow-up — see plan doc.
+ */
+class PageImageLoader(
+    private val nomadnet: RnsNomadnet,
+    private val cache: NomadNetImageCache,
+    private val scope: CoroutineScope,
+    private val currentNodeHash: () -> String,
+    private val imageLoadingMode: () -> ImageLoadingMode,
+    /** Fallback EDR: speed of the last page response, bits/s. */
+    private val lastResponseSpeedBps: () -> Double?,
+) {
+    private companion object {
+        const val TAG = "PageImageLoader"
+        const val MEDIA_TIMEOUT_SECONDS = 60f
+    }
+
+    private val states = PageImageStates()
+
+    private val _snapshot = MutableStateFlow<Map<String, PageImageState>>(emptyMap())
+
+    /** UI-observable image states, keyed by [pageImageKey]. */
+    val imageStates: StateFlow<Map<String, PageImageState>> = _snapshot.asStateFlow()
+
+    @Volatile
+    private var queueJob: Job? = null
+
+    @Volatile
+    private var epoch = 0
+
+    /**
+     * Register the page's images after a parse. [refs] come from the page's
+     * Image elements via [imageRefFor]. Cache hits go straight to LOADED;
+     * everything else waits as PLACEHOLDER. Auto mode starts the queue when
+     * the bandwidth gate passes; manual/never stay idle.
+     */
+    fun scan(
+        refs: List<ParsedImageRef>,
+        forceReload: Boolean = false,
+    ) {
+        val myEpoch = ++epoch
+        queueJob?.cancel()
+        states.clear()
+
+        var needsQueue = false
+        for (ref in refs) {
+            val resolved = resolveImageUrl(ref.url, currentNodeHash())
+            if (resolved == null) {
+                states.put(
+                    ref.key,
+                    PageImageState(ref = ref, error = "Malformed image URL: ${ref.url}"),
+                )
+                continue
+            }
+            val resolvedRef = ref.withResolved(resolved)
+            if (forceReload) cache.remove(resolved)
+            val cached = if (forceReload) null else cache.get(resolved)
+            if (cached != null) {
+                states.put(ref.key, PageImageState(ref = resolvedRef, status = PageImageStatus.LOADED, file = cached))
+            } else {
+                states.put(ref.key, PageImageState(ref = resolvedRef))
+                needsQueue = true
+            }
+        }
+        publish()
+        if (!needsQueue) return
+        // The queue itself decides by mode + auto gate (the gate needs a
+        // suspend call for link stats, so the decision lives in the coroutine).
+        startQueue(myEpoch)
+    }
+
+    /** Explicit load (upstream Ctrl+L / placeholder tap). Bypasses the auto gate. */
+    fun loadImages(forceReload: Boolean = false) {
+        if (imageLoadingMode() == ImageLoadingMode.NEVER) return
+        if (forceReload) {
+            // Upstream Ctrl+X: drop caches for this page's images and re-queue
+            // them as placeholders so they re-download.
+            for ((key, state) in states.snapshot()) {
+                val ref = state.ref ?: continue
+                val resolved = resolveImageUrl(ref.url, currentNodeHash()) ?: continue
+                cache.remove(resolved)
+                states.put(key, PageImageState(ref = ref.withResolved(resolved)))
+            }
+            publish()
+        }
+        startQueueForExplicitLoad(epoch)
+    }
+
+    /** Retry one failed/denied/placeholder image (per-image reload affordance). */
+    fun retryImage(key: String) {
+        if (imageLoadingMode() == ImageLoadingMode.NEVER) return
+        val state = states.get(key) ?: return
+        val ref = state.ref ?: return
+        states.put(key, PageImageState(ref = ref))
+        publish()
+        startQueueForExplicitLoad(epoch)
+    }
+
+    fun cancelAll() {
+        epoch++
+        queueJob?.cancel()
+        queueJob = null
+    }
+
+    fun clear() {
+        cancelAll()
+        states.clear()
+        publish()
+    }
+
+    private suspend fun gatePasses(): Boolean {
+        val hash = currentNodeHash()
+        val stats = runCatching { nomadnet.getNomadnetLinkStats(hash) }.getOrNull()
+        return NomadNetImagePolicy.shouldLoadAutomatically(
+            mode = imageLoadingMode(),
+            // No loopback nodes in Columba's browsing model.
+            isLoopback = false,
+            rttSeconds = stats?.rttSeconds,
+            expectedRateBps = stats?.expectedRateBps,
+            measuredResponseSpeedBps = lastResponseSpeedBps(),
+        )
+    }
+
+    private fun startQueue(myEpoch: Int) = startQueue(myEpoch, respectModeAndGate = true)
+
+    /** Explicit (user-triggered) queue run: skips the mode/gate check but still honors NEVER. */
+    private fun startQueueForExplicitLoad(myEpoch: Int) = startQueue(myEpoch, respectModeAndGate = false)
+
+    private fun startQueue(
+        myEpoch: Int,
+        respectModeAndGate: Boolean,
+    ) {
+        queueJob?.cancel()
+        queueJob =
+            scope.launch(kotlinx.coroutines.Dispatchers.IO) {
+                // Mode + auto-gate decision happens inside the coroutine
+                // (the gate needs a suspend call). Explicit user loads skip
+                // the gate but NEVER mode still blocks everything.
+                if (imageLoadingMode() == ImageLoadingMode.NEVER) return@launch
+                if (respectModeAndGate) {
+                    when (imageLoadingMode()) {
+                        ImageLoadingMode.MANUAL -> return@launch
+                        ImageLoadingMode.ALWAYS -> Unit
+                        ImageLoadingMode.AUTO ->
+                            if (!gatePasses()) return@launch
+                        ImageLoadingMode.NEVER -> return@launch
+                    }
+                }
+                // Snapshot keys once; a new scan bumps the epoch and restarts.
+                val keys = states.snapshot().keys.toList()
+                for (key in keys) {
+                    if (epoch != myEpoch) return@launch
+                    val state = states.get(key) ?: continue
+                    if (state.status != PageImageStatus.PLACEHOLDER) continue
+                    fetchOne(key, myEpoch)
+                }
+            }
+    }
+
+    private suspend fun fetchOne(
+        key: String,
+        myEpoch: Int,
+    ) {
+        val state = states.get(key) ?: return
+        val ref = state.ref ?: return
+        val hash = ref.nodeHash ?: return
+        states.update(key) { it.copy(status = PageImageStatus.LOADING) }
+        publish()
+
+        val result =
+            runCatching {
+                nomadnet.requestNomadnetMedia(hash, ref.mediaPath, MEDIA_TIMEOUT_SECONDS).getOrThrow()
+            }
+
+        if (epoch != myEpoch) {
+            // Stale: drop the staged file if any.
+            result.getOrNull()?.let { runCatching { File(it.filePath).delete() } }
+            return
+        }
+
+        result.fold(
+            onSuccess = { media ->
+                val cached = cache.put("$hash:${ref.mediaPath}", File(media.filePath))
+                if (cached != null) {
+                    states.update(key) {
+                        it.copy(
+                            status = PageImageStatus.LOADED,
+                            file = cached,
+                            progress = 1f,
+                            totalBytes = media.fileSize,
+                            receivedBytes = media.fileSize,
+                        )
+                    }
+                } else {
+                    states.update(key) {
+                        it.copy(status = PageImageStatus.FAILED, error = "Not a WebP image (rejected)")
+                    }
+                }
+            },
+            onFailure = { error ->
+                val denied = (error as? RnsException)?.error is RnsError.NomadnetRequestDenied
+                Log.d(TAG, "Image $key ${if (denied) "denied by node" else "failed"}: ${error.message}")
+                states.update(key) {
+                    it.copy(
+                        status = if (denied) PageImageStatus.DENIED else PageImageStatus.FAILED,
+                        error = error.message,
+                    )
+                }
+            },
+        )
+        publish()
+    }
+
+    private fun publish() {
+        _snapshot.value = states.snapshot()
+    }
+}
+
+/** One image element on a page, reduced to what the loader needs. */
+data class ParsedImageRef(
+    val url: String,
+    val key: String,
+    /** Filled by the scan pass from [resolveImageUrl]; null = unresolved. */
+    val nodeHash: String? = null,
+    val mediaPath: String = "",
+)
+
+private fun ParsedImageRef.withResolved(resolved: String): ParsedImageRef {
+    val idx = resolved.indexOf(':')
+    return copy(
+        nodeHash = resolved.substring(0, idx),
+        mediaPath = resolved.substring(idx + 1),
+    )
+}

--- a/app/src/main/java/network/columba/app/nomadnet/PageImageLoader.kt
+++ b/app/src/main/java/network/columba/app/nomadnet/PageImageLoader.kt
@@ -75,9 +75,18 @@ class PageImageLoader(
         for (ref in refs) {
             val resolved = resolveImageUrl(ref.url, currentNodeHash())
             if (resolved == null) {
+                // Structurally invalid URL: it can never resolve to a fetch, so
+                // mark it MALFORMED (not PLACEHOLDER) - the UI renders the
+                // error without a tap-to-retry affordance, and retryImage is a
+                // no-op for it. A PLACEHOLDER here would advertise "tap to load"
+                // on a reference that is permanently unfetchable (issue 8).
                 states.put(
                     ref.key,
-                    PageImageState(ref = ref, error = "Malformed image URL: ${ref.url}"),
+                    PageImageState(
+                        ref = ref,
+                        status = PageImageStatus.MALFORMED,
+                        error = "Malformed image URL: ${ref.url}",
+                    ),
                 )
                 continue
             }
@@ -130,8 +139,14 @@ class PageImageLoader(
      */
     fun retryImage(key: String) {
         if (imageLoadingMode() == ImageLoadingMode.NEVER) return
-        val state = states.get(key) ?: return
-        val ref = state.ref ?: return
+        val state = states.get(key)
+        val ref = state?.ref
+        // A malformed reference is structurally unfetchable - retrying it just
+        // resets it to a placeholder and fetchOne returns (no node hash), so it
+        // would sit as a permanently tappable no-op. DENIED and FAILED stay
+        // retryable: the node may allow it later, or a transient fetch may
+        // succeed on retry.
+        if (state == null || state.status == PageImageStatus.MALFORMED || ref == null) return
         states.put(key, PageImageState(ref = ref))
         publish()
         startQueueForSingle(key, epoch)
@@ -149,9 +164,59 @@ class PageImageLoader(
         publish()
     }
 
-    private suspend fun gatePasses(): Boolean {
-        val hash = currentNodeHash()
-        val stats = runCatching { nomadnet.getNomadnetLinkStats(hash) }.getOrNull()
+    /**
+     * Apply a loading-mode transition to the active loader (issue 5). Called
+     * when the user selects a new [ImageLoadingMode] for a page that is
+     * already displayed: a mode change must take effect on the current page,
+     * not only on the next navigation.
+     *
+     * Every transition first cancels any running queue and resets in-flight
+     * LOADING states back to placeholders, so no queue left over from a
+     * previous mode keeps fetching under the new mode, and an abandoned
+     * fetch does not sit in a stale "loading" state. The transition is then
+     * re-derived from scratch:
+     *
+     * - ALWAYS: start an explicit load of every registered placeholder (the
+     *   user just asked for all images to load).
+     * - AUTO: re-evaluate the bandwidth gate for the registered placeholders.
+     * - MANUAL: leave placeholders as-is (a manual user loads on demand).
+     * - NEVER: leave placeholders as-is; nothing auto-fetches, so tapping is
+     *   blocked and the queue simply does not start.
+     *
+     * Already-LOADED / DENIED / FAILED / MALFORMED states are untouched, so
+     * switching modes never discards an already-rendered image.
+     */
+    fun applyMode(mode: ImageLoadingMode) {
+        // Clean transition: stop any queue from the previous mode and reset
+        // in-flight fetches so the new mode re-evaluates them.
+        cancelAll()
+        resetLoadingStates()
+        publish()
+        when (mode) {
+            ImageLoadingMode.ALWAYS -> startQueueForExplicitLoad(epoch)
+            ImageLoadingMode.AUTO -> startQueue(epoch)
+            ImageLoadingMode.MANUAL -> Unit
+            ImageLoadingMode.NEVER -> Unit
+        }
+    }
+
+    /**
+     * Reset any LOADING image states back to placeholders. Called after a
+     * queue cancel so an abandoned fetch is re-evaluated by the new mode
+     * instead of hanging in a perpetual "loading" state (the cancelled
+     * [fetchOne] leaves its result unapplied because the epoch no longer
+     * matches).
+     */
+    private fun resetLoadingStates() {
+        for ((key, state) in states.snapshot()) {
+            if (state.status == PageImageStatus.LOADING) {
+                states.put(key, PageImageState(ref = state.ref))
+            }
+        }
+    }
+
+    private suspend fun gatePasses(nodeHash: String): Boolean {
+        val stats = runCatching { nomadnet.getNomadnetLinkStats(nodeHash) }.getOrNull()
         return NomadNetImagePolicy.shouldLoadAutomatically(
             mode = imageLoadingMode(),
             // No loopback nodes in Columba's browsing model.
@@ -183,28 +248,56 @@ class PageImageLoader(
         queueJob?.cancel()
         queueJob =
             scope.launch(kotlinx.coroutines.Dispatchers.IO) {
-                // Mode + auto-gate decision happens inside the coroutine
-                // (the gate needs a suspend call). Explicit user loads skip
-                // the gate but NEVER mode still blocks everything.
+                // Mode decision happens inside the coroutine (the gate needs a
+                // suspend call). Explicit user loads skip the gate but NEVER
+                // mode still blocks everything.
                 if (imageLoadingMode() == ImageLoadingMode.NEVER) return@launch
-                if (respectModeAndGate) {
-                    when (imageLoadingMode()) {
-                        ImageLoadingMode.MANUAL -> return@launch
-                        ImageLoadingMode.ALWAYS -> Unit
-                        ImageLoadingMode.AUTO ->
-                            if (!gatePasses()) return@launch
-                        ImageLoadingMode.NEVER -> return@launch
-                    }
-                }
+                if (respectModeAndGate && imageLoadingMode() == ImageLoadingMode.MANUAL) return@launch
                 // Snapshot keys once; a new scan bumps the epoch and restarts.
                 val keys = (states.snapshot().keys.toList()).filter { onlyKey == null || it == onlyKey }
                 for (key in keys) {
-                    if (epoch != myEpoch) return@launch
-                    val state = states.get(key)
-                    if (state == null || state.status != PageImageStatus.PLACEHOLDER) continue
-                    fetchOne(key, myEpoch)
+                    // processKey returns false when the epoch changed mid-loop
+                    // (a new scan superseded this run), which stops the queue.
+                    if (!processKey(key, myEpoch, respectModeAndGate)) return@launch
                 }
             }
+    }
+
+    /**
+     * Fetch a single registered image if it is a placeholder and passes the
+     * per-image auto gate; no-op otherwise. Returns [false] only when the
+     * epoch changed (a newer scan superseded this run), signalling the queue
+     * loop to stop; [true] when this key was processed (fetched or
+     * intentionally skipped) and the loop should continue.
+     *
+     * The per-image auto gate (issue 6) evaluates the RTT/EDR policy against
+     * THIS image's own destination node, not the current page's node once for
+     * the whole queue. A page can reference cross-node images (explicit
+     * `<hash>:` path) that ride a different - possibly slow - link than the
+     * page itself; gating the whole queue on the page node would authorize a
+     * fast page's link to download from a slow destination, or block a fast
+     * destination because the page node is slow.
+     */
+    private suspend fun processKey(
+        key: String,
+        myEpoch: Int,
+        respectModeAndGate: Boolean,
+    ): Boolean {
+        if (epoch != myEpoch) return false
+        val state = states.get(key)
+        val placeholder = state != null && state.status == PageImageStatus.PLACEHOLDER
+        // Auto-gate (issue 6): evaluate the RTT/EDR policy against THIS image's
+        // own destination node. A null node hash means the reference never
+        // resolved, so it cannot pass the gate (no fetch). Explicit loads
+        // (respectModeAndGate = false) skip the gate entirely.
+        val gateOk =
+            !respectModeAndGate ||
+                imageLoadingMode() != ImageLoadingMode.AUTO ||
+                (state?.ref?.nodeHash?.let { gatePasses(it) } == true)
+        if (placeholder && gateOk) {
+            fetchOne(key, myEpoch)
+        }
+        return epoch == myEpoch
     }
 
     private suspend fun fetchOne(
@@ -220,10 +313,15 @@ class PageImageLoader(
 
         val result =
             runCatching {
-                val media = nomadnet.requestNomadnetMedia(hash, ref.mediaPath, MEDIA_TIMEOUT_SECONDS).getOrThrow()
-                // Client-side size cap (plan: "always mode still hits the per-image
-                // size cap"). The backends stage whatever the link delivers, so the
-                // app layer is the enforcement point that holds for both of them.
+                // Pass the transfer cap to the backend so it refuses an
+                // oversized payload at the response boundary (before staging to
+                // disk), instead of the app layer deleting it after the fact.
+                // The client-side check below remains as a belt-and-suspenders
+                // guard for backends that predate the cap (or tests that stub
+                // the interface without it).
+                val media =
+                    nomadnet.requestNomadnetMedia(hash, ref.mediaPath, MEDIA_TIMEOUT_SECONDS, NomadNetImagePolicy.MAX_IMAGE_BYTES)
+                        .getOrThrow()
                 if (media.fileSize > NomadNetImagePolicy.MAX_IMAGE_BYTES) {
                     runCatching { java.io.File(media.filePath).delete() }
                     error("Image too large (${media.fileSize} bytes; cap ${NomadNetImagePolicy.MAX_IMAGE_BYTES})")

--- a/app/src/main/java/network/columba/app/repository/SettingsRepository.kt
+++ b/app/src/main/java/network/columba/app/repository/SettingsRepository.kt
@@ -141,6 +141,7 @@ class SettingsRepository
             val MAP_MARKER_DECLUTTER_ENABLED = booleanPreferencesKey("map_marker_declutter_enabled")
             val MAP_STYLE_PREFERENCE = stringPreferencesKey("map_style_preference")
             val NOMADNET_RENDERING_MODE = stringPreferencesKey("nomadnet_rendering_mode")
+            val NOMADNET_IMAGE_LOADING_MODE = stringPreferencesKey("nomadnet_image_loading_mode")
             val NOMADNET_LAST_NODE = stringPreferencesKey("nomadnet_last_node")
             val BOTTOM_NAV_TABS = stringPreferencesKey("bottom_nav_tabs")
             val HTTP_ENABLED_FOR_DOWNLOAD = booleanPreferencesKey("http_enabled_for_download")
@@ -1478,6 +1479,23 @@ class SettingsRepository
         suspend fun saveNomadNetRenderingMode(modeName: String) {
             context.dataStore.edit { preferences ->
                 preferences[PreferencesKeys.NOMADNET_RENDERING_MODE] = modeName
+            }
+        }
+
+        /**
+         * Flow of the NomadNet image loading mode ("never" | "manual" |
+         * "auto" | "always"; upstream `image_loading` mirror). Null when
+         * unset — callers default to auto.
+         */
+        val nomadNetImageLoadingModeFlow: Flow<String?> =
+            context.dataStore.data
+                .map { preferences -> preferences[PreferencesKeys.NOMADNET_IMAGE_LOADING_MODE] }
+                .distinctUntilChanged()
+
+        /** Persist the NomadNet image loading mode (lowercase name). */
+        suspend fun saveNomadNetImageLoadingMode(modeName: String) {
+            context.dataStore.edit { preferences ->
+                preferences[PreferencesKeys.NOMADNET_IMAGE_LOADING_MODE] = modeName.lowercase()
             }
         }
 

--- a/app/src/main/java/network/columba/app/ui/components/MicronComposables.kt
+++ b/app/src/main/java/network/columba/app/ui/components/MicronComposables.kt
@@ -80,6 +80,10 @@ fun MicronPageContent(
     modifier: Modifier = Modifier,
     minLineWidth: Dp = Dp.Unspecified,
     partialStates: Map<String, PartialManager.PartialState> = emptyMap(),
+    imageStates: Map<String, network.columba.app.nomadnet.PageImageState> = emptyMap(),
+    onImageTapToLoad: (String) -> Unit = {},
+    onImageReload: (String) -> Unit = {},
+    onCopyImageLink: (String) -> Unit = {},
     lineIndexOffset: Int = 0,
 ) {
     val defaultFg = MaterialTheme.colorScheme.onSurface
@@ -117,6 +121,10 @@ fun MicronPageContent(
                     onFieldUpdate = onFieldUpdate,
                     minLineWidth = minLineWidth,
                     partialStates = partialStates,
+                    imageStates = imageStates,
+                    onImageTapToLoad = onImageTapToLoad,
+                    onImageReload = onImageReload,
+                    onCopyImageLink = onCopyImageLink,
                     squareLineHeightSp = squareLineHeightSp,
                 )
             }
@@ -136,6 +144,10 @@ private fun MicronLineComposable(
     onFieldUpdate: (name: String, value: String) -> Unit,
     minLineWidth: Dp = Dp.Unspecified,
     partialStates: Map<String, PartialManager.PartialState> = emptyMap(),
+    imageStates: Map<String, network.columba.app.nomadnet.PageImageState> = emptyMap(),
+    onImageTapToLoad: (String) -> Unit = {},
+    onImageReload: (String) -> Unit = {},
+    onCopyImageLink: (String) -> Unit = {},
     squareLineHeightSp: TextUnit = TextUnit.Unspecified,
 ) {
     // Check if line is a line break
@@ -191,6 +203,21 @@ private fun MicronLineComposable(
                 )
             }
         }
+        return
+    }
+
+    // Check if line is an inline image (upstream parity: block-level, own line)
+    val image = line.elements.firstOrNull() as? MicronElement.Image
+    if (image != null) {
+        val key = network.columba.app.nomadnet.pageImageKey(image.url, image.width, image.height)
+        MicronImageBlock(
+            element = image,
+            state = imageStates[key],
+            indentLevel = line.indentLevel,
+            onImageTapToLoad = { onImageTapToLoad(key) },
+            onImageReload = { onImageReload(key) },
+            onCopyLink = onCopyImageLink,
+        )
         return
     }
 
@@ -473,6 +500,14 @@ private fun buildMicronAnnotatedString(
     buildAnnotatedString {
         for (element in elements) {
             when (element) {
+                is MicronElement.Image -> {
+                    // Block-level; handled by MicronLineComposable directly.
+                    // Inside mixed inline runs (which upstream never emits),
+                    // render the alt text so nothing silently disappears.
+                    if (element.alt.isNotEmpty()) {
+                        append(element.alt)
+                    }
+                }
                 is MicronElement.Text -> {
                     if (element.content.isNotEmpty()) {
                         appendTextWithAutolinkedUrls(element.content, element.style.toSpanStyle(defaultFg))

--- a/app/src/main/java/network/columba/app/ui/components/MicronComposables.kt
+++ b/app/src/main/java/network/columba/app/ui/components/MicronComposables.kt
@@ -214,6 +214,7 @@ private fun MicronLineComposable(
             element = image,
             state = imageStates[key],
             indentLevel = line.indentLevel,
+            minLineWidth = minLineWidth,
             onImageTapToLoad = { onImageTapToLoad(key) },
             onImageReload = { onImageReload(key) },
             onCopyLink = onCopyImageLink,

--- a/app/src/main/java/network/columba/app/ui/components/MicronImageBlock.kt
+++ b/app/src/main/java/network/columba/app/ui/components/MicronImageBlock.kt
@@ -1,0 +1,408 @@
+package network.columba.app.ui.components
+
+import androidx.compose.foundation.Image
+import androidx.compose.foundation.combinedClickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.width
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.outlined.Image
+import androidx.compose.material.icons.outlined.Lock
+import androidx.compose.material.icons.outlined.Refresh
+import androidx.compose.material.icons.outlined.SaveAlt
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme.colorScheme
+import androidx.compose.material3.MaterialTheme.typography
+import androidx.compose.material3.ModalBottomSheet
+import androidx.compose.material3.Text
+import androidx.compose.material3.rememberModalBottomSheetState
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.drawWithContent
+import androidx.compose.ui.graphics.PathEffect
+import androidx.compose.ui.graphics.drawscope.Stroke
+import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.graphics.graphicsLayer
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.platform.LocalDensity
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.dp
+import coil.compose.rememberAsyncImagePainter
+import coil.request.ImageRequest
+import kotlinx.coroutines.launch
+import network.columba.app.micron.MicronElement
+import network.columba.app.nomadnet.PageImageState
+import network.columba.app.nomadnet.PageImageStatus
+import kotlin.math.max
+import kotlin.math.min
+import kotlin.math.roundToInt
+
+/**
+ * Renders one Micron `Image` element, upstream-parity chrome rules (Torlando
+ * 2026-09-07):
+ *
+ * - LOADED: the image, raw and inline. No border, no card, no scrim — the
+ *   terminal draws graphics with no chrome and neither do we. Tap does
+ *   nothing; long-press is the only affordance (M3 modal bottom sheet:
+ *   Save to gallery / Reload / Copy link).
+ * - Everything else (placeholder, loading, denied, failed) is *text in place
+ *   of the image* — a subtle dashed-outline low-emphasis box, mirroring the
+ *   terminal's one-line placeholder, not a Material component.
+ *
+ * Sizing (locked decision: fixed constant, clamp to viewport):
+ * `w=40` -> 40 * 8.dp, `h=10` -> 10 * 16.dp (2:1 terminal cell aspect),
+ * `50%` -> fraction of available width, `n` -> intrinsic size clamped to
+ * width, none -> full width with height derived from the image aspect.
+ */
+
+private const val DP_PER_COLUMN = 8f
+private const val DP_PER_ROW = 16f
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun MicronImageBlock(
+    element: MicronElement.Image,
+    state: PageImageState?,
+    maxBlockSize: Dp = Dp.Unspecified,
+    indentLevel: Int = 0,
+    onImageTapToLoad: () -> Unit = {},
+    onImageReload: () -> Unit = {},
+    onCopyLink: (String) -> Unit = {},
+    modifier: Modifier = Modifier,
+) {
+    val indent = (indentLevel * 8).dp
+    val effectiveState = state ?: PageImageState()
+
+    // Long-press action sheet (M3: non-destructive item actions -> modal
+    // bottom sheet, the Google Photos idiom).
+    var showSheet by remember { mutableStateOf(false) }
+    val sheetState = rememberModalBottomSheetState()
+    val scope = rememberCoroutineScope()
+    val context = LocalContext.current
+
+    val blockModifier =
+        modifier
+            .padding(start = indent, top = 6.dp, bottom = 6.dp)
+            .let { m ->
+                if (maxBlockSize != Dp.Unspecified) {
+                    m.graphicsLayer { clip = false }
+                } else {
+                    m
+                }
+            }
+
+    when (effectiveState.status) {
+        PageImageStatus.LOADED -> {
+            val file = effectiveState.file
+            if (file != null) {
+                val targetWidth = resolveImageWidth(element.width, Dp.Unspecified)
+                val targetHeight = resolveImageWidth(element.height, Dp.Unspecified)
+                val painter =
+                    rememberAsyncImagePainter(
+                        ImageRequest.Builder(context)
+                            .data(file)
+                            .build(),
+                    )
+                Row(
+                    modifier =
+                        blockModifier
+                            .fillMaxWidth()
+                            .testTag("micron-image-loaded"),
+                    horizontalArrangement = horizontalArrangementFor(element.align),
+                ) {
+                    val imageModifier =
+                        Modifier
+                            .combinedClickable(
+                                onClick = {}, // tap-inert, upstream parity
+                                onLongClick = { showSheet = true },
+                            )
+                            .let { m ->
+                                val w = targetWidth
+                                if (w != null) m.width(w.coerceAtLeast(0.dp)) else m.fillMaxWidth()
+                            }
+                            .let { m ->
+                                val h = targetHeight
+                                if (h != null) m.height(h) else m
+                            }
+                    Image(
+                        painter = painter,
+                        contentDescription = element.alt.ifBlank { "Image" },
+                        contentScale = ContentScale.Fit,
+                        modifier = imageModifier,
+                    )
+                }
+            } else {
+                ImagePlaceholder(
+                    element = element,
+                    statusLine = null,
+                    showTapAffordance = false,
+                    onClick = onImageTapToLoad,
+                    modifier = blockModifier,
+                )
+            }
+        }
+
+        PageImageStatus.LOADING -> {
+            ImagePlaceholder(
+                element = element,
+                statusLine = loadingStatusLine(effectiveState),
+                showTapAffordance = false,
+                onClick = {},
+                modifier = blockModifier.testTag("micron-image-loading"),
+            )
+        }
+
+        PageImageStatus.DENIED -> {
+            ImagePlaceholder(
+                element = element,
+                statusLine = "Access denied by node",
+                showTapAffordance = false,
+                onClick = {},
+                icon = { Icon(Icons.Outlined.Lock, contentDescription = null) },
+                modifier = blockModifier.testTag("micron-image-denied"),
+            )
+        }
+
+        PageImageStatus.FAILED -> {
+            ImagePlaceholder(
+                element = element,
+                statusLine = effectiveState.error ?: "Error loading image",
+                showTapAffordance = true,
+                onClick = onImageReload,
+                modifier = blockModifier.testTag("micron-image-failed"),
+            )
+        }
+
+        PageImageStatus.PLACEHOLDER -> {
+            ImagePlaceholder(
+                element = element,
+                statusLine = null,
+                showTapAffordance = true,
+                onClick = onImageTapToLoad,
+                modifier = blockModifier.testTag("micron-image-placeholder"),
+            )
+        }
+    }
+
+    if (showSheet) {
+        ModalBottomSheet(
+            onDismissRequest = { showSheet = false },
+            sheetState = sheetState,
+            modifier = Modifier.testTag("micron-image-sheet"),
+        ) {
+            Text(
+                text = element.alt.ifBlank { "Image" },
+                style = typography.titleSmall,
+                modifier = Modifier.padding(horizontal = 24.dp, vertical = 8.dp),
+            )
+            SheetAction(Icons.Outlined.SaveAlt, "Save to gallery") {
+                effectiveState.file?.let { f ->
+                    saveImageToGallery(context, f.absolutePath, f.name)
+                }
+                scope.launch { sheetState.hide() }.invokeOnCompletion { showSheet = false }
+            }
+            SheetAction(Icons.Outlined.Refresh, "Reload image") {
+                onImageReload()
+                scope.launch { sheetState.hide() }.invokeOnCompletion { showSheet = false }
+            }
+            SheetAction(Icons.Outlined.Image, "Copy image link") {
+                onCopyLink(element.url)
+                scope.launch { sheetState.hide() }.invokeOnCompletion { showSheet = false }
+            }
+            Spacer(Modifier.height(24.dp))
+        }
+    }
+}
+
+@Composable
+private fun SheetAction(
+    icon: androidx.compose.ui.graphics.vector.ImageVector,
+    label: String,
+    onClick: () -> Unit,
+) {
+    Row(
+        modifier =
+            Modifier
+                .fillMaxWidth()
+                .combinedClickable(onClick = onClick)
+                .padding(horizontal = 24.dp, vertical = 14.dp),
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
+        Icon(icon, contentDescription = null, tint = colorScheme.onSurfaceVariant)
+        Spacer(Modifier.width(20.dp))
+        Text(label, style = typography.bodyLarge, color = colorScheme.onSurface)
+    }
+}
+
+@Composable
+private fun ImagePlaceholder(
+    element: MicronElement.Image,
+    statusLine: String?,
+    showTapAffordance: Boolean,
+    onClick: () -> Unit,
+    modifier: Modifier = Modifier,
+    icon: (@Composable () -> Unit)? = null,
+) {
+    val dashColor = colorScheme.outlineVariant
+    Column(
+        modifier =
+            modifier
+                .fillMaxWidth()
+                .drawWithContent {
+                    drawContent()
+                    drawRect(
+                        color = dashColor,
+                        style =
+                            Stroke(
+                                width = 1.dp.toPx(),
+                                pathEffect =
+                                    PathEffect.dashPathEffect(
+                                        floatArrayOf(6.dp.toPx(), 6.dp.toPx()),
+                                        0f,
+                                    ),
+                            ),
+                    )
+                }
+                .combinedClickable(
+                    onClick = onClick,
+                    enabled = showTapAffordance,
+                )
+                .padding(horizontal = 16.dp, vertical = 14.dp),
+        horizontalAlignment = Alignment.CenterHorizontally,
+        verticalArrangement = Arrangement.Center,
+    ) {
+        Row(verticalAlignment = Alignment.CenterVertically) {
+            icon?.invoke()
+                ?: Icon(
+                    Icons.Outlined.Image,
+                    contentDescription = null,
+                    tint = colorScheme.onSurfaceVariant,
+                )
+            Spacer(Modifier.width(8.dp))
+            Text(
+                text = element.alt.ifBlank { "image" },
+                style = typography.bodyMedium,
+                color = colorScheme.onSurfaceVariant,
+                textAlign = TextAlign.Center,
+            )
+        }
+        if (statusLine != null) {
+            Spacer(Modifier.height(4.dp))
+            Text(
+                text = statusLine,
+                style = typography.bodySmall,
+                color = colorScheme.onSurfaceVariant,
+            )
+        }
+        if (showTapAffordance) {
+            Spacer(Modifier.height(4.dp))
+            Text(
+                text = "Tap to load image",
+                style = typography.labelSmall,
+                color = colorScheme.primary,
+            )
+        }
+    }
+}
+
+@Composable
+private fun loadingStatusLine(state: PageImageState): String {
+    val pct = (state.progress * 100).roundToInt()
+    val sizePart =
+        if (state.totalBytes > 0) {
+            " (${formatBytes(state.receivedBytes)} of ${formatBytes(state.totalBytes)})"
+        } else {
+            ""
+        }
+    val speedPart = state.speedBps?.let { " - ${formatSpeed(it)}" } ?: ""
+    return "$pct%$sizePart$speedPart".ifBlank { "Loading..." }
+}
+
+/** Terminal-cell size spec -> Dp (locked: 1 col = 8.dp, 1 row = 16.dp). */
+@Composable
+internal fun resolveImageWidth(
+    spec: String?,
+    @Suppress("UNUSED_PARAMETER") fallback: Dp,
+): Dp? {
+    if (spec == null) return null
+    if (spec == "n") return null // native: intrinsic size, clamped by parent
+    val density = LocalDensity.current
+    return when {
+        spec.endsWith("%") -> {
+            val pct = spec.removeSuffix("%").toFloatOrNull() ?: return null
+            with(density) { (max(0f, min(100f, pct)) * 4.11f).toDp() }
+        }
+        spec.toFloatOrNull() != null -> with(density) { (spec.toFloat() * DP_PER_COLUMN).toDp() }
+        else -> null
+    }
+}
+
+private fun horizontalArrangementFor(align: String?): Arrangement.Horizontal =
+    when (align) {
+        "left" -> Arrangement.Start
+        "right" -> Arrangement.End
+        else -> Arrangement.Center
+    }
+
+internal fun formatBytes(bytes: Long): String =
+    when {
+        bytes >= 1_000_000 -> "%.1f MB".format(bytes / 1_000_000.0)
+        bytes >= 1_000 -> "%.1f KiB".format(bytes / 1024.0)
+        else -> "$bytes B"
+    }
+
+internal fun formatSpeed(bps: Long): String =
+    when {
+        bps >= 1_000_000 -> "%.1f Mbps".format(bps / 1_000_000.0)
+        bps >= 1_000 -> "%.1f kbps".format(bps / 1000.0)
+        else -> "$bps bps"
+    }
+
+/**
+ * Insert a media file into the system gallery via MediaStore (user-initiated,
+ * so no storage permission needed on API 29+).
+ */
+fun saveImageToGallery(
+    context: android.content.Context,
+    filePath: String,
+    displayName: String,
+) {
+    val resolver = context.contentResolver
+    val values =
+        android.content.ContentValues().apply {
+            put(android.provider.MediaStore.Images.Media.DISPLAY_NAME, displayName)
+            put(android.provider.MediaStore.Images.Media.MIME_TYPE, "image/webp")
+            put(
+                android.provider.MediaStore.Images.Media.RELATIVE_PATH,
+                "Pictures/Columba",
+            )
+        }
+    val uri = resolver.insert(android.provider.MediaStore.Images.Media.EXTERNAL_CONTENT_URI, values)
+    if (uri != null) {
+        resolver.openOutputStream(uri)?.use { out ->
+            java.io.File(filePath).inputStream().use { it.copyTo(out) }
+        }
+        android.widget.Toast
+            .makeText(context, "Saved to gallery", android.widget.Toast.LENGTH_SHORT)
+            .show()
+    } else {
+        android.widget.Toast
+            .makeText(context, "Could not save image", android.widget.Toast.LENGTH_SHORT)
+            .show()
+    }
+}

--- a/app/src/main/java/network/columba/app/ui/components/MicronImageBlock.kt
+++ b/app/src/main/java/network/columba/app/ui/components/MicronImageBlock.kt
@@ -1,5 +1,6 @@
 package network.columba.app.ui.components
 
+import android.graphics.BitmapFactory
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.combinedClickable
 import androidx.compose.foundation.layout.Arrangement
@@ -7,10 +8,12 @@ import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.aspectRatio
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.layout.widthIn
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.outlined.Image
 import androidx.compose.material.icons.outlined.Lock
@@ -24,6 +27,7 @@ import androidx.compose.material3.ModalBottomSheet
 import androidx.compose.material3.Text
 import androidx.compose.material3.rememberModalBottomSheetState
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
@@ -32,7 +36,9 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.drawWithContent
+import androidx.compose.ui.graphics.ImageBitmap
 import androidx.compose.ui.graphics.PathEffect
+import androidx.compose.ui.graphics.asImageBitmap
 import androidx.compose.ui.graphics.drawscope.Stroke
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.graphics.graphicsLayer
@@ -42,9 +48,9 @@ import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
-import coil.compose.rememberAsyncImagePainter
-import coil.request.ImageRequest
+import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
 import network.columba.app.micron.MicronElement
 import network.columba.app.nomadnet.PageImageState
 import network.columba.app.nomadnet.PageImageStatus
@@ -78,6 +84,18 @@ fun MicronImageBlock(
     state: PageImageState?,
     maxBlockSize: Dp = Dp.Unspecified,
     indentLevel: Int = 0,
+    /**
+     * Viewport width to fall back to when the element has no explicit `w=`
+     * spec. In MONOSPACE_SCROLL the page Column is wrapped in a
+     * `horizontalScroll`, which measures children with unbounded width -
+     * `fillMaxWidth()` then resolves to 0 and the image collapses (issue:
+     * "tap to load" loads but nothing renders). Passing the viewport width
+     * (the screen already captures it in `BoxWithConstraints` before the
+     * scrolls unbind) gives the image a finite width to lay out against.
+     * Left `Unspecified` in bounded contexts (PROPORTIONAL_WRAP's
+     * LazyColumn) where `fillMaxWidth` is correct.
+     */
+    minLineWidth: Dp = Dp.Unspecified,
     onImageTapToLoad: () -> Unit = {},
     onImageReload: () -> Unit = {},
     onCopyLink: (String) -> Unit = {},
@@ -110,19 +128,65 @@ fun MicronImageBlock(
             if (file != null) {
                 val targetWidth = resolveImageSize(element.width, DP_PER_COLUMN)
                 val targetHeight = resolveImageSize(element.height, DP_PER_ROW)
-                val painter =
-                    rememberAsyncImagePainter(
-                        ImageRequest.Builder(context)
-                            .data(file)
-                            .build(),
-                    )
+                // Decode the cached file directly off the main thread and
+                // render a bitmap. Coil's rememberAsyncImagePainter gates its
+                // load on onDraw, but this Image is laid out at height 0 while
+                // the painter is in the Loading state (no intrinsic size), so
+                // the load never dispatches and the state is stuck at Loading
+                // forever - Coil 2.7.0 documents this: "will not finish
+                // loading if onDraw is not called". The image cache enforces
+                // the WebP magic before this status exists, so a local decode
+                // cannot reject the payload; it only fails on corrupt files,
+                // which fall back to the in-flight placeholder.
+                // Key on the absolute path (not the File instance): the cache
+                // hands back a fresh File wrapper per lookup, and File has
+                // identity equality, so an instance key would re-decode on
+                // every re-scan.
+                val filePath = file.absolutePath
+                var decoded by remember(filePath) { mutableStateOf<ImageBitmap?>(null) }
+                LaunchedEffect(filePath) {
+                    val loaded =
+                        withContext(Dispatchers.IO) {
+                            runCatching {
+                                BitmapFactory.decodeFile(filePath)?.asImageBitmap()
+                            }.getOrNull()
+                        }
+                    // Guard against a stale decode landing after the file key
+                    // changed (rapid re-scan): only apply the result for the
+                    // path this launch started with.
+                    if (decoded != loaded) decoded = loaded
+                }
+                // The Row is the block-level element (mirrors a text line, which
+                // stays visible in MONOSPACE_SCROLL via widthIn(min = viewport)).
+                // That mode wraps the page Column in a horizontalScroll that
+                // measures children with unbounded width, so a child with no
+                // explicit width (fillMaxWidth) resolves to ~0 and the image is
+                // invisible even though fetch + cache + LOADED state all succeeded
+                // (issue: "tap to load" loads but nothing renders). A hard
+                // .width(viewport) - not widthIn(min) - is required: it bounds the
+                // Row so the inner Image's fillMaxWidth resolves against a finite
+                // width instead of infinity. In bounded contexts (PROPORTIONAL_
+                // WRAP's LazyColumn) fillMaxWidth is correct as before.
+                val rowModifier =
+                    blockModifier
+                        .let { m ->
+                            if (minLineWidth != Dp.Unspecified) m.width(minLineWidth)
+                            else m.fillMaxWidth()
+                        }
+                        .testTag("micron-image-loaded")
                 Row(
-                    modifier =
-                        blockModifier
-                            .fillMaxWidth()
-                            .testTag("micron-image-loaded"),
+                    modifier = rowModifier,
                     horizontalArrangement = horizontalArrangementFor(element.align),
                 ) {
+                    // Height: explicit h= wins; otherwise derive from the
+                    // decoded bitmap's aspect ratio so the image scales to its
+                    // width (full-width no-spec or explicit w=) instead of
+                    // falling back to the bitmap's intrinsic height (which left
+                    // a full-width square drawn small-and-centered). w=n keeps
+                    // its intrinsic height.
+                    val imageBitmap = decoded
+                    // Compose aspectRatio is width/height.
+                    val aspect = imageBitmap?.let { it.width.toFloat() / it.height.toFloat() }
                     val imageModifier =
                         Modifier
                             .combinedClickable(
@@ -130,19 +194,46 @@ fun MicronImageBlock(
                                 onLongClick = { showSheet = true },
                             )
                             .let { m ->
-                                val w = targetWidth
-                                if (w != null) m.width(w.coerceAtLeast(0.dp)) else m.fillMaxWidth()
+                                when {
+                                    // Explicit numeric/% width (narrower than the
+                                    // Row, so horizontal alignment applies).
+                                    targetWidth != null -> m.width(targetWidth.coerceAtLeast(0.dp))
+                                    // w=n: intrinsic size, clamped to the viewport.
+                                    element.width == "n" ->
+                                        m.let { mm ->
+                                            if (minLineWidth != Dp.Unspecified) mm.widthIn(max = minLineWidth) else mm
+                                        }
+                                    // No spec: fill the Row, which already carries
+                                    // the block width.
+                                    else -> m.fillMaxWidth()
+                                }
                             }
                             .let { m ->
                                 val h = targetHeight
                                 if (h != null) m.height(h) else m
                             }
-                    Image(
-                        painter = painter,
-                        contentDescription = element.alt.ifBlank { "Image" },
-                        contentScale = ContentScale.Fit,
-                        modifier = imageModifier,
-                    )
+                            .let { m ->
+                                // Responsive height for the width-constrained,
+                                // height-free cases (no spec and explicit w=).
+                                if (targetHeight == null && element.width != "n" && aspect != null) {
+                                    m.aspectRatio(aspect)
+                                } else {
+                                    m
+                                }
+                            }
+                    if (imageBitmap != null) {
+                        Image(
+                            bitmap = imageBitmap,
+                            contentDescription = element.alt.ifBlank { "Image" },
+                            contentScale = ContentScale.Fit,
+                            modifier = imageModifier,
+                        )
+                    } else {
+                        // Local decode in flight (bounded by the 16 MiB policy
+                        // cap): hold a same-width blank so the row keeps its
+                        // position until the bitmap lands.
+                        Box(modifier = imageModifier)
+                    }
                 }
             } else {
                 ImagePlaceholder(

--- a/app/src/main/java/network/columba/app/ui/components/MicronImageBlock.kt
+++ b/app/src/main/java/network/columba/app/ui/components/MicronImageBlock.kt
@@ -48,8 +48,6 @@ import kotlinx.coroutines.launch
 import network.columba.app.micron.MicronElement
 import network.columba.app.nomadnet.PageImageState
 import network.columba.app.nomadnet.PageImageStatus
-import kotlin.math.max
-import kotlin.math.min
 import kotlin.math.roundToInt
 
 /**
@@ -110,8 +108,8 @@ fun MicronImageBlock(
         PageImageStatus.LOADED -> {
             val file = effectiveState.file
             if (file != null) {
-                val targetWidth = resolveImageWidth(element.width, Dp.Unspecified)
-                val targetHeight = resolveImageWidth(element.height, Dp.Unspecified)
+                val targetWidth = resolveImageSize(element.width, DP_PER_COLUMN)
+                val targetHeight = resolveImageSize(element.height, DP_PER_ROW)
                 val painter =
                     rememberAsyncImagePainter(
                         ImageRequest.Builder(context)
@@ -333,23 +331,27 @@ private fun loadingStatusLine(state: PageImageState): String {
     return "$pct%$sizePart$speedPart".ifBlank { "Loading..." }
 }
 
-/** Terminal-cell size spec -> Dp (locked: 1 col = 8.dp, 1 row = 16.dp). */
+/**
+ * Terminal-cell size spec -> Dp (locked decision: fixed constants, clamp to
+ * viewport — width is `1 col = 8.dp`, height is `1 row = 16.dp`, the 2:1
+ * terminal cell aspect). `NN%` is a fraction of the 411 dp width baseline
+ * (upstream: fraction of the terminal's width/height; on mobile both resolve
+ * against the width baseline, which is the only natural constraint inside
+ * the scrolling page column). `n` (intrinsic) -> null, letting the image use
+ * its natural size clamped by the parent. Malformed specs -> null.
+ */
 @Composable
-internal fun resolveImageWidth(
+internal fun resolveImageSize(
     spec: String?,
-    @Suppress("UNUSED_PARAMETER") fallback: Dp,
+    dpPerUnit: Float,
 ): Dp? {
-    if (spec == null) return null
-    if (spec == "n") return null // native: intrinsic size, clamped by parent
+    if (spec == null || spec == "n") return null
     val density = LocalDensity.current
-    return when {
-        spec.endsWith("%") -> {
-            val pct = spec.removeSuffix("%").toFloatOrNull() ?: return null
-            with(density) { (max(0f, min(100f, pct)) * 4.11f).toDp() }
-        }
-        spec.toFloatOrNull() != null -> with(density) { (spec.toFloat() * DP_PER_COLUMN).toDp() }
-        else -> null
+    val value = when {
+        spec.endsWith("%") -> spec.removeSuffix("%").toFloatOrNull()?.coerceIn(0f, 100f)?.times(4.11f)
+        else -> spec.toFloatOrNull()?.times(dpPerUnit)
     }
+    return value?.let { with(density) { it.toDp() } }
 }
 
 private fun horizontalArrangementFor(align: String?): Arrangement.Horizontal =

--- a/app/src/main/java/network/columba/app/ui/components/MicronImageBlock.kt
+++ b/app/src/main/java/network/columba/app/ui/components/MicronImageBlock.kt
@@ -43,7 +43,6 @@ import androidx.compose.ui.graphics.drawscope.Stroke
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.graphics.graphicsLayer
 import androidx.compose.ui.platform.LocalContext
-import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.Dp
@@ -128,6 +127,10 @@ fun MicronImageBlock(
             if (file != null) {
                 val targetWidth = resolveImageSize(element.width, DP_PER_COLUMN)
                 val targetHeight = resolveImageSize(element.height, DP_PER_ROW)
+                // Percentage width -> parent-relative fraction (100% = full
+                // width). Resolved separately from targetWidth (which only
+                // handles explicit numeric dp values).
+                val widthFraction = resolveImageFraction(element.width)
                 // Decode the cached file directly off the main thread and
                 // render a bitmap. Coil's rememberAsyncImagePainter gates its
                 // load on onDraw, but this Image is laid out at height 0 while
@@ -195,7 +198,13 @@ fun MicronImageBlock(
                             )
                             .let { m ->
                                 when {
-                                    // Explicit numeric/% width (narrower than the
+                                    // Percent width: a fraction of the Row,
+                                    // which already carries the block width.
+                                    // Resolves correctly in MONOSPACE_SCROLL
+                                    // (bounded by the viewport) and bounded
+                                    // layouts (the content column).
+                                    widthFraction != null -> m.fillMaxWidth(widthFraction)
+                                    // Explicit numeric width (narrower than the
                                     // Row, so horizontal alignment applies).
                                     targetWidth != null -> m.width(targetWidth.coerceAtLeast(0.dp))
                                     // w=n: intrinsic size, clamped to the viewport.
@@ -424,25 +433,35 @@ private fun loadingStatusLine(state: PageImageState): String {
 
 /**
  * Terminal-cell size spec -> Dp (locked decision: fixed constants, clamp to
- * viewport — width is `1 col = 8.dp`, height is `1 row = 16.dp`, the 2:1
- * terminal cell aspect). `NN%` is a fraction of the 411 dp width baseline
- * (upstream: fraction of the terminal's width/height; on mobile both resolve
- * against the width baseline, which is the only natural constraint inside
- * the scrolling page column). `n` (intrinsic) -> null, letting the image use
- * its natural size clamped by the parent. Malformed specs -> null.
+ * viewport - width is `1 col = 8.dp`, height is `1 row = 16.dp`, the 2:1
+ * terminal cell aspect). `NN` (a count of units) -> `NN * dpPerUnit` dp.
+ * `NN%` -> null here (handled as a parent-relative fraction by
+ * resolveImageFraction). `n` (intrinsic) -> null, letting the image use its
+ * natural size clamped by the parent. Malformed specs -> null.
  */
-@Composable
 internal fun resolveImageSize(
     spec: String?,
     dpPerUnit: Float,
 ): Dp? {
-    if (spec == null || spec == "n") return null
-    val density = LocalDensity.current
-    val value = when {
-        spec.endsWith("%") -> spec.removeSuffix("%").toFloatOrNull()?.coerceIn(0f, 100f)?.times(4.11f)
-        else -> spec.toFloatOrNull()?.times(dpPerUnit)
-    }
-    return value?.let { with(density) { it.toDp() } }
+    // Percent specs are resolved as a parent-relative fraction
+    // (resolveImageFraction), not an absolute dp value.
+    if (spec == null || spec == "n" || spec.endsWith("%")) return null
+    // `spec` is a count of width/height units; each unit maps to `dpPerUnit`
+    // dp, so the product is already a dp value (no density conversion).
+    return spec.toFloatOrNull()?.times(dpPerUnit)?.dp
+}
+
+/**
+ * Percentage width spec -> fraction of the available (parent) width.
+ * `100%` -> 1.0f (full width), `50%` -> 0.5f. Non-percent and malformed
+ * specs -> null. The fraction is applied via `fillMaxWidth(fraction)`, which
+ * Compose resolves against the parent width (the Row already carries the
+ * block width), so it is correct in both MONOSPACE_SCROLL (bounded by the
+ * viewport) and bounded layouts (the content column).
+ */
+internal fun resolveImageFraction(spec: String?): Float? {
+    if (spec == null || !spec.endsWith("%")) return null
+    return spec.removeSuffix("%").toFloatOrNull()?.let { (it.coerceIn(0f, 100f)) / 100f }
 }
 
 private fun horizontalArrangementFor(align: String?): Arrangement.Horizontal =

--- a/app/src/main/java/network/columba/app/ui/components/MicronImageBlock.kt
+++ b/app/src/main/java/network/columba/app/ui/components/MicronImageBlock.kt
@@ -1,6 +1,5 @@
 package network.columba.app.ui.components
 
-import android.graphics.BitmapFactory
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.combinedClickable
 import androidx.compose.foundation.layout.Arrangement
@@ -53,6 +52,7 @@ import kotlinx.coroutines.withContext
 import network.columba.app.micron.MicronElement
 import network.columba.app.nomadnet.PageImageState
 import network.columba.app.nomadnet.PageImageStatus
+import network.columba.app.util.ImageUtils
 import kotlin.math.roundToInt
 
 /**
@@ -150,9 +150,11 @@ fun MicronImageBlock(
                 LaunchedEffect(filePath) {
                     val loaded =
                         withContext(Dispatchers.IO) {
-                            runCatching {
-                                BitmapFactory.decodeFile(filePath)?.asImageBitmap()
-                            }.getOrNull()
+                            // Bounds-first, sampled decode: caps the decoded
+                            // dimension so a page-controlled image cannot
+                            // allocate an unbounded bitmap and crash the app
+                            // with an uncaught OutOfMemoryError (issue 2).
+                            decodePageImageFile(file)
                         }
                     // Guard against a stale decode landing after the file key
                     // changed (rapid re-scan): only apply the result for the
@@ -293,6 +295,19 @@ fun MicronImageBlock(
                 showTapAffordance = true,
                 onClick = onImageTapToLoad,
                 modifier = blockModifier.testTag("micron-image-placeholder"),
+            )
+        }
+
+        PageImageStatus.MALFORMED -> {
+            // Structurally invalid image URL: render the error, but no
+            // tap-to-retry affordance - it can never resolve to a fetch, so
+            // offering a retry would be a dead no-op (issue 8).
+            ImagePlaceholder(
+                element = element,
+                statusLine = effectiveState.error ?: "Invalid image URL",
+                showTapAffordance = false,
+                onClick = {},
+                modifier = blockModifier.testTag("micron-image-malformed"),
             )
         }
     }
@@ -462,6 +477,50 @@ internal fun resolveImageSize(
 internal fun resolveImageFraction(spec: String?): Float? {
     if (spec == null || !spec.endsWith("%")) return null
     return spec.removeSuffix("%").toFloatOrNull()?.let { (it.coerceIn(0f, 100f)) / 100f }
+}
+
+/**
+ * Max decoded dimension (px) for an inline page image. A wire-size-compliant
+ * WebP can still carry dimensions whose decoded pixel buffer (width * height *
+ * 4 bytes) far exceeds the 16 MiB compressed-file cap, and an unrestricted
+ * `BitmapFactory.decodeFile` on such a payload throws `OutOfMemoryError` - an
+ * `Error` that `runCatching` does not catch - crashing the app while rendering
+ * a page-controlled image. We bounds-first decode (read dimensions with
+ * `inJustDecodeBounds`), pick an `inSampleSize` via [ImageUtils.calculateSampleSize],
+ * and decode at the sampled size, mirroring the repository's existing preview
+ * load path (`ImageUtils.loadBitmap`). Capping the decoded dimension to
+ * [MAX_DECODED_IMAGE_DIMENSION] keeps the worst-case bitmap allocation bounded
+ * (<= ~16 MB) instead of proportional to the source resolution.
+ */
+internal const val MAX_DECODED_IMAGE_DIMENSION = 2048
+
+/**
+ * Decode a cached page-image [file] to an [ImageBitmap] using a bounds-first,
+ * sampled strategy (see [MAX_DECODED_IMAGE_DIMENSION]). Returns null if the
+ * file is missing, not a decodable image, or the decoded bitmap is empty.
+ * Call on a background dispatcher; this is a blocking file + decode operation.
+ */
+internal fun decodePageImageFile(
+    file: java.io.File,
+    maxDimensionPx: Int = MAX_DECODED_IMAGE_DIMENSION,
+): ImageBitmap? {
+    // Bounds pass: read only the dimensions, no pixel allocation.
+    val bounds = android.graphics.BitmapFactory.Options().apply { inJustDecodeBounds = true }
+    android.graphics.BitmapFactory.decodeFile(file.absolutePath, bounds)
+    val sampleSize = ImageUtils.calculateSampleSize(bounds.outWidth, bounds.outHeight, maxDimensionPx)
+    // Sampled pass: the allocation is now bounded by maxDimensionPx.
+    val options =
+        if (sampleSize > 1) {
+            android.graphics.BitmapFactory.Options().apply { inSampleSize = sampleSize }
+        } else {
+            null
+        }
+    val bitmap = android.graphics.BitmapFactory.decodeFile(file.absolutePath, options) ?: return null
+    if (bitmap.width <= 0 || bitmap.height <= 0) {
+        bitmap.recycle()
+        return null
+    }
+    return bitmap.asImageBitmap()
 }
 
 private fun horizontalArrangementFor(align: String?): Arrangement.Horizontal =

--- a/app/src/main/java/network/columba/app/ui/screens/NomadNetBrowserScreen.kt
+++ b/app/src/main/java/network/columba/app/ui/screens/NomadNetBrowserScreen.kt
@@ -86,6 +86,7 @@ import androidx.compose.ui.text.input.TextFieldValue
 import androidx.compose.ui.unit.dp
 import androidx.core.content.FileProvider
 import androidx.hilt.navigation.compose.hiltViewModel
+import network.columba.app.nomadnet.ImageLoadingMode
 import network.columba.app.ui.components.MicronPageContent
 import network.columba.app.viewmodel.NomadNetBrowserViewModel
 import network.columba.app.viewmodel.NomadNetBrowserViewModel.BrowserState
@@ -114,6 +115,8 @@ fun NomadNetBrowserScreen(
     val identifyInProgress by viewModel.identifyInProgress.collectAsState()
     val identifyError by viewModel.identifyError.collectAsState()
     val partialStates by viewModel.partialStates.collectAsState()
+    val imageStates by viewModel.imageStates.collectAsState()
+    val imageLoadingMode by viewModel.imageLoadingMode.collectAsState()
     val isPullRefreshing by viewModel.isPullRefreshing.collectAsState()
     val canGoBack by viewModel.canGoBack.collectAsState()
     val downloadState by viewModel.downloadState.collectAsState()
@@ -400,6 +403,35 @@ fun NomadNetBrowserScreen(
                                 )
                             }
                             HorizontalDivider()
+
+                            // Image loading (upstream `image_loading`: "How, or
+                            // if at all, to load page images").
+                            ImageLoadingMode.entries.forEach { mode ->
+                                DropdownMenuItem(
+                                    text = {
+                                        val label =
+                                            when (mode) {
+                                                ImageLoadingMode.NEVER -> "Images: never"
+                                                ImageLoadingMode.MANUAL -> "Images: manual"
+                                                ImageLoadingMode.AUTO -> "Images: auto"
+                                                ImageLoadingMode.ALWAYS -> "Images: always"
+                                            }
+                                        Text(label)
+                                    },
+                                    leadingIcon = {
+                                        RadioButton(
+                                            selected = imageLoadingMode == mode,
+                                            onClick = null,
+                                            modifier = Modifier.size(20.dp),
+                                        )
+                                    },
+                                    onClick = {
+                                        viewModel.setImageLoadingMode(mode)
+                                        showMenu = false
+                                    },
+                                )
+                            }
+                            HorizontalDivider()
                             BrowserCloseSiteMenuItem(
                                 onCloseSite = {
                                     showMenu = false
@@ -653,6 +685,10 @@ fun NomadNetBrowserScreen(
                                     },
                                     minLineWidth = viewportLineWidth,
                                     partialStates = partialStates,
+                                    imageStates = imageStates,
+                                    onImageTapToLoad = { key -> viewModel.retryPageImage(key) },
+                                    onImageReload = { key -> viewModel.retryPageImage(key) },
+                                    onCopyImageLink = { url -> clipboardManager.setText(AnnotatedString(url)) },
                                 )
                             }
                         }
@@ -684,6 +720,10 @@ fun NomadNetBrowserScreen(
                                         viewModel.updateField(name, value)
                                     },
                                     partialStates = partialStates,
+                                    imageStates = imageStates,
+                                    onImageTapToLoad = { key -> viewModel.retryPageImage(key) },
+                                    onImageReload = { key -> viewModel.retryPageImage(key) },
+                                    onCopyImageLink = { url -> clipboardManager.setText(AnnotatedString(url)) },
                                     lineIndexOffset = index,
                                 )
                             }

--- a/app/src/main/java/network/columba/app/ui/screens/NomadNetBrowserScreen.kt
+++ b/app/src/main/java/network/columba/app/ui/screens/NomadNetBrowserScreen.kt
@@ -30,9 +30,11 @@ import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.ArrowBack
 import androidx.compose.material.icons.filled.Close
+import androidx.compose.material.icons.filled.DeleteSweep
 import androidx.compose.material.icons.filled.Fingerprint
 import androidx.compose.material.icons.filled.Language
 import androidx.compose.material.icons.filled.MoreVert
+import androidx.compose.material.icons.filled.PhotoLibrary
 import androidx.compose.material.icons.filled.Refresh
 import androidx.compose.material3.Button
 import androidx.compose.material3.CircularProgressIndicator
@@ -431,6 +433,40 @@ fun NomadNetBrowserScreen(
                                     },
                                 )
                             }
+                            HorizontalDivider()
+
+                            // Upstream Ctrl+L / Ctrl+X: explicit bulk load.
+                            // Visible only in manual mode (auto/always load on
+                            // their own; never blocks even explicit loads).
+                            if (imageLoadingMode == ImageLoadingMode.MANUAL) {
+                                val hasPageImages = imageStates.isNotEmpty()
+                                if (hasPageImages) {
+                                    DropdownMenuItem(
+                                        text = { Text("Load all images") },
+                                        leadingIcon = { Icon(Icons.Default.PhotoLibrary, contentDescription = null) },
+                                        onClick = {
+                                            viewModel.loadPageImages(forceReload = false)
+                                            showMenu = false
+                                        },
+                                    )
+                                    DropdownMenuItem(
+                                        text = { Text("Reload all images") },
+                                        leadingIcon = { Icon(Icons.Default.Refresh, contentDescription = null) },
+                                        onClick = {
+                                            viewModel.loadPageImages(forceReload = true)
+                                            showMenu = false
+                                        },
+                                    )
+                                }
+                            }
+                            DropdownMenuItem(
+                                text = { Text("Clear image cache") },
+                                leadingIcon = { Icon(Icons.Default.DeleteSweep, contentDescription = null) },
+                                onClick = {
+                                    viewModel.clearImageCache()
+                                    showMenu = false
+                                },
+                            )
                             HorizontalDivider()
                             BrowserCloseSiteMenuItem(
                                 onCloseSite = {

--- a/app/src/main/java/network/columba/app/viewmodel/NomadNetBrowserViewModel.kt
+++ b/app/src/main/java/network/columba/app/viewmodel/NomadNetBrowserViewModel.kt
@@ -201,6 +201,31 @@ class NomadNetBrowserViewModel
         @Volatile
         private var imageLoadingModeUserSelected = false
 
+        // Restore the user's persisted image-loading mode so it survives a
+        // ViewModel recreation (process death / config change). Mirrors the
+        // rendering-mode restore in the init block above: a user who selected
+        // never/manual/always must not silently fall back to AUTO. Without this
+        // _imageLoadingMode always started at AUTO and the saved choice was
+        // dropped (issue 4). Lives here (not the init block) because Kotlin
+        // initializes properties in declaration order and this field must exist
+        // before we write to it.
+        init {
+            viewModelScope.launch {
+                val restored =
+                    try {
+                        ImageLoadingMode.fromName(settingsRepository.nomadNetImageLoadingModeFlow.first())
+                    } catch (e: kotlinx.coroutines.CancellationException) {
+                        throw e
+                    } catch (e: Exception) {
+                        Log.w(TAG, "Failed to read persisted image loading mode; using default", e)
+                        ImageLoadingMode.AUTO
+                    }
+                if (!imageLoadingModeUserSelected) {
+                    _imageLoadingMode.value = restored
+                }
+            }
+        }
+
         /** Wall-clock timing of the last successful page fetch (bits/s EDR fallback). */
         @Volatile
         private var lastPageFetchSeconds: Double? = null
@@ -240,10 +265,22 @@ class NomadNetBrowserViewModel
          * in-flight image states back to placeholders, so the user can re-load
          * them on demand. Upstream's `clear`-and-renavigate, collapsed onto the
          * mobile "Clear image cache" action.
+         *
+         * After clearing, re-scan the current document (if any) so its image
+         * references are re-registered as placeholders. [PageImageLoader.clear]
+         * on its own would wipe the registered states and leave the displayed
+         * page with unfetchable placeholders: retryImage would no-op (the key
+         * no longer exists) and the bulk-load menu would vanish because
+         * imageStates is empty (issue 3).
          */
         fun clearImageCache() {
             imageCache.clear()
-            pageImageLoader.clear()
+            val current = browserState.value as? BrowserState.PageLoaded
+            if (current != null) {
+                pageImageLoader.scan(imageRefsFor(current.document), forceReload = true)
+            } else {
+                pageImageLoader.clear()
+            }
         }
 
         /** Retry/load one image (placeholder tap, sheet Reload). */
@@ -254,6 +291,11 @@ class NomadNetBrowserViewModel
         fun setImageLoadingMode(mode: ImageLoadingMode) {
             imageLoadingModeUserSelected = true
             _imageLoadingMode.value = mode
+            // Apply the transition to the active loader so it takes effect on
+            // the currently-displayed page, not only on the next navigation
+            // (issue 5): ALWAYS starts loading pending images, NEVER cancels a
+            // running queue, AUTO re-evaluates the gate.
+            pageImageLoader.applyMode(mode)
             viewModelScope.launch { settingsRepository.saveNomadNetImageLoadingMode(mode.name) }
         }
 
@@ -821,6 +863,15 @@ class NomadNetBrowserViewModel
             cacheResponse: Boolean,
         ) {
             val epoch = ++fetchEpoch
+            // Navigation starts a new page request over the shared NomadNet
+            // link. Cancel any in-flight page-image queue first so stale image
+            // traffic doesn't compete with the page request this single-flight
+            // design prioritizes (issue 7). The new page's own images are
+            // re-scanned (and their queue started) in emitPageLoaded when the
+            // fetch completes. Without this, an image fetch could sit in a
+            // long backend await for the whole link timeout after the user
+            // already navigated away.
+            pageImageLoader.cancelAll()
             stopProgressCollection()
             lastFetchNodeHash = nodeHash
             lastFetchPath = path

--- a/app/src/main/java/network/columba/app/viewmodel/NomadNetBrowserViewModel.kt
+++ b/app/src/main/java/network/columba/app/viewmodel/NomadNetBrowserViewModel.kt
@@ -18,9 +18,15 @@ import kotlinx.coroutines.launch
 import network.columba.app.micron.MicronDocument
 import network.columba.app.micron.MicronElement
 import network.columba.app.micron.MicronParser
+import network.columba.app.nomadnet.ImageLoadingMode
+import network.columba.app.nomadnet.NomadNetImageCache
+import network.columba.app.nomadnet.PageImageLoader
+import network.columba.app.nomadnet.PageImageState
+import network.columba.app.nomadnet.ParsedImageRef
 import network.columba.app.nomadnet.NomadNetPageCache
 import network.columba.app.nomadnet.PartialManager
 import network.columba.app.nomadnet.buildNomadNetRequestData
+import network.columba.app.nomadnet.pageImageKey
 import network.columba.app.nomadnet.splitNomadNetPathFields
 import network.columba.app.repository.SettingsRepository
 import network.columba.app.rns.api.RnsNomadnet
@@ -33,6 +39,7 @@ class NomadNetBrowserViewModel
     constructor(
         private val nomadnet: RnsNomadnet,
         private val pageCache: NomadNetPageCache,
+        private val imageCache: NomadNetImageCache,
         private val settingsRepository: SettingsRepository,
     ) : ViewModel() {
         companion object {
@@ -117,6 +124,9 @@ class NomadNetBrowserViewModel
                     _renderingMode.value = restored
                 }
             }
+            // NOTE: the image-loading-mode restore lives below, next to the
+            // _imageLoadingMode declaration — Kotlin initializes properties in
+            // declaration order and this init block runs before them.
         }
 
         private val _isIdentified = MutableStateFlow(false)
@@ -180,6 +190,61 @@ class NomadNetBrowserViewModel
 
         val partialStates: StateFlow<Map<String, PartialManager.PartialState>>
             get() = partialManager.states
+
+        // ==================== Page images ====================
+
+        private val _imageLoadingMode = MutableStateFlow(ImageLoadingMode.AUTO)
+
+        /** Current image loading mode (upstream `image_loading` mirror). */
+        val imageLoadingMode: StateFlow<ImageLoadingMode> = _imageLoadingMode.asStateFlow()
+
+        @Volatile
+        private var imageLoadingModeUserSelected = false
+
+        /** Wall-clock timing of the last successful page fetch (bits/s EDR fallback). */
+        @Volatile
+        private var lastPageFetchSeconds: Double? = null
+
+        @Volatile
+        private var lastPageFetchBytes: Long = 0L
+
+        private val pageImageLoader: PageImageLoader by lazy {
+            PageImageLoader(
+                nomadnet = nomadnet,
+                cache = imageCache,
+                scope = viewModelScope,
+                currentNodeHash = { currentNodeHash },
+                imageLoadingMode = { _imageLoadingMode.value },
+                lastResponseSpeedBps = {
+                    val seconds = lastPageFetchSeconds
+                    if (seconds != null && seconds > 0 && lastPageFetchBytes > 0) {
+                        lastPageFetchBytes * 8 / seconds
+                    } else {
+                        null
+                    }
+                },
+            )
+        }
+
+        /** Per-image fetch states keyed by [pageImageKey]. */
+        val imageStates: StateFlow<Map<String, PageImageState>>
+            get() = pageImageLoader.imageStates
+
+        /** Explicit load of all pending images (upstream Ctrl+L). */
+        fun loadPageImages(forceReload: Boolean = false) {
+            pageImageLoader.loadImages(forceReload)
+        }
+
+        /** Retry/load one image (placeholder tap, sheet Reload). */
+        fun retryPageImage(key: String) {
+            pageImageLoader.retryImage(key)
+        }
+
+        fun setImageLoadingMode(mode: ImageLoadingMode) {
+            imageLoadingModeUserSelected = true
+            _imageLoadingMode.value = mode
+            viewModelScope.launch { settingsRepository.saveNomadNetImageLoadingMode(mode.name) }
+        }
 
         /** Returns "nodeHash:/path" format for display in the URL bar. */
         fun getCurrentUrl(): String? {
@@ -481,6 +546,7 @@ class NomadNetBrowserViewModel
             stopStatusCollection()
             stopProgressCollection()
             partialManager.clear()
+            pageImageLoader.clear()
             history.clear()
             _canGoBack.value = false
             _formFields.value = emptyMap()
@@ -569,6 +635,7 @@ class NomadNetBrowserViewModel
             super.onCleared()
             stopStatusCollection()
             stopProgressCollection()
+            pageImageLoader.cancelAll()
             // Cancel any in-flight Python page request so the IO thread isn't blocked
             // for up to PAGE_TIMEOUT_SECONDS after the user navigates away.
             // Use NonCancellable because viewModelScope is already cancelled at this point.
@@ -634,7 +701,20 @@ class NomadNetBrowserViewModel
                 }
             }
             partialManager.detectAndLoad(document)
+            pageImageLoader.scan(imageRefsFor(document))
         }
+
+        /** All image elements in a document, reduced to loader refs. */
+        private fun imageRefsFor(document: MicronDocument): List<ParsedImageRef> =
+            document.lines
+                .flatMap { it.elements }
+                .filterIsInstance<MicronElement.Image>()
+                .map { img ->
+                    ParsedImageRef(
+                        url = img.url,
+                        key = pageImageKey(img.url, img.width, img.height),
+                    )
+                }
 
         /**
          * Return a copy of [current] with parser-declared text-field defaults filled
@@ -737,6 +817,9 @@ class NomadNetBrowserViewModel
             _browserState.value = BrowserState.Loading("Requesting page...")
             startStatusCollection(epoch)
 
+            // Wall-clock fetch timing feeds the image auto-gate's fallback
+            // EDR (upstream last_response_speed()).
+            val fetchStartedAt = System.nanoTime()
             viewModelScope.launch(Dispatchers.IO) {
                 try {
                     val result =
@@ -754,6 +837,9 @@ class NomadNetBrowserViewModel
 
                     result.fold(
                         onSuccess = { pageResult ->
+                            lastPageFetchSeconds = (System.nanoTime() - fetchStartedAt) / 1_000_000_000.0
+                            lastPageFetchBytes =
+                                if (pageResult.type == "file") pageResult.fileSize else pageResult.content.length.toLong()
                             if (pageResult.type == "file") {
                                 // Unexpected file response on a page path —
                                 // clear loading state so screen doesn't get stuck

--- a/app/src/main/java/network/columba/app/viewmodel/NomadNetBrowserViewModel.kt
+++ b/app/src/main/java/network/columba/app/viewmodel/NomadNetBrowserViewModel.kt
@@ -235,6 +235,17 @@ class NomadNetBrowserViewModel
             pageImageLoader.loadImages(forceReload)
         }
 
+        /**
+         * Clear the on-disk NomadNet image cache entirely and reset the
+         * in-flight image states back to placeholders, so the user can re-load
+         * them on demand. Upstream's `clear`-and-renavigate, collapsed onto the
+         * mobile "Clear image cache" action.
+         */
+        fun clearImageCache() {
+            imageCache.clear()
+            pageImageLoader.clear()
+        }
+
         /** Retry/load one image (placeholder tap, sheet Reload). */
         fun retryPageImage(key: String) {
             pageImageLoader.retryImage(key)

--- a/app/src/test/java/network/columba/app/nomadnet/NomadNetImagePolicyTest.kt
+++ b/app/src/test/java/network/columba/app/nomadnet/NomadNetImagePolicyTest.kt
@@ -1,0 +1,166 @@
+package network.columba.app.nomadnet
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * Unit tests for [NomadNetImagePolicy.shouldLoadAutomatically] — the auto-load
+ * bandwidth gate (upstream NomadNet `should_load_images`, commit 0db7d4b).
+ */
+class NomadNetImagePolicyTest {
+    @Test
+    fun `loopback always loads regardless of mode`() {
+        assertTrue(
+            NomadNetImagePolicy.shouldLoadAutomatically(
+                mode = ImageLoadingMode.NEVER,
+                isLoopback = true,
+                rttSeconds = null,
+                expectedRateBps = null,
+                measuredResponseSpeedBps = null,
+            ),
+        )
+    }
+
+    @Test
+    fun `never mode never auto-loads`() {
+        assertFalse(
+            NomadNetImagePolicy.shouldLoadAutomatically(
+                mode = ImageLoadingMode.NEVER,
+                isLoopback = false,
+                rttSeconds = 0.1,
+                expectedRateBps = 100_000L,
+                measuredResponseSpeedBps = null,
+            ),
+        )
+    }
+
+    @Test
+    fun `manual mode never auto-loads even on a fast link`() {
+        assertFalse(
+            NomadNetImagePolicy.shouldLoadAutomatically(
+                mode = ImageLoadingMode.MANUAL,
+                isLoopback = false,
+                rttSeconds = 0.1,
+                expectedRateBps = 100_000L,
+                measuredResponseSpeedBps = null,
+            ),
+        )
+    }
+
+    @Test
+    fun `always mode auto-loads without any link data`() {
+        assertTrue(
+            NomadNetImagePolicy.shouldLoadAutomatically(
+                mode = ImageLoadingMode.ALWAYS,
+                isLoopback = false,
+                rttSeconds = null,
+                expectedRateBps = null,
+                measuredResponseSpeedBps = null,
+            ),
+        )
+    }
+
+    @Test
+    fun `auto fast link with sufficient rate loads`() {
+        assertTrue(
+            NomadNetImagePolicy.shouldLoadAutomatically(
+                mode = ImageLoadingMode.AUTO,
+                isLoopback = false,
+                rttSeconds = 0.2,
+                expectedRateBps = 50_000L,
+                measuredResponseSpeedBps = null,
+            ),
+        )
+    }
+
+    @Test
+    fun `auto slow rtt does not load`() {
+        assertFalse(
+            NomadNetImagePolicy.shouldLoadAutomatically(
+                mode = ImageLoadingMode.AUTO,
+                isLoopback = false,
+                rttSeconds = 2.0,
+                expectedRateBps = 50_000L,
+                measuredResponseSpeedBps = null,
+            ),
+        )
+    }
+
+    @Test
+    fun `auto low rate does not load`() {
+        // 9k6-class LoRa links (~9600 bps) must never spend airtime on images.
+        assertFalse(
+            NomadNetImagePolicy.shouldLoadAutomatically(
+                mode = ImageLoadingMode.AUTO,
+                isLoopback = false,
+                rttSeconds = 0.2,
+                expectedRateBps = 9_600L,
+                measuredResponseSpeedBps = null,
+            ),
+        )
+    }
+
+    @Test
+    fun `auto without any link data does not load`() {
+        assertFalse(
+            NomadNetImagePolicy.shouldLoadAutomatically(
+                mode = ImageLoadingMode.AUTO,
+                isLoopback = false,
+                rttSeconds = null,
+                expectedRateBps = null,
+                measuredResponseSpeedBps = null,
+            ),
+        )
+    }
+
+    @Test
+    fun `auto falls back to measured page response speed when no expected rate`() {
+        assertTrue(
+            NomadNetImagePolicy.shouldLoadAutomatically(
+                mode = ImageLoadingMode.AUTO,
+                isLoopback = false,
+                rttSeconds = 0.2,
+                expectedRateBps = null,
+                measuredResponseSpeedBps = 25_000.0,
+            ),
+        )
+    }
+
+    @Test
+    fun `auto rtt exactly at the limit does not load`() {
+        // Gate is strictly `< 1.5 s`.
+        assertFalse(
+            NomadNetImagePolicy.shouldLoadAutomatically(
+                mode = ImageLoadingMode.AUTO,
+                isLoopback = false,
+                rttSeconds = NomadNetImagePolicy.AUTO_RTT_LIMIT_S,
+                expectedRateBps = 50_000L,
+                measuredResponseSpeedBps = null,
+            ),
+        )
+    }
+
+    @Test
+    fun `auto rate exactly at the limit does not load`() {
+        // Gate is strictly `> 10 000 bps`.
+        assertFalse(
+            NomadNetImagePolicy.shouldLoadAutomatically(
+                mode = ImageLoadingMode.AUTO,
+                isLoopback = false,
+                rttSeconds = 0.2,
+                expectedRateBps = NomadNetImagePolicy.AUTO_EDR_LIMIT_BPS,
+                measuredResponseSpeedBps = null,
+            ),
+        )
+    }
+
+    @Test
+    fun `fromName maps config values case-insensitively with auto default`() {
+        assertEquals(ImageLoadingMode.MANUAL, ImageLoadingMode.fromName("manual"))
+        assertEquals(ImageLoadingMode.ALWAYS, ImageLoadingMode.fromName(" Always "))
+        assertEquals(ImageLoadingMode.AUTO, ImageLoadingMode.fromName(null))
+        assertEquals(ImageLoadingMode.AUTO, ImageLoadingMode.fromName("garbage"))
+    }
+}

--- a/app/src/test/java/network/columba/app/nomadnet/PageImageLoaderTest.kt
+++ b/app/src/test/java/network/columba/app/nomadnet/PageImageLoaderTest.kt
@@ -33,8 +33,11 @@ import org.robolectric.RuntimeEnvironment
 
 /**
  * Tests for [PageImageLoader] — the page-image orchestration: cache-hit fast
- * path, the auto bandwidth gate, manual/never/explicit-load semantics, denial
- * surfacing, the WebP-only cache rule, and the per-image size cap.
+ * path, the per-image auto bandwidth gate (including cross-node images that
+ * ride a different link than the page), manual/never/explicit-load semantics,
+ * denial surfacing, the WebP-only cache rule, the per-image transfer cap
+ * (passed to the backend and enforced there), and the malformed-URL no-retry
+ * path.
  *
  * The loader's fetch queue runs on Dispatchers.IO, so assertions wait on a
  * short polling loop (deterministic: every state transition is driven by the
@@ -135,7 +138,7 @@ class PageImageLoaderTest {
         assertNotNull(state)
         assertEquals(PageImageStatus.LOADED, state!!.status)
         assertNotNull(state.file)
-        coVerify(exactly = 0) { nomadnet.requestNomadnetMedia(any(), any(), any()) }
+        coVerify(exactly = 0) { nomadnet.requestNomadnetMedia(any(), any(), any(), any()) }
     }
 
     // ── Auto gate ──────────────────────────────────────────────────────────
@@ -147,14 +150,14 @@ class PageImageLoaderTest {
             NomadnetLinkStats(rttSeconds = 0.2, expectedRateBps = 50_000L)
         }
         val stage = writeWebP(context.cacheDir, "auto.webp")
-        coEvery { nomadnet.requestNomadnetMedia(nodeHash, "/media/auto.webp", 60f) } returns
+        coEvery { nomadnet.requestNomadnetMedia(nodeHash, "/media/auto.webp", 60f, NomadNetImagePolicy.MAX_IMAGE_BYTES) } returns
             Result.success(mediaResult(stage))
 
         loader.scan(listOf(ref(":/media/auto.webp", "img")))
 
         val state = awaitState("img") { it.status == PageImageStatus.LOADED }
         assertNotNull(state.file)
-        coVerify(exactly = 1) { nomadnet.requestNomadnetMedia(nodeHash, "/media/auto.webp", 60f) }
+        coVerify(exactly = 1) { nomadnet.requestNomadnetMedia(nodeHash, "/media/auto.webp", 60f, NomadNetImagePolicy.MAX_IMAGE_BYTES) }
     }
 
     @Test
@@ -169,7 +172,7 @@ class PageImageLoaderTest {
         // The gate must have run before we assert (deterministic hand-off).
         assertTrue("gate did not run", gateRan.await(2, TimeUnit.SECONDS))
         assertEquals(PageImageStatus.PLACEHOLDER, loader.imageStates.value["img"]!!.status)
-        coVerify(exactly = 0) { nomadnet.requestNomadnetMedia(any(), any(), any()) }
+        coVerify(exactly = 0) { nomadnet.requestNomadnetMedia(any(), any(), any(), any()) }
     }
 
     @Test
@@ -178,7 +181,104 @@ class PageImageLoaderTest {
         loader.scan(listOf(ref(":/media/noStats.webp", "img")))
         assertTrue("gate did not run", gateRan.await(2, TimeUnit.SECONDS))
         assertEquals(PageImageStatus.PLACEHOLDER, loader.imageStates.value["img"]!!.status)
-        coVerify(exactly = 0) { nomadnet.requestNomadnetMedia(any(), any(), any()) }
+        coVerify(exactly = 0) { nomadnet.requestNomadnetMedia(any(), any(), any(), any()) }
+    }
+
+    @Test
+    fun `auto gate uses each image's own destination node not the page node`() {
+        // Regression for the cross-node gate: the auto RTT/EDR policy must be
+        // evaluated against the node that actually carries the image, not the
+        // current page's node once for the whole queue. Here the page node is
+        // fast but the cross-node image's destination is slow, so the image
+        // must NOT auto-load even though the page's link is fast.
+        imageMode = ImageLoadingMode.AUTO
+        val other = "deadbeefdeadbeefdeadbeefdeadbeef"
+        coEvery { nomadnet.getNomadnetLinkStats(nodeHash) } answers {
+            gateRan.countDown()
+            NomadnetLinkStats(rttSeconds = 0.2, expectedRateBps = 50_000L) // fast page node
+        }
+        coEvery { nomadnet.getNomadnetLinkStats(other) } answers {
+            gateRan.countDown()
+            NomadnetLinkStats(rttSeconds = 2.0, expectedRateBps = 50_000L) // slow image node
+        }
+        val stage = writeWebP(context.cacheDir, "xnode2.webp")
+        coEvery { nomadnet.requestNomadnetMedia(other, "/media/xnode2.webp", 60f, NomadNetImagePolicy.MAX_IMAGE_BYTES) } returns
+            Result.success(mediaResult(stage))
+
+        loader.scan(listOf(ref("$other:/media/xnode2.webp", "img")))
+
+        // The gate must have run (against the image's own, slow, node).
+        assertTrue("gate did not run", gateRan.await(2, TimeUnit.SECONDS))
+        Thread.sleep(100)
+        // Because the image's own node is slow, the image stays a placeholder.
+        assertEquals(PageImageStatus.PLACEHOLDER, loader.imageStates.value["img"]!!.status)
+        coVerify(exactly = 0) { nomadnet.requestNomadnetMedia(any(), any(), any(), any()) }
+    }
+
+    @Test
+    fun `auto gate loads a cross-node image when its own node is fast`() {
+        // The inverse of the previous test: the page node is slow, but the
+        // cross-node image's destination is fast, so the image auto-loads.
+        imageMode = ImageLoadingMode.AUTO
+        val other = "deadbeefdeadbeefdeadbeefdeadbeef"
+        coEvery { nomadnet.getNomadnetLinkStats(nodeHash) } answers {
+            gateRan.countDown()
+            NomadnetLinkStats(rttSeconds = 2.0, expectedRateBps = 50_000L) // slow page node
+        }
+        coEvery { nomadnet.getNomadnetLinkStats(other) } answers {
+            gateRan.countDown()
+            NomadnetLinkStats(rttSeconds = 0.2, expectedRateBps = 50_000L) // fast image node
+        }
+        val stage = writeWebP(context.cacheDir, "xnode3.webp")
+        coEvery { nomadnet.requestNomadnetMedia(other, "/media/xnode3.webp", 60f, NomadNetImagePolicy.MAX_IMAGE_BYTES) } returns
+            Result.success(mediaResult(stage))
+
+        loader.scan(listOf(ref("$other:/media/xnode3.webp", "img")))
+
+        val state = awaitState("img") { it.status == PageImageStatus.LOADED }
+        assertNotNull(state.file)
+        coVerify(exactly = 1) { nomadnet.requestNomadnetMedia(other, "/media/xnode3.webp", 60f, NomadNetImagePolicy.MAX_IMAGE_BYTES) }
+    }
+
+    // ── Transfer cap passed to backend ─────────────────────────────────────
+
+    @Test
+    fun `loader passes the transfer cap to the backend`() {
+        // The per-image cap must be handed to the backend so it refuses an
+        // oversized payload at the response boundary, not deleted after the
+        // fact in the app layer.
+        imageMode = ImageLoadingMode.ALWAYS
+        val stage = writeWebP(context.cacheDir, "cap.webp")
+        coEvery { nomadnet.requestNomadnetMedia(nodeHash, "/media/cap.webp", 60f, NomadNetImagePolicy.MAX_IMAGE_BYTES) } returns
+            Result.success(mediaResult(stage))
+
+        loader.scan(listOf(ref(":/media/cap.webp", "img")))
+        val state = awaitState("img") { it.status == PageImageStatus.LOADED }
+        assertEquals(PageImageStatus.LOADED, state.status)
+        assertNotNull(state.file)
+        coVerify(exactly = 1) { nomadnet.requestNomadnetMedia(nodeHash, "/media/cap.webp", 60f, NomadNetImagePolicy.MAX_IMAGE_BYTES) }
+    }
+
+    @Test
+    fun `backend too-large error surfaces FAILED`() {
+        // When the backend enforces the cap, it returns a typed
+        // NomadnetResponseTooLarge failure; the loader must surface FAILED.
+        imageMode = ImageLoadingMode.ALWAYS
+        coEvery { nomadnet.requestNomadnetMedia(nodeHash, "/media/toolarge.webp", 60f, NomadNetImagePolicy.MAX_IMAGE_BYTES) } returns
+            Result.failure(
+                RnsException(
+                    RnsError.NomadnetResponseTooLarge(
+                        nodeHash,
+                        "/media/toolarge.webp",
+                        NomadNetImagePolicy.MAX_IMAGE_BYTES + 1,
+                        NomadNetImagePolicy.MAX_IMAGE_BYTES,
+                    ),
+                ),
+            )
+
+        loader.scan(listOf(ref(":/media/toolarge.webp", "img")))
+        val state = awaitState("img") { it.status == PageImageStatus.FAILED }
+        assertTrue(state.error!!.contains("too large"))
     }
 
     // ── Manual / never / explicit ──────────────────────────────────────────
@@ -187,18 +287,18 @@ class PageImageLoaderTest {
     fun `manual mode waits for explicit load`() {
         imageMode = ImageLoadingMode.MANUAL
         val stage = writeWebP(context.cacheDir, "manual.webp")
-        coEvery { nomadnet.requestNomadnetMedia(nodeHash, "/media/manual.webp", 60f) } returns
+        coEvery { nomadnet.requestNomadnetMedia(nodeHash, "/media/manual.webp", 60f, NomadNetImagePolicy.MAX_IMAGE_BYTES) } returns
             Result.success(mediaResult(stage))
 
         loader.scan(listOf(ref(":/media/manual.webp", "img")))
         // Give any (wrongly started) queue a beat to run.
         Thread.sleep(100)
         assertEquals(PageImageStatus.PLACEHOLDER, loader.imageStates.value["img"]!!.status)
-        coVerify(exactly = 0) { nomadnet.requestNomadnetMedia(any(), any(), any()) }
+        coVerify(exactly = 0) { nomadnet.requestNomadnetMedia(any(), any(), any(), any()) }
 
         loader.loadImages(forceReload = false)
         awaitState("img") { it.status == PageImageStatus.LOADED }
-        coVerify(exactly = 1) { nomadnet.requestNomadnetMedia(nodeHash, "/media/manual.webp", 60f) }
+        coVerify(exactly = 1) { nomadnet.requestNomadnetMedia(nodeHash, "/media/manual.webp", 60f, NomadNetImagePolicy.MAX_IMAGE_BYTES) }
     }
 
     @Test
@@ -206,9 +306,9 @@ class PageImageLoaderTest {
         imageMode = ImageLoadingMode.MANUAL
         val stageA = writeWebP(context.cacheDir, "a.webp")
         val stageB = writeWebP(context.cacheDir, "b.webp")
-        coEvery { nomadnet.requestNomadnetMedia(nodeHash, "/media/a.webp", 60f) } returns
+        coEvery { nomadnet.requestNomadnetMedia(nodeHash, "/media/a.webp", 60f, NomadNetImagePolicy.MAX_IMAGE_BYTES) } returns
             Result.success(mediaResult(stageA))
-        coEvery { nomadnet.requestNomadnetMedia(nodeHash, "/media/b.webp", 60f) } returns
+        coEvery { nomadnet.requestNomadnetMedia(nodeHash, "/media/b.webp", 60f, NomadNetImagePolicy.MAX_IMAGE_BYTES) } returns
             Result.success(mediaResult(stageB))
 
         loader.scan(listOf(ref(":/media/a.webp", "imgA"), ref(":/media/b.webp", "imgB")))
@@ -222,8 +322,8 @@ class PageImageLoaderTest {
         awaitState("imgA") { it.status == PageImageStatus.LOADED }
         Thread.sleep(150)
         assertEquals(PageImageStatus.PLACEHOLDER, loader.imageStates.value["imgB"]!!.status)
-        coVerify(exactly = 1) { nomadnet.requestNomadnetMedia(nodeHash, "/media/a.webp", 60f) }
-        coVerify(exactly = 0) { nomadnet.requestNomadnetMedia(nodeHash, "/media/b.webp", 60f) }
+        coVerify(exactly = 1) { nomadnet.requestNomadnetMedia(nodeHash, "/media/a.webp", 60f, NomadNetImagePolicy.MAX_IMAGE_BYTES) }
+        coVerify(exactly = 0) { nomadnet.requestNomadnetMedia(nodeHash, "/media/b.webp", 60f, NomadNetImagePolicy.MAX_IMAGE_BYTES) }
     }
 
     @Test
@@ -234,20 +334,40 @@ class PageImageLoaderTest {
         loader.retryImage("img")
         Thread.sleep(100)
         assertEquals(PageImageStatus.PLACEHOLDER, loader.imageStates.value["img"]!!.status)
-        coVerify(exactly = 0) { nomadnet.requestNomadnetMedia(any(), any(), any()) }
+        coVerify(exactly = 0) { nomadnet.requestNomadnetMedia(any(), any(), any(), any()) }
     }
 
     @Test
     fun `always mode loads without link stats`() {
         imageMode = ImageLoadingMode.ALWAYS
         val stage = writeWebP(context.cacheDir, "always.webp")
-        coEvery { nomadnet.requestNomadnetMedia(nodeHash, "/media/always.webp", 60f) } returns
+        coEvery { nomadnet.requestNomadnetMedia(nodeHash, "/media/always.webp", 60f, NomadNetImagePolicy.MAX_IMAGE_BYTES) } returns
             Result.success(mediaResult(stage))
 
         loader.scan(listOf(ref(":/media/always.webp", "img")))
         val state = awaitState("img") { it.status == PageImageStatus.LOADED }
         assertNotNull(state.file)
-        coVerify(exactly = 1) { nomadnet.requestNomadnetMedia(nodeHash, "/media/always.webp", 60f) }
+        coVerify(exactly = 1) { nomadnet.requestNomadnetMedia(nodeHash, "/media/always.webp", 60f, NomadNetImagePolicy.MAX_IMAGE_BYTES) }
+    }
+
+    // ── Mode transition applies to the active loader ───────────────────────
+
+    @Test
+    fun `applyMode always starts loading pending placeholders`() {
+        imageMode = ImageLoadingMode.MANUAL
+        val stage = writeWebP(context.cacheDir, "mode.webp")
+        coEvery { nomadnet.requestNomadnetMedia(nodeHash, "/media/mode.webp", 60f, NomadNetImagePolicy.MAX_IMAGE_BYTES) } returns
+            Result.success(mediaResult(stage))
+
+        loader.scan(listOf(ref(":/media/mode.webp", "img")))
+        Thread.sleep(100)
+        assertEquals(PageImageStatus.PLACEHOLDER, loader.imageStates.value["img"]!!.status)
+
+        // Switching the active page to ALWAYS must load the pending image now,
+        // not only on the next navigation.
+        loader.applyMode(ImageLoadingMode.ALWAYS)
+        awaitState("img") { it.status == PageImageStatus.LOADED }
+        coVerify(exactly = 1) { nomadnet.requestNomadnetMedia(nodeHash, "/media/mode.webp", 60f, NomadNetImagePolicy.MAX_IMAGE_BYTES) }
     }
 
     // ── Failure kinds ──────────────────────────────────────────────────────
@@ -255,7 +375,7 @@ class PageImageLoaderTest {
     @Test
     fun `denied media surfaces DENIED not FAILED`() {
         imageMode = ImageLoadingMode.ALWAYS
-        coEvery { nomadnet.requestNomadnetMedia(nodeHash, "/media/gated.webp", 60f) } returns
+        coEvery { nomadnet.requestNomadnetMedia(nodeHash, "/media/gated.webp", 60f, NomadNetImagePolicy.MAX_IMAGE_BYTES) } returns
             Result.failure(
                 RnsException(RnsError.NomadnetRequestDenied(nodeHash, "/media/gated.webp")),
             )
@@ -269,7 +389,7 @@ class PageImageLoaderTest {
     @Test
     fun `generic failure surfaces FAILED`() {
         imageMode = ImageLoadingMode.ALWAYS
-        coEvery { nomadnet.requestNomadnetMedia(nodeHash, "/media/broken.webp", 60f) } returns
+        coEvery { nomadnet.requestNomadnetMedia(nodeHash, "/media/broken.webp", 60f, NomadNetImagePolicy.MAX_IMAGE_BYTES) } returns
             Result.failure(RuntimeException("link reset"))
 
         loader.scan(listOf(ref(":/media/broken.webp", "img")))
@@ -282,7 +402,7 @@ class PageImageLoaderTest {
     fun `non-webp response is rejected as FAILED`() {
         imageMode = ImageLoadingMode.ALWAYS
         val png = File(context.cacheDir, "fake.webp").apply { writeBytes(byteArrayOf(0x89.toByte(), 0x50.toByte(), 0x4E.toByte(), 0x47.toByte(), 1, 2, 3, 4, 5, 6, 7, 8)) }
-        coEvery { nomadnet.requestNomadnetMedia(nodeHash, "/media/fake.webp", 60f) } returns
+        coEvery { nomadnet.requestNomadnetMedia(nodeHash, "/media/fake.webp", 60f, NomadNetImagePolicy.MAX_IMAGE_BYTES) } returns
             Result.success(mediaResult(png))
 
         loader.scan(listOf(ref(":/media/fake.webp", "img")))
@@ -296,7 +416,7 @@ class PageImageLoaderTest {
         // Torlando 2026-09-07: "always mode still hits the per-image size cap."
         imageMode = ImageLoadingMode.ALWAYS
         val small = writeWebP(context.cacheDir, "big.webp")
-        coEvery { nomadnet.requestNomadnetMedia(nodeHash, "/media/big.webp", 60f) } returns
+        coEvery { nomadnet.requestNomadnetMedia(nodeHash, "/media/big.webp", 60f, NomadNetImagePolicy.MAX_IMAGE_BYTES) } returns
             Result.success(mediaResult(small, size = NomadNetImagePolicy.MAX_IMAGE_BYTES + 1))
 
         loader.scan(listOf(ref(":/media/big.webp", "img")))
@@ -308,13 +428,22 @@ class PageImageLoaderTest {
     // ── URL resolution / reload ────────────────────────────────────────────
 
     @Test
-    fun `malformed image url yields an error placeholder`() {
+    fun `malformed image url yields MALFORMED status and is not retryable`() {
         loader.scan(listOf(ref("not-a-valid-url", "img")))
         val state = loader.imageStates.value["img"]
         assertNotNull(state)
-        assertNotNull(state!!.error)
+        // A structurally invalid URL is permanent, not a transient placeholder:
+        // it is MALFORMED (not PLACEHOLDER) so the UI does not advertise a
+        // dead "tap to load", and retry is a no-op.
+        assertEquals(PageImageStatus.MALFORMED, state!!.status)
+        assertNotNull(state.error)
         assertTrue(state.error!!.startsWith("Malformed image URL"))
-        coVerify(exactly = 0) { nomadnet.requestNomadnetMedia(any(), any(), any()) }
+        coVerify(exactly = 0) { nomadnet.requestNomadnetMedia(any(), any(), any(), any()) }
+
+        loader.retryImage("img")
+        Thread.sleep(50)
+        assertEquals(PageImageStatus.MALFORMED, loader.imageStates.value["img"]!!.status)
+        coVerify(exactly = 0) { nomadnet.requestNomadnetMedia(any(), any(), any(), any()) }
     }
 
     @Test
@@ -322,13 +451,13 @@ class PageImageLoaderTest {
         val other = "deadbeefdeadbeefdeadbeefdeadbeef"
         imageMode = ImageLoadingMode.ALWAYS
         val stage = writeWebP(context.cacheDir, "xnode.webp")
-        coEvery { nomadnet.requestNomadnetMedia(other, "/media/xnode.webp", 60f) } returns
+        coEvery { nomadnet.requestNomadnetMedia(other, "/media/xnode.webp", 60f, NomadNetImagePolicy.MAX_IMAGE_BYTES) } returns
             Result.success(mediaResult(stage))
 
         loader.scan(listOf(ref("$other:/media/xnode.webp", "img")))
         val state = awaitState("img") { it.status == PageImageStatus.LOADED }
         assertNotNull(state.file)
-        coVerify(exactly = 1) { nomadnet.requestNomadnetMedia(other, "/media/xnode.webp", 60f) }
+        coVerify(exactly = 1) { nomadnet.requestNomadnetMedia(other, "/media/xnode.webp", 60f, NomadNetImagePolicy.MAX_IMAGE_BYTES) }
     }
 
     @Test
@@ -340,19 +469,19 @@ class PageImageLoaderTest {
         assertEquals(PageImageStatus.LOADED, loader.imageStates.value["img"]!!.status)
 
         val stage = writeWebP(context.cacheDir, "reload2.webp")
-        coEvery { nomadnet.requestNomadnetMedia(nodeHash, "/media/reload.webp", 60f) } returns
+        coEvery { nomadnet.requestNomadnetMedia(nodeHash, "/media/reload.webp", 60f, NomadNetImagePolicy.MAX_IMAGE_BYTES) } returns
             Result.success(mediaResult(stage))
 
         loader.scan(listOf(ref(":/media/reload.webp", "img")), forceReload = true)
         awaitState("img") { it.status == PageImageStatus.LOADED && it.file != cached }
-        coVerify(exactly = 1) { nomadnet.requestNomadnetMedia(nodeHash, "/media/reload.webp", 60f) }
+        coVerify(exactly = 1) { nomadnet.requestNomadnetMedia(nodeHash, "/media/reload.webp", 60f, NomadNetImagePolicy.MAX_IMAGE_BYTES) }
     }
 
     @Test
     fun `second scan of a cached page is instant with zero requests`() {
         imageMode = ImageLoadingMode.ALWAYS
         val stage = writeWebP(context.cacheDir, "twice.webp")
-        coEvery { nomadnet.requestNomadnetMedia(nodeHash, "/media/twice.webp", 60f) } returns
+        coEvery { nomadnet.requestNomadnetMedia(nodeHash, "/media/twice.webp", 60f, NomadNetImagePolicy.MAX_IMAGE_BYTES) } returns
             Result.success(mediaResult(stage))
 
         loader.scan(listOf(ref(":/media/twice.webp", "img")))
@@ -362,7 +491,7 @@ class PageImageLoaderTest {
         loader.clear()
         loader.scan(listOf(ref(":/media/twice.webp", "img")))
         assertEquals(PageImageStatus.LOADED, loader.imageStates.value["img"]!!.status)
-        coVerify(exactly = 1) { nomadnet.requestNomadnetMedia(nodeHash, "/media/twice.webp", 60f) }
+        coVerify(exactly = 1) { nomadnet.requestNomadnetMedia(nodeHash, "/media/twice.webp", 60f, NomadNetImagePolicy.MAX_IMAGE_BYTES) }
     }
 
     // ── Cache primitives ───────────────────────────────────────────────────

--- a/app/src/test/java/network/columba/app/nomadnet/PageImageLoaderTest.kt
+++ b/app/src/test/java/network/columba/app/nomadnet/PageImageLoaderTest.kt
@@ -1,0 +1,358 @@
+package network.columba.app.nomadnet
+
+import android.content.Context
+import io.mockk.Runs
+import io.mockk.clearAllMocks
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.every
+import io.mockk.just
+import io.mockk.mockk
+import java.io.File
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.TimeUnit
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.cancel
+import network.columba.app.rns.api.RnsError
+import network.columba.app.rns.api.RnsException
+import network.columba.app.rns.api.RnsNomadnet
+import network.columba.app.rns.api.model.NomadnetLinkStats
+import network.columba.app.rns.api.model.NomadnetMediaResult
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.RuntimeEnvironment
+
+/**
+ * Tests for [PageImageLoader] — the page-image orchestration: cache-hit fast
+ * path, the auto bandwidth gate, manual/never/explicit-load semantics, denial
+ * surfacing, the WebP-only cache rule, and the per-image size cap.
+ *
+ * The loader's fetch queue runs on Dispatchers.IO, so assertions wait on a
+ * short polling loop (deterministic: every state transition is driven by the
+ * mocked [RnsNomadnet], which returns immediately).
+ */
+@RunWith(RobolectricTestRunner::class)
+class PageImageLoaderTest {
+    private lateinit var context: Context
+    private lateinit var cache: NomadNetImageCache
+    private lateinit var scope: CoroutineScope
+    private lateinit var nomadnet: RnsNomadnet
+    private lateinit var loader: PageImageLoader
+
+    private val nodeHash = "a1b2c3d4e5f6a7b8c9d0e1f2a3b4c5d6"
+    private var imageMode = ImageLoadingMode.AUTO
+
+    /** Released inside the stats stub so "the gate ran" is provable. */
+    private var gateRan = CountDownLatch(1)
+
+    /** Minimal 16-byte WebP payload (RIFF....WEBP). */
+    private fun writeWebP(dir: File, name: String): File = File(dir, name).apply {
+        writeBytes(
+            buildString {
+                append("RIFF")
+                repeat(4) { append('0') }
+                append("WEBP")
+                repeat(4) { append(' ') }
+            }.toByteArray(),
+        )
+    }
+
+    private fun mediaResult(file: File, size: Long = file.length()): NomadnetMediaResult =
+        NomadnetMediaResult(
+            filePath = file.absolutePath,
+            fileName = file.name,
+            fileSize = size,
+            path = file.name,
+        )
+
+    @Before
+    fun setUp() {
+        context = RuntimeEnvironment.getApplication()
+        context.cacheDir.deleteRecursively()
+        cache = NomadNetImageCache(context)
+        scope = CoroutineScope(SupervisorJob() + Dispatchers.Default)
+        nomadnet = mockk()
+        coEvery { nomadnet.getNomadnetRequestStatus() } returns "idle"
+        coEvery { nomadnet.getNomadnetLinkStats(any()) } answers {
+            gateRan.countDown()
+            null
+        }
+        imageMode = ImageLoadingMode.AUTO
+        loader =
+            PageImageLoader(
+                nomadnet = nomadnet,
+                cache = cache,
+                scope = scope,
+                currentNodeHash = { nodeHash },
+                imageLoadingMode = { imageMode },
+                lastResponseSpeedBps = { null },
+            )
+    }
+
+    @After
+    fun tearDown() {
+        scope.cancel()
+        context.cacheDir.deleteRecursively()
+        clearAllMocks()
+    }
+
+    private fun ref(url: String, key: String): ParsedImageRef = ParsedImageRef(url = url, key = key)
+
+    /** Poll until the state for [key] satisfies [predicate] or time runs out. */
+    private fun awaitState(
+        key: String,
+        timeoutMs: Long = 5_000,
+        predicate: (PageImageState) -> Boolean,
+    ): PageImageState {
+        val deadline = System.currentTimeMillis() + timeoutMs
+        while (System.currentTimeMillis() < deadline) {
+            loader.imageStates.value[key]?.let { if (predicate(it)) return it }
+            Thread.sleep(10)
+        }
+        throw AssertionError("Timed out waiting for state of $key; last=${loader.imageStates.value[key]}")
+    }
+
+    // ── Cache hit ──────────────────────────────────────────────────────────
+
+    @Test
+    fun `cache hit renders immediately with zero requests`() {
+        val cached = writeWebP(context.cacheDir, "seed.webp")
+        val put = cache.put("$nodeHash:/media/seed.webp", cached)
+        assertNotNull(put)
+
+        loader.scan(listOf(ref(":/media/seed.webp", "img")))
+
+        val state = loader.imageStates.value["img"]
+        assertNotNull(state)
+        assertEquals(PageImageStatus.LOADED, state!!.status)
+        assertNotNull(state.file)
+        coVerify(exactly = 0) { nomadnet.requestNomadnetMedia(any(), any(), any()) }
+    }
+
+    // ── Auto gate ──────────────────────────────────────────────────────────
+
+    @Test
+    fun `auto mode with fast link loads the image`() {
+        coEvery { nomadnet.getNomadnetLinkStats(any()) } answers {
+            gateRan.countDown()
+            NomadnetLinkStats(rttSeconds = 0.2, expectedRateBps = 50_000L)
+        }
+        val stage = writeWebP(context.cacheDir, "auto.webp")
+        coEvery { nomadnet.requestNomadnetMedia(nodeHash, "/media/auto.webp", 60f) } returns
+            Result.success(mediaResult(stage))
+
+        loader.scan(listOf(ref(":/media/auto.webp", "img")))
+
+        val state = awaitState("img") { it.status == PageImageStatus.LOADED }
+        assertNotNull(state.file)
+        coVerify(exactly = 1) { nomadnet.requestNomadnetMedia(nodeHash, "/media/auto.webp", 60f) }
+    }
+
+    @Test
+    fun `auto mode with slow link leaves placeholders and makes no request`() {
+        coEvery { nomadnet.getNomadnetLinkStats(any()) } answers {
+            gateRan.countDown()
+            NomadnetLinkStats(rttSeconds = 2.0, expectedRateBps = 50_000L)
+        }
+
+        loader.scan(listOf(ref(":/media/slow.webp", "img")))
+
+        // The gate must have run before we assert (deterministic hand-off).
+        assertTrue("gate did not run", gateRan.await(2, TimeUnit.SECONDS))
+        assertEquals(PageImageStatus.PLACEHOLDER, loader.imageStates.value["img"]!!.status)
+        coVerify(exactly = 0) { nomadnet.requestNomadnetMedia(any(), any(), any()) }
+    }
+
+    @Test
+    fun `auto mode with no link stats does not load`() {
+        // getNomadnetLinkStats returns null (default stub); gate fails closed.
+        loader.scan(listOf(ref(":/media/noStats.webp", "img")))
+        assertTrue("gate did not run", gateRan.await(2, TimeUnit.SECONDS))
+        assertEquals(PageImageStatus.PLACEHOLDER, loader.imageStates.value["img"]!!.status)
+        coVerify(exactly = 0) { nomadnet.requestNomadnetMedia(any(), any(), any()) }
+    }
+
+    // ── Manual / never / explicit ──────────────────────────────────────────
+
+    @Test
+    fun `manual mode waits for explicit load`() {
+        imageMode = ImageLoadingMode.MANUAL
+        val stage = writeWebP(context.cacheDir, "manual.webp")
+        coEvery { nomadnet.requestNomadnetMedia(nodeHash, "/media/manual.webp", 60f) } returns
+            Result.success(mediaResult(stage))
+
+        loader.scan(listOf(ref(":/media/manual.webp", "img")))
+        // Give any (wrongly started) queue a beat to run.
+        Thread.sleep(100)
+        assertEquals(PageImageStatus.PLACEHOLDER, loader.imageStates.value["img"]!!.status)
+        coVerify(exactly = 0) { nomadnet.requestNomadnetMedia(any(), any(), any()) }
+
+        loader.loadImages(forceReload = false)
+        awaitState("img") { it.status == PageImageStatus.LOADED }
+        coVerify(exactly = 1) { nomadnet.requestNomadnetMedia(nodeHash, "/media/manual.webp", 60f) }
+    }
+
+    @Test
+    fun `never mode blocks even explicit loads`() {
+        imageMode = ImageLoadingMode.NEVER
+        loader.scan(listOf(ref(":/media/never.webp", "img")))
+        loader.loadImages(forceReload = false)
+        loader.retryImage("img")
+        Thread.sleep(100)
+        assertEquals(PageImageStatus.PLACEHOLDER, loader.imageStates.value["img"]!!.status)
+        coVerify(exactly = 0) { nomadnet.requestNomadnetMedia(any(), any(), any()) }
+    }
+
+    @Test
+    fun `always mode loads without link stats`() {
+        imageMode = ImageLoadingMode.ALWAYS
+        val stage = writeWebP(context.cacheDir, "always.webp")
+        coEvery { nomadnet.requestNomadnetMedia(nodeHash, "/media/always.webp", 60f) } returns
+            Result.success(mediaResult(stage))
+
+        loader.scan(listOf(ref(":/media/always.webp", "img")))
+        val state = awaitState("img") { it.status == PageImageStatus.LOADED }
+        assertNotNull(state.file)
+        coVerify(exactly = 1) { nomadnet.requestNomadnetMedia(nodeHash, "/media/always.webp", 60f) }
+    }
+
+    // ── Failure kinds ──────────────────────────────────────────────────────
+
+    @Test
+    fun `denied media surfaces DENIED not FAILED`() {
+        imageMode = ImageLoadingMode.ALWAYS
+        coEvery { nomadnet.requestNomadnetMedia(nodeHash, "/media/gated.webp", 60f) } returns
+            Result.failure(
+                RnsException(RnsError.NomadnetRequestDenied(nodeHash, "/media/gated.webp")),
+            )
+
+        loader.scan(listOf(ref(":/media/gated.webp", "img")))
+
+        val state = awaitState("img") { it.status == PageImageStatus.DENIED || it.status == PageImageStatus.FAILED }
+        assertEquals(PageImageStatus.DENIED, state.status)
+    }
+
+    @Test
+    fun `generic failure surfaces FAILED`() {
+        imageMode = ImageLoadingMode.ALWAYS
+        coEvery { nomadnet.requestNomadnetMedia(nodeHash, "/media/broken.webp", 60f) } returns
+            Result.failure(RuntimeException("link reset"))
+
+        loader.scan(listOf(ref(":/media/broken.webp", "img")))
+
+        val state = awaitState("img") { it.status == PageImageStatus.FAILED }
+        assertEquals("link reset", state.error)
+    }
+
+    @Test
+    fun `non-webp response is rejected as FAILED`() {
+        imageMode = ImageLoadingMode.ALWAYS
+        val png = File(context.cacheDir, "fake.webp").apply { writeBytes(byteArrayOf(0x89.toByte(), 0x50.toByte(), 0x4E.toByte(), 0x47.toByte(), 1, 2, 3, 4, 5, 6, 7, 8)) }
+        coEvery { nomadnet.requestNomadnetMedia(nodeHash, "/media/fake.webp", 60f) } returns
+            Result.success(mediaResult(png))
+
+        loader.scan(listOf(ref(":/media/fake.webp", "img")))
+
+        val state = awaitState("img") { it.status == PageImageStatus.FAILED }
+        assertTrue(state.error!!.contains("WebP"))
+    }
+
+    @Test
+    fun `oversized media exceeds the cap and fails in always mode`() {
+        // Torlando 2026-09-07: "always mode still hits the per-image size cap."
+        imageMode = ImageLoadingMode.ALWAYS
+        val small = writeWebP(context.cacheDir, "big.webp")
+        coEvery { nomadnet.requestNomadnetMedia(nodeHash, "/media/big.webp", 60f) } returns
+            Result.success(mediaResult(small, size = NomadNetImagePolicy.MAX_IMAGE_BYTES + 1))
+
+        loader.scan(listOf(ref(":/media/big.webp", "img")))
+
+        val state = awaitState("img") { it.status == PageImageStatus.FAILED }
+        assertTrue(state.error!!.contains("too large"))
+    }
+
+    // ── URL resolution / reload ────────────────────────────────────────────
+
+    @Test
+    fun `malformed image url yields an error placeholder`() {
+        loader.scan(listOf(ref("not-a-valid-url", "img")))
+        val state = loader.imageStates.value["img"]
+        assertNotNull(state)
+        assertNotNull(state!!.error)
+        assertTrue(state.error!!.startsWith("Malformed image URL"))
+        coVerify(exactly = 0) { nomadnet.requestNomadnetMedia(any(), any(), any()) }
+    }
+
+    @Test
+    fun `cross-node url resolves to the explicit hash`() {
+        val other = "deadbeefdeadbeefdeadbeefdeadbeef"
+        imageMode = ImageLoadingMode.ALWAYS
+        val stage = writeWebP(context.cacheDir, "xnode.webp")
+        coEvery { nomadnet.requestNomadnetMedia(other, "/media/xnode.webp", 60f) } returns
+            Result.success(mediaResult(stage))
+
+        loader.scan(listOf(ref("$other:/media/xnode.webp", "img")))
+        val state = awaitState("img") { it.status == PageImageStatus.LOADED }
+        assertNotNull(state.file)
+        coVerify(exactly = 1) { nomadnet.requestNomadnetMedia(other, "/media/xnode.webp", 60f) }
+    }
+
+    @Test
+    fun `force reload drops the cache and re-downloads`() {
+        imageMode = ImageLoadingMode.ALWAYS
+        val cached = writeWebP(context.cacheDir, "reload.webp")
+        cache.put("$nodeHash:/media/reload.webp", cached)
+        loader.scan(listOf(ref(":/media/reload.webp", "img")))
+        assertEquals(PageImageStatus.LOADED, loader.imageStates.value["img"]!!.status)
+
+        val stage = writeWebP(context.cacheDir, "reload2.webp")
+        coEvery { nomadnet.requestNomadnetMedia(nodeHash, "/media/reload.webp", 60f) } returns
+            Result.success(mediaResult(stage))
+
+        loader.scan(listOf(ref(":/media/reload.webp", "img")), forceReload = true)
+        awaitState("img") { it.status == PageImageStatus.LOADED && it.file != cached }
+        coVerify(exactly = 1) { nomadnet.requestNomadnetMedia(nodeHash, "/media/reload.webp", 60f) }
+    }
+
+    @Test
+    fun `second scan of a cached page is instant with zero requests`() {
+        imageMode = ImageLoadingMode.ALWAYS
+        val stage = writeWebP(context.cacheDir, "twice.webp")
+        coEvery { nomadnet.requestNomadnetMedia(nodeHash, "/media/twice.webp", 60f) } returns
+            Result.success(mediaResult(stage))
+
+        loader.scan(listOf(ref(":/media/twice.webp", "img")))
+        awaitState("img") { it.status == PageImageStatus.LOADED }
+
+        // Navigate away and back (same page, image now cached).
+        loader.clear()
+        loader.scan(listOf(ref(":/media/twice.webp", "img")))
+        assertEquals(PageImageStatus.LOADED, loader.imageStates.value["img"]!!.status)
+        coVerify(exactly = 1) { nomadnet.requestNomadnetMedia(nodeHash, "/media/twice.webp", 60f) }
+    }
+
+    // ── Cache primitives ───────────────────────────────────────────────────
+
+    @Test
+    fun `image cache clear removes all entries`() {
+        val a = writeWebP(context.cacheDir, "a.webp")
+        val b = writeWebP(context.cacheDir, "b.webp")
+        cache.put("$nodeHash:/media/a.webp", a)
+        cache.put("$nodeHash:/media/b.webp", b)
+        assertNotNull(cache.get("$nodeHash:/media/a.webp"))
+
+        cache.clear()
+
+        assertNull(cache.get("$nodeHash:/media/a.webp"))
+        assertEquals(0L, cache.totalBytes())
+    }
+}

--- a/app/src/test/java/network/columba/app/nomadnet/PageImageLoaderTest.kt
+++ b/app/src/test/java/network/columba/app/nomadnet/PageImageLoaderTest.kt
@@ -202,6 +202,31 @@ class PageImageLoaderTest {
     }
 
     @Test
+    fun `manual mode retry loads only the tapped image not its siblings`() {
+        imageMode = ImageLoadingMode.MANUAL
+        val stageA = writeWebP(context.cacheDir, "a.webp")
+        val stageB = writeWebP(context.cacheDir, "b.webp")
+        coEvery { nomadnet.requestNomadnetMedia(nodeHash, "/media/a.webp", 60f) } returns
+            Result.success(mediaResult(stageA))
+        coEvery { nomadnet.requestNomadnetMedia(nodeHash, "/media/b.webp", 60f) } returns
+            Result.success(mediaResult(stageB))
+
+        loader.scan(listOf(ref(":/media/a.webp", "imgA"), ref(":/media/b.webp", "imgB")))
+        Thread.sleep(100)
+        assertEquals(PageImageStatus.PLACEHOLDER, loader.imageStates.value["imgA"]!!.status)
+        assertEquals(PageImageStatus.PLACEHOLDER, loader.imageStates.value["imgB"]!!.status)
+
+        // Tapping one placeholder must fetch only that one - the sibling stays
+        // a placeholder (previously retryImage re-queued the whole page).
+        loader.retryImage("imgA")
+        awaitState("imgA") { it.status == PageImageStatus.LOADED }
+        Thread.sleep(150)
+        assertEquals(PageImageStatus.PLACEHOLDER, loader.imageStates.value["imgB"]!!.status)
+        coVerify(exactly = 1) { nomadnet.requestNomadnetMedia(nodeHash, "/media/a.webp", 60f) }
+        coVerify(exactly = 0) { nomadnet.requestNomadnetMedia(nodeHash, "/media/b.webp", 60f) }
+    }
+
+    @Test
     fun `never mode blocks even explicit loads`() {
         imageMode = ImageLoadingMode.NEVER
         loader.scan(listOf(ref(":/media/never.webp", "img")))

--- a/app/src/test/java/network/columba/app/ui/components/MicronImageSizeResolutionTest.kt
+++ b/app/src/test/java/network/columba/app/ui/components/MicronImageSizeResolutionTest.kt
@@ -1,0 +1,54 @@
+package network.columba.app.ui.components
+
+import androidx.compose.ui.unit.dp
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Test
+
+class MicronImageSizeResolutionTest {
+
+    @Test
+    fun `percentage width resolves to a parent-relative fraction`() {
+        assertEquals(1.0f, resolveImageFraction("100%")!!, 0.0001f)
+        assertEquals(0.5f, resolveImageFraction("50%")!!, 0.0001f)
+        assertEquals(0.25f, resolveImageFraction("25%")!!, 0.0001f)
+    }
+
+    @Test
+    fun `out-of-range percentage is coerced to the valid fraction`() {
+        assertEquals(1.0f, resolveImageFraction("150%")!!, 0.0001f)
+        assertEquals(0.0f, resolveImageFraction("-20%")!!, 0.0001f)
+        assertEquals(0.0f, resolveImageFraction("0%")!!, 0.0001f)
+    }
+
+    @Test
+    fun `non-percentage and malformed specs are not fractions`() {
+        assertNull(resolveImageFraction(null))
+        assertNull(resolveImageFraction("n"))
+        assertNull(resolveImageFraction("40"))
+        assertNull(resolveImageFraction("abc%"))
+        assertNull(resolveImageFraction("%"))
+    }
+
+    @Test
+    fun `numeric width spec is a count of columns in dp`() {
+        // 40 columns * 8 dp/col = 320 dp (no density conversion).
+        assertEquals(320.dp, resolveImageSize("40", 8f))
+        assertEquals(8.dp, resolveImageSize("1", 8f))
+    }
+
+    @Test
+    fun `numeric height spec is a count of rows in dp`() {
+        // 10 rows * 16 dp/row = 160 dp.
+        assertEquals(160.dp, resolveImageSize("10", 16f))
+    }
+
+    @Test
+    fun `percentage and intrinsic width resolve to null from the dp resolver`() {
+        // Percentages are handled by resolveImageFraction, not the dp resolver.
+        assertNull(resolveImageSize("100%", 8f))
+        assertNull(resolveImageSize("n", 8f))
+        assertNull(resolveImageSize(null, 8f))
+        assertNull(resolveImageSize("abc", 8f))
+    }
+}

--- a/app/src/test/java/network/columba/app/viewmodel/NomadNetBrowserViewModelTest.kt
+++ b/app/src/test/java/network/columba/app/viewmodel/NomadNetBrowserViewModelTest.kt
@@ -61,9 +61,14 @@ class NomadNetBrowserViewModelTest {
         Dispatchers.setMain(testDispatcher)
         protocol = mockk()
         pageCache = mockk()
-        imageCache = mockk(relaxed = true)
+        imageCache = mockk()
         settingsRepository = mockk()
         every { pageCache.put(any(), any(), any(), any()) } just Runs
+        // Page-image cache: only the explicit clear (clearImageCache) and the
+        // loader's miss-path get() are reachable from these tests; stub both
+        // explicitly rather than using a relaxed mock.
+        every { imageCache.clear() } just Runs
+        every { imageCache.get(any()) } returns null
         coEvery { protocol.cancelNomadnetPageRequest() } just Runs
         coEvery { protocol.getNomadnetRequestStatus() } returns ""
         coEvery { protocol.getNomadnetLinkStats(any()) } returns null
@@ -959,5 +964,29 @@ class NomadNetBrowserViewModelTest {
             viewModel.retry()
             advanceUntilIdle()
             assertTrue(viewModel.browserState.value is NomadNetBrowserViewModel.BrowserState.Initial)
+        }
+
+    // ── Page images ──
+
+    @Test
+    fun `setImageLoadingMode updates state and persists the choice`() =
+        runTest(testDispatcher) {
+            viewModel.setImageLoadingMode(network.columba.app.nomadnet.ImageLoadingMode.MANUAL)
+
+            assertEquals(
+                network.columba.app.nomadnet.ImageLoadingMode.MANUAL,
+                viewModel.imageLoadingMode.value,
+            )
+            coVerify(exactly = 1) { settingsRepository.saveNomadNetImageLoadingMode("MANUAL") }
+        }
+
+    @Test
+    fun `clearImageCache wipes the disk cache and resets in-flight image states`() =
+        runTest(testDispatcher) {
+            viewModel.clearImageCache()
+            advanceUntilIdle()
+
+            verify { imageCache.clear() }
+            assertTrue(viewModel.imageStates.value.isEmpty())
         }
 }

--- a/app/src/test/java/network/columba/app/viewmodel/NomadNetBrowserViewModelTest.kt
+++ b/app/src/test/java/network/columba/app/viewmodel/NomadNetBrowserViewModelTest.kt
@@ -49,6 +49,7 @@ class NomadNetBrowserViewModelTest {
     private val testDispatcher = UnconfinedTestDispatcher()
     private lateinit var protocol: RnsNomadnet
     private lateinit var pageCache: NomadNetPageCache
+    private lateinit var imageCache: network.columba.app.nomadnet.NomadNetImageCache
     private lateinit var settingsRepository: SettingsRepository
     private lateinit var viewModel: NomadNetBrowserViewModel
 
@@ -60,16 +61,20 @@ class NomadNetBrowserViewModelTest {
         Dispatchers.setMain(testDispatcher)
         protocol = mockk()
         pageCache = mockk()
+        imageCache = mockk(relaxed = true)
         settingsRepository = mockk()
         every { pageCache.put(any(), any(), any(), any()) } just Runs
         coEvery { protocol.cancelNomadnetPageRequest() } just Runs
         coEvery { protocol.getNomadnetRequestStatus() } returns ""
+        coEvery { protocol.getNomadnetLinkStats(any()) } returns null
         // No persisted rendering mode by default; individual tests can override.
         every { settingsRepository.nomadNetRenderingModeFlow } returns flowOf(null)
+        every { settingsRepository.nomadNetImageLoadingModeFlow } returns flowOf(null)
         coEvery { settingsRepository.saveNomadNetRenderingMode(any()) } just Runs
+        coEvery { settingsRepository.saveNomadNetImageLoadingMode(any()) } just Runs
         coEvery { settingsRepository.saveNomadNetLastNodeHash(any(), any()) } just Runs
         coEvery { settingsRepository.clearNomadNetLastNodeHash() } just Runs
-        viewModel = NomadNetBrowserViewModel(protocol, pageCache, settingsRepository)
+        viewModel = NomadNetBrowserViewModel(protocol, pageCache, imageCache, settingsRepository)
     }
 
     @Suppress("SleepInsteadOfDelay")
@@ -573,7 +578,7 @@ class NomadNetBrowserViewModelTest {
         runTest(testDispatcher) {
             every { settingsRepository.nomadNetRenderingModeFlow } returns flowOf("PROPORTIONAL_WRAP")
 
-            val restoredViewModel = NomadNetBrowserViewModel(protocol, pageCache, settingsRepository)
+            val restoredViewModel = NomadNetBrowserViewModel(protocol, pageCache, imageCache, settingsRepository)
             advanceUntilIdle()
 
             assertEquals(
@@ -602,7 +607,7 @@ class NomadNetBrowserViewModelTest {
             every { settingsRepository.nomadNetRenderingModeFlow } returns controllableFlow
 
             // init launches and suspends on first() because nothing has been emitted yet.
-            val racingViewModel = NomadNetBrowserViewModel(protocol, pageCache, settingsRepository)
+            val racingViewModel = NomadNetBrowserViewModel(protocol, pageCache, imageCache, settingsRepository)
 
             // User picks a mode before the persisted value has been read back.
             racingViewModel.setRenderingMode(NomadNetBrowserViewModel.RenderingMode.MONOSPACE_ZOOM)

--- a/micron/src/main/java/network/columba/app/micron/MicronElement.kt
+++ b/micron/src/main/java/network/columba/app/micron/MicronElement.kt
@@ -48,5 +48,20 @@ sealed class MicronElement {
         val partialId: String?,
     ) : MicronElement()
 
+    /**
+     * Inline image (upstream NomadNet `c0091db`): `` `(alt`w=<spec>`h=<spec>`a=<l|c|r>`:url) ``.
+     * Block-level — always its own line. Size specs stay raw strings
+     * (`"40"` cells, `"50%"` percent, `"n"` native) so layout policy lives
+     * in the renderer, not the parser. [alt] doubles as the placeholder text
+     * for renderers that can't (or haven't yet) fetched the image.
+     */
+    data class Image(
+        val alt: String,
+        val url: String,
+        val width: String?,
+        val height: String?,
+        val align: String?,
+    ) : MicronElement()
+
     data object LineBreak : MicronElement()
 }

--- a/micron/src/main/java/network/columba/app/micron/MicronParser.kt
+++ b/micron/src/main/java/network/columba/app/micron/MicronParser.kt
@@ -197,6 +197,27 @@ object MicronParser {
                 }
             }
 
+            // Images: `(alt`w=..`h=..`a=c`:url) — block-level, own line.
+            // Mirrors upstream MicronParser.parse_image: everything up to the
+            // last ")" is the tag; fields split on backtick; first field is
+            // alt text, last is the URL, middle fields are key=value
+            // properties (w, h, a; unknown keys ignored). A malformed tag
+            // (no closing paren or fewer than two backtick-separated fields)
+            // falls through to plain inline text, exactly like upstream.
+            if (line.startsWith("`(")) {
+                val image = parseImage(line.substring(2))
+                if (image != null) {
+                    outputLines.add(
+                        MicronLine(
+                            elements = listOf(image),
+                            alignment = currentAlignment,
+                            indentLevel = sectionDepth,
+                        ),
+                    )
+                    continue
+                }
+            }
+
             // Regular content line — parse inline elements
             val (elements, updatedStyle, updatedAlignment) =
                 parseInline(
@@ -427,6 +448,62 @@ object MicronParser {
 
             else -> null
         }
+    }
+
+    /**
+     * Parse an image tag body (everything after the leading `` `(` ``).
+     * Mirrors upstream `MicronParser.parse_image`:
+     * `alt`w=<spec>`h=<spec>`a=<l|c|r>`:/media/foo.webp)` — the tag ends at
+     * the last ")" ; fields split on backtick; first field alt text, last
+     * field the URL (leading colon = relative to the current page's node;
+     * `<hash>:/path` for cross-node), middle fields `key=value` properties
+     * where w/h are size specs and a is alignment (l/c/r expanded to
+     * left/center/right). Unknown property keys are ignored.
+     *
+     * Returns null for structurally malformed tags (no closing paren, or
+     * fewer than two backtick-separated fields) so the line falls through to
+     * plain inline text, exactly like upstream. A well-formed tag with an
+     * empty URL still yields an Image — renderers show the alt text as an
+     * error placeholder, matching upstream's "Error loading image" line.
+     */
+    internal fun parseImage(body: String): MicronElement.Image? {
+        val endpos = body.lastIndexOf(')')
+        if (endpos <= 0) return null
+        val fields = body.substring(0, endpos).split('`')
+        if (fields.size < 2) return null
+
+        val alt = fields.first().trim()
+        val url = fields.last().trim()
+        var width: String? = null
+        var height: String? = null
+        var align: String? = null
+
+        for (prop in fields.subList(1, fields.size - 1)) {
+            val eq = prop.indexOf('=')
+            if (eq == -1) continue
+            val key = prop.substring(0, eq).trim()
+            val value = prop.substring(eq + 1).trim()
+            when (key) {
+                "w" -> width = value
+                "h" -> height = value
+                "a" ->
+                    align =
+                        when (value) {
+                            "c" -> "center"
+                            "l" -> "left"
+                            "r" -> "right"
+                            else -> value
+                        }
+            }
+        }
+
+        return MicronElement.Image(
+            alt = alt,
+            url = url,
+            width = width,
+            height = height,
+            align = align,
+        )
     }
 
     /**

--- a/micron/src/test/java/network/columba/app/micron/MicronParserTest.kt
+++ b/micron/src/test/java/network/columba/app/micron/MicronParserTest.kt
@@ -1152,6 +1152,25 @@ class MicronParserTest {
     }
 
     @Test
+    fun `image tag height property parses`() {
+        val image = parseSingleImage("`(" + "alt" + "`w=40`h=80`" + ":x.webp)")
+        assertEquals("40", image.width)
+        assertEquals("80", image.height)
+    }
+
+    @Test
+    fun `image tag left shorthand alignment expands`() {
+        val image = parseSingleImage("`(" + "alt" + "`w=n`a=l`" + ":x.webp)")
+        assertEquals("left", image.align)
+    }
+
+    @Test
+    fun `image tag right shorthand alignment expands`() {
+        val image = parseSingleImage("`(" + "alt" + "`w=n`a=r`" + ":x.webp)")
+        assertEquals("right", image.align)
+    }
+
+    @Test
     fun `image tag without properties parses alt and url only`() {
         val image = parseSingleImage("`(" + "pic" + "`" + ":/media/pic.webp)")
         assertEquals("pic", image.alt)
@@ -1167,6 +1186,14 @@ class MicronParserTest {
     @Test
     fun `unknown image properties are ignored`() {
         val image = parseSingleImage("`(" + "alt" + "`z=9`w=40`" + ":x.webp)")
+        assertEquals("40", image.width)
+    }
+
+    @Test
+    fun `image property field without equals is skipped`() {
+        // A middle property field with no `=` (e.g. `foo`) is skipped by the
+        // property loop (mirrors upstream, which only reads key=value pairs).
+        val image = parseSingleImage("`(" + "alt" + "`foo`w=40`" + ":x.webp)")
         assertEquals("40", image.width)
     }
 

--- a/micron/src/test/java/network/columba/app/micron/MicronParserTest.kt
+++ b/micron/src/test/java/network/columba/app/micron/MicronParserTest.kt
@@ -1126,5 +1126,86 @@ class MicronParserTest {
         assertEquals('\u2500', divider.character)
     }
 
+    // ==================== Images ====================
+
+    private fun parseSingleImage(tag: String): MicronElement.Image {
+        val doc = MicronParser.parse(tag)
+        val line = doc.lines.single { it.elements.none { e -> e is MicronElement.LineBreak } }
+        return line.elements.single() as MicronElement.Image
+    }
+
+    @Test
+    fun `full image tag parses alt url and properties`() {
+        val image = parseSingleImage("`(" + "RNS logo" + "`w=60%`a=center`" + ":/media/demo.webp)")
+        assertEquals("RNS logo", image.alt)
+        assertEquals(":/media/demo.webp", image.url)
+        assertEquals("60%", image.width)
+        assertEquals("center", image.align)
+        assertNull(image.height)
+    }
+
+    @Test
+    fun `image tag shorthand alignment expands`() {
+        val image = parseSingleImage("`(" + "alt" + "`w=n`a=c`" + ":x.webp)")
+        assertEquals("n", image.width)
+        assertEquals("center", image.align)
+    }
+
+    @Test
+    fun `image tag without properties parses alt and url only`() {
+        val image = parseSingleImage("`(" + "pic" + "`" + ":/media/pic.webp)")
+        assertEquals("pic", image.alt)
+        assertEquals(":/media/pic.webp", image.url)
+    }
+
+    @Test
+    fun `image tag cross-node url keeps hash prefix`() {
+        val image = parseSingleImage("`(" + "far" + "`" + "ff00aa11bb22cc33dd44ee55ff667788:/media/x.webp)")
+        assertEquals("ff00aa11bb22cc33dd44ee55ff667788:/media/x.webp", image.url)
+    }
+
+    @Test
+    fun `unknown image properties are ignored`() {
+        val image = parseSingleImage("`(" + "alt" + "`z=9`w=40`" + ":x.webp)")
+        assertEquals("40", image.width)
+    }
+
+    @Test
+    fun `malformed image tag falls through to inline text`() {
+        // No closing paren -> upstream parse_image bails (returns None) and
+        // the line renders as plain text. Columba mirrors exactly.
+        val doc = MicronParser.parse("`(" + "broken thing")
+        val line = doc.lines.single { it.elements.none { e -> e is MicronElement.LineBreak } }
+        assertTrue(line.elements.none { it is MicronElement.Image })
+    }
+
+    @Test
+    fun `well-formed tag with empty url yields image for error placeholder`() {
+        // Upstream: empty URL in a well-formed tag -> "Error loading image"
+        // placeholder widget, not a fall-through. Columba models this as an
+        // Image with empty url; the renderer shows the alt as placeholder.
+        val image = parseSingleImage("`(" + "pic" + "`w=n`" + ")")
+        assertEquals("", image.url)
+        assertEquals("pic", image.alt)
+    }
+
+    @Test
+    fun `url without backtick separator falls through to inline text`() {
+        // Upstream splits the tag on backtick: "pic:/media/pic.webp" is a
+        // single field -> parse_image bails -> the line renders as plain
+        // inline text (the backtick-entry path consumes the "(" as an
+        // unknown command). Columba mirrors: no Image element is produced.
+        val doc = MicronParser.parse("`(" + "pic:/media/pic.webp)")
+        val line = doc.lines.single { it.elements.none { e -> e is MicronElement.LineBreak } }
+        assertTrue(line.elements.none { it is MicronElement.Image })
+    }
+
+    @Test
+    fun `image alt with inner parens keeps last paren as terminator`() {
+        val image = parseSingleImage("`(" + "logo (fresh)" + "`w=n`" + ":y.webp)")
+        assertEquals("logo (fresh)", image.alt)
+        assertEquals(":y.webp", image.url)
+    }
+
     private fun MicronDocument.singleText(): MicronElement.Text = lines.single().elements.single() as MicronElement.Text
 }

--- a/rns-api/src/main/aidl/network/columba/app/rns/api/model/NomadnetLinkStats.aidl
+++ b/rns-api/src/main/aidl/network/columba/app/rns/api/model/NomadnetLinkStats.aidl
@@ -1,0 +1,3 @@
+package network.columba.app.rns.api.model;
+
+parcelable NomadnetLinkStats;

--- a/rns-api/src/main/aidl/network/columba/app/rns/api/model/NomadnetMediaResult.aidl
+++ b/rns-api/src/main/aidl/network/columba/app/rns/api/model/NomadnetMediaResult.aidl
@@ -1,0 +1,3 @@
+package network.columba.app.rns.api.model;
+
+parcelable NomadnetMediaResult;

--- a/rns-api/src/main/aidl/network/columba/app/rns/ipc/IRnsNomadnet.aidl
+++ b/rns-api/src/main/aidl/network/columba/app/rns/ipc/IRnsNomadnet.aidl
@@ -29,6 +29,9 @@ oneway interface IRnsNomadnet {
         float timeoutSeconds,
         in IRnsResultCallback cb);
 
+    // getNomadnetLinkStats → "stats": NomadnetLinkStats; null when no active link
+    void getNomadnetLinkStats(String destinationHash, in IRnsResultCallback cb);
+
     // Snapshot getters for the request status / download progress flows.
     void getNomadnetRequestStatus(in IRnsStringCallback cb);
     void getNomadnetDownloadProgress(in IRnsFloatCallback cb);

--- a/rns-api/src/main/aidl/network/columba/app/rns/ipc/IRnsNomadnet.aidl
+++ b/rns-api/src/main/aidl/network/columba/app/rns/ipc/IRnsNomadnet.aidl
@@ -22,6 +22,13 @@ oneway interface IRnsNomadnet {
 
     void cancelNomadnetPageRequest(in IRnsResultCallback cb);
 
+    // requestNomadnetMedia → "media": NomadnetMediaResult
+    void requestNomadnetMedia(
+        String destinationHash,
+        String path,
+        float timeoutSeconds,
+        in IRnsResultCallback cb);
+
     // Snapshot getters for the request status / download progress flows.
     void getNomadnetRequestStatus(in IRnsStringCallback cb);
     void getNomadnetDownloadProgress(in IRnsFloatCallback cb);

--- a/rns-api/src/main/aidl/network/columba/app/rns/ipc/IRnsNomadnet.aidl
+++ b/rns-api/src/main/aidl/network/columba/app/rns/ipc/IRnsNomadnet.aidl
@@ -23,10 +23,13 @@ oneway interface IRnsNomadnet {
     void cancelNomadnetPageRequest(in IRnsResultCallback cb);
 
     // requestNomadnetMedia → "media": NomadnetMediaResult
+    // maxBytes: transfer cap; Long.MAX_VALUE = no cap. The backend fails the
+    // fetch (RnsError.NomadnetResponseTooLarge) if the node delivers more.
     void requestNomadnetMedia(
         String destinationHash,
         String path,
         float timeoutSeconds,
+        long maxBytes,
         in IRnsResultCallback cb);
 
     // getNomadnetLinkStats → "stats": NomadnetLinkStats; null when no active link

--- a/rns-api/src/main/java/network/columba/app/rns/api/RnsError.kt
+++ b/rns-api/src/main/java/network/columba/app/rns/api/RnsError.kt
@@ -154,6 +154,30 @@ sealed class RnsError : Parcelable {
         }
     }
 
+    /**
+     * A NomadNet media (page-image) response exceeded the per-image transfer
+     * cap before it could be retained. Distinct from [NomadnetRequestDenied]
+     * (the node answered "no") and [NomadnetPageNotFound] (unreachable): the
+     * node sent bytes, but more than [maxBytes], so the backend failed the
+     * fetch at the response boundary instead of writing the oversized payload
+     * to temporary storage or returning it to the UI. [receivedBytes] is the
+     * actual size the node delivered.
+     */
+    data class NomadnetResponseTooLarge(
+        val destHash: String,
+        val path: String,
+        val receivedBytes: Long,
+        val maxBytes: Long,
+    ) : RnsError() {
+        override fun writeToParcel(parcel: Parcel, flags: Int) {
+            parcel.writeInt(TAG_NOMADNET_RESPONSE_TOO_LARGE)
+            parcel.writeString(destHash)
+            parcel.writeString(path)
+            parcel.writeLong(receivedBytes)
+            parcel.writeLong(maxBytes)
+        }
+    }
+
     companion object {
         private const val TAG_GENERIC = 0
         private const val TAG_BACKEND_NOT_READY = 1
@@ -163,6 +187,7 @@ sealed class RnsError : Parcelable {
         private const val TAG_CALL_STATE_INVALID = 5
         private const val TAG_NOMADNET_PAGE_NOT_FOUND = 6
         private const val TAG_NOMADNET_REQUEST_DENIED = 7
+        private const val TAG_NOMADNET_RESPONSE_TOO_LARGE = 8
 
         @JvmField
         val CREATOR: Parcelable.Creator<RnsError> = object : Parcelable.Creator<RnsError> {
@@ -176,6 +201,12 @@ sealed class RnsError : Parcelable {
                     TAG_CALL_STATE_INVALID -> CallStateInvalid(parcel.readString().orEmpty(), parcel.readString().orEmpty())
                     TAG_NOMADNET_PAGE_NOT_FOUND -> NomadnetPageNotFound(parcel.readString().orEmpty(), parcel.readString().orEmpty())
                     TAG_NOMADNET_REQUEST_DENIED -> NomadnetRequestDenied(parcel.readString().orEmpty(), parcel.readString().orEmpty())
+                    TAG_NOMADNET_RESPONSE_TOO_LARGE -> NomadnetResponseTooLarge(
+                        parcel.readString().orEmpty(),
+                        parcel.readString().orEmpty(),
+                        parcel.readLong(),
+                        parcel.readLong(),
+                    )
                     else -> error("Unknown RnsError tag: $tag")
                 }
 
@@ -214,6 +245,8 @@ class RnsException(val error: RnsError) : RuntimeException(describe(error)) {
                     "NomadNet page not found: ${error.destHash}${error.path}"
                 is RnsError.NomadnetRequestDenied ->
                     "NomadNet request denied: ${error.destHash}${error.path}"
+                is RnsError.NomadnetResponseTooLarge ->
+                    "NomadNet media too large: got ${error.receivedBytes} bytes, cap ${error.maxBytes} (${error.destHash}${error.path})"
             }
     }
 }

--- a/rns-api/src/main/java/network/columba/app/rns/api/RnsError.kt
+++ b/rns-api/src/main/java/network/columba/app/rns/api/RnsError.kt
@@ -136,6 +136,24 @@ sealed class RnsError : Parcelable {
         }
     }
 
+    /**
+     * The destination explicitly refused a NomadNet request — the server-
+     * side access list (`.allowed` gating) rejected the caller. Distinct
+     * from [NomadnetPageNotFound] (unreachable / 404): the node is alive
+     * and answered, it just said no. Surfaced by `/media/` fetches of
+     * gated images (upstream Node.py returns `False`, 3028301).
+     */
+    data class NomadnetRequestDenied(
+        val destHash: String,
+        val path: String,
+    ) : RnsError() {
+        override fun writeToParcel(parcel: Parcel, flags: Int) {
+            parcel.writeInt(TAG_NOMADNET_REQUEST_DENIED)
+            parcel.writeString(destHash)
+            parcel.writeString(path)
+        }
+    }
+
     companion object {
         private const val TAG_GENERIC = 0
         private const val TAG_BACKEND_NOT_READY = 1
@@ -144,6 +162,7 @@ sealed class RnsError : Parcelable {
         private const val TAG_FEATURE_UNSUPPORTED = 4
         private const val TAG_CALL_STATE_INVALID = 5
         private const val TAG_NOMADNET_PAGE_NOT_FOUND = 6
+        private const val TAG_NOMADNET_REQUEST_DENIED = 7
 
         @JvmField
         val CREATOR: Parcelable.Creator<RnsError> = object : Parcelable.Creator<RnsError> {
@@ -156,6 +175,7 @@ sealed class RnsError : Parcelable {
                     TAG_FEATURE_UNSUPPORTED -> FeatureUnsupported(parcel.readString().orEmpty())
                     TAG_CALL_STATE_INVALID -> CallStateInvalid(parcel.readString().orEmpty(), parcel.readString().orEmpty())
                     TAG_NOMADNET_PAGE_NOT_FOUND -> NomadnetPageNotFound(parcel.readString().orEmpty(), parcel.readString().orEmpty())
+                    TAG_NOMADNET_REQUEST_DENIED -> NomadnetRequestDenied(parcel.readString().orEmpty(), parcel.readString().orEmpty())
                     else -> error("Unknown RnsError tag: $tag")
                 }
 
@@ -192,6 +212,8 @@ class RnsException(val error: RnsError) : RuntimeException(describe(error)) {
                     "Invalid call state: expected ${error.expected}, was ${error.actual}"
                 is RnsError.NomadnetPageNotFound ->
                     "NomadNet page not found: ${error.destHash}${error.path}"
+                is RnsError.NomadnetRequestDenied ->
+                    "NomadNet request denied: ${error.destHash}${error.path}"
             }
     }
 }

--- a/rns-api/src/main/java/network/columba/app/rns/api/RnsNomadnet.kt
+++ b/rns-api/src/main/java/network/columba/app/rns/api/RnsNomadnet.kt
@@ -1,6 +1,7 @@
 package network.columba.app.rns.api
 
 import kotlinx.coroutines.flow.StateFlow
+import network.columba.app.rns.api.model.NomadnetLinkStats
 import network.columba.app.rns.api.model.NomadnetMediaResult
 import network.columba.app.rns.api.model.NomadnetPageResult
 
@@ -54,6 +55,15 @@ interface RnsNomadnet {
         path: String,
         timeoutSeconds: Float = 45f,
     ): Result<NomadnetMediaResult>
+
+    /**
+     * Live stats of the currently-active NomadNet link to a node, for the
+     * image auto-load gate (upstream reads `link.rtt` /
+     * `link.get_expected_rate()`). Returns null when there is no active link
+     * or no backend — callers treat null as "insufficient data" (auto mode:
+     * do not load).
+     */
+    suspend fun getNomadnetLinkStats(destinationHash: String): NomadnetLinkStats?
 
     /**
      * One-shot snapshot of the current NomadNet request status.

--- a/rns-api/src/main/java/network/columba/app/rns/api/RnsNomadnet.kt
+++ b/rns-api/src/main/java/network/columba/app/rns/api/RnsNomadnet.kt
@@ -1,6 +1,7 @@
 package network.columba.app.rns.api
 
 import kotlinx.coroutines.flow.StateFlow
+import network.columba.app.rns.api.model.NomadnetMediaResult
 import network.columba.app.rns.api.model.NomadnetPageResult
 
 /**
@@ -33,6 +34,26 @@ interface RnsNomadnet {
 
     /** Cancel an in-flight [requestNomadnetPage]. No-op if no request is active. */
     suspend fun cancelNomadnetPageRequest()
+
+    /**
+     * Fetch a media object (page image) from a NomadNet host's `/media/`
+     * handler. The body is written to a fresh file inside the backend cache
+     * dir and returned as a [NomadnetMediaResult]; the caller owns its
+     * lifecycle from there (move into the image cache, delete on eviction).
+     *
+     * Server-side `.allowed` gating surfaces as a failed Result carrying
+     * [RnsError.NomadnetRequestDenied] (upstream Node.py `False` deny),
+     * distinct from timeouts and unreachable hosts.
+     *
+     * @param destinationHash 32-char hex destination hash of the NomadNet host.
+     * @param path Media path on the host (e.g. `/media/images/logo.webp`).
+     * @param timeoutSeconds Hard deadline for the round-trip.
+     */
+    suspend fun requestNomadnetMedia(
+        destinationHash: String,
+        path: String,
+        timeoutSeconds: Float = 45f,
+    ): Result<NomadnetMediaResult>
 
     /**
      * One-shot snapshot of the current NomadNet request status.

--- a/rns-api/src/main/java/network/columba/app/rns/api/RnsNomadnet.kt
+++ b/rns-api/src/main/java/network/columba/app/rns/api/RnsNomadnet.kt
@@ -49,11 +49,17 @@ interface RnsNomadnet {
      * @param destinationHash 32-char hex destination hash of the NomadNet host.
      * @param path Media path on the host (e.g. `/media/images/logo.webp`).
      * @param timeoutSeconds Hard deadline for the round-trip.
+     * @param maxBytes Transfer cap in bytes. The backend enforces this at the
+     *   response boundary - if the node delivers more than [maxBytes], the
+     *   fetch fails with [RnsError.NomadnetResponseTooLarge] and the oversized
+     *   payload is not written to temporary storage or returned. Defaults to
+     *   no cap for callers that do not need one (page-file downloads).
      */
     suspend fun requestNomadnetMedia(
         destinationHash: String,
         path: String,
         timeoutSeconds: Float = 45f,
+        maxBytes: Long = Long.MAX_VALUE,
     ): Result<NomadnetMediaResult>
 
     /**

--- a/rns-api/src/main/java/network/columba/app/rns/api/model/NomadnetLinkStats.kt
+++ b/rns-api/src/main/java/network/columba/app/rns/api/model/NomadnetLinkStats.kt
@@ -1,0 +1,21 @@
+package network.columba.app.rns.api.model
+
+import android.os.Parcelable
+import kotlinx.parcelize.Parcelize
+
+/**
+ * Live stats of an existing NomadNet link to a node, for image-loading and
+ * other bandwidth decisions. Mirrors what upstream Browser.py reads directly
+ * off `self.link` (`link.rtt`, `link.get_expected_rate()`).
+ *
+ * Never establishes anything: null means "no active link data available".
+ *
+ * @property rttSeconds link round-trip time in seconds, if measured
+ * @property expectedRateBps expected data rate in bits/s (from measured
+ *   transfers on this link), null before any transfer has been measured
+ */
+@Parcelize
+data class NomadnetLinkStats(
+    val rttSeconds: Double?,
+    val expectedRateBps: Long?,
+) : Parcelable

--- a/rns-api/src/main/java/network/columba/app/rns/api/model/NomadnetMediaResult.kt
+++ b/rns-api/src/main/java/network/columba/app/rns/api/model/NomadnetMediaResult.kt
@@ -1,0 +1,31 @@
+package network.columba.app.rns.api.model
+
+import android.os.Parcelable
+import kotlinx.parcelize.Parcelize
+
+/**
+ * Result of a NomadNet `/media/` request (page image fetch).
+ *
+ * Returned by `RnsNomadnet.requestNomadnetMedia`. The body is written to
+ * [filePath] (a fresh file in the backend's cache dir, name derived from the
+ * requested path, uniquified so concurrent fetches never clobber each other);
+ * the caller (image cache layer) is expected to move or copy it into its own
+ * URL-keyed cache and manage its lifecycle from there.
+ *
+ * A server-side denial (`.allowed` gating) is surfaced as a failure with
+ * [network.columba.app.rns.api.RnsError.NomadnetRequestDenied], not as a
+ * result — matching upstream NomadNet's `False` deny signal (Node.py).
+ *
+ * @param filePath Absolute path to the downloaded media file.
+ * @param fileName Display name of the media file (server-advertised name or
+ *   basename of the requested path).
+ * @param fileSize Size in bytes of the downloaded file.
+ * @param path The `/media/...` path that was requested.
+ */
+@Parcelize
+data class NomadnetMediaResult(
+    val filePath: String,
+    val fileName: String,
+    val fileSize: Long,
+    val path: String,
+) : Parcelable

--- a/rns-api/src/test/java/network/columba/app/rns/api/ParcelRoundTripTest.kt
+++ b/rns-api/src/test/java/network/columba/app/rns/api/ParcelRoundTripTest.kt
@@ -140,6 +140,13 @@ class ParcelRoundTripTest {
         assertEquals(original, restored)
     }
 
+    @Test
+    fun `RnsError NomadnetResponseTooLarge round-trips`() {
+        val original = RnsError.NomadnetResponseTooLarge("abc123", "/media/big.webp", 17_000_000L, 16_000_000L)
+        val restored = roundTrip(original, RnsError.CREATOR)
+        assertEquals(original, restored)
+    }
+
     // ==================== NetworkStatus ====================
 
     @Test

--- a/rns-api/src/test/java/network/columba/app/rns/api/RnsErrorTest.kt
+++ b/rns-api/src/test/java/network/columba/app/rns/api/RnsErrorTest.kt
@@ -55,6 +55,20 @@ class RnsErrorTest {
     }
 
     @Test
+    fun `NomadnetResponseTooLarge carries dest hash, path, and byte counts`() {
+        val err = RnsError.NomadnetResponseTooLarge(
+            destHash = "abc123",
+            path = "/media/big.webp",
+            receivedBytes = 17_000_000L,
+            maxBytes = 16_000_000L,
+        )
+        assertEquals("abc123", err.destHash)
+        assertEquals("/media/big.webp", err.path)
+        assertEquals(17_000_000L, err.receivedBytes)
+        assertEquals(16_000_000L, err.maxBytes)
+    }
+
+    @Test
     fun `equality is structural for data classes`() {
         val a = RnsError.IdentityNotFound("aa")
         val b = RnsError.IdentityNotFound("aa")

--- a/rns-backend-kt/src/main/kotlin/network/columba/app/rns/backend/kt/NativeNomadNetHandler.kt
+++ b/rns-backend-kt/src/main/kotlin/network/columba/app/rns/backend/kt/NativeNomadNetHandler.kt
@@ -158,6 +158,17 @@ internal class NativeNomadNetHandler(
     internal fun isMsgpackFalse(bytes: ByteArray): Boolean =
         bytes.size == 1 && bytes[0] == 0xC0.toByte()
 
+    /** Live stats of the active NomadNet link, for the image auto-load gate
+     *  (upstream Browser.py reads `link.rtt` / `link.get_expected_rate()`). */
+    fun getLinkStats(destinationHash: String): network.columba.app.rns.api.model.NomadnetLinkStats? {
+        val link = nomadnetLinks[destinationHash] ?: return null
+        if (link.status != network.reticulum.link.LinkConstants.ACTIVE) return null
+        return network.columba.app.rns.api.model.NomadnetLinkStats(
+            rttSeconds = link.rtt?.let { it / 1000.0 },
+            expectedRateBps = link.getExpectedRate()?.let { it.toLong() },
+        )
+    }
+
     private suspend fun resolveNodeIdentity(
         destinationHash: String,
         destBytes: ByteArray,

--- a/rns-backend-kt/src/main/kotlin/network/columba/app/rns/backend/kt/NativeNomadNetHandler.kt
+++ b/rns-backend-kt/src/main/kotlin/network/columba/app/rns/backend/kt/NativeNomadNetHandler.kt
@@ -1,6 +1,8 @@
 package network.columba.app.rns.backend.kt
 
 import android.util.Log
+import kotlinx.coroutines.currentCoroutineContext
+import kotlinx.coroutines.job
 import kotlinx.coroutines.flow.MutableStateFlow
 import network.columba.app.rns.api.util.hexToBytes
 import network.columba.app.rns.api.util.toHex
@@ -98,6 +100,7 @@ internal class NativeNomadNetHandler(
         destinationHash: String,
         path: String,
         timeoutSeconds: Float,
+        maxBytes: Long = Long.MAX_VALUE,
     ): Result<network.columba.app.rns.api.model.NomadnetMediaResult> =
         kotlinx.coroutines.withContext(kotlinx.coroutines.Dispatchers.IO) {
             runCatching {
@@ -121,6 +124,20 @@ internal class NativeNomadNetHandler(
                     Log.i(TAG, "NomadNet: media request denied by node for $path")
                     throw network.columba.app.rns.api.RnsException(
                         network.columba.app.rns.api.RnsError.NomadnetRequestDenied(destinationHash, path),
+                    )
+                }
+                // Enforce the transfer cap at the response boundary, before the
+                // payload is written to temporary storage or handed back. The RNS
+                // Link API delivers the full body to the callback at once (no
+                // streaming), so this is the earliest point after delivery; failing
+                // here keeps an oversized payload off disk and out of the image
+                // cache, and surfaces a typed error instead of a generic one.
+                if (data.size.toLong() > maxBytes) {
+                    Log.w(TAG, "NomadNet: media response too large for $path (${data.size} > $maxBytes)")
+                    throw network.columba.app.rns.api.RnsException(
+                        network.columba.app.rns.api.RnsError.NomadnetResponseTooLarge(
+                            destinationHash, path, data.size.toLong(), maxBytes,
+                        ),
                     )
                 }
                 if (data.isEmpty()) error("Empty media response for $path")
@@ -314,7 +331,7 @@ internal class NativeNomadNetHandler(
         val error: String?,
     )
 
-    private fun sendPageRequest(
+    private suspend fun sendPageRequest(
         link: network.reticulum.link.Link,
         path: String,
         requestData: Any?,
@@ -351,7 +368,29 @@ internal class NativeNomadNetHandler(
         )
 
         val requestTimeout = (timeoutSeconds * 1000 * 2 / 3).toLong().coerceAtLeast(10000)
-        responseLatch.await(requestTimeout, java.util.concurrent.TimeUnit.MILLISECONDS)
+        // Poll the latch in short increments instead of one blocking
+        // `await(timeout)` so a cancelled caller (the page-image loader queue
+        // unwinding on navigation, or cancelNomadnetPageRequest) releases the
+        // wait promptly. A non-cancellable full-timeout await left the native
+        // backend blocked for up to the whole deadline even after the request's
+        // coroutine was cancelled, so stale image traffic kept competing with
+        // the next page request over the shared NomadNet link. ensureActive()
+        // throws CancellationException on the next tick, which the caller's
+        // withContext/runCatching surfaces as a cancelled fetch.
+        val deadline = System.currentTimeMillis() + requestTimeout
+        var finished = false
+        while (!finished) {
+            // Cancellation check: if the caller's job was cancelled (page-image
+            // loader queue unwinding on navigation, or cancelNomadnetPageRequest),
+            // stop waiting and surface a CancellationException so the stale fetch
+            // is dropped instead of holding the link for the whole deadline.
+            if (currentCoroutineContext().job?.isActive == false) {
+                throw java.util.concurrent.CancellationException("Cancelled")
+            }
+            val remaining = deadline - System.currentTimeMillis()
+            finished = remaining <= 0L ||
+                responseLatch.await(minOf(100L, remaining), java.util.concurrent.TimeUnit.MILLISECONDS)
+        }
         Log.i(TAG, "NomadNet: latch returned gotResponse=${responseBytes != null}, responseBytes=${responseBytes?.size}, error=$responseError")
 
         return PageResponse(responseBytes, responseMetadata, responseError)

--- a/rns-backend-kt/src/main/kotlin/network/columba/app/rns/backend/kt/NativeNomadNetHandler.kt
+++ b/rns-backend-kt/src/main/kotlin/network/columba/app/rns/backend/kt/NativeNomadNetHandler.kt
@@ -83,6 +83,81 @@ internal class NativeNomadNetHandler(
             }
         }
 
+    /**
+     * Fetch a `/media/` object (page image) from a NomadNet node.
+     *
+     * Mirrors upstream Browser.py `__load_image`: request `/media` with data
+     * `{"path": <full media path>, "key": None}` on the (reused, else fresh)
+     * node link. A file response arrives with metadata and the raw body in
+     * `receipt.response`; a server-side denial (Node.py `serve_media`
+     * returning `False`, commit 3028301) arrives as a msgpack `false` body
+     * (single byte 0xC0 after reticulum-kt re-serialises the scalar) and is
+     * surfaced as [network.columba.app.rns.api.RnsError.NomadnetRequestDenied].
+     */
+    suspend fun requestNomadnetMedia(
+        destinationHash: String,
+        path: String,
+        timeoutSeconds: Float,
+    ): Result<network.columba.app.rns.api.model.NomadnetMediaResult> =
+        kotlinx.coroutines.withContext(kotlinx.coroutines.Dispatchers.IO) {
+            runCatching {
+                nomadnetCancelled = false
+                requestStatusFlow.value = "requesting media"
+                downloadProgressFlow.value = 0f
+
+                val destBytes = destinationHash.hexToBytes()
+                val nodeIdentity = resolveNodeIdentity(destinationHash, destBytes)
+                val (link, _) = resolveOrEstablishLink(destinationHash, nodeIdentity, destBytes, timeoutSeconds)
+
+                // Upstream serve_media requires both keys; "path" carries the
+                // full "/media/..." path (it strips the prefix itself).
+                val requestData: Map<String, Any?> = mapOf("path" to path, "key" to null)
+                val response = sendPageRequest(link, "/media", requestData, timeoutSeconds)
+
+                if (nomadnetCancelled) throw java.util.concurrent.CancellationException("Cancelled")
+                val data = response.bytes
+                    ?: error(response.error ?: "Media request timed out")
+                if (isMsgpackFalse(data)) {
+                    Log.i(TAG, "NomadNet: media request denied by node for $path")
+                    throw network.columba.app.rns.api.RnsException(
+                        network.columba.app.rns.api.RnsError.NomadnetRequestDenied(destinationHash, path),
+                    )
+                }
+                if (data.isEmpty()) error("Empty media response for $path")
+
+                // Unique per-fetch destination file so concurrent media loads
+                // of same-named files never clobber each other; the image
+                // cache layer moves this into its URL-keyed cache.
+                val rawName = java.io.File(path).name.ifBlank { "media" }
+                val mediaDir =
+                    appContext?.cacheDir?.resolve("nomadnet_media")
+                        ?: java.io.File(System.getProperty("java.io.tmpdir") ?: "/tmp", "nomadnet_media")
+                mediaDir.mkdirs()
+                val outFile = mediaDir.resolve("${System.nanoTime()}.$rawName")
+                check(outFile.canonicalPath.startsWith(mediaDir.canonicalPath + java.io.File.separator)) {
+                    "Rejected path traversal attempt in NomadNet media: $rawName"
+                }
+                outFile.writeBytes(data)
+
+                requestStatusFlow.value = "complete"
+                downloadProgressFlow.value = 1f
+                Log.i(TAG, "NomadNet: media fetched $path (${data.size} bytes)")
+                network.columba.app.rns.api.model.NomadnetMediaResult(
+                    filePath = outFile.absolutePath,
+                    fileName = rawName,
+                    fileSize = data.size.toLong(),
+                    path = path,
+                )
+            }.onFailure {
+                requestStatusFlow.value = if (nomadnetCancelled) "cancelled" else "failed"
+            }
+        }
+
+    /** True when [bytes] is exactly the msgpack encoding of `false` (0xC0),
+     *  the deny signal upstream NomadNet nodes send for gated media. */
+    internal fun isMsgpackFalse(bytes: ByteArray): Boolean =
+        bytes.size == 1 && bytes[0] == 0xC0.toByte()
+
     private suspend fun resolveNodeIdentity(
         destinationHash: String,
         destBytes: ByteArray,

--- a/rns-backend-kt/src/main/kotlin/network/columba/app/rns/backend/kt/NativeRnsBackendImpl.kt
+++ b/rns-backend-kt/src/main/kotlin/network/columba/app/rns/backend/kt/NativeRnsBackendImpl.kt
@@ -2259,6 +2259,9 @@ class NativeRnsBackendImpl(
     ): Result<network.columba.app.rns.api.model.NomadnetMediaResult> =
         nomadNetHandler.requestNomadnetMedia(destinationHash, path, timeoutSeconds)
 
+    override suspend fun getNomadnetLinkStats(destinationHash: String): network.columba.app.rns.api.model.NomadnetLinkStats? =
+        nomadNetHandler.getLinkStats(destinationHash)
+
     override suspend fun getNomadnetRequestStatus(): String = nomadNetHandler.requestStatusFlow.value
 
     override suspend fun getNomadnetDownloadProgress(): Float = nomadNetHandler.downloadProgressFlow.value

--- a/rns-backend-kt/src/main/kotlin/network/columba/app/rns/backend/kt/NativeRnsBackendImpl.kt
+++ b/rns-backend-kt/src/main/kotlin/network/columba/app/rns/backend/kt/NativeRnsBackendImpl.kt
@@ -2252,6 +2252,13 @@ class NativeRnsBackendImpl(
         nomadNetHandler.requestStatusFlow.value = "cancelled"
     }
 
+    override suspend fun requestNomadnetMedia(
+        destinationHash: String,
+        path: String,
+        timeoutSeconds: Float,
+    ): Result<network.columba.app.rns.api.model.NomadnetMediaResult> =
+        nomadNetHandler.requestNomadnetMedia(destinationHash, path, timeoutSeconds)
+
     override suspend fun getNomadnetRequestStatus(): String = nomadNetHandler.requestStatusFlow.value
 
     override suspend fun getNomadnetDownloadProgress(): Float = nomadNetHandler.downloadProgressFlow.value

--- a/rns-backend-kt/src/main/kotlin/network/columba/app/rns/backend/kt/NativeRnsBackendImpl.kt
+++ b/rns-backend-kt/src/main/kotlin/network/columba/app/rns/backend/kt/NativeRnsBackendImpl.kt
@@ -2256,8 +2256,9 @@ class NativeRnsBackendImpl(
         destinationHash: String,
         path: String,
         timeoutSeconds: Float,
+        maxBytes: Long,
     ): Result<network.columba.app.rns.api.model.NomadnetMediaResult> =
-        nomadNetHandler.requestNomadnetMedia(destinationHash, path, timeoutSeconds)
+        nomadNetHandler.requestNomadnetMedia(destinationHash, path, timeoutSeconds, maxBytes)
 
     override suspend fun getNomadnetLinkStats(destinationHash: String): network.columba.app.rns.api.model.NomadnetLinkStats? =
         nomadNetHandler.getLinkStats(destinationHash)

--- a/rns-backend-py/src/main/kotlin/network/columba/app/rns/backend/py/PythonRnsNomadnet.kt
+++ b/rns-backend-py/src/main/kotlin/network/columba/app/rns/backend/py/PythonRnsNomadnet.kt
@@ -462,7 +462,12 @@ class PythonRnsNomadnet(
      * poll the capture to completion (same pattern as [sendPageRequest] /
      * [awaitResponse]: file-response bodies are snapshot Python-side before
      * upstream closes the backing temp file).
+     *
+     * Each failure mode (denied / error / null body / FAILED status /
+     * timeout) throws a distinct typed RnsException — collapsing them would
+     * lose the failure distinction (see [awaitResponse]).
      */
+    @Suppress("ThrowsCount")
     private suspend fun sendMediaRequest(
         link: PyObject,
         requestData: PyObject,

--- a/rns-backend-py/src/main/kotlin/network/columba/app/rns/backend/py/PythonRnsNomadnet.kt
+++ b/rns-backend-py/src/main/kotlin/network/columba/app/rns/backend/py/PythonRnsNomadnet.kt
@@ -411,6 +411,7 @@ class PythonRnsNomadnet(
         destinationHash: String,
         path: String,
         timeoutSeconds: Float,
+        maxBytes: Long,
     ): Result<NomadnetMediaResult> =
         pyResult {
             runtime.requireRunning()
@@ -428,6 +429,22 @@ class PythonRnsNomadnet(
                 // (toPyDict's __setitem__ passthrough maps Kotlin null).
                 val requestData = mapOf("path" to path, "key" to null).toPyDict()
                 val response = sendMediaRequest(link, requestData, timeoutSeconds, destinationHash)
+
+                // Enforce the transfer cap at the response boundary, before the
+                // payload is written to the staging file. RNS/LXMF deliver the
+                // full body to the receipt callback at once (no streaming), so
+                // this is the earliest point the Kotlin layer can act after
+                // delivery; failing here keeps an oversized payload off disk and
+                // out of the image cache and surfaces a typed error instead of
+                // the caller-side size check in PageImageLoader.fetchOne.
+                if (response.size.toLong() > maxBytes) {
+                    Log.w(TAG, "NomadNet: media response too large for $path (${response.size} > $maxBytes)")
+                    throw RnsException(
+                        RnsError.NomadnetResponseTooLarge(
+                            destinationHash, path, response.size.toLong(), maxBytes,
+                        ),
+                    )
+                }
 
                 _nomadnetRequestStatusFlow.value = "complete"
                 _nomadnetDownloadProgressFlow.value = 1f

--- a/rns-backend-py/src/main/kotlin/network/columba/app/rns/backend/py/PythonRnsNomadnet.kt
+++ b/rns-backend-py/src/main/kotlin/network/columba/app/rns/backend/py/PythonRnsNomadnet.kt
@@ -10,6 +10,7 @@ import kotlinx.coroutines.flow.asStateFlow
 import network.columba.app.rns.api.RnsError
 import network.columba.app.rns.api.RnsException
 import network.columba.app.rns.api.RnsNomadnet
+import network.columba.app.rns.api.model.NomadnetMediaResult
 import network.columba.app.rns.api.model.NomadnetPageResult
 import org.json.JSONObject
 import java.io.File
@@ -398,6 +399,119 @@ class PythonRnsNomadnet(
     }
 
     // ==================== Cancellation & status ====================
+
+    /**
+     * Fetch a `/media/` object (page image), mirroring
+     * [requestNomadnetPage]'s choreography. The capture's `denied` flag
+     * (event_bridge) carries upstream's explicit `False` deny signal for
+     * gated media, surfaced as [RnsError.NomadnetRequestDenied].
+     */
+    override suspend fun requestNomadnetMedia(
+        destinationHash: String,
+        path: String,
+        timeoutSeconds: Float,
+    ): Result<NomadnetMediaResult> =
+        pyResult {
+            runtime.requireRunning()
+            cancelled = false
+            _nomadnetRequestStatusFlow.value = "requesting"
+            _nomadnetDownloadProgressFlow.value = 0f
+
+            try {
+                val destBytes = destinationHash.hexToBytes()
+                val nodeIdentity = resolveNodeIdentity(destinationHash, destBytes, timeoutSeconds)
+                val link = establishLink(destinationHash, nodeIdentity, timeoutSeconds)
+
+                // Upstream serve_media requires {"path", "key"}; "path"
+                // carries the full "/media/..." path, "key" is Python None
+                // (toPyDict's __setitem__ passthrough maps Kotlin null).
+                val requestData = mapOf("path" to path, "key" to null).toPyDict()
+                val response = sendMediaRequest(link, requestData, timeoutSeconds, destinationHash)
+
+                _nomadnetRequestStatusFlow.value = "complete"
+                _nomadnetDownloadProgressFlow.value = 1f
+
+                // Unique per-fetch file name so same-named images on one page
+                // never clobber each other in flight.
+                val rawName = java.io.File(path).name.ifBlank { "media" }
+                val mediaDir = File(
+                    System.getProperty("java.io.tmpdir") ?: "/tmp",
+                    "nomadnet_media",
+                ).apply { mkdirs() }
+                val outFile = File(mediaDir, "${System.nanoTime()}.$rawName")
+                check(
+                    outFile.canonicalPath.startsWith(mediaDir.canonicalPath + File.separator),
+                ) { "Rejected path traversal in NomadNet media: $rawName" }
+                outFile.writeBytes(response)
+                Log.i(TAG, "NomadNet: media fetched $path (${response.size} bytes)")
+                NomadnetMediaResult(
+                    filePath = outFile.absolutePath,
+                    fileName = rawName,
+                    fileSize = response.size.toLong(),
+                    path = path,
+                )
+            } catch (e: Throwable) {
+                _nomadnetRequestStatusFlow.value = if (cancelled) "idle" else "failed"
+                throw e
+            }
+        }
+
+    /**
+     * Issue `link.request("/media", {"path": ..., "key": None}, ...)` and
+     * poll the capture to completion (same pattern as [sendPageRequest] /
+     * [awaitResponse]: file-response bodies are snapshot Python-side before
+     * upstream closes the backing temp file).
+     */
+    private suspend fun sendMediaRequest(
+        link: PyObject,
+        requestData: PyObject,
+        timeoutSeconds: Float,
+        destinationHash: String,
+    ): ByteArray {
+        val capture = runtime.eventBridge.callAttr("make_nomadnet_response_capture")
+        val receipt = link.callAttr(
+            "request",
+            "/media",
+            requestData,
+            capture["on_response"],
+            capture["on_failed"],
+            null,
+            timeoutSeconds.toDouble(),
+        )
+        if (receipt == null || receipt.toString() == "False") {
+            throw RnsException(
+                RnsError.Generic("NomadNet media request could not be sent", null),
+            )
+        }
+
+        _nomadnetRequestStatusFlow.value = "receiving"
+        val deadline = System.currentTimeMillis() + (timeoutSeconds * 1000).toLong()
+        while (System.currentTimeMillis() < deadline) {
+            throwIfCancelled()
+            val progress = receipt["progress"]?.toJava(Float::class.javaObjectType) ?: 0f
+            _nomadnetDownloadProgressFlow.value = progress.coerceIn(0f, 1f)
+
+            if (capture["done"]?.toJava(Boolean::class.javaObjectType) == true) {
+                if (capture["denied"]?.toJava(Boolean::class.javaObjectType) == true) {
+                    throw RnsException(RnsError.NomadnetRequestDenied(destinationHash, "/media"))
+                }
+                capture["error"]?.toString()?.takeIf { it.isNotEmpty() && it != "None" }?.let {
+                    throw RnsException(
+                        RnsError.Generic("NomadNet media request failed: $it", null),
+                    )
+                }
+                return capture["response_bytes"]?.toJava(ByteArray::class.java)
+                    ?: throw RnsException(
+                        RnsError.Generic("NomadNet media response READY but body was null", null),
+                    )
+            }
+            if (receipt["status"]?.toJava(Long::class.javaObjectType) == RECEIPT_FAILED) {
+                throw RnsException(RnsError.Generic("NomadNet media request failed", null))
+            }
+            delay(POLL_INTERVAL_MS)
+        }
+        throw RnsException(RnsError.Generic("NomadNet media request timed out", null))
+    }
 
     override suspend fun cancelNomadnetPageRequest() {
         cancelled = true

--- a/rns-backend-py/src/main/kotlin/network/columba/app/rns/backend/py/PythonRnsNomadnet.kt
+++ b/rns-backend-py/src/main/kotlin/network/columba/app/rns/backend/py/PythonRnsNomadnet.kt
@@ -10,6 +10,7 @@ import kotlinx.coroutines.flow.asStateFlow
 import network.columba.app.rns.api.RnsError
 import network.columba.app.rns.api.RnsException
 import network.columba.app.rns.api.RnsNomadnet
+import network.columba.app.rns.api.model.NomadnetLinkStats
 import network.columba.app.rns.api.model.NomadnetMediaResult
 import network.columba.app.rns.api.model.NomadnetPageResult
 import org.json.JSONObject
@@ -562,6 +563,20 @@ class PythonRnsNomadnet(
             Log.i(TAG, "NomadNet: sent identify proof on link to $destinationHash")
             false
         }
+
+    /** Live stats of the cached link, mirroring the kotlin backend's gate data. */
+    override suspend fun getNomadnetLinkStats(destinationHash: String): NomadnetLinkStats? {
+        val link = nomadnetLinks[destinationHash] ?: return null
+        if (linkStatus(link) != LINK_ACTIVE) return null
+        return NomadnetLinkStats(
+            // Python RNS exposes link.rtt in SECONDS (reticulum-kt uses millis).
+            rttSeconds = link["rtt"]?.toJava(Double::class.javaObjectType)
+                ?: link["rtt"]?.toJava(Float::class.javaObjectType)?.toDouble(),
+            expectedRateBps = runCatching {
+                link.callAttr("get_expected_rate")?.toJava(Float::class.javaObjectType)?.toLong()
+            }.getOrNull(),
+        )
+    }
 
     // ==================== Internal helpers ====================
 

--- a/rns-backend-py/src/main/python/event_bridge.py
+++ b/rns-backend-py/src/main/python/event_bridge.py
@@ -1655,13 +1655,21 @@ def make_nomadnet_response_capture():
         # unnecessary work. The Kotlin consumer
         # (`PythonRnsNomadnet.buildPageResult`) only ever needed the name.
         metadata_name_bytes=b"",
+        # True iff the server's response value was exactly `False` — the
+        # explicit deny signal upstream NomadNet nodes send for gated
+        # requests (Node.py serve_media returning False, 3028301). Kept
+        # separate from response_bytes so the deny never reaches Kotlin as
+        # the mangled literal b"False".
+        denied=False,
         error=None,
     )
 
     def _on_response(receipt):
         try:
             r = getattr(receipt, "response", None)
-            if hasattr(r, "read"):
+            if r is False:
+                cap.denied = True
+            elif hasattr(r, "read"):
                 cap.response_bytes = r.read()
             elif isinstance(r, (bytes, bytearray)):
                 cap.response_bytes = bytes(r)

--- a/rns-host/src/main/kotlin/network/columba/app/rns/host/ipc/BoundRnsNomadnet.kt
+++ b/rns-host/src/main/kotlin/network/columba/app/rns/host/ipc/BoundRnsNomadnet.kt
@@ -10,6 +10,7 @@ import kotlinx.coroutines.flow.flatMapLatest
 import kotlinx.coroutines.flow.stateIn
 import network.columba.app.rns.api.RnsBackend
 import network.columba.app.rns.api.RnsNomadnet
+import network.columba.app.rns.api.model.NomadnetMediaResult
 import network.columba.app.rns.api.model.NomadnetPageResult
 
 /**
@@ -38,6 +39,13 @@ internal class BoundRnsNomadnet(
     override suspend fun cancelNomadnetPageRequest() {
         awaitBound().nomadnet.cancelNomadnetPageRequest()
     }
+
+    override suspend fun requestNomadnetMedia(
+        destinationHash: String,
+        path: String,
+        timeoutSeconds: Float,
+    ): Result<NomadnetMediaResult> =
+        awaitBound().nomadnet.requestNomadnetMedia(destinationHash, path, timeoutSeconds)
 
     override suspend fun getNomadnetRequestStatus(): String =
         awaitBound().nomadnet.getNomadnetRequestStatus()

--- a/rns-host/src/main/kotlin/network/columba/app/rns/host/ipc/BoundRnsNomadnet.kt
+++ b/rns-host/src/main/kotlin/network/columba/app/rns/host/ipc/BoundRnsNomadnet.kt
@@ -10,6 +10,7 @@ import kotlinx.coroutines.flow.flatMapLatest
 import kotlinx.coroutines.flow.stateIn
 import network.columba.app.rns.api.RnsBackend
 import network.columba.app.rns.api.RnsNomadnet
+import network.columba.app.rns.api.model.NomadnetLinkStats
 import network.columba.app.rns.api.model.NomadnetMediaResult
 import network.columba.app.rns.api.model.NomadnetPageResult
 
@@ -46,6 +47,9 @@ internal class BoundRnsNomadnet(
         timeoutSeconds: Float,
     ): Result<NomadnetMediaResult> =
         awaitBound().nomadnet.requestNomadnetMedia(destinationHash, path, timeoutSeconds)
+
+    override suspend fun getNomadnetLinkStats(destinationHash: String): NomadnetLinkStats? =
+        runCatching { awaitBound().nomadnet.getNomadnetLinkStats(destinationHash) }.getOrNull()
 
     override suspend fun getNomadnetRequestStatus(): String =
         awaitBound().nomadnet.getNomadnetRequestStatus()

--- a/rns-host/src/main/kotlin/network/columba/app/rns/host/ipc/BoundRnsNomadnet.kt
+++ b/rns-host/src/main/kotlin/network/columba/app/rns/host/ipc/BoundRnsNomadnet.kt
@@ -45,8 +45,9 @@ internal class BoundRnsNomadnet(
         destinationHash: String,
         path: String,
         timeoutSeconds: Float,
+        maxBytes: Long,
     ): Result<NomadnetMediaResult> =
-        awaitBound().nomadnet.requestNomadnetMedia(destinationHash, path, timeoutSeconds)
+        awaitBound().nomadnet.requestNomadnetMedia(destinationHash, path, timeoutSeconds, maxBytes)
 
     override suspend fun getNomadnetLinkStats(destinationHash: String): NomadnetLinkStats? =
         runCatching { awaitBound().nomadnet.getNomadnetLinkStats(destinationHash) }.getOrNull()

--- a/rns-host/src/test/kotlin/network/columba/app/rns/host/ipc/BoundRnsBackendTest.kt
+++ b/rns-host/src/test/kotlin/network/columba/app/rns/host/ipc/BoundRnsBackendTest.kt
@@ -413,6 +413,7 @@ class BoundRnsBackendTest {
     private class StubRnsNomadnet : RnsNomadnet {
         override suspend fun requestNomadnetPage(destinationHash: String, path: String, formDataJson: String?, timeoutSeconds: Float): Result<NomadnetPageResult> = error("not used")
         override suspend fun cancelNomadnetPageRequest() {}
+        override suspend fun requestNomadnetMedia(destinationHash: String, path: String, timeoutSeconds: Float): Result<network.columba.app.rns.api.model.NomadnetMediaResult> = error("not used")
         override suspend fun getNomadnetRequestStatus(): String = "idle"
         override suspend fun getNomadnetDownloadProgress(): Float = 0f
         override suspend fun identifyNomadnetLink(destinationHash: String) = Result.success(false)

--- a/rns-host/src/test/kotlin/network/columba/app/rns/host/ipc/BoundRnsBackendTest.kt
+++ b/rns-host/src/test/kotlin/network/columba/app/rns/host/ipc/BoundRnsBackendTest.kt
@@ -41,6 +41,7 @@ import network.columba.app.rns.api.model.LinkSpeedProbeResult
 import network.columba.app.rns.api.model.LocationTelemetry
 import network.columba.app.rns.api.model.MessageReceipt
 import network.columba.app.rns.api.model.NetworkStatus
+import network.columba.app.rns.api.model.NomadnetLinkStats
 import network.columba.app.rns.api.model.NomadnetPageResult
 import network.columba.app.rns.api.model.PacketReceipt
 import network.columba.app.rns.api.model.PacketType
@@ -414,6 +415,7 @@ class BoundRnsBackendTest {
         override suspend fun requestNomadnetPage(destinationHash: String, path: String, formDataJson: String?, timeoutSeconds: Float): Result<NomadnetPageResult> = error("not used")
         override suspend fun cancelNomadnetPageRequest() {}
         override suspend fun requestNomadnetMedia(destinationHash: String, path: String, timeoutSeconds: Float): Result<network.columba.app.rns.api.model.NomadnetMediaResult> = error("not used")
+        override suspend fun getNomadnetLinkStats(destinationHash: String): NomadnetLinkStats? = null
         override suspend fun getNomadnetRequestStatus(): String = "idle"
         override suspend fun getNomadnetDownloadProgress(): Float = 0f
         override suspend fun identifyNomadnetLink(destinationHash: String) = Result.success(false)

--- a/rns-host/src/test/kotlin/network/columba/app/rns/host/ipc/BoundRnsBackendTest.kt
+++ b/rns-host/src/test/kotlin/network/columba/app/rns/host/ipc/BoundRnsBackendTest.kt
@@ -414,7 +414,12 @@ class BoundRnsBackendTest {
     private class StubRnsNomadnet : RnsNomadnet {
         override suspend fun requestNomadnetPage(destinationHash: String, path: String, formDataJson: String?, timeoutSeconds: Float): Result<NomadnetPageResult> = error("not used")
         override suspend fun cancelNomadnetPageRequest() {}
-        override suspend fun requestNomadnetMedia(destinationHash: String, path: String, timeoutSeconds: Float): Result<network.columba.app.rns.api.model.NomadnetMediaResult> = error("not used")
+        override suspend fun requestNomadnetMedia(
+            destinationHash: String,
+            path: String,
+            timeoutSeconds: Float,
+            maxBytes: Long,
+        ): Result<network.columba.app.rns.api.model.NomadnetMediaResult> = error("not used")
         override suspend fun getNomadnetLinkStats(destinationHash: String): NomadnetLinkStats? = null
         override suspend fun getNomadnetRequestStatus(): String = "idle"
         override suspend fun getNomadnetDownloadProgress(): Float = 0f

--- a/rns-ipc/src/main/kotlin/network/columba/app/rns/ipc/BundleKeys.kt
+++ b/rns-ipc/src/main/kotlin/network/columba/app/rns/ipc/BundleKeys.kt
@@ -42,6 +42,7 @@ internal object BundleKeys {
     // RnsNomadnet
     const val PAGE = "page"
     const val MEDIA = "media"
+    const val STATS = "stats"
 
     // RnsTransportAdmin
     const val INTERFACES = "interfaces"

--- a/rns-ipc/src/main/kotlin/network/columba/app/rns/ipc/BundleKeys.kt
+++ b/rns-ipc/src/main/kotlin/network/columba/app/rns/ipc/BundleKeys.kt
@@ -41,6 +41,7 @@ internal object BundleKeys {
 
     // RnsNomadnet
     const val PAGE = "page"
+    const val MEDIA = "media"
 
     // RnsTransportAdmin
     const val INTERFACES = "interfaces"

--- a/rns-ipc/src/main/kotlin/network/columba/app/rns/ipc/client/ClientRnsNomadnet.kt
+++ b/rns-ipc/src/main/kotlin/network/columba/app/rns/ipc/client/ClientRnsNomadnet.kt
@@ -47,9 +47,10 @@ internal class ClientRnsNomadnet(
         destinationHash: String,
         path: String,
         timeoutSeconds: Float,
+        maxBytes: Long,
     ): Result<NomadnetMediaResult> = runCatching {
         val bundle = awaitResult { cb ->
-            remote.requestNomadnetMedia(destinationHash, path, timeoutSeconds, cb)
+            remote.requestNomadnetMedia(destinationHash, path, timeoutSeconds, maxBytes, cb)
         }
         bundle.classLoader = NomadnetMediaResult::class.java.classLoader
         @Suppress("DEPRECATION")

--- a/rns-ipc/src/main/kotlin/network/columba/app/rns/ipc/client/ClientRnsNomadnet.kt
+++ b/rns-ipc/src/main/kotlin/network/columba/app/rns/ipc/client/ClientRnsNomadnet.kt
@@ -12,6 +12,7 @@ import kotlinx.coroutines.launch
 import network.columba.app.rns.api.RnsError
 import network.columba.app.rns.api.RnsException
 import network.columba.app.rns.api.RnsNomadnet
+import network.columba.app.rns.api.model.NomadnetLinkStats
 import network.columba.app.rns.api.model.NomadnetMediaResult
 import network.columba.app.rns.api.model.NomadnetPageResult
 import network.columba.app.rns.ipc.BundleKeys
@@ -54,6 +55,15 @@ internal class ClientRnsNomadnet(
         @Suppress("DEPRECATION")
         bundle.getParcelable<NomadnetMediaResult>(BundleKeys.MEDIA)
             ?: throw RnsException(RnsError.Generic("requestNomadnetMedia payload missing 'media'", null))
+    }
+
+    override suspend fun getNomadnetLinkStats(destinationHash: String): NomadnetLinkStats? {
+        val bundle =
+            runCatching { awaitResult { cb -> remote.getNomadnetLinkStats(destinationHash, cb) } }
+                .getOrNull() ?: return null
+        bundle.classLoader = NomadnetLinkStats::class.java.classLoader
+        @Suppress("DEPRECATION")
+        return bundle.getParcelable<NomadnetLinkStats>(BundleKeys.STATS)
     }
 
     override suspend fun getNomadnetRequestStatus(): String =

--- a/rns-ipc/src/main/kotlin/network/columba/app/rns/ipc/client/ClientRnsNomadnet.kt
+++ b/rns-ipc/src/main/kotlin/network/columba/app/rns/ipc/client/ClientRnsNomadnet.kt
@@ -12,6 +12,7 @@ import kotlinx.coroutines.launch
 import network.columba.app.rns.api.RnsError
 import network.columba.app.rns.api.RnsException
 import network.columba.app.rns.api.RnsNomadnet
+import network.columba.app.rns.api.model.NomadnetMediaResult
 import network.columba.app.rns.api.model.NomadnetPageResult
 import network.columba.app.rns.ipc.BundleKeys
 import network.columba.app.rns.ipc.IRnsNomadnet
@@ -39,6 +40,20 @@ internal class ClientRnsNomadnet(
 
     override suspend fun cancelNomadnetPageRequest() {
         awaitResult { cb -> remote.cancelNomadnetPageRequest(cb) }
+    }
+
+    override suspend fun requestNomadnetMedia(
+        destinationHash: String,
+        path: String,
+        timeoutSeconds: Float,
+    ): Result<NomadnetMediaResult> = runCatching {
+        val bundle = awaitResult { cb ->
+            remote.requestNomadnetMedia(destinationHash, path, timeoutSeconds, cb)
+        }
+        bundle.classLoader = NomadnetMediaResult::class.java.classLoader
+        @Suppress("DEPRECATION")
+        bundle.getParcelable<NomadnetMediaResult>(BundleKeys.MEDIA)
+            ?: throw RnsException(RnsError.Generic("requestNomadnetMedia payload missing 'media'", null))
     }
 
     override suspend fun getNomadnetRequestStatus(): String =

--- a/rns-ipc/src/main/kotlin/network/columba/app/rns/ipc/server/ServerRnsNomadnet.kt
+++ b/rns-ipc/src/main/kotlin/network/columba/app/rns/ipc/server/ServerRnsNomadnet.kt
@@ -56,6 +56,13 @@ internal class ServerRnsNomadnet(
         Bundle().apply { putParcelable(BundleKeys.MEDIA, media) }
     }
 
+    override fun getNomadnetLinkStats(
+        destinationHash: String,
+        cb: IRnsResultCallback,
+    ) = dispatch(cb, scope) {
+        Bundle().apply { putParcelable(BundleKeys.STATS, impl.getNomadnetLinkStats(destinationHash)) }
+    }
+
     override fun getNomadnetRequestStatus(cb: IRnsStringCallback) = dispatchNullableString(cb, scope) {
         impl.getNomadnetRequestStatus()
     }

--- a/rns-ipc/src/main/kotlin/network/columba/app/rns/ipc/server/ServerRnsNomadnet.kt
+++ b/rns-ipc/src/main/kotlin/network/columba/app/rns/ipc/server/ServerRnsNomadnet.kt
@@ -50,9 +50,10 @@ internal class ServerRnsNomadnet(
         destinationHash: String,
         path: String,
         timeoutSeconds: Float,
+        maxBytes: Long,
         cb: IRnsResultCallback,
     ) = dispatch(cb, scope) {
-        val media = impl.requestNomadnetMedia(destinationHash, path, timeoutSeconds).getOrThrow()
+        val media = impl.requestNomadnetMedia(destinationHash, path, timeoutSeconds, maxBytes).getOrThrow()
         Bundle().apply { putParcelable(BundleKeys.MEDIA, media) }
     }
 

--- a/rns-ipc/src/main/kotlin/network/columba/app/rns/ipc/server/ServerRnsNomadnet.kt
+++ b/rns-ipc/src/main/kotlin/network/columba/app/rns/ipc/server/ServerRnsNomadnet.kt
@@ -46,6 +46,16 @@ internal class ServerRnsNomadnet(
         Bundle.EMPTY
     }
 
+    override fun requestNomadnetMedia(
+        destinationHash: String,
+        path: String,
+        timeoutSeconds: Float,
+        cb: IRnsResultCallback,
+    ) = dispatch(cb, scope) {
+        val media = impl.requestNomadnetMedia(destinationHash, path, timeoutSeconds).getOrThrow()
+        Bundle().apply { putParcelable(BundleKeys.MEDIA, media) }
+    }
+
     override fun getNomadnetRequestStatus(cb: IRnsStringCallback) = dispatchNullableString(cb, scope) {
         impl.getNomadnetRequestStatus()
     }

--- a/rns-ipc/src/test/java/network/columba/app/rns/ipc/RnsBackendIpcRoundTripTest.kt
+++ b/rns-ipc/src/test/java/network/columba/app/rns/ipc/RnsBackendIpcRoundTripTest.kt
@@ -733,6 +733,7 @@ private class FakeRnsNomadnet : RnsNomadnet {
         destinationHash: String,
         path: String,
         timeoutSeconds: Float,
+        maxBytes: Long,
     ): Result<network.columba.app.rns.api.model.NomadnetMediaResult> = Result.failure(NotImplementedError())
     override suspend fun getNomadnetLinkStats(destinationHash: String): NomadnetLinkStats? = null
     override suspend fun getNomadnetRequestStatus(): String = status.value

--- a/rns-ipc/src/test/java/network/columba/app/rns/ipc/RnsBackendIpcRoundTripTest.kt
+++ b/rns-ipc/src/test/java/network/columba/app/rns/ipc/RnsBackendIpcRoundTripTest.kt
@@ -44,6 +44,7 @@ import network.columba.app.rns.api.model.LinkSpeedProbeResult
 import network.columba.app.rns.api.model.LinkStatus
 import network.columba.app.rns.api.model.MessageReceipt
 import network.columba.app.rns.api.model.NetworkStatus
+import network.columba.app.rns.api.model.NomadnetLinkStats
 import network.columba.app.rns.api.model.NomadnetPageResult
 import network.columba.app.rns.api.model.PacketReceipt
 import network.columba.app.rns.api.model.PacketType
@@ -733,6 +734,7 @@ private class FakeRnsNomadnet : RnsNomadnet {
         path: String,
         timeoutSeconds: Float,
     ): Result<network.columba.app.rns.api.model.NomadnetMediaResult> = Result.failure(NotImplementedError())
+    override suspend fun getNomadnetLinkStats(destinationHash: String): NomadnetLinkStats? = null
     override suspend fun getNomadnetRequestStatus(): String = status.value
     override suspend fun getNomadnetDownloadProgress(): Float = progress.value
     override suspend fun identifyNomadnetLink(destinationHash: String) = Result.success(true)

--- a/rns-ipc/src/test/java/network/columba/app/rns/ipc/RnsBackendIpcRoundTripTest.kt
+++ b/rns-ipc/src/test/java/network/columba/app/rns/ipc/RnsBackendIpcRoundTripTest.kt
@@ -728,6 +728,11 @@ private class FakeRnsNomadnet : RnsNomadnet {
         timeoutSeconds: Float,
     ): Result<NomadnetPageResult> = Result.failure(NotImplementedError())
     override suspend fun cancelNomadnetPageRequest() {}
+    override suspend fun requestNomadnetMedia(
+        destinationHash: String,
+        path: String,
+        timeoutSeconds: Float,
+    ): Result<network.columba.app.rns.api.model.NomadnetMediaResult> = Result.failure(NotImplementedError())
     override suspend fun getNomadnetRequestStatus(): String = status.value
     override suspend fun getNomadnetDownloadProgress(): Float = progress.value
     override suspend fun identifyNomadnetLink(destinationHash: String) = Result.success(true)


### PR DESCRIPTION
## Summary

Render inline images in the NomadNet page browser, with upstream-parity loading semantics. This is the full image feature: the `/media` seam, micron image-tag parsing, the page-image loader, the policy/auto-gate, the Compose render, and the tests.

## What's here

**1. `/media` request on the RnsNomadnet seam** (8bfe4185b)
- `requestNomadnetMedia(nodeHash, mediaPath, timeout)` on both backend flavors. Server-side `.allowed` denials surface as a distinct `NomadnetRequestDenied`, not a generic failure.

**2. Micron inline image tags** (d66f17eb6)
- Parser handles the block-level image tag `(alt`w=<spec>`h=<spec>`a=<l|c|r>`:/media/foo.webp)` (upstream c0091db parity). `MicronElement.Image` with alt/url/width/height/align.

**3. Page-image loader + policy** (38e16b3fe, ea92987d1, 227241f38)
- `PageImageLoader` orchestrates a per-page image queue: parse-pass cache hits render instantly with zero requests; everything else waits as a placeholder. Sequential single-flight fetch (one image at a time) so images never starve page traffic.
- `NomadNetImagePolicy` mirrors upstream `Browser.should_load_images`: modes never/manual/auto/always (default auto). Auto gates on link `rtt < 1.5s` AND `edr > 10000 bps` (EDR from link stats, fallback to last page-fetch speed). 16 MiB per-image wire cap in all modes. WebP-only rule at the cache boundary.
- Image loading mode is a persisted setting (browser overflow menu: Images never/manual/auto/always). Manual mode leaves placeholders until an explicit load; the per-image tap loads just that image.

**4. Render fix: decode the cached WebP directly** (3e1090848)
- Coil 2.7.0's `rememberAsyncImagePainter` gates its load on `onDraw`, which never fires for a zero-height node in an unbounded-height scroll - the load deadlocks at `Loading(painter=null)` and nothing renders. The WebP is already on disk when the state is LOADED, so decode it off the main thread (`BitmapFactory.decodeFile` -> `asImageBitmap`) and render `Image(bitmap = ...)`, the same pattern MessagingScreen uses. Height derives from the decoded bitmap's aspect ratio for the width-constrained cases.

**5. Percent + numeric width resolution fix** (26df86cf8)
- `w=100%` was rendering at ~30% width: the old code approximated a percent with a hardcoded `4.11x` multiplier then ran the result through a second `.toDp()` density conversion, collapsing 100% to ~110dp. Percent specs now resolve as a parent-relative fraction (`100%` -> 1.0, `50%` -> 0.5) applied via `fillMaxWidth(fraction)`, which Compose resolves against the Row width - correct in both the monospace scroll (bounded by the viewport) and bounded layouts. The numeric path's spurious `.toDp()` is dropped too, so `w=N` renders at N-times the unit (its documented value).

**6. Per-image tap/reload scope fix** (36c8181d6)
- `retryImage(key)` re-ran the explicit-load queue, which fetches every image still in the placeholder state - so tapping one placeholder in manual mode loaded the whole page. The per-image path now runs the queue restricted to that single key; the "load all" action is unchanged.

**7. Resource-bound + lifecycle hardening** (9dd7356bf)
- 16 MiB per-image transfer cap is now enforced at the response boundary in both backends (before anything is staged to disk or returned to the UI), not just after the fact. A new typed `RnsError.NomadnetResponseTooLarge(destHash, path, receivedBytes, maxBytes)` crosses the IPC seam so the UI can render a precise "image too large" error instead of a generic failure.
- The LOADED render path decodes with a bounds-first pass (`inJustDecodeBounds`, then a computed `inSampleSize` via `ImageUtils.calculateSampleSize`, capped at 2048px), so a page-controlled image can't throw an uncaught `OutOfMemoryError` during decode.
- Cache-clear now re-scans the current document so its images stay loadable; the persisted image-loading mode is restored across ViewModel recreation; a mode change applies to the active loader immediately; the auto-gate is evaluated per-image against each image's own destination node (not once against the page's node); malformed URLs render a non-retryable error (new `MALFORMED` status); navigation cancels the in-flight image queue so stale image traffic doesn't compete over the shared link.
- Test fakes + a `RnsError` round-trip/property test were updated/added for the new error type (9423697e9).

## Known transport-layer constraints (accepted, no RNS changes)
Two items sit at the RNS/reticulum-kt transport boundary and are **accepted as-is** (no reticulum-kt changes in scope):
- **Transfer cap enforced at the earliest point the app controls.** The RNS `Link.request` API delivers the complete response body into `receipt.response` before the response callback fires - it exposes no size-limit, streaming, or early-abort parameter (confirmed against rns-core). The app can therefore only reject an oversized payload once the full body has arrived; it rejects it at the response boundary, before disk staging, cache write, or UI handoff, and surfaces the typed error. Bounding the in-transfer allocation itself would require a reticulum-kt change.
- **Backend media transfer is not interrupted by local cancellation.** Cancelling the UI-side image queue releases the local await, but the media fetch runs in the separate `:reticulum` backend process with no IPC cancellation signal, so the underlying RNS transfer continues until it completes or times out. On a low-bandwidth mesh hop this is bounded by the existing request timeout; adding a real `cancelNomadnetMediaRequest` IPC + backend link teardown would be a follow-up (out of scope here).

Both are hardening against a hostile NomadNet node, not functional defects: a well-behaved node respects the upstream 16 MiB cap, and mesh links are low-bandwidth.

## Testing
- Verified against `main` on device (SM-G998U1, Android 15, 600dpi) against the Mac mini NomadNet test hub:
  - Images render (previously deadlocked at the Coil load gate).
  - `w=100%` spans full content width (360dp), matching the no-spec image; `w=n` intrinsic unchanged.
  - Manual mode: tapping one placeholder fetches only that image (log shows a single media request); siblings stay placeholders.
- New/updated tests:
  - `MicronImageSizeResolutionTest` - fraction resolution, clamping, malformed specs, numeric dp (no density conversion).
  - `PageImageLoaderTest` - 22 tests incl. regressions for per-image cross-node auto-gating (both directions), the 16 MiB cap passed to the backend, backend-too-large surfaced as FAILED, `applyMode` transitioning to ALWAYS, and malformed refs being non-retryable.
  - `RnsErrorTest` / `ParcelRoundTripTest` - the new `NomadnetResponseTooLarge` type (property + AIDL round-trip).
  - micron parser image-tag tests.
- ktlint + detekt clean; all module unit tests green; `:app:assembleNoSentryPythonBackendDebug` green.

## Notes
- Upstream-parity for the auto-gate was checked line-by-line against `nomadnet/ui/textui/Browser.py` `should_load_images`.
- Scoped to the NomadNet/micron image feature; no unrelated changes included.