### PR TITLE
Remove automatic update check from app startup

### DIFF
--- a/app/src/main/java/network/columba/app/repository/SettingsRepository.kt
+++ b/app/src/main/java/network/columba/app/repository/SettingsRepository.kt
@@ -168,7 +168,6 @@ class SettingsRepository
 
             // Update checker preferences
             val INCLUDE_PRERELEASE_UPDATES = booleanPreferencesKey("include_prerelease_updates")
-            val LAST_UPDATE_CHECK_TIME = longPreferencesKey("last_update_check_time")
 
             // Message sort order: false = received time (default), true = sent time
             val SORT_MESSAGES_BY_SENT_TIME = booleanPreferencesKey("sort_messages_by_sent_time")
@@ -2328,14 +2327,6 @@ class SettingsRepository
         suspend fun setIncludePrereleaseUpdates(enabled: Boolean) {
             context.dataStore.edit { preferences ->
                 preferences[PreferencesKeys.INCLUDE_PRERELEASE_UPDATES] = enabled
-            }
-        }
-
-        suspend fun getLastUpdateCheckTime(): Long = context.dataStore.data.first()[PreferencesKeys.LAST_UPDATE_CHECK_TIME] ?: 0L
-
-        suspend fun setLastUpdateCheckTime(time: Long) {
-            context.dataStore.edit { preferences ->
-                preferences[PreferencesKeys.LAST_UPDATE_CHECK_TIME] = time
             }
         }
 

--- a/app/src/main/java/network/columba/app/viewmodel/SettingsViewModel.kt
+++ b/app/src/main/java/network/columba/app/viewmodel/SettingsViewModel.kt
@@ -248,7 +248,6 @@ class SettingsViewModel
             private const val RETRY_DELAY_MS = 1000L
             private const val SHARED_INSTANCE_MONITOR_INTERVAL_MS = 5_000L // Check every 5 seconds
             private const val SHARED_INSTANCE_PORT = 37428 // Default RNS shared instance port (for logging)
-            private const val UPDATE_CHECK_INTERVAL_MS = 24 * 60 * 60 * 1000L // 24 hours
 
             /**
              * Controls whether shared instance monitors are started in init.
@@ -2505,12 +2504,10 @@ class SettingsViewModel
 
         private fun loadUpdateSettings() {
             viewModelScope.launch {
-                // Eagerly read the persisted value before the startup check fires,
-                // so the check uses the correct API endpoint (not the default false).
+                // Eagerly read the persisted value so the state holds the correct
+                // endpoint choice (not the default false) before the user acts.
                 val initial = settingsRepository.includePrereleaseUpdates.first()
                 _state.update { it.copy(includePrereleaseUpdates = initial) }
-
-                maybeCheckForUpdatesOnStartup()
 
                 // Continue observing subsequent changes
                 settingsRepository.includePrereleaseUpdates.drop(1).collect { include ->
@@ -2519,22 +2516,11 @@ class SettingsViewModel
             }
         }
 
-        private suspend fun maybeCheckForUpdatesOnStartup() {
-            val lastCheck = settingsRepository.getLastUpdateCheckTime()
-            val now = System.currentTimeMillis()
-            if (now - lastCheck >= UPDATE_CHECK_INTERVAL_MS) {
-                checkForUpdates()
-            }
-        }
-
         fun checkForUpdates(includePrerelease: Boolean = _state.value.includePrereleaseUpdates) {
             _state.update { it.copy(updateCheckResult = network.columba.app.service.AppUpdateResult.Checking) }
             viewModelScope.launch {
                 val result = updateChecker.check(includePrerelease)
                 _state.update { it.copy(updateCheckResult = result) }
-                if (result !is network.columba.app.service.AppUpdateResult.Error) {
-                    settingsRepository.setLastUpdateCheckTime(System.currentTimeMillis())
-                }
             }
         }
 

--- a/app/src/test/java/network/columba/app/viewmodel/SettingsViewModelIncomingMessageLimitTest.kt
+++ b/app/src/test/java/network/columba/app/viewmodel/SettingsViewModelIncomingMessageLimitTest.kt
@@ -229,7 +229,6 @@ class SettingsViewModelIncomingMessageLimitTest {
         every { settingsRepository.includePrereleaseUpdates } returns MutableStateFlow(false)
         every { settingsRepository.sortMessagesBySentTime } returns flowOf(false)
         every { settingsRepository.tryPropagationOnFailFlow } returns MutableStateFlow(true)
-        coEvery { settingsRepository.getLastUpdateCheckTime() } returns System.currentTimeMillis()
 
         // Mock PropagationNodeManager flows (StateFlows)
         every { propagationNodeManager.currentRelay } returns MutableStateFlow(null)

--- a/app/src/test/java/network/columba/app/viewmodel/SettingsViewModelTest.kt
+++ b/app/src/test/java/network/columba/app/viewmodel/SettingsViewModelTest.kt
@@ -217,7 +217,6 @@ class SettingsViewModelTest {
         every { settingsRepository.telemetryAllowedRequestersFlow } returns flowOf(emptySet<String>())
         every { settingsRepository.includePrereleaseUpdates } returns MutableStateFlow(false)
         every { settingsRepository.sortMessagesBySentTime } returns flowOf(false)
-        coEvery { settingsRepository.getLastUpdateCheckTime() } returns System.currentTimeMillis()
 
         // Stub settings save methods
         coEvery { settingsRepository.savePreferOwnInstance(any()) } just Runs


### PR DESCRIPTION
## Summary

Columba was calling api.github.com on app startup: SettingsViewModel is created in MainActivity (theme/splash loading), and its init fired an automatic update check (throttled to 24h, first launch always checked) hitting https://api.github.com/repos/torlando-tech/columba/releases/latest.

This removes the automatic startup check. The update check now only runs on explicit user action:
- 'Check for Updates' button in Settings > About (pre-existing, unchanged)
- Toggling the 'Include pre-releases' switch (re-checks with the chosen endpoint, pre-existing)

## Dead code removed

The startup throttle state became unused and was deleted:
- maybeCheckForUpdatesOnStartup() and UPDATE_CHECK_INTERVAL_MS in SettingsViewModel
- SettingsRepository.getLastUpdateCheckTime() / setLastUpdateCheckTime() and the LAST_UPDATE_CHECK_TIME DataStore key (existing stored values are simply no longer read or written)
- Two now-unneeded test stubs (coEvery { settingsRepository.getLastUpdateCheckTime() })

## Verification

- Focused unit tests (standard dev variant): :app:testNoSentryKotlinBackendDebugUnitTest --tests SettingsViewModelTest --tests SettingsViewModelIncomingMessageLimitTest -> 150 tests, 0 failures (SettingsViewModelTest 141/0, SettingsViewModelIncomingMessageLimitTest 9/0)
- ./gradlew detekt ktlintCheck -> BUILD SUCCESSFUL
- Repo-wide grep: no remaining references to removed symbols
- No behavior change to the manual check path; AboutCard UI untouched